### PR TITLE
fix(tests): make directory auto-marking work on Windows, unhiding 66 cases

### DIFF
--- a/src/qwenpaw/browser/execution/subprocess_plane.py
+++ b/src/qwenpaw/browser/execution/subprocess_plane.py
@@ -597,7 +597,10 @@ class SubprocessPlane:
                 continue
             if worker.lock.locked():
                 continue
-            if now - worker.last_used > effective_ttl:
+            # Non-strict: a ttl of 0 means "reclaim whatever is idle now", and
+            # on Windows loop.time() has ~15ms resolution, so now - last_used
+            # is frequently exactly 0 right after a run.
+            if now - worker.last_used >= effective_ttl:
                 self._workers.pop(key, None)
                 await self._terminate(worker)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,8 +424,10 @@ def pytest_collection_modifyitems(
 ) -> None:
     """Modify test collection to add markers based on test location."""
     for item in items:
-        # Auto-mark tests based on directory
-        path_str = str(item.path)
+        # Auto-mark tests based on directory. as_posix() keeps the separator
+        # forward-slashed on Windows, where str() would yield backslashes and
+        # silently drop these tests from any -m filtered run.
+        path_str = item.path.as_posix()
         if "/unit/" in path_str:
             item.add_marker(pytest.mark.unit)
         elif "/integration/" in path_str:


### PR DESCRIPTION
## Problem

Windows was silently skipping 66 integration cases while reporting a green job.

`tests/conftest.py` auto-marks tests by directory:

```python
path_str = str(item.path)          # Windows: tests\integration\...
elif "/integration/" in path_str:  # never matches there
```

`str(Path)` is backslash-separated on Windows, so the hardcoded `/integration/` never matched and the `integration` marker was never applied. Any case relying on the auto-marker instead of an explicit `@pytest.mark.integration` therefore vanished from every `-m` filtered run — with no warning and no error.

Evidence:

- Windows collected **431 items**, ubuntu/macOS **497**.
- The files missing on Windows (all of `tests/integration/browser`, plus several `test_chrome_*` and `test_driver_mcp_*` at the time) contained **zero** explicit `integration` markers, while files that did run, e.g. `test_coding_project.py`, carry 11 of them.

The same bug disabled `/unit/` and `/e2e/` auto-marking, harmless today only because those tiers run unfiltered.

## Changes

**1. `tests/conftest.py` — use `as_posix()`** so the separator is always forward-slashed. Semantics are otherwise unchanged.

**2. `src/qwenpaw/browser/execution/subprocess_plane.py` — non-strict idle reclaim.** Unhiding the browser cases on Windows exposed a real defect that had never executed there:

```python
if now - worker.last_used > effective_ttl:   # strict
```

A `ttl` of 0 means "reclaim whatever is not in use right now", but with a strict `>` it reclaims nothing whenever the loop clock has not ticked since the worker's last use. Windows `loop.time()` has ~15ms resolution, so `now - last_used` is frequently exactly 0 right after a run and the worker survived, failing `test_worker_is_reused_then_reclaimed`.

Since a monotonic clock guarantees `now >= last_used`, a failing strict comparison can only mean the two are equal — so this is a boundary bug, not flakiness. `>=` keeps the `ttl=0` intent valid at any clock resolution and matches the session idle check further down the same file, which already uses `<=`. Production callers (`_app.py`, `kernel.py`) pass a non-zero ttl, where the only behavioural change is reclaiming exactly at the boundary rather than just past it.

The two changes ship together on purpose: landing the marker fix alone would turn Windows red on a defect it merely revealed.

## Verification (fork CI, four rounds)

Final round — all four platforms collect **497 items** and fail on exactly the same single case:

| Platform | Collected | Result |
| --- | --- | --- |
| ubuntu py3.11 | 497 | 1 failed, 493 passed |
| ubuntu py3.13 | 497 | 1 failed, 493 passed |
| macOS py3.11 | 497 | 1 failed, 493 passed |
| Windows py3.11 | 497 | 1 failed, 492 passed |

- Windows went from 431 to 497 collected, matching every other platform.
- Windows no longer aborts collection, and `test_worker_is_reused_then_reclaimed` now passes there.
- Unit tests are green on all four platforms.

The one remaining failure, `test_skills_pool_autosync.py::test_auto_update_persists_targets` (`KeyError: 'auto_update_targets'`), is **pre-existing and unrelated** — it fails identically on main's own nightly (run 30940502146, 8 occurrences) and reproduces on all four platforms with or without this PR.

Earlier rounds also surfaced two failures that are already fixed upstream and are not caused by this change: the Windows `PermissionError` in the restore lock (fixed by #6703) and `tests/unit/tauri/test_entry.py` module pollution (fixed by #6713). This branch is rebased on top of both.

## Follow-up

`tests/integration/browser` still has no explicit priority markers, so it is selected only by expressions without a p0/p1 filter. Worth adding markers there so those cases can enter the PR gate.