### PR TITLE
fix(openrouter): preserve multimodal capabilities during metadata probe

### DIFF
--- a/src/qwenpaw/providers/multimodal_prober.py
+++ b/src/qwenpaw/providers/multimodal_prober.py
@@ -81,6 +81,7 @@ class ProbeResult:
     supports_video: bool = False
     image_message: str = ""
     video_message: str = ""
+    probe_source: str = "probed"
 
     @property
     def supports_multimodal(self) -> bool:

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -10,6 +10,7 @@ from agentscope.model import ChatModelBase
 from openai import APIError, AsyncOpenAI
 from pydantic import Field
 
+from qwenpaw.exceptions import ProviderError
 from qwenpaw.providers.provider import (
     Provider,
     ExtendedModelInfo,
@@ -17,6 +18,7 @@ from qwenpaw.providers.provider import (
 )
 from .capping_formatter import _CappingOpenAIFormatter
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
+from .multimodal_prober import ProbeResult
 
 
 class OpenRouterProvider(Provider):
@@ -273,6 +275,68 @@ class OpenRouterProvider(Provider):
             timeout=timeout,
             include_extended=True,
         )  # type: ignore
+
+    async def probe_model_multimodal(
+        self,
+        model_id: str,
+        timeout: float = 10,
+        image_only: bool = False,
+    ) -> ProbeResult:
+        """Resolve multimodal support from OpenRouter's model catalog.
+
+        OpenRouter publishes input modalities in its ``/models`` response.
+        Treat that metadata as authoritative instead of sending a paid chat
+        completion.  A missing or unavailable catalog is inconclusive and
+        must raise so the provider manager does not persist false capability
+        flags over previously known values.
+        """
+        try:
+            client = self._client(timeout=timeout)
+            payload = await client.models.list(timeout=timeout)
+        except APIError as exc:
+            raise ProviderError(
+                message=(
+                    "Unable to read OpenRouter model metadata while probing "
+                    f"'{model_id}'"
+                ),
+                details={"model_id": model_id},
+            ) from exc
+
+        models = self._normalize_models_payload(
+            payload,
+            include_extended=True,
+        )
+        model = next((item for item in models if item.id == model_id), None)
+        if model is None:
+            raise ProviderError(
+                message=(
+                    f"Model '{model_id}' was not found in the OpenRouter "
+                    "model catalog"
+                ),
+                details={"model_id": model_id},
+            )
+
+        supports_image = bool(model.supports_image)
+        supports_video = False if image_only else bool(model.supports_video)
+        image_message = (
+            "Image capability reported by OpenRouter model metadata: "
+            f"{supports_image}"
+        )
+        video_message = (
+            "Skipped: image_only=True"
+            if image_only
+            else (
+                "Video capability reported by OpenRouter model metadata: "
+                f"{supports_video}"
+            )
+        )
+        return ProbeResult(
+            supports_image=supports_image,
+            supports_video=supports_video,
+            image_message=image_message,
+            video_message=video_message,
+            probe_source="documentation",
+        )
 
     def filter_models(
         self,

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1848,7 +1848,11 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     # image alone; video will be updated by the full probe.
                     if result.supports_image:
                         model.supports_multimodal = True
-                model.probe_source = "probed"
+                model.probe_source = getattr(
+                    result,
+                    "probe_source",
+                    "probed",
+                )
                 break
 
         # Compare probe result against expected baseline

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -22,6 +22,7 @@ from qwenpaw.providers.openai_provider import (
     GitHubModelsProvider,
     OpenAIProvider,
 )
+from qwenpaw.providers.openrouter_provider import OpenRouterProvider
 from qwenpaw.providers.provider import ModelInfo, ProviderInfo
 from qwenpaw.providers.provider_manager import ProviderManager
 
@@ -489,6 +490,114 @@ def test_builtin_capability_probe_results_survive_storage_reload(
     assert model.supports_multimodal is False
     assert model.supports_image is False
     assert model.supports_video is False
+
+
+async def test_openrouter_metadata_probe_restores_and_persists_capabilities(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("openrouter")
+    assert isinstance(provider, OpenRouterProvider)
+
+    model_id = "x-ai/grok-4.5"
+    poisoned_model = ModelInfo(
+        id=model_id,
+        name="Grok 4.5",
+        supports_multimodal=False,
+        supports_image=False,
+        supports_video=False,
+        probe_source="probed",
+    )
+    monkeypatch.setattr(provider, "extra_models", [poisoned_model])
+
+    row = SimpleNamespace(
+        id=model_id,
+        name="Grok 4.5",
+        pricing=None,
+        architecture={
+            "input_modalities": ["text", "image", "file"],
+            "output_modalities": ["text"],
+        },
+    )
+
+    class FakeModels:
+        async def list(self, timeout=None):
+            _ = timeout
+            return SimpleNamespace(data=[row])
+
+    fake_client = SimpleNamespace(models=FakeModels())
+    monkeypatch.setattr(
+        OpenRouterProvider,
+        "_client",
+        lambda self, timeout=30: fake_client,
+    )
+
+    result = await manager.probe_model_multimodal("openrouter", model_id)
+
+    assert result["supports_image"] is True
+    assert poisoned_model.supports_image is True
+    assert poisoned_model.supports_video is False
+    assert poisoned_model.supports_multimodal is True
+    assert poisoned_model.probe_source == "documentation"
+
+    saved_path = (
+        isolated_secret_dir / "providers" / "builtin" / "openrouter.json"
+    )
+    saved = json.loads(saved_path.read_text(encoding="utf-8"))
+    saved_model = next(
+        item for item in saved["extra_models"] if item["id"] == model_id
+    )
+    assert saved_model["supports_image"] is True
+    assert saved_model["supports_multimodal"] is True
+    assert saved_model["probe_source"] == "documentation"
+
+
+async def test_openrouter_inconclusive_probe_does_not_overwrite_capabilities(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("openrouter")
+    assert isinstance(provider, OpenRouterProvider)
+
+    model_id = "x-ai/grok-4.5"
+    configured_model = ModelInfo(
+        id=model_id,
+        name="Grok 4.5",
+        supports_multimodal=True,
+        supports_image=True,
+        supports_video=False,
+        probe_source="documentation",
+    )
+    monkeypatch.setattr(provider, "extra_models", [configured_model])
+
+    class FakeModels:
+        async def list(self, timeout=None):
+            _ = timeout
+            return SimpleNamespace(data=[])
+
+    fake_client = SimpleNamespace(models=FakeModels())
+    monkeypatch.setattr(
+        OpenRouterProvider,
+        "_client",
+        lambda self, timeout=30: fake_client,
+    )
+    save_calls = []
+    monkeypatch.setattr(
+        manager,
+        "_save_provider",
+        lambda *args, **kwargs: save_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(ProviderError, match="was not found"):
+        await manager.probe_model_multimodal("openrouter", model_id)
+
+    assert configured_model.supports_multimodal is True
+    assert configured_model.supports_image is True
+    assert configured_model.supports_video is False
+    assert configured_model.probe_source == "documentation"
+    assert not save_calls
 
 
 def test_update_provider_for_unknown_returns_false(


### PR DESCRIPTION
## Description

Fix OpenRouter multimodal probing to use /models metadata instead of the base no-op result. Catalog failures or missing models are now treated as inconclusive, preventing known capabilities from being overwritten with false. Metadata-derived results also retain probe_source="documentation".

**Related Issue:** Fixes #6687

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
