### PR TITLE
test(integration): verify auto-update targets via pool detail endpoint

### DIFF
--- a/tests/integration/test_skills_pool_autosync.py
+++ b/tests/integration/test_skills_pool_autosync.py
@@ -143,12 +143,17 @@ def test_auto_update_persists_targets(app_server) -> None:
       1. Create a pool skill.
       2. PUT .../auto-update {enabled:True, targets:[...]} -> 200,
          response echoes the targets.
-      3. GET /pool: auto_update_targets reflects the list.
-      4. finally: delete the pool skill.
+      3. GET /pool: the slim list entry shows auto_update=True.
+      4. GET /pool/{name}: the detail entry exposes the persisted
+         auto_update_targets (the list view intentionally only carries
+         lightweight fields; per-skill detail lives on the detail
+         endpoint).
+      5. finally: delete the pool skill.
 
     API endpoints:
       - PUT /api/skills/pool/{skill_name}/auto-update
       - GET /api/skills/pool
+      - GET /api/skills/pool/{skill_name}
     """
     name = "integ-pool-au-targets"
     targets = ["default"]
@@ -165,7 +170,14 @@ def test_auto_update_persists_targets(app_server) -> None:
         entry = _pool_entry(app_server, name)
         assert entry is not None, "pool skill missing after auto-update"
         assert entry["auto_update"] is True
-        assert entry["auto_update_targets"] == targets, entry
+        detail = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert detail.status_code == 200, app_server.logs_tail()
+        detail_body = detail.json()
+        assert detail_body["auto_update_targets"] == targets, detail_body
     finally:
         _delete_pool_skill_quietly(app_server, name)
 


### PR DESCRIPTION
## Description

`#6650` ("fix(skill): loading redundancy") split the pool skill API into a slim list view (`PoolSkillSpec`) and a detail view (`PoolSkillDetail`, served by the new `GET /api/skills/pool/{skill_name}`). As part of that change, `auto_update_targets` moved out of the list contract into the detail contract.

The integration test `test_auto_update_persists_targets` (added in #6417) was not updated and still asserts `auto_update_targets` on the **list** entry, so it fails deterministically with `KeyError: 'auto_update_targets'` — visible in the nightly `full-tests-nightly` integration suite on all 4 platforms since 2026-08-04 (e.g. run 30940502146: `1 failed, 492 passed`):

```
E           KeyError: 'auto_update_targets'
tests/integration/test_skills_pool_autosync.py:168: KeyError
FAILED tests/integration/test_skills_pool_autosync.py::test_auto_update_persists_targets
```

This is a stale-test issue, not a product defect. I verified the persistence behavior end-to-end against current `main`:

1. `PUT /api/skills/pool/{name}/auto-update` with `{enabled: true, targets: ["default"]}` → 200, and the pool manifest file on disk contains `auto_update_targets: ["default"]`.
2. `GET /api/skills/pool` (list) → slim entry: has `auto_update: true`, no `auto_update_targets` (by design since #6650).
3. `GET /api/skills/pool/{name}` (detail) → 200 with `auto_update_targets: ["default"]` and `auto_update: true`.

This PR updates the test to assert the persisted targets on the detail endpoint, keeping the list assertion on the still-supported `auto_update` flag. No product code changes.

**Related Issue:** Relates to #6650 (API contract change that left this test stale)

**Security Considerations:** None — test-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

(Checklist note: the pre-commit hook environments are not installable in my environment, so those two boxes are left unchecked. I ran the relevant checks manually instead — `black --line-length=79 --diff` reports no changes in the edited region (the only diff in the file is a pre-existing divergence from a newer black version) and `flake8 --extend-ignore=E203` passes on the touched file.)

## Testing

```bash
pytest tests/integration/test_skills_pool_autosync.py -v
```

## Evidence

Local run against current `main` with this PR applied (Python 3.11.2, pytest 9.1.1):

```bash
$ pytest tests/integration/test_skills_pool_autosync.py -v
tests/integration/test_skills_pool_autosync.py::test_auto_update_enable_then_disable_roundtrip PASSED [ 11%]
tests/integration/test_skills_pool_autosync.py::test_auto_update_persists_targets PASSED [ 22%]
tests/integration/test_skills_pool_autosync.py::test_auto_update_unknown_skill_returns_404 PASSED [ 33%]
tests/integration/test_skills_pool_autosync.py::test_builtin_notice_returns_contract PASSED [ 44%]
tests/integration/test_skills_pool_autosync.py::test_builtin_sources_lists_candidates PASSED [ 55%]
tests/integration/test_skills_pool_autosync.py::test_builtin_notice_reflects_import PASSED [ 66%]
tests/integration/test_skills_pool_autosync.py::test_refresh_returns_pool_list_with_created_skill PASSED [ 77%]
tests/integration/test_skills_pool_autosync.py::test_list_workspace_skill_sources PASSED [ 88%]
tests/integration/test_skills_pool_autosync.py::test_hub_install_cancel_unknown_task_returns_404 PASSED [100%]

============================== 9 passed in 6.57s ===============================
```

Contract probe on unmodified `main` (manifest file + both endpoints after the same PUT):

```
manifest auto_update_targets = ['default']          <- persisted on disk
list entry keys = ['auto_update', 'description', 'emoji', 'external',
                   'external_path', 'last_updated', 'name', 'source',
                   'sync_status', 'tags']           <- slim by design
GET /pool/{name} -> 200, auto_update_targets = ['default'], auto_update = True
```

## Additional Notes

Because the integration suite itself was down (Playwright Chromium missing) from 2026-07-28 until #6678 landed, #6650 merged without the integration suite running, and this stale assertion was only exposed by the first healthy nightly run on 2026-08-04.
