### PR TITLE
fix(agents): report fork finalization failures in background tasks

### DIFF
--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -638,6 +638,36 @@ def _parse_sse_payload(line: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+async def _mark_background_fork_failed(
+    project_dir: str,
+    branch: str,
+    *,
+    scope_id: str,
+    reason: str,
+    context: str,
+) -> None:
+    """Best-effort fork failure bookkeeping for background tasks."""
+    if not project_dir or not branch:
+        return
+    try:
+        from qwenpaw.agents.fork_project import mark_fork_failed
+
+        await asyncio.to_thread(
+            mark_fork_failed,
+            project_dir,
+            branch,
+            reason=reason,
+            expected_scope=scope_id or None,
+        )
+    except Exception:
+        logger.warning(
+            "mark_fork_failed after %s failed for %s",
+            context,
+            sanitize_log_value(branch),
+            exc_info=True,
+        )
+
+
 @router.post(
     "/chat/task",
     status_code=200,
@@ -742,6 +772,47 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 parsed = _parse_sse_payload(sse_line)
                 if parsed and parsed.get("type") != "turn_usage":
                     last_response = parsed
+
+            # Fork subagents: commit dirty worktree so branch tips are
+            # mergeable before exposing a completed task result.
+            if fork_project_dir and fork_worktree_branch:
+                try:
+                    from qwenpaw.agents.fork_project import (
+                        finalize_fork_worktree_or_fail,
+                    )
+
+                    finalized = await asyncio.to_thread(
+                        finalize_fork_worktree_or_fail,
+                        fork_project_dir,
+                        fork_worktree_branch,
+                        message=f"fork worker {fork_worktree_branch}",
+                        expected_scope=fork_scope_id or None,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Background fork finalize failed for %s (%s)",
+                        sanitize_log_value(fork_worktree_branch),
+                        sanitize_log_value(fork_project_dir),
+                        exc_info=True,
+                    )
+                    await _mark_background_fork_failed(
+                        fork_project_dir,
+                        fork_worktree_branch,
+                        scope_id=fork_scope_id,
+                        reason="Fork finalization raised an exception",
+                        context="finalize error",
+                    )
+                    finalized = False
+                if not finalized:
+                    bg.status = "finished"
+                    bg.finished_at = time.time()
+                    bg.result = {
+                        "status": "failed",
+                        "error": {
+                            "message": "Failed to finalize fork worktree",
+                        },
+                    }
+                    return
         except asyncio.CancelledError:
             bg.status = "finished"
             bg.finished_at = time.time()
@@ -749,23 +820,13 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 "status": "failed",
                 "error": {"message": "Task cancelled"},
             }
-            if fork_project_dir and fork_worktree_branch:
-                try:
-                    from qwenpaw.agents.fork_project import mark_fork_failed
-
-                    await asyncio.to_thread(
-                        mark_fork_failed,
-                        fork_project_dir,
-                        fork_worktree_branch,
-                        reason="Task cancelled",
-                        expected_scope=fork_scope_id or None,
-                    )
-                except Exception:
-                    logger.warning(
-                        "mark_fork_failed on cancel failed for %s",
-                        sanitize_log_value(fork_worktree_branch),
-                        exc_info=True,
-                    )
+            await _mark_background_fork_failed(
+                fork_project_dir,
+                fork_worktree_branch,
+                scope_id=fork_scope_id,
+                reason="Task cancelled",
+                context="cancel",
+            )
             return
         except Exception as exc:
             bg.status = "finished"
@@ -774,23 +835,13 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 "status": "failed",
                 "error": {"message": str(exc)},
             }
-            if fork_project_dir and fork_worktree_branch:
-                try:
-                    from qwenpaw.agents.fork_project import mark_fork_failed
-
-                    await asyncio.to_thread(
-                        mark_fork_failed,
-                        fork_project_dir,
-                        fork_worktree_branch,
-                        reason=str(exc),
-                        expected_scope=fork_scope_id or None,
-                    )
-                except Exception:
-                    logger.warning(
-                        "mark_fork_failed on error failed for %s",
-                        sanitize_log_value(fork_worktree_branch),
-                        exc_info=True,
-                    )
+            await _mark_background_fork_failed(
+                fork_project_dir,
+                fork_worktree_branch,
+                scope_id=fork_scope_id,
+                reason=str(exc),
+                context="task error",
+            )
             return
 
         bg.status = "finished"
@@ -807,27 +858,6 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 "session_id": session_id,
                 "output": [],
             }
-        # Fork subagents: commit dirty worktree so branch tips are mergeable.
-        if fork_project_dir and fork_worktree_branch:
-            try:
-                from qwenpaw.agents.fork_project import (
-                    finalize_fork_worktree_or_fail,
-                )
-
-                await asyncio.to_thread(
-                    finalize_fork_worktree_or_fail,
-                    fork_project_dir,
-                    fork_worktree_branch,
-                    message=f"fork worker {fork_worktree_branch}",
-                    expected_scope=fork_scope_id or None,
-                )
-            except Exception:
-                logger.warning(
-                    "Background fork finalize failed for %s (%s)",
-                    sanitize_log_value(fork_worktree_branch),
-                    sanitize_log_value(fork_project_dir),
-                    exc_info=True,
-                )
 
     atask = asyncio.create_task(_run())
     bg.asyncio_task = atask

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -638,6 +638,37 @@ def _parse_sse_payload(line: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+async def _finalize_background_fork(
+    project_dir: str,
+    branch: str,
+    *,
+    scope_id: str,
+) -> bool:
+    """Finish an in-flight fork commit before publishing task state.
+
+    Cancelling an ``asyncio.to_thread`` await cannot stop its worker thread.
+    Once finalization starts, keep waiting for its authoritative result so the
+    task API, fork registry, and branch HEAD cannot report conflicting states.
+    """
+    from qwenpaw.agents.fork_project import finalize_fork_worktree_or_fail
+
+    finalizer = asyncio.create_task(
+        asyncio.to_thread(
+            finalize_fork_worktree_or_fail,
+            project_dir,
+            branch,
+            message=f"fork worker {branch}",
+            expected_scope=scope_id or None,
+        ),
+    )
+    while True:
+        try:
+            return await asyncio.shield(finalizer)
+        except asyncio.CancelledError:
+            if finalizer.done():
+                return finalizer.result()
+
+
 async def _mark_background_fork_failed(
     project_dir: str,
     branch: str,
@@ -777,16 +808,10 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
             # mergeable before exposing a completed task result.
             if fork_project_dir and fork_worktree_branch:
                 try:
-                    from qwenpaw.agents.fork_project import (
-                        finalize_fork_worktree_or_fail,
-                    )
-
-                    finalized = await asyncio.to_thread(
-                        finalize_fork_worktree_or_fail,
+                    finalized = await _finalize_background_fork(
                         fork_project_dir,
                         fork_worktree_branch,
-                        message=f"fork worker {fork_worktree_branch}",
-                        expected_scope=fork_scope_id or None,
+                        scope_id=fork_scope_id,
                     )
                 except Exception:
                     logger.warning(

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, AsyncGenerator
 
 import pytest
@@ -84,8 +85,12 @@ def _install_hook(fork: _Fork, tmp_path: Path, body: str) -> None:
 
 
 class _ChatManager:
-    async def get_or_create_chat(self, *args: Any, **kwargs: Any) -> object:
-        return object()
+    async def get_or_create_chat(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(id="test-chat", meta={})
 
 
 class _ConsoleChannel:
@@ -110,8 +115,11 @@ class _ChannelManager:
 
 
 class _Workspace:
-    chat_manager = _ChatManager()
-    channel_manager = _ChannelManager()
+    def __init__(self, workspace_dir: Path) -> None:
+        self.agent_id = "test-agent"
+        self.workspace_dir = workspace_dir
+        self.chat_manager = _ChatManager()
+        self.channel_manager = _ChannelManager()
 
 
 @pytest.fixture(autouse=True)
@@ -130,9 +138,13 @@ async def _submit_forked_task(
     timeout: float | None = None,
 ) -> tuple[str, asyncio.Task]:
     async def _get_workspace(_request):
-        return _Workspace()
+        return _Workspace(Path(worktree))
 
     monkeypatch.setattr(console, "get_agent_for_request", _get_workspace)
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda _agent_id: SimpleNamespace(project_dir=None),
+    )
     request_context = {
         "fork_project_dir": str(worktree),
         "fork_worktree_branch": branch,

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -179,6 +179,14 @@ async def _wait_for_task_to_finish(task_id: str) -> dict[str, Any]:
     raise TimeoutError(f"background task did not finish: {task_id}")
 
 
+async def _wait_for_task_cancellation(task: asyncio.Task[Any]) -> None:
+    for _ in range(200):
+        if task.cancelling() > 0:
+            return
+        await asyncio.sleep(0.05)
+    raise TimeoutError("background task was not cancelled")
+
+
 @pytest.mark.asyncio
 async def test_forked_task_reports_failed_when_worktree_cannot_be_finalized(
     tmp_path: Path,
@@ -253,11 +261,11 @@ async def test_forked_task_reports_failed_when_worktree_finalization_raises(
 
 
 @pytest.mark.asyncio
-async def test_forked_task_timeout_during_finalization_reports_failed(
+async def test_forked_task_timeout_during_finalization_waits_for_commit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Timeout during the Git commit must leave a terminal task result."""
+    """Once a Git commit starts, timeout waits for its authoritative result."""
     fork = _create_fork(tmp_path, "finalize-timeout")
     _install_hook(
         fork,
@@ -274,12 +282,24 @@ async def test_forked_task_timeout_during_finalization_reports_failed(
     )
     try:
         await _wait_for_file(fork.worktree / ".hook-started")
-        task = await _wait_for_task_to_finish(task_id)
+        await _wait_for_task_cancellation(background_task)
+        before_release = await console.get_console_chat_task(task_id)
+
+        (fork.worktree / ".hook-release").touch()
+        await asyncio.wait_for(background_task, timeout=10)
+        completed = await console.get_console_chat_task(task_id)
+        registry = json.loads(
+            (fork.project / REGISTRY_REL).read_text(encoding="utf-8"),
+        )
+        fork_head = _git(fork.worktree, "rev-parse", "HEAD").stdout.strip()
 
         assert (
-            task["status"],
-            (task.get("result") or {}).get("status"),
-        ) == ("finished", "failed")
+            before_release["status"],
+            completed["status"],
+            completed["result"]["status"],
+            registry["forks"][fork.branch]["status"],
+            fork_head != fork.base_head,
+        ) == ("running", "finished", "completed", "finalized", True)
     finally:
         (fork.worktree / ".hook-release").touch(exist_ok=True)
         await asyncio.gather(background_task, return_exceptions=True)

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for background console task completion."""
+# pylint: disable=protected-access,unused-argument
+from __future__ import annotations
+
+import asyncio
+import json
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from qwenpaw.agents import fork_project
+from qwenpaw.agents.fork_project import (
+    REGISTRY_REL,
+    begin_fork_scope,
+    register_fork,
+)
+from qwenpaw.app.routers import console
+
+
+@dataclass(frozen=True)
+class _Fork:
+    project: Path
+    worktree: Path
+    branch: str
+    scope: str
+    base_head: str
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _create_fork(tmp_path: Path, name: str) -> _Fork:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _git(project, "init", "-q")
+    _git(project, "config", "user.name", "QwenPaw Test")
+    _git(project, "config", "user.email", "test@example.invalid")
+    (project / "README.md").write_text("base\n", encoding="utf-8")
+    _git(project, "add", "README.md")
+    _git(project, "commit", "-qm", "base")
+
+    scope = begin_fork_scope(project)
+    branch = f"fork/{name}"
+    worktree = project / ".qwenpaw" / "worktrees" / name
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    _git(project, "worktree", "add", "-q", str(worktree), "-b", branch)
+    assert register_fork(
+        str(worktree),
+        branch,
+        workspace_dir=project,
+        scope_id=scope,
+    )
+    base_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    (worktree / "result.txt").write_text(
+        "subagent output\n",
+        encoding="utf-8",
+    )
+    return _Fork(project, worktree, branch, scope, base_head)
+
+
+def _install_hook(fork: _Fork, tmp_path: Path, body: str) -> None:
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    hook = hooks / "pre-commit"
+    hook.write_text(
+        f"#!/bin/sh\n{body}",
+        encoding="utf-8",
+        newline="\n",
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+    _git(fork.worktree, "config", "core.hooksPath", str(hooks))
+
+
+class _ChatManager:
+    async def get_or_create_chat(self, *args: Any, **kwargs: Any) -> object:
+        return object()
+
+
+class _ConsoleChannel:
+    def resolve_session_id(
+        self,
+        *,
+        sender_id: str,
+        channel_meta: dict[str, Any],
+    ) -> str:
+        return channel_meta["session_id"]
+
+    async def stream_one(
+        self,
+        payload: dict[str, Any],
+    ) -> AsyncGenerator[str, None]:
+        yield 'data: {"type":"message","output":[]}\n\n'
+
+
+class _ChannelManager:
+    async def get_channel(self, name: str) -> _ConsoleChannel | None:
+        return _ConsoleChannel() if name == "console" else None
+
+
+class _Workspace:
+    chat_manager = _ChatManager()
+    channel_manager = _ChannelManager()
+
+
+@pytest.fixture(autouse=True)
+def _clear_background_tasks():
+    console._bg_tasks.clear()
+    yield
+    console._bg_tasks.clear()
+
+
+async def _submit_forked_task(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    worktree: str | Path,
+    branch: str,
+    scope: str | None = None,
+    timeout: float | None = None,
+) -> tuple[str, asyncio.Task]:
+    async def _get_workspace(_request):
+        return _Workspace()
+
+    monkeypatch.setattr(console, "get_agent_for_request", _get_workspace)
+    request_context = {
+        "fork_project_dir": str(worktree),
+        "fork_worktree_branch": branch,
+    }
+    if scope is not None:
+        request_context["fork_scope_id"] = scope
+    payload: dict[str, Any] = {
+        "channel": "console",
+        "user_id": "test-user",
+        "session_id": "test-session",
+        "input": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": [{"type": "text", "text": "run"}],
+            },
+        ],
+        "request_context": request_context,
+    }
+    if timeout is not None:
+        payload["timeout"] = timeout
+
+    submitted = await console.post_console_chat_task(payload, None)
+    task_id = submitted["task_id"]
+    background_task = console._bg_tasks[task_id].asyncio_task
+    assert background_task is not None
+    return task_id, background_task
+
+
+async def _wait_for_file(path: Path) -> None:
+    for _ in range(100):
+        if path.exists():
+            return
+        await asyncio.sleep(0.05)
+    pytest.fail(f"file was not created: {path.name}")
+
+
+async def _wait_for_task_to_finish(task_id: str) -> dict[str, Any]:
+    for _ in range(200):
+        task = await console.get_console_chat_task(task_id)
+        if task["status"] == "finished":
+            return task
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f"background task did not finish: {task_id}")
+
+
+@pytest.mark.asyncio
+async def test_forked_task_reports_failed_when_worktree_cannot_be_finalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fork without a deliverable commit must be reported as failed."""
+    fork = _create_fork(tmp_path, "finalize-failure")
+    _install_hook(fork, tmp_path, "exit 1\n")
+    task_id, background_task = await _submit_forked_task(
+        monkeypatch,
+        worktree=fork.worktree,
+        branch=fork.branch,
+        scope=fork.scope,
+    )
+
+    await asyncio.wait_for(background_task, timeout=10)
+    task = await console.get_console_chat_task(task_id)
+    registry = json.loads(
+        (fork.project / REGISTRY_REL).read_text(encoding="utf-8"),
+    )
+    fork_head = _git(fork.worktree, "rev-parse", "HEAD").stdout.strip()
+
+    assert (
+        task["status"],
+        task["result"]["status"],
+        registry["forks"][fork.branch]["status"],
+        fork_head,
+        (fork.worktree / "result.txt").read_text(encoding="utf-8"),
+    ) == (
+        "finished",
+        "failed",
+        "failed",
+        fork.base_head,
+        "subagent output\n",
+    )
+
+
+@pytest.mark.asyncio
+async def test_forked_task_reports_failed_when_worktree_finalization_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finalizer exception must fail both the task and fork registry."""
+    fork = _create_fork(tmp_path, "finalize-exception")
+
+    def _raise_git_error(*args: Any, **kwargs: Any) -> bool:
+        raise OSError("simulated git failure")
+
+    monkeypatch.setattr(
+        fork_project,
+        "commit_dirty_worktree",
+        _raise_git_error,
+    )
+    task_id, background_task = await _submit_forked_task(
+        monkeypatch,
+        worktree=fork.worktree,
+        branch=fork.branch,
+        scope=fork.scope,
+    )
+
+    await asyncio.wait_for(background_task, timeout=10)
+    task = await console.get_console_chat_task(task_id)
+    registry = json.loads(
+        (fork.project / REGISTRY_REL).read_text(encoding="utf-8"),
+    )
+
+    assert (
+        task["result"]["status"],
+        registry["forks"][fork.branch]["status"],
+        (fork.worktree / "result.txt").read_text(encoding="utf-8"),
+    ) == ("failed", "failed", "subagent output\n")
+
+
+@pytest.mark.asyncio
+async def test_forked_task_timeout_during_finalization_reports_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeout during the Git commit must leave a terminal task result."""
+    fork = _create_fork(tmp_path, "finalize-timeout")
+    _install_hook(
+        fork,
+        tmp_path,
+        "touch .hook-started\n"
+        "while [ ! -f .hook-release ]; do sleep 0.05; done\n",
+    )
+    task_id, background_task = await _submit_forked_task(
+        monkeypatch,
+        worktree=fork.worktree,
+        branch=fork.branch,
+        scope=fork.scope,
+        timeout=3.0,
+    )
+    try:
+        await _wait_for_file(fork.worktree / ".hook-started")
+        task = await _wait_for_task_to_finish(task_id)
+
+        assert (
+            task["status"],
+            (task.get("result") or {}).get("status"),
+        ) == ("finished", "failed")
+    finally:
+        (fork.worktree / ".hook-release").touch(exist_ok=True)
+        await asyncio.gather(background_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_forked_task_stays_running_until_worktree_is_finalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Success is exposed only after the fork commit becomes deliverable."""
+    fork = _create_fork(tmp_path, "finalize-success")
+    _install_hook(
+        fork,
+        tmp_path,
+        "touch .hook-started\n"
+        "while [ ! -f .hook-release ]; do sleep 0.05; done\n",
+    )
+    task_id, background_task = await _submit_forked_task(
+        monkeypatch,
+        worktree=fork.worktree,
+        branch=fork.branch,
+        scope=fork.scope,
+    )
+    try:
+        await _wait_for_file(fork.worktree / ".hook-started")
+        in_progress = await console.get_console_chat_task(task_id)
+        assert in_progress["status"] == "running"
+
+        (fork.worktree / ".hook-release").touch()
+        await asyncio.wait_for(background_task, timeout=10)
+        completed = await console.get_console_chat_task(task_id)
+        fork_head = _git(fork.worktree, "rev-parse", "HEAD").stdout.strip()
+
+        assert (
+            completed["status"],
+            completed["result"]["status"],
+            fork_head != fork.base_head,
+        ) == ("finished", "completed", True)
+    finally:
+        (fork.worktree / ".hook-release").touch(exist_ok=True)
+        await asyncio.gather(background_task, return_exceptions=True)


### PR DESCRIPTION
## Description

While using a forked background subagent, I saw the task endpoint report `completed` even though the worktree had not been finalized. A rejecting Git hook left the fork branch at its original HEAD, but `/console/chat/task/{task_id}` still exposed a successful result because it wrote that result before finalization and ignored the finalizer's return value.

This change keeps the task `running` until finalization reaches an authoritative result. A `False` return or an exception produces a terminal `finished` / `failed` result, and unexpected finalizer errors also update the fork registry on a best-effort basis so it is not left at `finalizing`. The existing worktree changes are preserved. Once Git finalization has started, timeout cancellation is deferred until the worker settles; a successful commit is then reported as `completed`, preventing the task API, fork registry, and branch HEAD from disagreeing.

**Related Issue:** Fixes #6722

**Security Considerations:** No authentication or configuration behavior changes. The task API returns a fixed generic finalization error; detailed exceptions remain in sanitized server logs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no public API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable: this changes the background task router, not a channel implementation or channel contract.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The regression tests use real temporary Git repositories, worktrees, commits, and hooks. Only the agent stream boundary is replaced with a small deterministic fake. They cover:

- a hook-rejected commit returning `False`;
- an exception after the fork registry enters `finalizing`;
- timeout during a blocked Git finalization waiting for its settled commit result;
- the successful path staying `running` until the fork branch HEAD advances.

## Evidence

```text
$ pre-commit run --files src/qwenpaw/app/routers/console.py tests/unit/app/routers/test_console_chat_task.py
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

$ python -m pytest tests/unit/app/routers/test_console_chat_task.py tests/unit/agents/test_fork_project.py tests/unit/app/routers/test_console_chat_reconnect.py -q
......................................                                   [100%]
38 passed, 1 warning in 44.19s
```

The primary reproduction now verifies all of these together: outer task status is `finished`, result status and fork-registry status are `failed`, the branch HEAD remains at its base commit, and the subagent's uncommitted file is still present.

## Additional Notes

`pre-commit run --all-files` is not checked above; every hook passes when scoped to the two files changed by this PR.

After `main` advanced, this branch was rebased onto `bacac7410cf2ac122dd892152beff8b03f38729f`. The background-task fixture now supplies the chat, workspace, and agent-config fields required by the current session project-directory contract. The reviewer-requested 38-test suite and scoped pre-commit checks pass on the rebased head.

