### PR TITLE
docs(memory): add embedding model configuration guide

### DIFF
--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -450,12 +450,21 @@ Controls agent runtime behavior, retry strategies, context management, and memor
 | `api_key`          | string | `""`       | API key for the embedding provider. Required for OpenAI-compatible and Gemini backends         |
 | `base_url`         | string | `""`       | Optional custom API URL for OpenAI-compatible backends. For Ollama, this is passed as the host |
 | `model_name`       | string | `""`       | Embedding model name (e.g., `"text-embedding-3-small"`)                                        |
-| `dimensions`       | int    | `1024`     | Embedding vector dimensions                                                                    |
+| `dimensions`       | int    | `1024`     | Expected Embedding vector dimensions, used for response validation, indexes, and caches        |
 | `enable_cache`     | bool   | `true`     | Whether to enable embedding cache                                                              |
-| `use_dimensions`   | bool   | `false`    | Whether to use custom dimensions                                                               |
+| `use_dimensions`   | bool   | `false`    | Whether the OpenAI backend sends the `dimensions` parameter in API requests                    |
 | `max_cache_size`   | int    | `10000`    | Maximum cache size                                                                             |
-| `max_input_length` | int    | `8192`     | Maximum input length for embeddings                                                            |
+| `max_input_length` | int    | `8192`     | Approximate character budget per Embedding input, not an exact token limit                     |
 | `max_batch_size`   | int    | `10`       | Maximum batch size for batch processing                                                        |
+
+`use_dimensions` only controls whether OpenAI-compatible requests include the `dimensions` parameter. When it is
+disabled, `dimensions` is still used to validate returned vectors and configure indexes and caches, so it must match
+the model's actual output dimensions. Disable `use_dimensions` for OpenAI-compatible services, including some vLLM
+deployments, that do not support this request parameter.
+
+Each Embedding input is truncated separately before the request according to `max_input_length`. This is a
+character-based estimate: Chinese, CJK, and other full-width characters use a more conservative weight with a safety
+margin. ReMe does not invoke the model tokenizer to calculate an exact token count.
 
 Vector retrieval is enabled only when the selected backend has the minimum runnable configuration. These conditions are aligned with AgentScope credential requirements:
 
@@ -468,9 +477,18 @@ Vector retrieval is enabled only when the selected backend has the minimum runna
 When the enable condition is not met, ReMe still keeps keyword indexes and wikilink graph indexes, but the embedding vector index is disabled.
 
 These settings can also be changed in the Console under **Agent → Runtime Config**. Fields read directly from
-`agent.json`, such as auto-memory cadence and auto-search limits, apply to later turns after saving. Embedded ReMe
-component settings, such as directories and embedding configuration, require restarting the agent process so the ReMe
-application is constructed with the new configuration.
+`agent.json`, such as auto-memory cadence and auto-search limits, apply to later turns after saving. For Embedding
+settings, QwenPaw attempts a hot update when the current service parameters have passed **Test Embedding Service**,
+the save changes only Embedding settings, and the tested service parameters remain unchanged. First-time enablement,
+disabling Embedding, saving without a current test, changing service parameters after testing, or changing other
+runtime settings at the same time causes QwenPaw to save the configuration and automatically reload the agent; no
+manual restart is required. Other embedded ReMe component settings that require reconstruction, such as directories,
+also use the automatic reload path.
+
+The Console's Embedding **Enabled/Disabled** status is calculated in real time from the current unsaved form. It only
+indicates whether the Backend, model name, and required credentials meet the enable conditions above; it does not prove
+that the service is reachable or that the draft has been applied to the running agent. **Verified** means a real test
+request succeeded. Changes affect runtime state only after the configuration is saved.
 
 ---
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -403,12 +403,19 @@ MCP（模型上下文协议）允许智能体连接外部服务（如 Filesystem
 | `api_key`          | string | `""`       | Embedding 提供商的 API Key。OpenAI 兼容和 Gemini 后端必填                             |
 | `base_url`         | string | `""`       | OpenAI 兼容后端的可选自定义 API 地址；Ollama 后端会作为 host 传递                     |
 | `model_name`       | string | `""`       | Embedding 模型名称（如 `"text-embedding-3-small"`）                                   |
-| `dimensions`       | int    | `1024`     | Embedding 向量维度                                                                    |
+| `dimensions`       | int    | `1024`     | 预期的 Embedding 向量维度，用于返回值校验、索引和缓存                                 |
 | `enable_cache`     | bool   | `true`     | 是否启用 Embedding 缓存                                                               |
-| `use_dimensions`   | bool   | `false`    | 是否使用自定义维度                                                                    |
+| `use_dimensions`   | bool   | `false`    | OpenAI 后端是否在 API 请求中传递 `dimensions` 参数                                    |
 | `max_cache_size`   | int    | `10000`    | 最大缓存大小                                                                          |
-| `max_input_length` | int    | `8192`     | Embedding 的最大输入长度                                                              |
+| `max_input_length` | int    | `8192`     | 单条 Embedding 输入的近似字符预算，并非精确的 Token 上限                              |
 | `max_batch_size`   | int    | `10`       | 批处理的最大批量大小                                                                  |
+
+`use_dimensions` 仅控制 OpenAI 兼容请求中是否携带 `dimensions` 参数。关闭后，`dimensions`
+仍用于校验服务返回的向量长度以及配置索引和缓存，因此必须填写模型实际输出的维度。部分 vLLM
+等 OpenAI 兼容服务不支持该请求参数，此时应关闭 `use_dimensions`。
+
+每条 Embedding 文本会在请求前按照 `max_input_length` 分别截断。该值按字符近似计算，中文、CJK
+及其他全角字符会使用更保守的权重并预留安全余量，不会调用模型 tokenizer 计算精确 Token 数。
 
 向量检索只有在当前后端具备最低可运行配置时才会启用；这些条件与 AgentScope credential 要求保持一致：
 
@@ -421,7 +428,12 @@ MCP（模型上下文协议）允许智能体连接外部服务（如 Filesystem
 不满足启用条件时，ReMe 仍会保留关键词索引和 wikilink 图谱索引，但不会启用 embedding 向量索引。
 
 这些配置也可以在控制台的 **智能体 → 运行配置** 页面中修改。直接从 `agent.json` 读取的字段，例如自动记忆间隔和自动搜索条数，
-保存后会在后续对话轮次生效。目录和 Embedding 等嵌入式 ReMe 组件配置需要重启 Agent 进程，让 ReMe 应用用新配置重新构造。
+保存后会在后续对话轮次生效。对于 Embedding 配置，如果当前服务参数已经通过“测试 Embedding 服务”验证、本次保存只修改了
+Embedding 配置且测试后的服务参数没有变化，系统会尝试热更新；首次启用、关闭、未先测试、测试后又修改服务参数，或同时修改其他
+运行配置时，系统会保存配置并自动重载 Agent，无需用户手动重启。目录等其他需要重新构造的嵌入式 ReMe 组件配置也会走自动重载。
+
+控制台中的 Embedding“已开启/未开启”状态会根据当前未保存表单实时计算，只表示 Backend、模型名称和必要凭证是否满足上述启用条件，
+不表示服务已经连通或配置已经应用到运行中的 Agent。“已验证”表示真实测试请求成功；只有保存配置后，变更才会应用到运行状态。
 
 ---
 

--- a/website/public/docs/embedding.en.md
+++ b/website/public/docs/embedding.en.md
@@ -1,0 +1,257 @@
+# Embedding Models
+
+Embeddings map text, images, or other inputs to fixed-dimensional numeric vectors. Semantically similar content is closer in vector space, allowing downstream modules to perform semantic search, clustering, deduplication, and similarity checks.
+
+QwenPaw currently provides an **embedding model configuration and runtime layer** based on AgentScope. It covers multiple provider adapters, real-request testing, strict dimension validation, batching and retry mapping, and configuration lifecycle management. ReMeLight is the current direct consumer and uses this layer to add vector support to memory.
+
+---
+
+## Capabilities and Boundaries
+
+| Capability                       | Description                                                                                                    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Multiple providers               | Supports `openai`, `dashscope`, `dashscope_multimodal`, `gemini`, and `ollama`                                 |
+| Unified model interface          | Uses AgentScope Credential and EmbeddingModel classes to hide provider SDK differences                         |
+| Text embedding                   | Accepts batches of text and returns fixed-dimensional vectors in input order                                   |
+| Dimension control and validation | Sends dimension settings according to provider rules and validates the actual output size                      |
+| Batching and retries             | QwenPaw sets an upstream batch size; AgentScope splits again for provider limits and retries eligible failures |
+| Pre-save test                    | Sends a real request with unsaved settings and reports actual dimensions, latency, and errors                  |
+| Configuration lifecycle          | Supports hot updates when possible and invalidates stale cache/index state after vector-space changes          |
+| Local cache                      | Lets the current consumer cache identical inputs to reduce repeated computation and API calls                  |
+
+QwenPaw's embedding capability is based on **AgentScope 2.x**. AgentScope supplies provider credentials, embedding models, request assembly, base batching, and retries. QwenPaw supplies configuration mapping, enablement rules, connectivity and response validation, saving, and hot updates.
+
+```mermaid
+graph LR
+    UI[QwenPaw configuration] --> Adapter[Mapping / test / lifecycle]
+    Adapter --> AS[AgentScope Credential + EmbeddingModel]
+    AS --> Provider[Embedding service API]
+    Adapter --> Consumer[Downstream consumer: currently ReMeLight]
+```
+
+AgentScope supports more input types than QwenPaw currently exposes:
+
+- `DashScopeEmbeddingModel` routes text and image/video `DataBlock` inputs based on the model name. `GeminiEmbeddingModel` also includes a multimodal path.
+- QwenPaw currently sends only text produced by ReMeLight. It does not expose a general embedding API or pass images, audio, video, or PDFs to these models. Selecting a multimodal type or model therefore does not add multimodal file parsing.
+- QwenPaw constructs AgentScope models with `parameters=None`. Extra call-level options that AgentScope may accept, such as `task_type` or `text_type`, have no Console or `agent.json` field in the current integration.
+
+---
+
+## Principles
+
+The same model maps documents and queries into one vector space. Systems commonly compare vector direction with cosine similarity: a higher value indicates closer semantics. Embeddings work well for synonyms, natural-language paraphrases, and topical similarity, but do not guarantee exact-token matches for function names or error codes. Retrieval consumers commonly combine them with keyword signals.
+
+```mermaid
+graph LR
+    Input[Text input] --> Batch[Truncate and batch]
+    Batch --> Model[AgentScope EmbeddingModel]
+    Model --> API[Provider or local service]
+    API --> Vector[Fixed-dimensional vectors]
+    Vector --> Consumer[Search / clustering / deduplication]
+```
+
+A change in model, version, endpoint, output dimensions, or dimension-control behavior can produce a different vector space. Document and query vectors must come from compatible spaces; equal output dimensions alone do not make two models compatible.
+
+### Test, Save, and Apply
+
+The Console's **Test Embedding Service** action sends the current unsaved form values to
+`POST /api/workspace/embedding/test`. The backend creates the real model and sends one test string. It requires the
+service to:
+
+1. return one non-empty vector within 15 seconds;
+2. return only finite numeric values; and
+3. return exactly the configured `dimensions`.
+
+On success, the model object is staged for the subsequent save. QwenPaw attempts a hot update only when the tested
+service parameters exactly match the saved values and this save changes no other runtime settings. First-time
+enablement, disabling embeddings, saving without a current successful test, changing service fields after testing, or
+changing other settings at the same time causes QwenPaw to save the configuration and automatically reload the agent.
+
+Changing the backend, Base URL, model name, dimensions, or `use_dimensions` changes the vector space. During a hot
+update, QwenPaw clears the local embedding cache and rebuilds the index, which produces new embedding requests and can
+temporarily consume substantial resources.
+
+---
+
+## Configuration
+
+### Configure in the Console
+
+Open **Agent Config → Running Config → Long-term Memory → Embedding Model Config**:
+
+1. Select the Embedding SDK Type.
+2. Enter the endpoint, model name, and credentials required by that backend.
+3. Enter the model's actual output dimensions.
+4. Tune cache, per-input character budget, and batch size for the service limits.
+5. Select **Test Embedding Service**. After the actual dimensions and latency are displayed, save the running config.
+
+If the form does not meet the enable condition, ReMeLight does not create vector components and memory search continues
+to use BM25.
+
+The **Enabled/Disabled** status in the Console overview and the **Embedding Service** card updates in real time from the
+current unsaved form. It uses the same configuration enablement rules as the backend and only indicates that the
+Backend, model name, and required credentials are complete. It does not make a network request and does not mean the
+draft has been saved or applied to the running agent. **Verified** means **Test Embedding Service** completed a real
+request with the current service parameters. Runtime state changes only after saving, through either a hot update or an
+automatic agent reload.
+
+### Backend Types and Parameters
+
+| QwenPaw type           | AgentScope Credential / Model                     | AgentScope input and model routing                                                                                                                                   | Authentication and endpoint                                                                                                                    | How dimensions are sent                                                                                                     | Enable condition and QwenPaw limit                                                                         |
+| ---------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `openai`               | `OpenAICredential` / `OpenAIEmbeddingModel`       | Text; supports `text-embedding-3-small`, `text-embedding-3-large`, and other OpenAI-compatible models                                                                | Required `api_key`; optional `base_url` passed to `openai.AsyncClient`; AgentScope also supports `organization`, which QwenPaw does not expose | Always sends `input`, `model`, and `encoding_format="float"`; sends `dimensions` only when `use_dimensions=true`            | Non-empty `model_name` and `api_key`; the only type that shows `use_dimensions` in the UI                  |
+| `dashscope`            | `DashScopeCredential` / `DashScopeEmbeddingModel` | `text-embedding-*` uses the text API; `qwen3-vl-embedding`, `qwen2.5-vl-embedding`, `multimodal-embedding-*`, and `tongyi-embedding-vision-*` use the multimodal API | Required `api_key`; the credential accepts `base_url`, but the current model calls do not use it                                               | Text API always sends `dimension`; multimodal API does not send dimensions, while QwenPaw still validates the response size | Non-empty `model_name` and `api_key`; QwenPaw currently supplies text only                                 |
+| `dashscope_multimodal` | Exactly the same as `dashscope`                   | A QwenPaw/ReMe configuration type; AgentScope still selects text or multimodal routing from `model_name`                                                             | Same as `dashscope`                                                                                                                            | Same as `dashscope`                                                                                                         | Non-empty `model_name` and `api_key`; does not make QwenPaw read images or videos automatically            |
+| `gemini`               | `GeminiCredential` / `GeminiEmbeddingModel`       | `gemini-embedding-001` uses the text path; `gemini-embedding-2*` uses the multimodal path                                                                            | `api_key` only; neither the AgentScope credential nor QwenPaw exposes Base URL                                                                 | Both paths send `dimensions` as `output_dimensionality`                                                                     | Non-empty `model_name` and `api_key`; QwenPaw currently supplies text only and does not expose `task_type` |
+| `ollama`               | `OllamaCredential` / `OllamaEmbeddingModel`       | Text; examples include `nomic-embed-text` and `mxbai-embed-large`                                                                                                    | No API key; maps `base_url` to `host`, with blank selecting Ollama's default host                                                              | Always sends `dimensions`                                                                                                   | Non-empty `model_name`; the QwenPaw process must be able to reach the Ollama host                          |
+
+For every AgentScope model, QwenPaw also sets `context_size=max_input_length` and uses `max_retries=3` during normal
+operation. **Test Embedding Service** lowers retries to `1` and adds a 15-second QwenPaw-level timeout.
+
+`max_batch_size` is the upstream batch size used by ReMeLight's `embedding_store`. AgentScope retains its own internal
+limits: in the pinned source these are 2048 for OpenAI, 10 for DashScope text, 100 for Gemini text, and 512 for Ollama.
+AgentScope splits again and dispatches batches concurrently when needed. The actual usable value still depends on the
+specific model and provider limits.
+
+### Fields
+
+The configuration lives at `running.reme_light_memory_config.embedding_model_config` in `agent.json`:
+
+| Field              | Default    | Purpose                                                                                                          |
+| ------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| `backend`          | `"openai"` | SDK type used to invoke the embedding model                                                                      |
+| `api_key`          | `""`       | Provider credential; unused by Ollama                                                                            |
+| `base_url`         | `""`       | Optional OpenAI API URL; Ollama interprets it as `host`; the current DashScope model calls do not use this value |
+| `model_name`       | `""`       | Model name; required by every backend                                                                            |
+| `dimensions`       | `1024`     | Expected actual vector size, also used for index and cache compatibility                                         |
+| `use_dimensions`   | `false`    | For the `openai` backend only; whether to send `dimensions` in the request                                       |
+| `enable_cache`     | `true`     | Whether to cache embedding results locally                                                                       |
+| `max_cache_size`   | `10000`    | Maximum local cache entries                                                                                      |
+| `max_input_length` | `8192`     | Approximate character budget per input, not an exact token count                                                 |
+| `max_batch_size`   | `10`       | Maximum items per batch request                                                                                  |
+
+Example for an OpenAI-compatible service:
+
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "embedding_model_config": {
+        "backend": "openai",
+        "api_key": "your-api-key",
+        "base_url": "https://your-embedding-service.example.com/v1",
+        "model_name": "your-embedding-model",
+        "dimensions": 1024,
+        "use_dimensions": false,
+        "enable_cache": true,
+        "max_cache_size": 10000,
+        "max_input_length": 8192,
+        "max_batch_size": 10
+      }
+    }
+  }
+}
+```
+
+If the service rejects a `dimensions` request parameter, keep `use_dimensions: false` but still set `dimensions` to
+the model's actual output size.
+
+---
+
+## Pitfalls and Troubleshooting
+
+### Dimensions Are Not an Arbitrary Target
+
+`dimensions` is first and foremost a strict validation value. Unless the model and API explicitly support variable
+dimensions, it must equal the model's native output size. A wrong value fails the test with a dimension mismatch;
+bypassing the test and saving can also break index construction.
+
+`use_dimensions` only controls whether the `openai` backend sends that parameter. It does not disable validation. Some
+OpenAI-compatible services and vLLM deployments reject the parameter; turn it off and enter the actual output size.
+
+### A Model Change Requires New Vectors
+
+Two models with the same output size can still use incompatible vector spaces. QwenPaw treats backend, endpoint, model,
+dimensions, and `use_dimensions` as vector-space identity and clears the cache and rebuilds the index after a change.
+Do not retain or manually copy an old `.npz` cache to bypass rebuilding.
+
+### Base URL, Host, and SDK Type Are Different Concepts
+
+- OpenAI passes `base_url` to `openai.AsyncClient`.
+- `DashScopeCredential` accepts `base_url`, but the AgentScope 2.x `DashScopeEmbeddingModel` used by the current project reads only the API key
+  for both its text and multimodal embedding calls; it does not forward that URL to the DashScope SDK. A custom Base URL
+  therefore does not change the embedding destination for `dashscope` or `dashscope_multimodal` in the current version.
+  Select the `openai` backend when targeting an OpenAI-compatible endpoint.
+- Gemini currently ignores `base_url`.
+- Ollama interprets the same field as `host`, for example `http://localhost:11434`.
+- The SDK type determines request format and credential class, not just the label shown in the UI.
+
+When QwenPaw runs in a container, Ollama at `localhost` refers to that container rather than the host machine. Use an
+address reachable from the QwenPaw process.
+
+### Input Length Is a Character Budget, Not a Token Limit
+
+`max_input_length` does not count with the target model's tokenizer. If the service returns HTTP 400 or a context-length
+error, especially for long Chinese text, reduce this value. It limits each item; `max_batch_size` limits how many items
+are sent together, so the two settings address different constraints.
+
+### Larger Batches and Caches Are Not Always Better
+
+A larger `max_batch_size` can improve throughput but can hit request-size, concurrency, or rate limits. Reduce it first
+when a remote service is unstable. A larger cache consumes more memory and disk. Disabling the cache increases repeated
+computation and API cost but does not disable the vector index.
+
+### A Successful Test Does Not Mean History Is Fully Indexed
+
+The test validates only one live request, numeric values, and dimensions. First-time enablement and index rebuilds must
+still process existing memories and can encounter quotas, rate limits, network errors, or oversized inputs. After saving,
+run a semantic `memory_search` query with little keyword overlap and confirm that the raw result contains a numeric
+`vector=...` value.
+
+### Running Without Embeddings Is Valid
+
+When the model name or required credentials are missing, QwenPaw disables vector components and BM25 continues to work.
+Paraphrase recall becomes weaker, but exact keywords, function names, and error codes remain searchable.
+
+---
+
+## Current QwenPaw Integration
+
+ReMeLight is currently the only direct consumer of this embedding configuration. It embeds Markdown text under
+`memory/` and `digest/` to add a semantic signal to `memory_search` and digest-node similarity queries; BM25 continues
+to handle exact keywords.
+
+Embeddings do not expose a standalone agent tool and do not generate memories or answers. Auto Memory Search,
+Auto-Dream, and agent context benefit only indirectly through ReMeLight retrieval. When another memory backend such as
+ADBPG is selected, that service manages its own vector behavior and is not configured by
+`reme_light_memory_config.embedding_model_config`.
+
+---
+
+## Verification
+
+Save a memory such as “My preferred commute is a lightweight bicycle,” then search for “How does the user usually travel
+to work?” The two sentences have little keyword overlap. If the memory is recalled and the raw tool output contains a
+numeric `vector=...`, the vector branch returned a candidate.
+
+Ask the agent to preserve the raw retrieval fields:
+
+```text
+Call memory_search for "How does the user usually travel to work?" Return the raw tool result,
+including the score, vector, and keyword fields, without summarizing or rewriting it.
+```
+
+- `score`: the RRF-fused score when both paths have candidates; it may be a raw branch score when only one path runs.
+- `vector`: raw cosine similarity; a number means a vector hit and `-` means no vector hit.
+- `keyword`: raw BM25 score; a number means a keyword hit and `-` means no keyword hit.
+
+If testing fails, check the enable condition, network reachability from the QwenPaw process, model name, exact dimensions,
+support for the `dimensions` parameter, input and batch limits, and provider quota or rate limits.
+
+---
+
+## Related Pages
+
+- [Long-term Memory](./memory) — ReMeLight memory files, automatic jobs, and search entry points
+- [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive) — Auto-Memory, Auto-Dream, Auto-Memory-Search, and Proactive workflows
+- [Configuration & Working Directory](./config) — Agent configuration files and workspace layout

--- a/website/public/docs/embedding.zh.md
+++ b/website/public/docs/embedding.zh.md
@@ -1,0 +1,236 @@
+# Embedding 向量模型
+
+Embedding 把文本、图片等输入映射为固定维度的数值向量。语义相近的内容在向量空间中距离更近，因此下游模块可以进行语义搜索、聚类、去重或相似度判断。
+
+QwenPaw 当前提供的是一套基于 AgentScope 的 **Embedding 模型配置与运行能力**，包括多后端适配、真实请求测试、严格维度校验、分批与重试参数映射，以及配置保存后的生命周期管理。当前直接接入方是 ReMeLight：它使用这套能力为记忆提供向量支持。
+
+---
+
+## 能力与边界
+
+| 能力           | 说明                                                                   |
+| -------------- | ---------------------------------------------------------------------- |
+| 多后端适配     | 支持 `openai`、`dashscope`、`dashscope_multimodal`、`gemini`、`ollama` |
+| 统一模型接口   | 通过 AgentScope Credential 和 EmbeddingModel 屏蔽厂商 SDK 差异         |
+| 文本向量化     | 接受一批文本并按输入顺序返回固定维度向量                               |
+| 维度控制与校验 | 按后端规则发送维度参数，并校验实际返回维度是否与配置一致               |
+| 分批与重试     | QwenPaw 设置上游批量大小；AgentScope 再按厂商限制拆批并处理可重试错误  |
+| 保存前测试     | 使用未保存配置发送真实请求，返回实际维度、延迟和错误原因               |
+| 配置生命周期   | 支持满足条件时热更新；向量空间变化时使旧缓存和索引失效                 |
+| 本地缓存       | 让当前接入方缓存相同输入的向量，降低重复计算和 API 调用                |
+
+QwenPaw 的 Embedding 能力基于 **AgentScope 2.x**。厂商 Credential、EmbeddingModel、请求组装、基础拆批和重试来自 AgentScope；QwenPaw 负责配置映射、启用判断、连通性与返回值测试、保存和热更新。
+
+```mermaid
+graph LR
+    UI[QwenPaw 配置] --> Adapter[配置映射 / 测试 / 生命周期]
+    Adapter --> AS[AgentScope Credential + EmbeddingModel]
+    AS --> Provider[Embedding 服务 API]
+    Adapter --> Consumer[下游接入方：当前为 ReMeLight]
+```
+
+AgentScope 的能力范围比 QwenPaw 当前开放的输入范围更广：
+
+- `DashScopeEmbeddingModel` 能根据模型名处理文本或图片/视频 `DataBlock`；`GeminiEmbeddingModel` 也包含多模态模型路径。
+- QwenPaw 当前只把 ReMeLight 产生的文本交给模型，没有通用 Embedding API，也没有把图片、音频、视频或 PDF 传入模型。因此选择多模态类型或模型不会自动获得多模态文件解析能力。
+- QwenPaw 构造 AgentScope 模型时传入 `parameters=None`。AgentScope 调用层可能接受的 `task_type`、`text_type` 等扩展参数，目前没有对应的控制台或 `agent.json` 配置项。
+
+---
+
+## 原理
+
+同一个模型把文档和查询映射到同一向量空间。系统通常使用余弦相似度比较方向：值越高，代表语义越接近。Embedding 擅长同义表达、自然语言改写和主题相关性，但不擅长保证函数名、错误码等精确 token 一定命中；下游检索模块通常会把它与关键词信号组合。
+
+```mermaid
+graph LR
+    Input[文本输入] --> Batch[截断与分批]
+    Batch --> Model[AgentScope EmbeddingModel]
+    Model --> API[厂商或本地服务]
+    API --> Vector[固定维度向量]
+    Vector --> Consumer[搜索 / 聚类 / 去重等下游能力]
+```
+
+模型、版本、服务地址、输出维度或维度控制方式变化，都可能产生不同的向量空间。文档向量和查询向量必须来自兼容空间；即使两个模型输出维度相同，也不能假定它们可以混用。
+
+### 测试、保存与生效
+
+控制台的“测试 Embedding 服务”会把当前尚未保存的表单配置发送到
+`POST /api/workspace/embedding/test`。后端会创建实际模型并发送一条测试文本，要求服务：
+
+1. 在 15 秒内返回一条非空向量；
+2. 向量中所有值都是有限数值；
+3. 实际维度与 `dimensions` 完全一致。
+
+测试成功的模型对象会暂存，用于随后保存时热更新。只有测试过的服务参数与保存值完全一致，并且本次没有同时修改其他运行配置时，
+系统才会尝试热更新。首次启用、关闭 Embedding、未先测试、测试后又修改服务参数，或同时修改其他配置时，系统会保存配置并自动重载 Agent。
+
+如果后端、Base URL、模型名称、维度或 `use_dimensions` 改变，既有向量不再被视为兼容。热更新流程会清空本地
+Embedding 缓存并重建索引，期间会产生重新向量化请求和额外资源消耗。
+
+---
+
+## 如何配置
+
+### 在控制台中配置
+
+进入 **Agent 配置 → 运行配置 → 长期记忆 → 向量模型配置**：
+
+1. 选择“向量模型 SDK 类型”。
+2. 填写该后端要求的地址、模型名称和凭证。
+3. 填写模型实际输出的向量维度。
+4. 按服务限制调整缓存、单条输入字符预算和批处理大小。
+5. 点击“测试 Embedding 服务”。确认显示实际维度和耗时后，再保存运行配置。
+
+只填表单但不满足启用条件时，ReMeLight 不会创建向量组件，记忆搜索会继续使用 BM25。
+
+控制台顶部和“Embedding 服务”卡片中的“已开启/未开启”会根据当前未保存表单实时更新。该状态复用后端的配置启用规则，
+只表示 Backend、模型名称和必要凭证是否完整，不会发起网络请求，也不代表草稿已经保存或运行中的 Agent 已经应用该配置。
+“已验证”表示“测试 Embedding 服务”已经使用当前服务参数完成一次真实请求；保存后，配置才会通过热更新或自动重载应用到运行状态。
+
+### 后端类型与参数总表
+
+| QwenPaw 类型           | AgentScope Credential / Model                     | AgentScope 输入与模型路由                                                                                                                       | 认证和地址参数                                                                                                  | 维度如何传给服务                                                                                     | 启用条件与 QwenPaw 限制                                                    |
+| ---------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `openai`               | `OpenAICredential` / `OpenAIEmbeddingModel`       | 文本；支持 `text-embedding-3-small`、`text-embedding-3-large` 等 OpenAI 兼容模型                                                                | `api_key` 必填；`base_url` 可选并传给 `openai.AsyncClient`；AgentScope 还支持 `organization`，但 QwenPaw 未开放 | 请求总是传 `input`、`model`、`encoding_format="float"`；仅当 `use_dimensions=true` 时传 `dimensions` | `model_name`、`api_key` 非空；只有此类型在前端显示 `use_dimensions`        |
+| `dashscope`            | `DashScopeCredential` / `DashScopeEmbeddingModel` | `text-embedding-*` 走文本 API；`qwen3-vl-embedding`、`qwen2.5-vl-embedding`、`multimodal-embedding-*`、`tongyi-embedding-vision-*` 走多模态 API | `api_key` 必填；Credential 接收 `base_url`，但当前模型调用未使用它                                              | 文本 API 始终传 `dimension`；多模态 API 不传维度，QwenPaw 仍校验返回维度                             | `model_name`、`api_key` 非空；QwenPaw 当前只输入文本                       |
+| `dashscope_multimodal` | 与 `dashscope` 完全相同                           | 这是 QwenPaw/ReMe 配置类型；AgentScope 仍由 `model_name` 决定文本或多模态路由                                                                   | 与 `dashscope` 相同                                                                                             | 与 `dashscope` 相同                                                                                  | `model_name`、`api_key` 非空；不会让 QwenPaw 自动读取图片或视频            |
+| `gemini`               | `GeminiCredential` / `GeminiEmbeddingModel`       | `gemini-embedding-001` 为文本路径；`gemini-embedding-2*` 为多模态路径                                                                           | 仅 `api_key`；AgentScope Credential 和 QwenPaw 都不提供 Base URL                                                | 文本和多模态路径都以 `output_dimensionality` 传入 `dimensions`                                       | `model_name`、`api_key` 非空；QwenPaw 当前只输入文本，且未开放 `task_type` |
+| `ollama`               | `OllamaCredential` / `OllamaEmbeddingModel`       | 文本；例如 `nomic-embed-text`、`mxbai-embed-large`                                                                                              | 不需要 API Key；`base_url` 映射为 `host`，留空使用 Ollama 默认 Host                                             | 始终传 `dimensions`                                                                                  | `model_name` 非空；QwenPaw 进程必须能访问 Ollama Host                      |
+
+QwenPaw 还向所有 AgentScope 模型传入 `context_size=max_input_length`、正常运行时 `max_retries=3`；
+“测试 Embedding 服务”会把重试次数降为 `1`，并在 QwenPaw 外层增加 15 秒超时。
+
+`max_batch_size` 是 ReMeLight `embedding_store` 的上游分批大小。AgentScope 模型内部仍有自己的批量上限：
+当前源码中 OpenAI 为 2048、DashScope 文本为 10、Gemini 文本为 100、Ollama 为 512；超出时 AgentScope
+还会再次拆分并并发请求。实际可用值仍受具体模型和服务端限制。
+
+### 配置字段
+
+配置位于 `agent.json` 的 `running.reme_light_memory_config.embedding_model_config`：
+
+| 字段               | 默认值     | 作用                                                                              |
+| ------------------ | ---------- | --------------------------------------------------------------------------------- |
+| `backend`          | `"openai"` | 调用 Embedding 模型使用的 SDK 类型                                                |
+| `api_key`          | `""`       | 服务凭证；Ollama 不使用                                                           |
+| `base_url`         | `""`       | OpenAI 的可选 API 地址；Ollama 中作为 `host`；当前 DashScope 模型调用不会使用该值 |
+| `model_name`       | `""`       | 模型名称；所有后端都必填                                                          |
+| `dimensions`       | `1024`     | 预期实际输出维度，也用于索引和缓存兼容性判断                                      |
+| `use_dimensions`   | `false`    | 仅对 `openai` 后端生效；是否在请求中发送 `dimensions` 参数                        |
+| `enable_cache`     | `true`     | 是否启用本地 Embedding 结果缓存                                                   |
+| `max_cache_size`   | `10000`    | 本地缓存最大条目数                                                                |
+| `max_input_length` | `8192`     | 单条输入的近似字符预算，不是精确 token 数                                         |
+| `max_batch_size`   | `10`       | 单次批量请求的最大条目数                                                          |
+
+示例（OpenAI 兼容服务）：
+
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "embedding_model_config": {
+        "backend": "openai",
+        "api_key": "your-api-key",
+        "base_url": "https://your-embedding-service.example.com/v1",
+        "model_name": "your-embedding-model",
+        "dimensions": 1024,
+        "use_dimensions": false,
+        "enable_cache": true,
+        "max_cache_size": 10000,
+        "max_input_length": 8192,
+        "max_batch_size": 10
+      }
+    }
+  }
+}
+```
+
+如果服务不支持请求中的 `dimensions` 参数，请保持 `use_dimensions: false`，但仍要把 `dimensions` 设置为模型的实际输出维度。
+
+---
+
+## 常见坑与排查
+
+### 维度不是“想要多少就填多少”
+
+`dimensions` 首先是严格校验值。除非模型和接口明确支持可变维度，否则它必须等于模型原生输出维度。
+填错会在测试阶段直接得到 dimension mismatch；绕过测试保存也可能使索引构建失败。
+
+`use_dimensions` 只决定 `openai` 后端是否把该参数发给服务，并不会关闭维度校验。部分 OpenAI 兼容服务和
+vLLM 部署不接受该参数，此时应关闭开关并填写实际维度。
+
+### 更换模型后必须重建向量
+
+不同模型即使输出维度相同，也不是同一个向量空间，旧向量不能与新查询向量混用。QwenPaw 会根据后端、地址、模型、维度和
+`use_dimensions` 判断向量空间是否变化，并在热更新时清缓存、重建索引。不要保留或手工复制旧 `.npz` 缓存来规避重建。
+
+### Base URL、Host 和 SDK 类型容易混淆
+
+- OpenAI 的 `base_url` 会传给 `openai.AsyncClient`。
+- DashScope Credential 接收 `base_url`，但当前项目所用的 AgentScope 2.x `DashScopeEmbeddingModel` 在文本和多模态
+  Embedding 调用中都只读取 API Key，没有把该地址传给 DashScope SDK。因此当前选择 `dashscope` 或
+  `dashscope_multimodal` 时，自定义 Base URL 不会改变 Embedding 请求目的地；如需调用 OpenAI 兼容地址，
+  应选择 `openai` 后端。
+- Gemini 当前不读取 `base_url`。
+- Ollama 把同一字段解释为 `host`，例如 `http://localhost:11434`。
+- “OpenAI 兼容接口”应选择其真正兼容的 SDK 类型；SDK 类型决定请求格式和凭证对象，不只是界面标签。
+
+如果 QwenPaw 运行在容器中，Ollama 的 `localhost` 指向容器自身，通常不是宿主机。应填写从 QwenPaw 进程所在网络可达的地址。
+
+### 输入长度是字符预算，不是 token 上限
+
+`max_input_length` 不会使用目标模型 tokenizer 精确计数。遇到 HTTP 400、context length exceeded，尤其是中文长文本时，
+继续调低该值。它控制单条输入；`max_batch_size` 控制一批多少条，两者解决的是不同限制。
+
+### 批量和缓存并非越大越好
+
+较大的 `max_batch_size` 能提高吞吐，但更容易触发请求体大小、并发或速率限制；远程服务不稳定时应先减小。
+较大的 `max_cache_size` 会占用更多内存和磁盘；关闭缓存会增加重复计算和 API 成本，但不会关闭向量索引。
+
+### “测试成功”不代表所有历史数据已完成索引
+
+测试只验证单条实时请求、数值合法性和维度。首次启用或重建索引还要处理现有记忆，可能受到速率限制、配额、网络波动或超长输入影响。
+保存后应再用 `memory_search` 做一次无明显关键词重合的语义查询，确认结果中出现数值形式的 `vector=...`。
+
+### 没配置 Embedding 不是故障
+
+模型名或必要凭证为空时，向量组件会被禁用，BM25 关键词索引仍然工作。此时自然语言改写的召回会变弱，但精确关键词、函数名和错误码仍可检索。
+
+---
+
+## 在 QwenPaw 中的当前接入
+
+当前只有 ReMeLight 直接消费这套 Embedding 配置。它把 `memory/`、`digest/` 中的 Markdown 文本向量化，
+为 `memory_search` 和 digest 节点相似度查询补充语义信号；精确关键词仍由 BM25 负责。
+
+Embedding 没有独立的 Agent 工具，也不会生成记忆或答案。Auto Memory Search、Auto-Dream 和 Agent 上下文只是通过
+ReMeLight 的检索结果间接受益。选择 ADBPG 等其他记忆后端时，向量能力由对应服务管理，
+`reme_light_memory_config.embedding_model_config` 不会配置这些后端。
+
+---
+
+## 验证建议
+
+先保存一条记忆：“我首选的通勤工具是一辆轻便自行车。”，再搜索“用户平时怎样去上班？”。两句话没有明显关键词重合，
+如果结果中出现该记忆且工具原始输出包含 `vector=<数值>`，说明向量分支实际返回了候选。
+
+可以要求 Agent 保留原始检索字段：
+
+```text
+请调用 memory_search 工具搜索“用户平时怎样去上班？”。请原样返回工具结果，
+包括 score、vector、keyword 字段，不要总结或改写。
+```
+
+- `score`：两路都有候选时为 RRF 融合分数；只有一路工作时可能是该分支的原始分数。
+- `vector`：原始余弦相似度；数值表示向量分支命中，`-` 表示未命中。
+- `keyword`：原始 BM25 分数；数值表示关键词分支命中，`-` 表示未命中。
+
+如果测试失败，依次检查：启用条件是否满足、QwenPaw 进程能否访问服务、模型名称是否存在、维度是否准确、
+服务是否接受 `dimensions` 参数、输入与批量限制是否过大，以及 API 配额或速率限制。
+
+---
+
+## 相关页面
+
+- [长期记忆](./memory) — ReMeLight 的记忆文件、自动任务与搜索入口
+- [智能体记忆进化与主动交互](./memory-evolving-and-proactive) — Auto-Memory、Auto-Dream、Auto-Memory-Search 与 Proactive 工作流
+- [配置与工作目录](./config) — Agent 配置文件与工作区结构

--- a/website/public/docs/memory-evolving-and-proactive.en.md
+++ b/website/public/docs/memory-evolving-and-proactive.en.md
@@ -1,322 +1,233 @@
-# Agent Memory Evolving & Proactive Interaction (Beta)
+# Memory Evolution and Proactive Interaction (Beta)
 
-> **Beta Feature**: QwenPaw's ReMeLight memory manager embeds [ReMe](https://github.com/agentscope-ai/ReMe) as an in-process application. Auto Memory, Auto Resource, Auto Dream, search, and ReMe's low-level proactive topic reader are ReMe jobs. QwenPaw's `/proactive` command is a separate runtime feature that reads recent chat sessions and optional screen context.
+> This page focuses on two questions: **how memory improves itself over time**, and **how QwenPaw can act before the user asks again**. For memory directories, configuration, capture, and search basics, see [Long-Term Memory](./memory).
 
-QwenPaw stores memory as files under the agent workspace. Conversations are saved as JSONL source logs, useful conversation facts are written to daily Markdown notes, resources can be converted into daily notes, and Auto Dream periodically integrates reusable abstractions into digest memory.
+QwenPaw does not treat memory as a growing transcript. Recent events remain as evidence, while Auto-Dream continually turns that evidence into reusable knowledge: it finds an existing idea, decides how new evidence changes it, updates the idea, and preserves links to its sources. Proactive interaction is the next step—using current activity to identify a useful next action and bring it to the user at the right time.
 
----
-
-## Core Idea: A Self-Evolving Personal Knowledge Base
-
-ReMe's goal is not to be a hidden vector store bolted onto a chat model. It is to grow a **self-evolving personal knowledge base** on the principle of **Memory as File, File as Memory**: every working or long-term memory node is a plain Markdown file you can open, read, edit, move, or delete, and at the same time an indexable, linkable node. Raw sources and derived system state use formats suited to their roles.
-
-Because memory lives as files rather than opaque database rows, long-term memory gains properties a black box cannot offer:
-
-| Property      | What it means in practice                                                              |
-| ------------- | -------------------------------------------------------------------------------------- |
-| Readable      | Open the workspace and read daily notes and digest nodes like ordinary Markdown.       |
-| Editable      | Correct, extend, move, or delete memory with plain file edits — no specialized client. |
-| Traceable     | Each long-term conclusion links back to its source through `derived_from:: [[...]]`.   |
-| Portable      | The workspace is an ordinary directory; back it up, sync it, or version it with git.   |
-| Collaborative | You judge and correct; the agent organizes, links, and retrieves — on the same files.  |
-
-### Memory Layers
-
-The workspace organizes memory into four layers, from raw evidence to reusable knowledge:
-
-```text
-raw input        → mem_session/ + resource/   original conversations and external material
-working memory   → memory/                     daily notes: facts, decisions, resource readings
-long-term memory → digest/                     reusable knowledge: personal / procedure / wiki
-system state     → mem_metadata/               indexes, wikilink graph, catalogs (not hand-edited)
-```
-
-QwenPaw's directory names differ from ReMe's upstream defaults, but the layer roles are identical: `mem_session/` ↔ ReMe `session/`, `memory/` ↔ `daily/`, `mem_metadata/` ↔ `metadata/`. `resource/` and `digest/` keep the same names.
-
-### How the Knowledge Base Evolves
-
-The base grows through a continuous **capture → index → consolidate → recall** loop:
-
-1. **Capture** — Auto Memory distills conversations into daily notes; Auto Resource turns files under `resource/` into daily notes. The raw conversation is retained as evidence.
-2. **Index** — A background job keeps `memory/` and `digest/` searchable through a BM25 keyword index, optional embeddings, and a wikilink graph.
-3. **Consolidate** — Auto Dream reads recent daily notes and integrates them into long-term `digest/` nodes. This is where memory actually _evolves_: instead of copying text, each extracted unit is merged into an existing node or creates a new one, and source and relationship wikilinks are woven in.
-4. **Recall** — `memory_search` retrieves the most relevant fragments and expands along the wikilink graph; interest topics and QwenPaw's `/proactive` surface what is worth attention.
-
-The digest layer is deliberately **not append-only**. When new material repeats, refines, or contradicts an existing node, Auto Dream corroborates, refines, or corrects it (see the integration actions below). Combined with the wikilink graph that keeps nodes connected and traceable, the knowledge base becomes denser and more accurate over time rather than merely larger.
-
----
-
-## Actual Flow
+## The Big Picture
 
 ```mermaid
-graph LR
-    A[Conversation turns] --> B[MemoryMiddleware]
-    B --> C[ReMe auto_memory job]
-    C --> D[mem_session/dialog/*.jsonl]
-    C --> E[memory/<date>/<note>.md]
-    R[resource/<date>/*] --> S[resource_watch_loop]
-    S --> T[ReMe auto_resource job]
-    T --> E
-    E --> U[ReMe auto_dream job]
-    U --> V["digest/personal | procedure | wiki/*.md"]
-    U --> W[memory/<date>/interests.yaml]
+flowchart TB
+    subgraph Evidence[Evidence layer: what happened]
+        C[Conversation turns] --> AM[Auto-Memory]
+        R[Text resources] --> AR[Auto-Resource]
+        AM --> D[Daily memory<br/>memory/date/*.md]
+        AR --> D
+        C --> S[Source conversations<br/>mem_session/dialog/*.jsonl]
+        S -. traceability .-> D
+    end
+
+    subgraph Evolution[Evolution layer: what remains useful]
+        D --> X[Auto-Dream extracts<br/>reusable units and topic candidates]
+        X --> NS[node_search finds<br/>similar and related digest nodes]
+        NS --> DEC{How does the new<br/>evidence change memory?}
+        DEC -->|new idea| CREATE[CREATE]
+        DEC -->|same idea| CORROBORATE[CORROBORATE]
+        DEC -->|more detail| REFINE[REFINE]
+        DEC -->|conflict or fix| CORRECT[CORRECT]
+        CREATE --> K[Long-term knowledge<br/>digest/personal · procedure · wiki]
+        CORROBORATE --> K
+        REFINE --> K
+        CORRECT --> K
+        K --> L[Auto-Link preserves source links<br/>and connects related knowledge]
+        X --> I[Interest topics<br/>memory/date/interests.yaml]
+    end
+
+    subgraph Use[Use layer: memory changes future behavior]
+        D --> IDX[Search index]
+        L --> IDX
+        IDX --> MS[memory_search + Wikilink expansion]
+        MS --> CTX[Relevant context for a later turn]
+    end
+
+    subgraph Proactive[Proactive layer: act before another request]
+        I --> RP[ReMe proactive job<br/>topic reader]
+        CH[Recent chat sessions] --> IDLE[QwenPaw /proactive<br/>idle-time trigger]
+        SCREEN[Optional screen context] --> IDLE
+        IDLE --> GOAL[Infer 1–3 likely goals]
+        GOAL --> WORK[Run a concrete next query]
+        WORK --> MSG[Send a helpful<br/>PROACTIVE message]
+    end
+
+    style Evolution fill:#f5f0ff,stroke:#7c3aed
+    style Proactive fill:#eef8ff,stroke:#0284c7
 ```
 
-| Capability           | Code path                                                    | Trigger                                                                                                     | Main output                                                                            |
-| -------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------- | --------------------------------------------------------- |
-| Auto Memory          | `ReMeLightMemoryManager.auto_memory()` -> ReMe `auto_memory` | `MemoryMiddleware` after every configured number of user turns, and before context compression when enabled | `mem_session/dialog/<session_id>.jsonl`, `memory/<date>/<note>.md`, `memory/<date>.md` |
-| Auto Resource        | ReMe `resource_watch_loop` -> `auto_resource`                | Embedded ReMe background watcher for `resource_dir`                                                         | `memory/<date>/<resource_note>.md`                                                     |
-| Auto Dream           | `ReMeLightMemoryManager.dream()` -> ReMe `auto_dream`        | `/dream` command or `dream_cron` scheduler                                                                  | `digest/*/*.md`, `memory/<date>/interests.yaml`                                        |
-| ReMe proactive job   | ReMe `proactive`                                             | Direct ReMe job call only                                                                                   | Metadata/content from `memory/<date>/interests.yaml`                                   |
-| QwenPaw `/proactive` | `src/qwenpaw/agents/memory/proactive`                        | `/proactive [minutes                                                                                        | on                                                                                     | off]` idle loop | A proactive chat request sent through `/api/console/chat` |
+There are two important loops:
 
-The important boundary is that `memory/<date>/interests.yaml` is produced by Auto Dream and can be read by ReMe's `proactive` job, but QwenPaw's current `/proactive` implementation does not call that job.
+- The **evolution loop** runs from daily evidence to durable `digest/` knowledge and then back into later conversations through retrieval.
+- The **proactive loop** watches for an appropriate moment, infers what may help next, does preparatory work, and starts a new interaction.
 
+These loops are related conceptually but are not fully connected in the current implementation. In particular, QwenPaw's `/proactive` command reads recent sessions and optional screen context; it does **not** currently read Auto-Dream's `interests.yaml` or `digest/` directly.
+
+## What “Self-Evolving” Means
+
+A static memory system can only append or retrieve. An evolving memory system must also decide what new evidence means for knowledge it already has.
+
+Auto-Dream processes changed daily notes and compares each reusable unit with existing `digest/` nodes. It then applies one of four semantic updates:
+
+| Action        | Effect on the knowledge base                                                | Typical signal                                          |
+| ------------- | --------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `CREATE`      | Creates a durable node because no equivalent idea exists                    | A new preference, procedure, fact, or principle         |
+| `CORROBORATE` | Keeps the existing conclusion and adds supporting evidence                  | The same preference or practice appears again           |
+| `REFINE`      | Makes a node more precise by adding scope, steps, conditions, or exceptions | A later conversation fills in missing detail            |
+| `CORRECT`     | Revises a stale or conflicting conclusion while retaining provenance        | The user changes a decision or corrects an earlier fact |
+
+This makes `digest/` a maintained model of the user and their work, not a pile of summaries. Daily notes stay as the historical record; long-term nodes can become more confident, more specific, or more accurate.
+
+### Why links matter
+
+Every evolution also strengthens the graph around the knowledge:
+
+- **Source links** connect a conclusion to the daily notes that support or changed it.
+- **Relationship links** connect preferences, procedures, projects, and concepts that should be recalled together.
+- Existing links are preserved when a node is updated, so a correction does not erase its history.
+
+The result is both usable and auditable: retrieval can expand from one matching node to related context, while a person can follow the links back to the evidence.
+
+## Example: A Release Process Learns Over Time
+
+Suppose a team discusses releases across several days. Auto-Memory records each conversation as daily evidence; Auto-Dream evolves one long-term procedure instead of creating four near-duplicate summaries.
+
+```mermaid
+timeline
+    title Evolution of the production-release memory
+    Day 1 : CREATE
+          : "Validate staging before production"
+    Day 3 : CORROBORATE
+          : The rule is repeated during another release
+    Day 8 : REFINE
+          : Add Chinese release notes, risks, and rollback steps
+    Day 20 : CORRECT
+           : Emergency hotfixes may skip full staging with incident approval
+```
+
+After Day 1, Auto-Dream may create:
+
+```markdown
+---
+name: Production release procedure
+description: Validate staging before every production release.
 ---
 
-## File Layout
+# Production release
 
-The embedded ReMe config comes from `src/qwenpaw/agents/memory/reme_config.py` and the user-facing defaults come from `ReMeLightMemoryConfig`.
+1. Validate the release in staging.
+2. Proceed to production only after validation passes.
+
+## Sources
+
+- [[memory/2026-08-01/release-planning.md]]
+```
+
+By Day 20, the same node can have evolved into:
+
+```markdown
+---
+name: Production release procedure
+description: Standard releases require staging validation; emergency hotfixes use an approved exception path.
+---
+
+# Production release
+
+## Standard path
+
+1. Validate the release in staging.
+2. Write release notes in Chinese, including risks and rollback steps.
+3. Proceed only after validation passes.
+
+## Emergency hotfix exception
+
+A full staging run may be skipped only with incident-lead approval. Record the reason and run the omitted checks afterward.
+
+relates_to:: [[digest/personal/release-communication-preference.md]]
+depends_on:: [[digest/procedure/rollback-verification.md]]
+
+## Sources
+
+- [[memory/2026-08-01/release-planning.md]]
+- [[memory/2026-08-03/release-review.md]]
+- [[memory/2026-08-08/release-notes.md]]
+- [[memory/2026-08-20/hotfix-retrospective.md]]
+```
+
+The important change is not the extra text. It is the accumulated judgment:
+
+1. repetition increases confidence without creating another node;
+2. new detail becomes an executable procedure;
+3. an apparent contradiction becomes a scoped exception rather than silently overwriting the old rule;
+4. source and relationship links make the final procedure explainable and easier to retrieve.
+
+On a later release request, `memory_search` can retrieve this procedure and expand its links, giving the Agent the communication preference and rollback verification context together.
+
+## From Evolution to Interest Topics
+
+During the same Auto-Dream run, recent evidence can also produce a small set of non-repetitive interest topics in `memory/<date>/interests.yaml`. A topic contains a title, a reason, evidence, keywords, and relevant paths. For the release example, one topic might be:
+
+```yaml
+- title: Verify the emergency rollback path
+  reason: The hotfix exception was added, but the follow-up checks are not yet documented.
+  evidence:
+    - Emergency staging bypass discussed in the hotfix retrospective.
+  keywords: [hotfix, rollback, release]
+  paths:
+    - memory/2026-08-20/hotfix-retrospective.md
+```
+
+ReMe exposes a low-level `proactive` job that reads this file and returns its metadata and, optionally, its raw content. This makes interest topics available to integrations. If the file does not exist, the job returns a normal skipped result.
+
+## Proactive Interaction in QwenPaw
+
+QwenPaw's user-facing proactive mode is enabled per session:
 
 ```text
-<workspace>/
-├── mem_metadata/   # ReMe persistent state, indexes, catalogs
-├── mem_session/    # Source conversation logs used by auto-memory
-│   └── dialog/
-│       └── <session_id>.jsonl
-├── mem_agent/      # Internal ReMe memory-agent sessions
-├── resource/       # External assets watched by Auto Resource
-│   └── YYYY-MM-DD/
-│       └── <resource>.<ext>
-├── memory/         # Daily memory notes and day indexes
-│   ├── YYYY-MM-DD.md
-│   └── YYYY-MM-DD/
-│       ├── <note>.md
-│       └── interests.yaml
-└── digest/         # Long-term digest memory
-    ├── personal/
-    ├── procedure/
-    └── wiki/
+/proactive           # enable; trigger after 30 minutes of inactivity
+/proactive on        # same as above
+/proactive 45        # use a 45-minute idle threshold
+/proactive off       # stop proactive monitoring
 ```
 
-Default directory names are configurable through `metadata_dir`, `session_dir`, `mem_session_dir`, `resource_dir`, `daily_dir`, and `digest_dir`.
+Once enabled, the runtime follows this sequence:
 
----
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant T as Idle monitor
+    participant P as Proactive assistant
+    participant Q as Tools
+    participant A as Active QwenPaw agent
 
-## Auto Memory
+    U->>T: No new activity for the configured interval
+    T->>T: Confirm the agent is idle<br/>and no proactive reply is pending
+    T->>P: Recent session context<br/>+ optional screen analysis
+    P->>P: Infer 1–3 likely goals
+    loop Up to 3 candidate queries
+        P->>Q: Perform a useful next query
+        Q-->>P: Result
+    end
+    P->>A: Send gathered information<br/>through /api/console/chat
+    A-->>U: [PROACTIVE] concise, actionable message
+```
 
-Auto Memory is invoked by `MemoryMiddleware`, not directly on every model call. The middleware:
+The monitor checks every 30 seconds. When the configured idle threshold is reached, it uses sessions updated in the last seven days; if fewer than five match, it falls back to the latest five sessions. It considers up to 100 recent text messages with a 50,000-character cap. If the active model supports multimodal input, it may also capture and analyze the current desktop.
 
-- skips automation requests whose source is `cron` or `heartbeat`;
-- optionally injects auto memory search context before model calls when `auto_memory_search_config.enabled` is true;
-- collects user-turn markers after replies;
-- flushes pending turns after `auto_memory_interval` user turns;
-- also flushes before context compression when `summarize_when_compact` is true and compression is about to happen.
+The proactive assistant infers one to three likely goals, attempts concrete queries for up to three candidates, and stops after the first successful result. If the user becomes active while this work is running, the attempt is interrupted. It also avoids sending another proactive message while the previous `[PROACTIVE]` message remains unanswered.
 
-`auto_memory_interval` defaults to `5`. `None`, `0`, or a negative value disables periodic auto-memory.
+### Example proactive message
 
-When flushed, QwenPaw calls ReMe's `auto_memory` job with:
-
-| Field         | Source                                                    |
-| ------------- | --------------------------------------------------------- |
-| `messages`    | Selected conversation messages for the pending user turns |
-| `session_id`  | Agent session id                                          |
-| `memory_hint` | Optional hint passed by caller                            |
-
-ReMe's `AutoMemoryStep` then:
-
-1. validates that `session_id` is present and valid;
-2. saves or appends sanitized source messages to `mem_session/dialog/<session_id>.jsonl`;
-3. removes tool-result blocks and base64 data blocks from the saved source log;
-4. chooses the note date from an explicit date, message timestamps, or the configured timezone's current date;
-5. looks for an existing daily note whose frontmatter has the same `session_id` or `source_conversation`;
-6. creates at most one note for a new session, or updates the existing note for that session;
-7. ensures frontmatter contains `session_id` and `source_conversation`;
-8. may rename the note from frontmatter `name`;
-9. refreshes the day index at `memory/<date>.md`;
-10. returns metadata including `date`, `path`, `created`, `modified`, `n_messages`, `source_conversation`, and `index`.
-
-If the job succeeds but no note was changed, QwenPaw does not push an inbox event for `auto_memory`. Otherwise it pushes an inbox event titled `Auto-memory result`.
-
----
-
-## Auto Resource
-
-QwenPaw configures a ReMe background job named `resource_watch_loop`. It watches `resource_dir` and dispatches change batches to `auto_resource`.
-
-Watched suffixes are:
+Assume recent chats show that a production release is approaching and the team has repeatedly discussed rollback risk. After the idle threshold, the proactive assistant might check the repository for the current rollback checklist and send:
 
 ```text
-md, txt, json, jsonl, csv, yaml, html
+[PROACTIVE] I noticed the production release is approaching. The current checklist
+covers staging validation and rollback ownership, but it does not include the
+post-hotfix verification step discussed in the retrospective. Would you like me
+to add that step to the release checklist?
 ```
 
-Files can be placed directly in the `resource_dir` root, in which case QwenPaw's configured timezone determines the
-current date, or under `resource_dir/YYYY-MM-DD/`, in which case the path supplies the date. Additional subdirectories
-may follow the date directory. For added and modified resources, ReMe reads the content as UTF-8 text and asks the
-memory agent to create or update a daily note. Deleting a resource also deletes its corresponding source-linked note.
+This example illustrates the current boundary precisely: the trigger and task inference come from recent chat activity (and possibly the screen), even if Auto-Dream independently produced a similar interest topic.
 
-Binary files such as PDF, Word, Excel, and images are not parsed automatically. The `yml` suffix is not in the default
-allowlist either; convert these inputs to one of the supported text formats first.
+### Privacy and safety boundary
 
-Each change item may contain `path` or `file_path` and a `change` value such as `added`, `modified`, or `deleted`. The ReMe step interprets changed resource files into daily notes. QwenPaw pushes an `Auto-resource result` inbox event only when the job reports a real modification.
+Proactive mode can read historical session context, may take a desktop screenshot when multimodal analysis is available, and initializes its own tool-enabled assistant. The `/proactive` command warns that this assistant bypasses normal tool-protection mechanisms. Enable it only when that access is appropriate, and use `/proactive off` to stop the in-memory monitoring task.
 
----
-
-## Auto Dream
-
-Auto Dream is exposed in QwenPaw through:
-
-- `/dream [hint]`, handled by `CommandHandler._process_dream()`;
-- the scheduler configured by `dream_cron` when `dream_cron_enabled` is true,
-  default `0 23 * * *`; scheduled runs start after a random delay of 0–60 seconds to avoid simultaneous calls;
-- `ReMeLightMemoryManager.dream(date="", hint="")`.
-
-QwenPaw runs the ReMe job named `auto_dream` with `needs_llm=True`, so the embedded ReMe app refreshes its LLM component from the active QwenPaw model before the job runs.
-
-The embedded job configuration uses these defaults:
-
-| Parameter              | Default | Meaning                                      |
-| ---------------------- | ------: | -------------------------------------------- |
-| `date`                 |    `""` | Empty means today in the configured timezone |
-| `hint`                 |    `""` | Optional user/operator hint                  |
-| `scan_days`            |     `2` | Scan target date and recent days             |
-| `max_units`            |     `5` | Maximum extracted reusable memory units      |
-| `topic_count`          |     `3` | Maximum final interest topics                |
-| `topic_diversity_days` |     `7` | Avoid repeating topics from recent days      |
-
-Auto Dream runs four ReMe steps:
-
-| Step                   | Actual behavior                                                                                                                                                                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `dream_extract_step`   | Refreshes day indexes, compares daily files against the dream catalog, deletes missing catalog entries, and extracts reusable memory units plus topic candidates only from changed daily inputs. |
-| `dream_integrate_step` | Integrates each extracted unit into one digest node. It uses `node_search`, `read`, `frontmatter_read`, `write`, `edit`, and `frontmatter_update`.                                               |
-| `dream_topics_step`    | Selects and de-duplicates interest topics, writes `memory/<date>/interests.yaml`, and refreshes the day index.                                                                                   |
-| `dream_finish_step`    | Upserts successful changed paths, interest files, and day indexes into the dream catalog, persists the catalog, and returns a summary.                                                           |
-
-If there are no changed daily inputs, extract finishes with a no-change response. If an LLM is unavailable, extract or integrate fails because those steps require an LLM.
-
-Digest nodes are stored by bucket:
-
-| Bucket       | What belongs there                                                                                     |
-| ------------ | ------------------------------------------------------------------------------------------------------ |
-| `personal/`  | User, team, or project identity, preferences, conventions, constraints, and avoid-rules                |
-| `procedure/` | How-to workflows, runbooks, recipes, methods, and executable patterns                                  |
-| `wiki/`      | Definitions, principles, observations, decisions as precedent, factual claims, and catch-all knowledge |
-
-Integration actions are `CREATE`, `CORROBORATE`, `REFINE`, or `CORRECT`. These four actions are what makes the knowledge base _self-evolving_: a unit that matches an existing node is not appended as a duplicate but merged into it — corroborated with an extra source, refined with new boundaries, or corrected when it conflicts.
-
-| Action        | Meaning                                                                         |
-| ------------- | ------------------------------------------------------------------------------- |
-| `CREATE`      | No equivalent abstraction exists yet; create a new digest node.                 |
-| `CORROBORATE` | The same memory appeared again; append a source and strengthen the description. |
-| `REFINE`      | New material adds boundaries, steps, prerequisites, applicability, or detail.   |
-| `CORRECT`     | New material corrects errors, omissions, or conflicts in the existing node.     |
-
-**Knowledge graph via wikilinks.** ReMe's wikilink integration logic runs in `dream_integrate_step`. Before writing, it calls `node_search` to recall similar or related digest nodes, decides between the actions above, and then weaves two kinds of workspace-relative wikilinks into the node body:
-
-- **Source edges** — `derived_from:: [[memory/<date>/<note>.md]]` keep every digest conclusion traceable back to the daily note or resource it came from.
-- **Relationship edges** — `relates_to:: [[digest/wiki/...]]`, `depends_on:: [[digest/procedure/...]]`, and similar typed links connect a node to adjacent concepts, prerequisites, and procedures.
-
-Updates are additive: existing wikilinks and `derived_from` entries are preserved, so the graph keeps growing without losing edges. `memory_search` later expands along these links, which is why recall can surface not just a matching fragment but the long-term nodes and sources it connects to.
-
-When Auto Dream completes, QwenPaw pushes an inbox event titled `Auto-dream result`.
-
----
-
-## Interest Topics and ReMe Proactive Job
-
-`dream_topics_step` writes:
-
-```text
-memory/<date>/interests.yaml
-```
-
-The YAML payload contains:
-
-| Field            | Meaning                                                                     |
-| ---------------- | --------------------------------------------------------------------------- |
-| `date`           | Target date                                                                 |
-| `topic_count`    | Requested maximum topic count                                               |
-| `diversity_days` | Recent-day duplicate avoidance window                                       |
-| `topics`         | Selected topics with `title`, `reason`, `evidence`, `keywords`, and `paths` |
-
-ReMe also defines a `proactive` job implemented by `proactive_step`. That job only reads `memory/<date>/interests.yaml`. It accepts:
-
-| Parameter         | Default | Meaning                           |
-| ----------------- | ------: | --------------------------------- |
-| `date`            |    `""` | Empty means today                 |
-| `include_content` |  `true` | Include raw YAML text in metadata |
-
-If the interests file is missing, the ReMe proactive job returns a normal skipped result.
-
----
-
-## QwenPaw `/proactive`
-
-QwenPaw's current `/proactive` command is implemented under `src/qwenpaw/agents/memory/proactive`. It is separate from ReMe's `proactive` job.
-
-Command behavior:
-
-```text
-/proactive           # enable with default 30 minute idle threshold
-/proactive on        # enable with default 30 minute idle threshold
-/proactive 45        # enable with a 45 minute idle threshold
-/proactive off       # cancel the background monitoring task
-```
-
-When enabled, QwenPaw stores an in-memory `ProactiveConfig` for the session and starts a background loop. The loop:
-
-- wakes every 30 seconds;
-- skips while the agent has active tasks;
-- reads the latest chat update time;
-- waits until the session has been idle for the configured number of minutes;
-- avoids retrying more than once per 60 seconds;
-- skips if the latest message is already an unanswered `[PROACTIVE]` message;
-- runs the proactive responder.
-
-The responder builds context from recent chat sessions, not from `interests.yaml`:
-
-- reads chat metadata from `workspace.chat_manager`;
-- keeps sessions updated within the last 7 days, or the latest 5 sessions when fewer than 5 match the date window;
-- loads up to 100 recent text messages, capped at 50,000 characters;
-- filters system messages, non-text blocks, and prior proactive helper requests;
-- optionally analyzes a desktop screenshot when the active model supports multimodal input.
-
-It then asks a temporary `ProactiveAssistant` agent to extract 1 to 3 likely tasks from that context, executes up to the first 3 task queries using tools, and sends a user-facing proactive request through:
-
-```text
-POST <agent-api-base>/api/console/chat
-session_id = proactive_mode:<active_agent_id>
-text starts with "[Agent proactive_helper requesting]"
-```
-
-The final user-facing prompt instructs the agent response to begin with `[PROACTIVE]`.
-
-The command warning is accurate: proactive mode may read historical session memory and may take screenshots when multimodal screen analysis is available. The proactive agent uses tool protection bypass mode through its own temporary agent/tool setup.
-
----
-
-## Search and Indexing
-
-The embedded ReMe app starts an `index_update_loop` background job. Search indexing watches:
-
-| Indexed directories       | Suffixes |
-| ------------------------- | -------- |
-| `daily_dir`, `digest_dir` | `md`     |
-
-The QwenPaw `memory_search` tool runs ReMe's `search` job with `query`, `limit`, and `min_score`. The job is configured as hybrid workspace search with vector recall, BM25 keyword recall, RRF fusion, and wikilink expansion. The storage backend in QwenPaw's embedded ReMe config is local.
-
----
-
-## Current Status
-
-This document describes the current code paths:
-
-- ReMeLight is implemented by `ReMeLightMemoryManager` and embedded `get_reme_app_config()`;
-- Auto Memory is turn-count based and defaults to every 5 user turns;
-- Auto Dream runs by `/dream` or `dream_cron`;
-- ReMe writes `interests.yaml`, and ReMe has a low-level reader for it;
-- QwenPaw `/proactive` currently uses recent chat/session/screen context rather than ReMe interest topics;
-- Auto Memory, Auto Resource, and Auto Dream results may be delivered to the inbox when they produce reportable output.
-
-The feature remains Beta, but the behavior above is the behavior represented by the current code.
+In short: Auto-Dream makes memory better over time; `memory_search` lets future conversations benefit from that evolution; and `/proactive` decides when recent activity justifies doing useful work before the next request.

--- a/website/public/docs/memory-evolving-and-proactive.zh.md
+++ b/website/public/docs/memory-evolving-and-proactive.zh.md
@@ -1,319 +1,231 @@
-# 智能体记忆进化与主动交互（Beta）
+# 记忆自进化与主动交互（Beta）
 
-> **Beta 功能**：QwenPaw 的 ReMeLight memory manager 会把 [ReMe](https://github.com/agentscope-ai/ReMe) 作为进程内应用嵌入。Auto Memory、Auto Resource、Auto Dream、搜索，以及 ReMe 底层的 proactive topic 读取能力都是 ReMe job。QwenPaw 的 `/proactive` 命令是另一条运行时逻辑，它读取近期 chat session 和可选屏幕上下文。
+> 本文只回答两个问题：**记忆如何随时间自我改进**，以及 **QwenPaw 如何在用户再次提问前主动行动**。记忆目录、配置、采集和检索等基础内容请参见[长期记忆](./memory)。
 
-QwenPaw 将记忆保存为 agent workspace 下的文件。对话先保存为 JSONL 来源日志，有价值的对话事实写入 daily Markdown note，资源可以转换成 daily note，Auto Dream 再定期把可复用抽象整合进 digest 记忆。
+QwenPaw 不把记忆当成不断增长的聊天记录。近期事件作为证据保留，Auto-Dream 则持续把证据转化为可复用知识：查找已有观点，判断新证据会如何改变它，更新内容，并保留通往来源的链接。主动交互更进一步——根据当前活动识别有价值的下一步，在合适的时机主动提供帮助。
 
----
-
-## 核心理念：自进化的个人知识库
-
-ReMe 的目标不是给聊天模型挂一个黑盒向量库，而是基于 **Memory as File, File as Memory** 原则，长出一个**自进化的个人知识库**：每个工作记忆或长期记忆节点都是一份可以直接打开、阅读、编辑、移动、删除的 Markdown 文件，同时又是一个可索引、可链接的节点；原始来源与派生系统状态则使用适合各自职责的格式。
-
-因为记忆以文件而非不透明的数据库记录形式存在，长期记忆获得了黑盒存储无法提供的特性：
-
-| 特性   | 实际意义                                                           |
-| ------ | ------------------------------------------------------------------ |
-| 可读   | 打开 workspace，像普通 Markdown 一样阅读 daily note 和 digest 节点 |
-| 可编辑 | 用普通文件编辑就能纠正、扩展、移动、删除记忆，无需专用客户端       |
-| 可追溯 | 每条长期结论都通过 `derived_from:: [[...]]` 链接回它的来源         |
-| 可迁移 | workspace 就是一个普通目录，可以备份、同步，或用 git 做版本管理    |
-| 可协作 | 你负责判断与纠正，agent 负责整理、链接、检索——都在同一批文件上     |
-
-### 记忆分层
-
-workspace 把记忆从"原始证据"到"可复用知识"组织为四层：
-
-```text
-原始输入   → mem_session/ + resource/   原始对话与外部资料
-工作记忆   → memory/                     daily note：事实、决策、资源解读
-长期记忆   → digest/                     可复用知识：personal / procedure / wiki
-系统状态   → mem_metadata/               索引、wikilink 图、catalog（不手工编辑）
-```
-
-QwenPaw 的目录名与 ReMe 上游默认值不同，但每层的职责一致：`mem_session/` 对应 ReMe `session/`，`memory/` 对应 `daily/`，`mem_metadata/` 对应 `metadata/`；`resource/` 和 `digest/` 保持同名。
-
-### 知识库如何进化
-
-知识库通过持续的 **capture → index → consolidate → recall** 闭环生长：
-
-1. **Capture（捕获）** — Auto Memory 把对话蒸馏成 daily note，Auto Resource 把 `resource/` 下的文件转成 daily note，同时保留原始对话作为证据。
-2. **Index（索引）** — 后台 job 通过 BM25 关键词索引、可选向量、以及 wikilink 图，让 `memory/` 和 `digest/` 始终可检索。
-3. **Consolidate（整合）** — Auto Dream 读取近期 daily note，整合进长期 `digest/` 节点。这一步才是记忆真正**进化**的地方：它不是复制文本，而是把每个抽取出的 unit 合并进已有节点或创建新节点，并织入来源与关系 wikilink。
-4. **Recall（召回）** — `memory_search` 召回最相关的片段并沿 wikilink 图展开；interest topics 和 QwenPaw 的 `/proactive` 主动浮现值得关注的内容。
-
-digest 层刻意**不是只追加**的。当新素材与已有节点重复、细化或冲突时，Auto Dream 会对其 corroborate、refine 或 correct（见下文整合动作）。再配合让节点保持连通、可追溯的 wikilink 图，知识库会随时间变得更密、更准，而不只是变得更大。
-
----
-
-## 实际流程
+## 全景图
 
 ```mermaid
-graph LR
-    A[Conversation turns] --> B[MemoryMiddleware]
-    B --> C[ReMe auto_memory job]
-    C --> D[mem_session/dialog/*.jsonl]
-    C --> E[memory/<date>/<note>.md]
-    R[resource/<date>/*] --> S[resource_watch_loop]
-    S --> T[ReMe auto_resource job]
-    T --> E
-    E --> U[ReMe auto_dream job]
-    U --> V["digest/personal | procedure | wiki/*.md"]
-    U --> W[memory/<date>/interests.yaml]
+flowchart TB
+    subgraph Evidence[证据层：发生过什么]
+        C[对话回合] --> AM[Auto-Memory]
+        R[文本资料] --> AR[Auto-Resource]
+        AM --> D[每日记忆<br/>memory/date/*.md]
+        AR --> D
+        C --> S[来源对话<br/>mem_session/dialog/*.jsonl]
+        S -. 可追溯 .-> D
+    end
+
+    subgraph Evolution[进化层：什么值得长期保留]
+        D --> X[Auto-Dream 抽取<br/>可复用单元与主题候选]
+        X --> NS[node_search 查找<br/>相似及相关 digest 节点]
+        NS --> DEC{新证据如何<br/>改变已有记忆？}
+        DEC -->|新观点| CREATE[CREATE]
+        DEC -->|相同观点| CORROBORATE[CORROBORATE]
+        DEC -->|更多细节| REFINE[REFINE]
+        DEC -->|冲突或纠错| CORRECT[CORRECT]
+        CREATE --> K[长期知识<br/>digest/personal · procedure · wiki]
+        CORROBORATE --> K
+        REFINE --> K
+        CORRECT --> K
+        K --> L[Auto-Link 保留来源链接<br/>并连接相关知识]
+        X --> I[兴趣主题<br/>memory/date/interests.yaml]
+    end
+
+    subgraph Use[使用层：记忆改变未来行为]
+        D --> IDX[搜索索引]
+        L --> IDX
+        IDX --> MS[memory_search + Wikilink 展开]
+        MS --> CTX[后续对话所需的相关上下文]
+    end
+
+    subgraph Proactive[主动层：无需等待下一次请求]
+        I --> RP[ReMe proactive job<br/>主题读取器]
+        CH[近期 chat sessions] --> IDLE[QwenPaw /proactive<br/>空闲触发器]
+        SCREEN[可选屏幕上下文] --> IDLE
+        IDLE --> GOAL[推断 1–3 个可能目标]
+        GOAL --> WORK[执行具体的下一步查询]
+        WORK --> MSG[发送有帮助的<br/>PROACTIVE 消息]
+    end
+
+    style Evolution fill:#f5f0ff,stroke:#7c3aed
+    style Proactive fill:#eef8ff,stroke:#0284c7
 ```
 
-| 能力                 | 代码路径                                                     | 触发方式                                                                | 主要产物                                                                               |
-| -------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------ |
-| Auto Memory          | `ReMeLightMemoryManager.auto_memory()` -> ReMe `auto_memory` | `MemoryMiddleware` 按配置的用户轮次数触发；启用时也会在上下文压缩前触发 | `mem_session/dialog/<session_id>.jsonl`、`memory/<date>/<note>.md`、`memory/<date>.md` |
-| Auto Resource        | ReMe `resource_watch_loop` -> `auto_resource`                | 嵌入式 ReMe 后台 watcher 监听 `resource_dir`                            | `memory/<date>/<resource_note>.md`                                                     |
-| Auto Dream           | `ReMeLightMemoryManager.dream()` -> ReMe `auto_dream`        | `/dream` 命令或 `dream_cron` 调度                                       | `digest/*/*.md`、`memory/<date>/interests.yaml`                                        |
-| ReMe proactive job   | ReMe `proactive`                                             | 仅在直接调用 ReMe job 时运行                                            | `memory/<date>/interests.yaml` 的 metadata/content                                     |
-| QwenPaw `/proactive` | `src/qwenpaw/agents/memory/proactive`                        | `/proactive [minutes                                                    | on                                                                                     | off]` 空闲循环 | 通过 `/api/console/chat` 发送的主动 chat request |
+图中有两个关键闭环：
 
-关键边界：`memory/<date>/interests.yaml` 由 Auto Dream 生成，也可以被 ReMe 的 `proactive` job 读取；但 QwenPaw 当前 `/proactive` 实现不会调用这个 job，也不会直接消费 `interests.yaml`。
+- **进化闭环**从每日证据流向稳定的 `digest/` 知识，再通过检索回到后续对话。
+- **主动闭环**等待合适的时机，推断接下来可能有帮助的事项，提前完成准备工作，并发起新交互。
 
+两者在理念上相关，但当前实现尚未完全打通。尤其要注意：QwenPaw 的 `/proactive` 命令读取近期 session 和可选屏幕上下文；它目前**不会**直接读取 Auto-Dream 生成的 `interests.yaml` 或 `digest/`。
+
+## “自进化”究竟是什么
+
+静态记忆系统只能追加和检索；自进化记忆还需要判断：新证据对已有知识意味着什么。
+
+Auto-Dream 处理发生变化的每日记忆，把每个可复用单元与已有 `digest/` 节点比较，再执行四种语义更新之一：
+
+| 动作          | 对知识库的影响                           | 典型信号                       |
+| ------------- | ---------------------------------------- | ------------------------------ |
+| `CREATE`      | 没有等价观点时创建长期节点               | 新偏好、新流程、新事实或新原则 |
+| `CORROBORATE` | 保留已有结论并增加支持证据               | 相同偏好或做法再次出现         |
+| `REFINE`      | 补充范围、步骤、条件或例外，使节点更准确 | 后续对话补齐了细节             |
+| `CORRECT`     | 修改过期或冲突的结论，同时保留来源       | 用户改变决定或纠正了旧事实     |
+
+因此，`digest/` 是一份持续维护的“用户与工作模型”，而不是摘要堆积。每日记忆保留历史现场，长期节点则可以变得更可信、更具体或更准确。
+
+### 链接为什么重要
+
+每次进化也会加强知识周围的关系图：
+
+- **来源链接**把结论连接到支持或改变它的每日记忆；
+- **关系链接**把应当一起召回的偏好、流程、项目和概念连接起来；
+- 更新节点时保留已有链接，因此纠错不会抹掉历史。
+
+最终结果既可用，也可审计：检索可以从一个命中节点展开相关上下文，人也可以沿链接回到原始证据。
+
+## 示例：发布流程如何越用越准确
+
+假设团队在不同日期多次讨论发布。Auto-Memory 把每次对话记为每日证据，Auto-Dream 则持续演化同一个长期流程，而不是创建四份近似摘要。
+
+```mermaid
+timeline
+    title 生产发布记忆的演化
+    第 1 天 : CREATE
+             : “生产发布前先验证 staging”
+    第 3 天 : CORROBORATE
+             : 另一次发布再次确认该规则
+    第 8 天 : REFINE
+             : 增加中文发布说明、风险与回滚步骤
+    第 20 天 : CORRECT
+              : 紧急 hotfix 经事故负责人批准可跳过完整 staging
+```
+
+第 1 天后，Auto-Dream 可能创建：
+
+```markdown
+---
+name: 生产发布流程
+description: 每次生产发布前都要先验证 staging。
 ---
 
-## 文件布局
+# 生产发布
 
-嵌入式 ReMe 配置来自 `src/qwenpaw/agents/memory/reme_config.py`，面向用户的默认值来自 `ReMeLightMemoryConfig`。
+1. 在 staging 验证版本。
+2. 验证通过后才能进入生产环境。
+
+## Sources
+
+- [[memory/2026-08-01/release-planning.md]]
+```
+
+到第 20 天，同一个节点可能已经演化为：
+
+```markdown
+---
+name: 生产发布流程
+description: 常规发布必须验证 staging；紧急 hotfix 使用经批准的例外流程。
+---
+
+# 生产发布
+
+## 常规流程
+
+1. 在 staging 验证版本。
+2. 使用中文编写发布说明，并列出风险和回滚步骤。
+3. 验证通过后才能进入生产环境。
+
+## 紧急 hotfix 例外
+
+只有取得事故负责人批准后，才可以跳过完整 staging。必须记录原因，并在事后补做省略的检查。
+
+relates_to:: [[digest/personal/release-communication-preference.md]]
+depends_on:: [[digest/procedure/rollback-verification.md]]
+
+## Sources
+
+- [[memory/2026-08-01/release-planning.md]]
+- [[memory/2026-08-03/release-review.md]]
+- [[memory/2026-08-08/release-notes.md]]
+- [[memory/2026-08-20/hotfix-retrospective.md]]
+```
+
+真正重要的不是文字变多，而是判断不断累积：
+
+1. 重复出现的信息会增强可信度，不会制造重复节点；
+2. 新细节会被组织成可执行流程；
+3. 表面上的冲突会变成有适用范围的例外，而不是悄悄覆盖旧规则；
+4. 来源和关系链接让最终流程既可解释，也更容易召回。
+
+以后再处理发布任务时，`memory_search` 可以召回这个流程并沿链接展开，让 Agent 同时获得沟通偏好与回滚验证上下文。
+
+## 从记忆进化到兴趣主题
+
+在同一次 Auto-Dream 中，近期证据还可以生成少量、避免重复的兴趣主题，写入 `memory/<date>/interests.yaml`。每个主题包含标题、原因、证据、关键词和相关路径。延续发布案例，其中一个主题可能是：
+
+```yaml
+- title: 验证紧急回滚流程
+  reason: 已增加 hotfix 例外，但尚未记录事后补做的检查。
+  evidence:
+    - hotfix 复盘中讨论了跳过 staging 的情况。
+  keywords: [hotfix, rollback, release]
+  paths:
+    - memory/2026-08-20/hotfix-retrospective.md
+```
+
+ReMe 提供了一个底层 `proactive` job，用来读取这个文件并返回其元数据，也可以返回原始内容。这样，其他集成可以消费兴趣主题；如果文件不存在，该 job 会正常返回 skipped 结果。
+
+## QwenPaw 的主动交互
+
+面向用户的主动模式按 session 开启：
 
 ```text
-<workspace>/
-├── mem_metadata/   # ReMe 持久状态、索引、catalog
-├── mem_session/    # Auto Memory 使用的来源对话日志
-│   └── dialog/
-│       └── <session_id>.jsonl
-├── mem_agent/      # ReMe 内部 memory-agent session
-├── resource/       # Auto Resource 监听的外部资料
-│   └── YYYY-MM-DD/
-│       └── <resource>.<ext>
-├── memory/         # Daily memory notes 和 day index
-│   ├── YYYY-MM-DD.md
-│   └── YYYY-MM-DD/
-│       ├── <note>.md
-│       └── interests.yaml
-└── digest/         # 长期 digest 记忆
-    ├── personal/
-    ├── procedure/
-    └── wiki/
+/proactive           # 开启；空闲 30 分钟后触发
+/proactive on        # 同上
+/proactive 45        # 使用 45 分钟空闲阈值
+/proactive off       # 停止主动监控
 ```
 
-默认目录名可通过 `metadata_dir`、`session_dir`、`mem_session_dir`、`resource_dir`、`daily_dir`、`digest_dir` 配置。
+开启后，运行时流程如下：
 
----
+```mermaid
+sequenceDiagram
+    participant U as 用户
+    participant T as 空闲监控器
+    participant P as Proactive assistant
+    participant Q as 工具
+    participant A as 当前 QwenPaw Agent
 
-## Auto Memory
+    U->>T: 在设定时长内没有新活动
+    T->>T: 确认 Agent 空闲<br/>且没有待回复的主动消息
+    T->>P: 近期 session 上下文<br/>+ 可选屏幕分析
+    P->>P: 推断 1–3 个可能目标
+    loop 最多 3 个候选查询
+        P->>Q: 执行有价值的下一步查询
+        Q-->>P: 返回结果
+    end
+    P->>A: 通过 /api/console/chat<br/>发送已收集的信息
+    A-->>U: [PROACTIVE] 简洁、可执行的消息
+```
 
-Auto Memory 由 `MemoryMiddleware` 调用，不是每次 model call 都直接运行。Middleware 会：
+监控器每 30 秒检查一次。达到设定的空闲阈值后，它读取最近 7 天更新过的 sessions；如果不足 5 个，则回退到最新的 5 个 sessions。上下文最多包含 100 条近期文本消息，总长度不超过 50,000 字符。当当前模型支持多模态输入时，还可能截取并分析桌面画面。
 
-- 跳过来源为 `cron` 或 `heartbeat` 的自动化请求；
-- 当 `auto_memory_search_config.enabled` 为 true 时，在模型调用前注入自动记忆搜索上下文；
-- 在回复后收集 user-turn marker；
-- 累计到 `auto_memory_interval` 个用户轮次后 flush；
-- 当 `summarize_when_compact` 为 true 且即将压缩上下文时，也会先 flush pending turns。
+Proactive assistant 会推断 1–3 个可能目标，为最多 3 个候选目标尝试具体查询，并在首次成功后停止。如果执行期间用户重新活跃，本次任务会被中断；如果上一条 `[PROACTIVE]` 消息尚未得到回应，也不会继续发送新的主动消息。
 
-`auto_memory_interval` 默认是 `5`。`None`、`0` 或负数会禁用周期性 Auto Memory。
+### 主动消息示例
 
-Flush 时，QwenPaw 调用 ReMe 的 `auto_memory` job，并传入：
-
-| 字段          | 来源                              |
-| ------------- | --------------------------------- |
-| `messages`    | pending user turns 对应的会话消息 |
-| `session_id`  | Agent session id                  |
-| `memory_hint` | 调用方可选提示                    |
-
-ReMe 的 `AutoMemoryStep` 随后会：
-
-1. 校验 `session_id` 存在且合法；
-2. 将清洗后的来源消息保存或追加到 `mem_session/dialog/<session_id>.jsonl`；
-3. 从保存的来源日志中移除 tool-result block 和 base64 data block；
-4. 从显式 date、消息时间戳或配置时区的当前日期中选择 note date；
-5. 查找 frontmatter 中 `session_id` 或 `source_conversation` 匹配的已有 daily note；
-6. 新 session 最多创建一条 note，已有 session 更新同一条 note；
-7. 确保 frontmatter 包含 `session_id` 和 `source_conversation`；
-8. 可能根据 frontmatter `name` 重命名 note；
-9. 刷新 `memory/<date>.md` day index；
-10. 返回 `date`、`path`、`created`、`modified`、`n_messages`、`source_conversation`、`index` 等 metadata。
-
-如果 job 成功但没有实际修改 note，QwenPaw 不会为 `auto_memory` 推送 inbox event。否则会推送标题为 `Auto-memory result` 的 inbox event。
-
----
-
-## Auto Resource
-
-QwenPaw 配置了名为 `resource_watch_loop` 的 ReMe 后台 job。它监听 `resource_dir`，并把变更批次派发给 `auto_resource`。
-
-监听的后缀是：
+假设近期聊天显示生产发布即将开始，并且团队反复讨论回滚风险。达到空闲阈值后，Proactive assistant 可能先检查仓库里的当前回滚清单，再发送：
 
 ```text
-md, txt, json, jsonl, csv, yaml, html
+[PROACTIVE] 我注意到生产发布临近。当前清单已经覆盖 staging 验证和回滚负责人，
+但还缺少复盘中提到的 hotfix 事后验证步骤。需要我把这一步补进发布清单吗？
 ```
 
-文件可以直接放在 `resource_dir` 根目录，此时使用 QwenPaw 配置的时区确定当天；也可放在
-`resource_dir/YYYY-MM-DD/` 下，此时使用路径中的日期。日期目录之后可以继续嵌套子目录。新增或修改资源时，
-ReMe 按 UTF-8 文本读取内容，由 memory agent 生成或更新 daily note；删除资源时也会删除对应的来源链接 note。
+这个例子准确体现了当前边界：触发和任务推断来自近期聊天活动（也可能包括屏幕），即使 Auto-Dream 独立生成了相似的兴趣主题，两条路径目前也没有直接连接。
 
-PDF、Word、Excel、图片等二进制文件不会被自动解析。`yml` 后缀也不在默认白名单中；需要先转换为受支持的文本格式。
+### 隐私与安全边界
 
-每个 change item 可以包含 `path` 或 `file_path`，以及类似 `added`、`modified`、`deleted` 的 `change` 值。ReMe step 会将变化的资源文件解读成 daily note。只有当 job 报告确实发生修改时，QwenPaw 才会推送 `Auto-resource result` inbox event。
+主动模式可以读取历史 session 上下文；多模态分析可用时，可能截取桌面画面；它还会初始化一个拥有工具的独立 assistant。`/proactive` 命令会明确警告，这个 assistant 会绕过常规工具保护机制。请只在这些访问权限合适时开启，并使用 `/proactive off` 停止内存中的监控任务。
 
----
-
-## Auto Dream
-
-QwenPaw 通过以下入口暴露 Auto Dream：
-
-- `/dream [hint]`，由 `CommandHandler._process_dream()` 处理；
-- `dream_cron_enabled` 为 true 时按 `dream_cron` 配置调度，默认 `0 23 * * *`；定时触发后会随机延迟 0–60 秒启动，以避免集中调用；
-- `ReMeLightMemoryManager.dream(date="", hint="")`。
-
-QwenPaw 运行名为 `auto_dream` 的 ReMe job，并设置 `needs_llm=True`，因此嵌入式 ReMe 会在 job 运行前用 QwenPaw 当前 active model 刷新自己的 LLM component。
-
-嵌入式 job 配置使用这些默认值：
-
-| 参数                   | 默认值 | 含义                              |
-| ---------------------- | -----: | --------------------------------- |
-| `date`                 |   `""` | 空值表示配置时区里的今天          |
-| `hint`                 |   `""` | 可选用户/操作者提示               |
-| `scan_days`            |    `2` | 扫描目标日期及最近日期            |
-| `max_units`            |    `5` | 最多抽取的可复用 memory units     |
-| `topic_count`          |    `3` | 最多最终 interest topics          |
-| `topic_diversity_days` |    `7` | 避免重复最近几天已经出现的 topics |
-
-Auto Dream 运行四个 ReMe steps：
-
-| Step                   | 实际行为                                                                                                                                              |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dream_extract_step`   | 刷新 day indexes，对比 daily files 和 dream catalog，删除缺失的 catalog entries，只从变化的 daily 输入中抽取可复用 memory units 和 topic candidates。 |
-| `dream_integrate_step` | 将每个抽取出的 unit 整合进一个 digest node。会使用 `node_search`、`read`、`frontmatter_read`、`write`、`edit`、`frontmatter_update`。                 |
-| `dream_topics_step`    | 选择并去重 interest topics，写入 `memory/<date>/interests.yaml`，并刷新 day index。                                                                   |
-| `dream_finish_step`    | 将成功处理的 changed paths、interest files 和 day indexes upsert 到 dream catalog，持久化 catalog，并返回 summary。                                   |
-
-如果没有变化的 daily 输入，extract 会以 no-change 响应结束。如果 LLM 不可用，extract 或 integrate 会失败，因为这些 step 需要 LLM。
-
-Digest node 按 bucket 存储：
-
-| Bucket       | 存什么                                                     |
-| ------------ | ---------------------------------------------------------- |
-| `personal/`  | 用户、团队或项目身份、偏好、约定、约束、avoid-rules        |
-| `procedure/` | How-to 工作流、runbook、recipe、方法、可执行模式           |
-| `wiki/`      | 定义、原则、观察、作为先例的决策、事实 claim，以及兜底知识 |
-
-Integration action 包括 `CREATE`、`CORROBORATE`、`REFINE`、`CORRECT`。正是这四个动作让知识库"自进化"：与已有节点匹配的 unit 不会被当作重复内容追加，而是合并进该节点——用新来源 corroborate、用新边界 refine、或在冲突时 correct。
-
-| Action        | 含义                                           |
-| ------------- | ---------------------------------------------- |
-| `CREATE`      | 尚不存在等价抽象，创建新的 digest 节点         |
-| `CORROBORATE` | 同一记忆再次出现，追加来源并强化描述           |
-| `REFINE`      | 新素材补充边界、步骤、前置条件、适用范围或细节 |
-| `CORRECT`     | 新素材纠正已有节点中的错误、遗漏或冲突         |
-
-**通过 wikilink 构建知识图谱。** ReMe 的 wikilink 整合逻辑运行在 `dream_integrate_step` 中。写入前它先用 `node_search` 召回相似或相关的 digest 节点，在上述动作间做出决策，然后向节点正文织入两类 workspace-relative wikilink：
-
-- **来源边** — `derived_from:: [[memory/<date>/<note>.md]]`，让每个 digest 结论都能追溯回它来自的 daily note 或资源。
-- **关系边** — `relates_to:: [[digest/wiki/...]]`、`depends_on:: [[digest/procedure/...]]` 等 typed link，把节点连接到相邻概念、前置条件和流程。
-
-更新是增量式的：已有 wikilink 和 `derived_from` 会被保留，图因此持续生长而不丢边。`memory_search` 之后会沿这些链接展开——这正是召回不仅能给出匹配片段、还能带出它连接的长期节点与来源的原因。
-
-Auto Dream 完成后，QwenPaw 会推送标题为 `Auto-dream result` 的 inbox event。
-
----
-
-## Interest Topics 和 ReMe Proactive Job
-
-`dream_topics_step` 写入：
-
-```text
-memory/<date>/interests.yaml
-```
-
-YAML payload 包含：
-
-| 字段             | 含义                                                                   |
-| ---------------- | ---------------------------------------------------------------------- |
-| `date`           | 目标日期                                                               |
-| `topic_count`    | 请求的最大 topic 数                                                    |
-| `diversity_days` | 最近日期去重窗口                                                       |
-| `topics`         | 选出的 topics，包含 `title`、`reason`、`evidence`、`keywords`、`paths` |
-
-ReMe 还定义了一个由 `proactive_step` 实现的 `proactive` job。这个 job 只读取 `memory/<date>/interests.yaml`。它接受：
-
-| 参数              | 默认值 | 含义                             |
-| ----------------- | -----: | -------------------------------- |
-| `date`            |   `""` | 空值表示今天                     |
-| `include_content` | `true` | 在 metadata 中包含原始 YAML 文本 |
-
-如果 interests 文件不存在，ReMe proactive job 会返回正常的 skipped result。
-
----
-
-## QwenPaw `/proactive`
-
-QwenPaw 当前 `/proactive` 命令实现位于 `src/qwenpaw/agents/memory/proactive`，它和 ReMe 的 `proactive` job 是两套逻辑。
-
-命令行为：
-
-```text
-/proactive           # 使用默认 30 分钟空闲阈值启用
-/proactive on        # 使用默认 30 分钟空闲阈值启用
-/proactive 45        # 使用 45 分钟空闲阈值启用
-/proactive off       # 取消后台 monitoring task
-```
-
-启用后，QwenPaw 会为 session 保存一个内存态 `ProactiveConfig`，并启动后台循环。该循环会：
-
-- 每 30 秒 wake 一次；
-- agent 有 active tasks 时跳过；
-- 读取最新 chat update time；
-- 等待 session 空闲达到配置分钟数；
-- 60 秒内不重复尝试；
-- 如果最后一条消息已经是未回应的 `[PROACTIVE]` 消息，则跳过；
-- 运行 proactive responder。
-
-Responder 构造上下文时读取近期 chat sessions，而不是读取 `interests.yaml`：
-
-- 通过 `workspace.chat_manager` 读取 chat metadata；
-- 保留最近 7 天更新过的 sessions；如果不足 5 个，则取最新 5 个 sessions；
-- 加载最多 100 条近期文本消息，总字符上限 50,000；
-- 过滤 system messages、非文本 blocks，以及之前 proactive helper 发出的请求；
-- 当 active model 支持多模态时，可选分析桌面截图。
-
-随后它让临时 `ProactiveAssistant` agent 从上下文中抽取 1 到 3 个可能任务，最多执行前 3 个任务 query，并通过以下接口发送面向用户的 proactive request：
-
-```text
-POST <agent-api-base>/api/console/chat
-session_id = proactive_mode:<active_agent_id>
-text starts with "[Agent proactive_helper requesting]"
-```
-
-最终面向用户的 prompt 要求 agent 回复以 `[PROACTIVE]` 开头。
-
-命令中的 warning 与代码一致：proactive mode 可能读取历史 session memory，并且在多模态屏幕分析可用时可能截图。Proactive agent 通过自己的临时 agent/tool setup 使用 tool protection bypass mode。
-
----
-
-## 搜索与索引
-
-嵌入式 ReMe app 会启动 `index_update_loop` 后台 job。搜索索引监听：
-
-| 索引目录                  | 后缀 |
-| ------------------------- | ---- |
-| `daily_dir`、`digest_dir` | `md` |
-
-QwenPaw 的 `memory_search` tool 会运行 ReMe 的 `search` job，参数是 `query`、`limit`、`min_score`。该 job 配置为 hybrid workspace search，包含向量召回、BM25 keyword 召回、RRF 融合和 wikilink expansion。QwenPaw 嵌入式 ReMe 配置里的存储后端是 local。
-
----
-
-## 当前状态
-
-本文档描述当前代码路径：
-
-- ReMeLight 由 `ReMeLightMemoryManager` 和嵌入式 `get_reme_app_config()` 实现；
-- Auto Memory 基于用户轮次数触发，默认每 5 个用户轮次一次；
-- Auto Dream 通过 `/dream` 或 `dream_cron` 运行；
-- ReMe 会写入 `interests.yaml`，也有读取它的底层 job；
-- QwenPaw `/proactive` 当前使用近期 chat/session/screen context，而不是 ReMe interest topics；
-- Auto Memory、Auto Resource、Auto Dream 产生可报告输出时，可能投递到 inbox。
-
-该能力仍处于 Beta 阶段，但以上行为与当前代码实现一致。
+简而言之：Auto-Dream 让记忆随时间变得更好，`memory_search` 让后续对话从这种进化中获益，而 `/proactive` 则判断何时值得在下一次请求到来前先做一些有用的工作。

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -1,452 +1,413 @@
-# Long-term Memory
+# Long-Term Memory
 
-**Long-term Memory** gives QwenPaw persistent memory across conversations. In the default backend, QwenPaw embeds the
-ReMe application in-process and runs ReMe jobs to save conversation facts, build daily notes, extract digest memories,
-watch resource files, and search the memory vault.
+QwenPaw's long-term memory is powered by [ReMe](https://github.com/agentscope-ai/ReMe). Instead of putting the entire conversation history back into context, it continuously turns conversations and resources into **readable, editable, searchable, and interconnected Markdown memories**. Over time, those files become a self-evolving personal knowledge base maintained jointly by the user and the Agent.
 
-> The long-term memory mechanism is inspired by [OpenClaw](https://github.com/openclaw/openclaw) and implemented via **ReMeLight** from [ReMe](https://github.com/agentscope-ai/ReMe) — a file-based memory backend where working and long-term memory nodes are plain Markdown files that can be read, edited, and migrated directly.
-
-ReMe's core goal is to grow a **self-evolving personal knowledge base** on the principle of _Memory as File, File as Memory_. Every working or long-term memory node is a plain Markdown file — readable, editable, traceable, portable, and maintained collaboratively by you and the agent — and at the same time indexable and linkable. Raw sources and derived system state use formats suited to their roles. The workspace organizes memory into four layers:
-
-| Layer            | QwenPaw directory           | Role                                                          |
-| ---------------- | --------------------------- | ------------------------------------------------------------- |
-| Raw input        | `mem_session/`, `resource/` | Original conversations and external material kept as evidence |
-| Working memory   | `memory/`                   | Daily notes: facts, decisions, and resource readings          |
-| Long-term memory | `digest/`                   | Reusable knowledge nodes (`personal` / `procedure` / `wiki`)  |
-| System state     | `mem_metadata/`             | Indexes, wikilink graph, catalogs — not hand-edited           |
-
-Memory evolves through a **capture → index → consolidate → recall** loop: Auto-Memory / Auto-Resource capture daily notes, indexing keeps them searchable, Auto-Dream consolidates them into linked digest nodes, and search / proactive recall them. For the full narrative — including how Auto-Dream corroborates, refines, and corrects digest nodes and weaves the wikilink graph — see [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive). The sections below cover the technical implementation and configuration.
-
----
-
-## Architecture Overview
+The default `remelight` backend embeds ReMe in the QwenPaw process and reuses the current Agent's model for memory extraction and consolidation. The system follows this loop:
 
 ```mermaid
-graph TB
-    User[User / Agent] --> Middleware[MemoryMiddleware]
-    Middleware --> Manager[ReMeLightMemoryManager]
-    Manager --> ReMe[Embedded ReMe Application]
-    ReMe --> Jobs[ReMe Jobs]
-    Jobs --> AutoMemory[auto_memory]
-    Jobs --> AutoDream[auto_dream]
-    Jobs --> Search[search]
-    Jobs --> Resource[auto_resource]
-    Jobs --> Reindex[reindex / index_update_loop]
-    AutoMemory --> Daily[memory/YYYY-MM-DD/*.md]
-    AutoMemory --> Session[mem_session/dialog/*.jsonl]
-    AutoDream --> Digest[digest/*.md and interests.yaml]
-    Resource --> ResourceDir[resource/*]
-    Search --> Store[mem_metadata file store + BM25 + optional embeddings]
+flowchart LR
+    A[Conversations and resources] --> B[Auto-Memory / Auto-Resource]
+    B --> C[Daily Markdown memories]
+    C --> D[Memory Index]
+    C --> E[Auto-Dream]
+    E --> F[Wikilink personal knowledge base]
+    F --> D
+    D --> G[memory_search]
+    G --> H[Current Agent context]
+    I[Auto-Memory-Search] --> G
 ```
 
-Long-term memory management includes the following capabilities:
+The framework has four core capabilities:
 
-| Capability             | Description                                                                                                      |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Embedded ReMe app**  | QwenPaw starts ReMe in-process and injects the active QwenPaw model into ReMe's default LLM component            |
-| **Auto-Memory**        | After a configurable number of user turns, ReMe extracts useful conversation facts into daily Markdown notes     |
-| **Context compaction** | Before context compression, pending turns can be flushed into the same `auto_memory` pipeline                    |
-| **Auto-Dream**         | A cron job extracts higher-level digest units and proactive-interest topics from recent daily notes              |
-| **Hybrid Search**      | `memory_search` calls ReMe's `search` job, using BM25 plus optional vector search and reciprocal-rank fusion     |
-| **Resource Memory**    | Files under `resource/` are cataloged and can be interpreted into source-linked daily notes                      |
-| **Inbox Results**      | `auto_memory`, `auto_dream`, and `auto_resource` results are pushed to QwenPaw's inbox when they produce changes |
+| Capability         | Purpose                                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **Memory as File** | Stores memory as Markdown with frontmatter and `[[wikilinks]]`; these user-owned files are the source of truth              |
+| **Auto-Memory**    | Extracts durable facts, preferences, decisions, and progress from conversations into daily memory                           |
+| **Auto-Dream**     | Distills stable knowledge from recent daily memory, merges or corrects long-term nodes, and creates links through Auto-Link |
+| **Memory Search**  | Retrieves chunks with BM25 and optional vector search, fuses rankings with RRF, then expands Wikilink context               |
+
+Auto-Memory is the prerequisite for building the knowledge base: it first turns conversations into reliable material. Auto-Dream is the key to its evolution: it consolidates scattered material into stable, connected long-term knowledge.
 
 ---
 
-## Memory File Structure
+## Memory as File
 
-Memories are stored as plain files under the agent workspace. ReMe's Markdown files are the readable source of memory,
-while `mem_metadata/` stores search indexes, catalogs, graphs, and embedding caches.
+ReMe follows the principle **Memory as File, File as Memory**:
 
-```
+- For users, memories are ordinary workspace files that can be read, edited, moved, deleted, backed up, and migrated directly.
+- For Agents, each Markdown file is also a memory node that can be chunked, indexed, linked, and evolved.
+- Search indexes, graphs, and caches are derived state that can be rebuilt from the source files; users retain control of the actual memory.
+
+### File Structure
+
+By default, each Agent workspace is located at `~/.qwenpaw/workspaces/{agent_id}/` and uses this memory layout:
+
+```text
 {workspace}/
-├── memory/                         ← Daily memory notes
-│   └── 2026-06-29/
-│       ├── project-plan.md          ← One note written/updated by auto_memory
-│       └── index.md                 ← Day index generated from the day's notes
-│
+├── memory/                              # Daily memory: lightly processed conversations and resources
+│   ├── 2026-08-06.md                    # Index page for the day
+│   └── 2026-08-06/
+│       ├── project-plan.md              # Memory card created or updated by Auto-Memory
+│       ├── market-report.md             # Resource memory produced by Auto-Resource
+│       └── interests.yaml               # Interest topics produced by Auto-Dream
 ├── mem_session/
 │   └── dialog/
-│       └── <session_id>.jsonl       ← Sanitized conversation history used as note source
-│
-├── digest/                         ← Auto-Dream digest memory and interest topics
-├── resource/                       ← External assets watched by auto_resource
-└── mem_metadata/                   ← ReMe persistent indexes, graph, catalogs, and caches
-    ├── file_store/
-    │   └── file_chunks_default_v1.jsonl.zst
-    ├── file_graph/
-    │   └── default.jsonl.zst
-    ├── file_catalog/
-    │   ├── default.jsonl.zst
-    │   ├── resource.jsonl.zst
-    │   ├── digest.jsonl.zst
-    │   └── dream.jsonl.zst
-    ├── embedding_store/
-    │   └── default_v1.npz
-    └── keyword_index/
-        └── bm25_default_<tokenizer>_<fingerprint>_v1.pkl
+│       └── <session_id>.jsonl           # Source conversation for Auto-Memory
+├── digest/                              # Long-term personal knowledge base
+│   ├── personal/                        # User, team, and project facts and preferences
+│   ├── procedure/                       # Processes, runbooks, and reusable experience
+│   └── wiki/                            # Concepts, principles, observations, and decision precedents
+├── resource/                            # Original external resources
+│   └── 2026-08-06/
+│       └── report.md
+└── mem_metadata/                        # Derived indexes, graph, catalogs, and caches
 ```
 
-Under the default workspace layout, the full path is
-`~/.qwenpaw/workspaces/{agent_id}/mem_metadata/`.
-`file_store/file_chunks_default_v1.jsonl.zst` is the authoritative chunk store. Vectors are encoded as float16 in
-the `_embedding_f16_b64` field of its compressed JSONL records, rather than in a separate vector-database directory.
-`embedding_store/default_v1.npz` is the local embedding cache used when `enable_cache` is enabled; it is not the
-authoritative index and may not appear until the cache is persisted. The tokenizer name and fingerprint in the actual
-BM25 filename vary with configuration.
+The four user-visible directories have distinct responsibilities:
 
-### memory/YYYY-MM-DD/\*.md (Daily Notes)
+| Directory                    | Content                                                                                | Directly indexed by QwenPaw memory search |
+| ---------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `memory/YYYY-MM-DD/*.md`     | Daily facts, conversation summaries, decisions, progress, and resource interpretations | Yes                                       |
+| `mem_session/dialog/*.jsonl` | Sanitized source conversations for traceability and later extraction                   | No                                        |
+| `digest/`                    | The long-term personal knowledge base consolidated by Auto-Dream                       | Yes                                       |
+| `resource/`                  | External material supplied by the user and processed by Auto-Resource                  | No                                        |
 
-Daily notes are the default Auto-Memory output. ReMe writes one or more notes per day, keyed by the source conversation
-session. Each note includes frontmatter such as `session_id` and `source_conversation`, so later updates can find and
-modify the existing note instead of creating duplicates.
+> QwenPaw's embedded ReMe indexes only `.md` files under `memory/` and `digest/`. Raw conversations are queried by the context system. Resource files become searchable by `memory_search` after Auto-Resource converts them into Markdown under `memory/`.
 
-- **Location**: `{working_dir}/memory/YYYY-MM-DD/*.md`
-- **Purpose**: Stores durable conversation facts, decisions, preferences, and work notes
-- **Updates**: ReMe `auto_memory` creates or edits notes using ReMe file jobs such as `daily_write`, `read`, `edit`,
-  `frontmatter_update`, and `write`
-- **Index**: After each successful write, ReMe refreshes the day's `index.md`
+### Markdown, Frontmatter, and Wikilinks
 
-### mem_session/dialog/\*.jsonl (Conversation Source)
+A memory typically combines YAML frontmatter, body text, and Wikilinks:
 
-Before extracting memory, ReMe saves the relevant messages into a session log. Tool-result blocks and base64 data blocks
-are stripped so recalled memory or large media cannot be mistaken for user-provided facts in future extraction runs.
+```markdown
+---
+name: User's release workflow preference
+description: The user wants staging validation before every production release.
+source_conversation: "[[mem_session/dialog/session-42.jsonl]]"
+---
 
-- **Location**: `{working_dir}/mem_session/dialog/<session_id>.jsonl` by default
-- **Purpose**: Source traceability for daily notes
-- **Linking**: Daily-note frontmatter links back to the source conversation with `[[mem_session/dialog/<session_id>.jsonl]]`
+# Release preference
 
-### digest/ (Dream Memory)
+Every production release must first run [[digest/procedure/staging-verification.md]].
 
-`digest/` is the long-term knowledge layer — the part of the knowledge base that actually evolves. Auto-Dream reads recent
-daily notes, extracts reusable memory units, integrates each into a digest node, updates the dream catalog, and writes
-user-interest topics for proactive use.
+## Sources
 
-- **Location**: `{working_dir}/digest/`
-- **Buckets**: `personal/` (user, team, and project identity, preferences, and conventions), `procedure/` (how-to
-  workflows, runbooks, and reusable methods), and `wiki/` (definitions, principles, observations, and decision precedents)
-- **Evolution, not append**: each unit is integrated with a `CREATE`, `CORROBORATE`, `REFINE`, or `CORRECT` action, so
-  repeated facts are merged and strengthened rather than duplicated
-- **Wikilink graph**: nodes carry source edges (`derived_from:: [[memory/<date>/<note>.md]]`) and relationship edges
-  (`relates_to:: [[digest/...]]`) so digest memory stays traceable and connected; `memory_search` expands along these links
-- **Updates**: ReMe `auto_dream`, usually triggered by `dream_cron`
-
-### resource/ (Resource Memory)
-
-Files placed under `resource/` are watched and cataloged. When supported files change, ReMe can interpret them into
-source-linked daily notes via `auto_resource`.
-
-- **Location**: `{working_dir}/resource/`
-- **Supported default suffixes**: `md`, `txt`, `json`, `jsonl`, `csv`, `yaml`, `html`
-- **Date assignment**: Files directly under `resource/` are assigned to the current date. Files under
-  `resource/YYYY-MM-DD/` use that date and may be nested in additional subdirectories.
-- **Output**: Creates or updates `memory/YYYY-MM-DD/<note>.md` and retains a `source_resource` link in its frontmatter
-- **Inbox behavior**: Resource processing results are pushed to the inbox only when memory changed
-
-```text
-resource/report.txt                    # Assigned to the current date
-resource/2026-07-14/report.txt         # Assigned to 2026-07-14
-resource/2026-07-14/project/data.json  # Subdirectories are allowed below the date
+- [[memory/2026-08-06/release-discussion.md]]
 ```
 
-> Auto Resource currently reads resources as UTF-8 text. Binary files such as PDF, Word, Excel, and images are not in
-> the watched-suffix list and are not parsed automatically; convert them to one of the supported text formats first.
-> The `yml` suffix is also not in the default allowlist; use `yaml`.
-
-> For a complete walkthrough of Auto-Memory, Auto-Dream, Auto-Memory-Search, and Proactive, see [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive). The sections below cover technical implementation details and configuration only.
+Frontmatter provides a node-level summary and source metadata. The body stores facts, conditions, and explanations. `[[...]]` uses workspace-relative paths to create file relationships. After search hits a file, ReMe can expand its incoming and outgoing links from the graph index, giving the Agent related long-term nodes and sources together with the matching text.
 
 ---
 
-## Searching Memory
+## Auto-Memory: Turning Conversations into Daily Memory
 
-The Agent has two ways to retrieve past memories:
+Auto-Memory is the entry point to the personal knowledge base. It does not preserve a chat transcript as a summary. It extracts information that may still be useful later, including:
 
-| Method        | Tool            | Use Case                                                    | Example                                        |
-| ------------- | --------------- | ----------------------------------------------------------- | ---------------------------------------------- |
-| Hybrid search | `memory_search` | Unsure which file contains the info; fuzzy recall by intent | "Previous discussion about deployment process" |
-| Direct read   | File tools      | Known specific date or file path; precise lookup            | Read `memory/2026-06-29/project-plan.md`       |
+- stable preferences and long-term agreements;
+- project context, important facts, and constraints;
+- confirmed decisions and their rationale;
+- current progress, blockers, and next steps;
+- reusable commands, procedures, and troubleshooting experience.
 
-### Hybrid Search Explained
-
-`memory_search` calls ReMe's `search` job. Search always tries keyword retrieval through BM25 and also runs vector
-retrieval when an embedding model is configured. When both paths return results, ReMe fuses the ranked lists with
-**Reciprocal Rank Fusion (RRF)**.
-
-#### Vector Semantic Search
-
-Maps text into a high-dimensional vector space and measures semantic distance via cosine similarity, capturing content
-with similar meaning but different wording:
-
-| Query                                   | Recalled Memory                                           | Why It Matches                                                  |
-| --------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------- |
-| "Database choice for the project"       | "Finally decided to replace MySQL with PostgreSQL"        | Semantically related: both discuss database technology choices  |
-| "How to reduce unnecessary rebuilds"    | "Configured incremental compilation to avoid full builds" | Semantic equivalence: reduce rebuilds ≈ incremental compilation |
-| "Performance issue discussed last time" | "Optimized P99 latency from 800ms to 200ms"               | Semantic association: performance issue ≈ latency optimization  |
-
-However, vector search is weaker on **precise, high-signal tokens**, as embedding models tend to capture overall
-semantics rather than exact matches of individual tokens.
-
-#### BM25 Keyword Search
-
-Based on term frequency statistics for substring matching, excellent for precise token hits, but weaker on semantic
-understanding (synonyms, paraphrasing).
-
-| Query                      | BM25 Hits                                      | BM25 Misses                                           |
-| -------------------------- | ---------------------------------------------- | ----------------------------------------------------- |
-| `handleWebSocketReconnect` | Memory fragments containing that function name | "WebSocket disconnection reconnection handling logic" |
-| `ECONNREFUSED`             | Log entries containing that error code         | "Database connection refused"                         |
-
-ReMe maintains a local BM25 index over indexed files. This gives reliable hits for exact identifiers, error codes,
-filenames, and uncommon words even when embeddings are unavailable.
-
-#### Hybrid Search Fusion
-
-When both vector and BM25 return candidates, ReMe uses weighted RRF. The default vector weight is `0.7`; the remaining
-`0.3` goes to keyword search.
-
-1. **Expand candidate pool**: Multiply the desired result count by `candidate_multiplier` (default 3×, capped at 200);
-   each path retrieves more candidates independently
-2. **Independent ranking**: Vector and BM25 each return ranked result lists
-3. **RRF merging**: Deduplicate by chunk id and add rank-based contributions:
-   - Vector contribution: `0.7 / (60 + vector_rank)`
-   - Keyword contribution: `0.3 / (60 + keyword_rank)`
-   - Chunks found by both paths receive both contributions
-4. **Sort and truncate**: Sort by `final_score` descending, return top-N results
-5. **Link expansion**: Search can include nearby linked files to provide additional context
-
-**Example**: Query `"handleWebSocketReconnect disconnection reconnect"`
-
-| Memory Fragment                                                               | Vector Rank | BM25 Rank | Why It Ranks Well                                   |
-| ----------------------------------------------------------------------------- | ----------- | --------- | --------------------------------------------------- |
-| "handleWebSocketReconnect function handles WebSocket disconnection reconnect" | 2           | 1         | Strong semantic match plus exact keyword hit        |
-| "Logic for automatic retry after network disconnection"                       | 1           | -         | Strong semantic match even without exact identifier |
-| "Fixed null pointer exception in handleWebSocketReconnect"                    | -           | 2         | Exact identifier hit keeps it in the candidate set  |
+### How It Works
 
 ```mermaid
-graph LR
-    Query[Search Query] --> Vector[Vector Semantic Search x0.7]
-    Query --> BM25[BM25 Keyword Search x0.3]
-    Vector --> Merge[Deduplicate by chunk + Weighted RRF]
-    BM25 --> Merge
-    Merge --> Sort[Sort by fused score descending]
-    Sort --> Results[Return top-N results]
+flowchart LR
+    A[Accumulate N user turns] --> B[Select messages from the batch]
+    B --> C[Remove tool results and large Base64 blocks]
+    C --> D[Append to mem_session/dialog/session.jsonl]
+    D --> E[LLM identifies durable information]
+    E --> F[Create or update memory/date/note.md]
+    F --> G[Refresh day index and incrementally update search]
 ```
 
-> **Summary**: Using any single search method alone has blind spots. Hybrid search lets the two signals complement each
-> other, delivering reliable recall whether you're asking in natural language or searching for exact terms.
+By default, QwenPaw triggers Auto-Memory after every five user turns. ReMe first saves the source conversation by `session_id`, then looks for an existing note for that session and date. It updates the existing card when one exists and creates a new card otherwise. Automatically recalled memory is removed before extraction so old search results cannot be mistaken for facts newly supplied by the user.
 
-### Verifying That Vector Search Is Working
+When context is about to be compacted, `summarize_when_compact` can flush pending turns through the same Auto-Memory pipeline even if the normal interval has not yet been reached.
 
-Ask the Agent to call `memory_search` and return its tool result verbatim. Replace `xxx` with the query to test:
+### Configuration
+
+Configure Auto-Memory under `running.reme_light_memory_config` in `agent.json`:
+
+```json
+{
+  "running": {
+    "memory_manager_backend": "remelight",
+    "reme_light_memory_config": {
+      "auto_memory_interval": 5,
+      "summarize_when_compact": true,
+      "inbox_push_enabled": true
+    }
+  }
+}
+```
+
+| Field                    | Default | Description                                                                     |
+| ------------------------ | ------- | ------------------------------------------------------------------------------- |
+| `auto_memory_interval`   | `5`     | Trigger after every N user turns; `null` or `<= 0` disables periodic triggering |
+| `summarize_when_compact` | `true`  | Save pending turns before context compaction                                    |
+| `inbox_push_enabled`     | `true`  | Push the job result to Inbox when Auto-Memory actually changes memory           |
+
+A smaller interval updates memory sooner, but increases model calls, token usage, and background work.
+
+### Inbox
+
+When `inbox_push_enabled` is on, Auto-Memory results appear in QwenPaw's Inbox. If the run finds nothing worth creating or updating, ReMe reports `modified=false` and QwenPaw does not create an Inbox event for that no-op.
+
+### Example
+
+Suppose the user says in `session-42`:
 
 ```text
-Please call the memory_search tool and search for "xxx". Return the raw tool result exactly as-is,
-including every separator line and all score, vector, and keyword fields. Do not summarize or rewrite the result.
+For every production release, validate staging first. Write the release notes in Chinese and include risks and rollback steps.
 ```
 
-To test semantic recall rather than keyword matching, first save a memory such as "My preferred commute is a
-lightweight bicycle.", then search for "How does the user usually travel to work?". The sentences have no obvious
-keyword overlap but are semantically related, making a vector hit easier to identify.
-
-The scores below are illustrative:
-
-**Only the vector branch has a hit:**
+After the configured interval, Auto-Memory preserves the source and creates or updates files such as:
 
 ```text
-========== memory/2026-07-23/commute.md:1-6 [score=0.8237] ==========
-My preferred commute is a lightweight bicycle.
+mem_session/dialog/session-42.jsonl
+memory/2026-08-06/release-discussion.md
 ```
 
-Here, `score` is the raw cosine-similarity score.
+```markdown
+---
+name: Production release agreement
+description: Validate staging first; Chinese release notes must include risks and rollback steps.
+source_conversation: "[[mem_session/dialog/session-42.jsonl]]"
+---
 
-**Only the BM25 branch has a hit:**
-
-```text
-========== memory/2026-07-23/commute.md:1-6 [score=3.1842] ==========
-My preferred commute is a lightweight bicycle.
+- Complete staging validation before a production release.
+- Write release notes in Chinese and include risks and rollback steps.
 ```
 
-Here, `score` is the raw BM25 score. When the output contains only `[score=...]`, the number alone does not strictly
-identify which branch produced it; consider whether the query contains an exact keyword match or inspect the search
-log described below.
-
-**Hybrid retrieval, with candidates from both branches:**
-
-```text
-========== memory/2026-07-23/commute.md:1-6 [score=0.0164 vector=0.8237 keyword=3.1842] ==========
-My preferred commute is a lightweight bicycle.
-
-========== memory/2026-07-20/purchase.md:3-7 [score=0.0113 vector=0.7915 keyword=-] ==========
-The user bought a lightweight two-wheeled vehicle.
-
-========== memory/2026-07-18/maintenance.md:2-5 [score=0.0048 vector=- keyword=2.5176] ==========
-Bicycle maintenance is scheduled for the weekend.
-```
-
-- `score`: the RRF-fused score
-- `vector`: the raw vector cosine similarity; a numeric value directly confirms that the vector branch returned this result
-- `keyword`: the raw BM25 score
-- `-`: the corresponding branch did not retrieve this result
-
-The search log contains `vector_hits=N keyword_hits=M`, which confirms how many candidates each branch returned.
-The embedding health check also sends a `"ping"` test request and validates the returned vector dimension:
-
-```text
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> OK
-```
-
-`-> OK` means that the embedding provider is reachable and its output dimension matches the configuration. Failures
-include the reason, for example:
-
-```text
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL timeout(5.0s)
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL RuntimeError: embedding dimension mismatch: <actual> != <configured>
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL <ExceptionType>: <message>
-```
-
-The health check runs while loading persisted chunks when vectors are missing and need to be backfilled. It may
-therefore not be emitted on every startup when all stored chunks already contain valid vectors. In that case, a
-numeric `vector=...` field in a search result remains direct evidence that the vector branch returned a hit.
+This is still daily material. When the same preference appears in more conversations, Auto-Dream can consolidate it into a stable `digest/` node.
 
 ---
 
-## Backup & Restore
+## Auto-Dream: Evolving the Personal Knowledge Base
 
-Backup & Restore is QwenPaw's backup and recovery capability, enabling safe saving and restoration of the entire agent environment for scenarios like version upgrades, cross-device migration, or undoing mistakes. Access: Console → Settings → Backup.
+Auto-Dream consolidates daily memory into long-term knowledge. It normally runs on a schedule, scans recently changed daily notes, extracts reusable memory units, updates `digest/`, and produces interest topics for proactive interaction.
 
-### Creating Backups
+### How It Works
 
-**Backup Storage**
+QwenPaw's Auto-Dream scans the target date and the previous day by default (`scan_days=2`) and extracts at most five memory units. It runs in four stages:
 
-All backups are saved as independent zip packages in `~/.qwenpaw/backups` (alongside the working directory `~/.qwenpaw`). Each backup contains `meta.json` metadata and packaged content files. The zip file is exported for easy migration. Note that backups do not include local model files; re-download is required for cross-device migration.
+```mermaid
+flowchart LR
+    A[Extract<br/>Find changes and extract units/topics] --> B[Integrate + Auto-Link<br/>Create, merge, correct, and link]
+    B --> C[Topics<br/>Select non-repetitive interests]
+    C --> D[Finish<br/>Persist processing state]
+```
 
-**Backup Scope**
+1. **Extract** refreshes the day indexes, compares files with the dream catalog, and sends only added or modified daily memory to the LLM. It extracts `personal`, `procedure`, and `wiki` units plus candidate interest topics.
+2. **Integrate + Auto-Link** runs `node_search` for every unit to find possibly identical or related digest nodes, then chooses `CREATE`, `CORROBORATE`, `REFINE`, or `CORRECT`.
+3. **Topics** deduplicates candidates against the previous seven days and writes up to three topics to `memory/<date>/interests.yaml`.
+4. **Finish** checkpoints successfully processed inputs in the dream catalog. Failed paths are not checkpointed, so a later run can retry them.
 
-- **Agent workspaces**: Selectable per Agent
-- **Global settings**: `config.json` and other global configurations
-- **Skill pool**: Shared skills directory
-- **Secrets**: Model API Keys, environment variables, etc.
+Auto-Dream does not rewrite daily memory. `memory/` preserves what happened at the time; `digest/` stores abstractions that remain useful across time.
 
-**Backup Modes**
+### Where Auto-Link Happens
 
-- **Full backup**: One-click package of all the above content
-- **Partial backup**: Backup selected modules and specific agent workspaces
+Auto-Link is not a separate scheduled job. It is part of Auto-Dream's **Integrate** stage:
 
-### Restoring Backups
+- `node_search` recalls only digest-node names, descriptions, and paths for deduplication and relationship discovery;
+- the same abstraction updates an existing node instead of creating a duplicate;
+- a digest node's `## Sources` section links back to evidence under `memory/`;
+- related digest nodes are connected through `[[digest/...]]` links in the body;
+- updates preserve existing sources and Wikilinks, allowing the knowledge graph to grow over time.
 
-**Restore Modes**
+The four integration actions mean:
 
-- **Full restore**: Completely replaces the current instance with the backup — current content is deleted and replaced with backup content. Requires the backup to contain all modules (agent workspaces, global settings, skill pool, secrets).
-- **Custom restore**: Restore by module or by Agent with fine-grained control. Local Agents not included in the restore scope remain unchanged.
+| Action        | Meaning                                                                          |
+| ------------- | -------------------------------------------------------------------------------- |
+| `CREATE`      | No equivalent abstraction exists; create a new long-term node                    |
+| `CORROBORATE` | New material confirms an existing memory; add evidence or strengthen its wording |
+| `REFINE`      | New material adds steps, boundaries, conditions, or detail                       |
+| `CORRECT`     | New material fixes an error, omission, or conflict in an existing node           |
 
-**Pre-restore Prompt**
+### Configuration
 
-Before restoring, the system prompts to create a snapshot of the current state. If the restore goes wrong, you can roll back with one click.
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "dream_cron_enabled": true,
+      "dream_cron": "0 23 * * *",
+      "inbox_push_enabled": true
+    }
+  }
+}
+```
 
-**Notes**
+| Field                | Default        | Description                                                                   |
+| -------------------- | -------------- | ----------------------------------------------------------------------------- |
+| `dream_cron_enabled` | `true`         | Enable scheduled Auto-Dream                                                   |
+| `dream_cron`         | `"0 23 * * *"` | Five-field cron expression; a run starts after a random delay of 0–60 seconds |
+| `inbox_push_enabled` | `true`         | Push Auto-Dream job results to Inbox                                          |
 
-- Backup files may contain sensitive credentials — store them safely and do not share with others
-- Service restart is required after restore for new configuration to take effect
+### Inbox
+
+With Inbox delivery enabled, each successful or failed Auto-Dream summary becomes a memory event so that you can inspect scanning, integration, and topic-generation results. Inbox is only the notification surface. The actual long-term knowledge remains in Markdown under `digest/`.
+
+### Example
+
+Suppose recent daily notes repeatedly mention staging validation and rollback steps before production releases. Auto-Dream may:
+
+1. use `node_search` to find `digest/procedure/production-release.md`;
+2. choose `REFINE` and add Chinese release notes, a risk list, and rollback steps to the procedure;
+3. add the new daily memory to `## Sources`;
+4. link `[[digest/personal/release-communication-preference.md]]`;
+5. add “Check whether the release process covers rollback drills” as a candidate topic in that day's `interests.yaml`.
+
+The result is not another copy of the chat summary. Existing long-term knowledge has been strengthened by evidence and connected to related knowledge.
 
 ---
 
-## Memory Configuration
+## Memory Index and Memory Search
 
-### Configuration Structure
+`memory_index` keeps files searchable, while `memory_search` retrieves the most relevant content when needed. The index is derived state and can be rebuilt from Markdown in `memory/` and `digest/`.
 
-Memory configuration is located in `agent.json` under `running.reme_light_memory_config`:
+### Index Capabilities and Scope
 
-| Field                    | Description                                                                                                                     | Default          |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `metadata_dir`           | ReMe persistent state directory for indexes, catalogs, graph data, and caches                                                   | `"mem_metadata"` |
-| `session_dir`            | Directory for saved source conversations                                                                                        | `"mem_session"`  |
-| `mem_session_dir`        | Directory for ReMe internal memory-agent sessions                                                                               | `"mem_agent"`    |
-| `resource_dir`           | Directory watched by `auto_resource`                                                                                            | `"resource"`     |
-| `daily_dir`              | Directory for daily memory notes                                                                                                | `"memory"`       |
-| `digest_dir`             | Directory for dream/digest memory                                                                                               | `"digest"`       |
-| `summarize_when_compact` | Whether pending turns are flushed to Auto-Memory before context compression                                                     | `true`           |
-| `inbox_push_enabled`     | Whether `auto_memory`, `auto_dream`, and `auto_resource` job results are pushed to the QwenPaw inbox                            | `true`           |
-| `auto_memory_interval`   | Auto-Memory every N user turns. `None` or `<= 0` disables periodic Auto-Memory                                                  | `5`              |
-| `dream_cron_enabled`     | Whether the scheduled Auto-Dream job is enabled                                                                                 | `true`           |
-| `dream_cron`             | Valid 5-field cron expression for Auto-Dream (required when enabled); scheduled runs start after a random delay of 0–60 seconds | `"0 23 * * *"`   |
+After QwenPaw starts embedded ReMe, the background `index_update_loop`:
 
-### Rebuilding the Memory Search Index
+- scans `daily_dir` (default `memory`) and `digest_dir` (default `digest`) at startup;
+- watches new, modified, and deleted `.md` files in those directories while running;
+- splits Markdown by headings and content blocks while retaining file paths and line numbers;
+- updates the BM25 index for every chunk and generates vectors when Embedding is enabled;
+- parses Wikilinks into file nodes and bidirectional graph relationships;
+- persists derived state under `mem_metadata/`.
 
-Rebuilding is an explicit maintenance operation for repairing a damaged index or abnormal search results. It clears
-and recreates the ReMe search index, so CPU and memory usage may increase significantly while it runs. The operation
-is available only when the agent uses the ReMeLight memory backend and its memory manager is running.
+Each indexed file is limited to 10 MiB. `resource/` and `mem_session/` are outside this indexing scope.
 
-In the Console, open the agent configuration, find **Long-term Memory**, and select **Rebuild Memory Index**. Review
-the warning and confirm the operation. You can also call the synchronous maintenance API:
+### How the BM25 + Vector Index Is Built
+
+```mermaid
+flowchart LR
+    A[memory/**/*.md<br/>digest/**/*.md] --> B[Watch file changes]
+    B --> C[Structure-aware Markdown chunking]
+    C --> D[FileChunk<br/>text + path + line range]
+    D --> E[BM25 inverted index]
+    D --> F[Embedding vector<br/>optional]
+    C --> G[Wikilink graph]
+    E --> H[mem_metadata]
+    F --> H
+    G --> H
+```
+
+BM25 treats each chunk as a document and records tokens, term frequencies, and posting lists. It is well suited to exact identifiers such as function names, error codes, and product terms. With Embedding enabled, the same chunk also receives a vector, allowing semantically similar text to match even when the wording differs.
+
+For supported providers, enablement conditions, field definitions, cache behavior, and troubleshooting, see [Embedding Models](./embedding). Without Embedding, BM25 and Wikilink expansion continue to work.
+
+### How BM25 + Vector Hybrid Search Works
+
+`memory_search(query, max_results, min_score)` runs ReMe's `search` job:
+
+```mermaid
+flowchart LR
+    A[Query] --> B[Expand candidate pool<br/>limit × 3, capped at 200]
+    B --> C[Vector retrieval]
+    B --> D[BM25 retrieval]
+    C --> E[Deduplicate by chunk id and fuse with RRF]
+    D --> E
+    E --> F[Apply min_score and keep Top N]
+    F --> G[Expand incoming and outgoing links]
+    G --> H[Chunks + paths + lines + related nodes]
+```
+
+When both branches return results, ReMe uses weighted Reciprocal Rank Fusion (RRF) by default:
+
+```text
+score = 0.7 / (60 + vector_rank)
+      + 0.3 / (60 + keyword_rank)
+```
+
+RRF compares positions in the two ranked lists instead of directly comparing cosine similarity and BM25 scores, whose numeric scales are unrelated. A chunk found by both branches receives both contributions. A chunk found by only one branch can still appear. If Embedding is disabled or vector retrieval produces no results, the BM25 ranking is used directly.
+
+After fusion, ReMe expands up to ten outgoing and ten incoming links for each hit file from the graph index. Results therefore include both the most relevant text and connected sources, procedures, and neighboring knowledge nodes.
+
+> `min_score` defaults to `0`. Keep it at the default for normal use because raw single-branch scores and fused RRF scores have different scales; increasing the threshold indiscriminately may hide valid results.
+
+### Manual Search and Auto-Memory-Search
+
+The Agent can call `memory_search` whenever an answer depends on past information. To recall memory before every normal user request, enable Auto-Memory-Search:
+
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "auto_memory_search_config": {
+        "enabled": true,
+        "max_results": 2
+      }
+    }
+  }
+}
+```
+
+When enabled, QwenPaw builds a query from the current user request and runs the same ReMe `search` job before the model handles it. The results are injected into the live context as a completed `memory_search` interaction and remain available to subsequent model calls in that turn. Automation-originated requests do not trigger this behavior. Injected results are also excluded from persistent conversation history and Auto-Memory, preventing memory from copying itself.
+
+| Field         | Default | Description                                               |
+| ------------- | ------- | --------------------------------------------------------- |
+| `enabled`     | `false` | Automatically search memory for every normal user request |
+| `max_results` | `2`     | Maximum number of results injected per automatic search   |
+
+### Search Example
+
+Assume these memories already exist:
+
+```text
+memory/2026-08-06/release-discussion.md
+digest/procedure/production-release.md
+```
+
+When the user asks, “What checks do we run before going live?”, `memory_search` can combine:
+
+- **Vector** matching between “checks before going live” and “staging validation before production release”;
+- **BM25** exact matches for terms such as `staging` and `rollback`;
+- **Wikilinks** from the daily discussion to the long-term procedure and related preferences.
+
+The result looks like:
+
+```text
+========== digest/procedure/production-release.md:1-18 [score=0.0162 vector=0.84 keyword=3.71] ==========
+...Complete staging validation and prepare risks and rollback steps before production release...
+  outlinks (1):
+    -> digest/personal/release-communication-preference.md
+  inlinks (1):
+    <- memory/2026-08-06/release-discussion.md
+```
+
+The Agent can then use the returned path and line range to read the source file precisely.
+
+### Complete ReMeLight Configuration
+
+All fields live under `running.reme_light_memory_config`:
+
+| Field                       | Default             | Description                                                              |
+| --------------------------- | ------------------- | ------------------------------------------------------------------------ |
+| `metadata_dir`              | `"mem_metadata"`    | Directory for indexes, graph data, catalogs, and caches                  |
+| `session_dir`               | `"mem_session"`     | Auto-Memory source conversation directory                                |
+| `mem_session_dir`           | `"mem_agent"`       | ReMe internal memory-agent session directory                             |
+| `resource_dir`              | `"resource"`        | Directory watched by Auto-Resource                                       |
+| `daily_dir`                 | `"memory"`          | Daily memory directory                                                   |
+| `digest_dir`                | `"digest"`          | Long-term knowledge base directory                                       |
+| `summarize_when_compact`    | `true`              | Save pending turns before context compaction                             |
+| `inbox_push_enabled`        | `true`              | Push automated memory job results to Inbox                               |
+| `auto_memory_interval`      | `5`                 | Auto-Memory interval in user turns                                       |
+| `dream_cron_enabled`        | `true`              | Enable scheduled Auto-Dream                                              |
+| `dream_cron`                | `"0 23 * * *"`      | Five-field Auto-Dream cron expression                                    |
+| `auto_memory_search_config` | See above           | Automatic memory search configuration                                    |
+| `embedding_model_config`    | Disabled by default | Optional vector model configuration; see [Embedding Models](./embedding) |
+
+### Rebuilding the Index
+
+The background loop normally maintains the index incrementally. Use **Rebuild Memory Index** in the Agent's long-term memory settings only when the index is damaged or search results are clearly abnormal. You can also call:
 
 ```http
 POST /api/agents/{agentId}/memory/reindex
 ```
 
-A successful rebuild returns `{"status":"completed"}`. Only one rebuild can run for an agent at a time; another
-request returns HTTP `409`. The endpoint may also return `400` for a non-ReMeLight backend, `404` for an unknown
-agent, `503` when ReMe is unavailable, or `500` when the rebuild job fails.
-
-> `rebuild_memory_index_on_start` is no longer supported. Remove it from `agent.json`; use the Console action or API
-> when an index rebuild is actually needed.
-
-### Auto Memory Search Configuration
-
-Configure in `running.reme_light_memory_config.auto_memory_search_config`:
-
-When enabled, search results are injected into the current live context as a
-completed `memory_search` interaction. They remain available to follow-up model
-calls in the same tool loop until normal context management evicts them.
-
-| Field         | Description                                              | Default |
-| ------------- | -------------------------------------------------------- | ------- |
-| `enabled`     | Whether to auto search memory on every conversation turn | `false` |
-| `max_results` | Maximum results for auto memory search                   | `2`     |
-
-### Embedding Configuration (Optional)
-
-Embedding configuration for vector semantic search, located in `running.reme_light_memory_config.embedding_model_config`:
-
-| Field              | Description                                                                                    | Default  |
-| ------------------ | ---------------------------------------------------------------------------------------------- | -------- |
-| `backend`          | Embedding backend type: `openai`, `dashscope`, `dashscope_multimodal`, `gemini`, `ollama`      | `openai` |
-| `api_key`          | API key for the embedding provider. Required for OpenAI-compatible and Gemini backends         | ``       |
-| `base_url`         | Optional custom API URL for OpenAI-compatible backends. For Ollama, this is passed as the host | ``       |
-| `model_name`       | Embedding model name                                                                           | ``       |
-| `dimensions`       | Embedding vector dimensions                                                                    | `1024`   |
-| `enable_cache`     | Whether to enable Embedding cache                                                              | `true`   |
-| `use_dimensions`   | Whether to pass dimensions parameter in API                                                    | `false`  |
-| `max_cache_size`   | Maximum Embedding cache entries                                                                | `10000`  |
-| `max_input_length` | Approximate character budget per Embedding request                                             | `8192`   |
-| `max_batch_size`   | Maximum batch size for Embedding requests                                                      | `10`     |
-
-> `use_dimensions` is for cases where some vLLM models don't support the dimensions parameter. Set to `false` to skip it.
-
-Starting with ReMe 0.4.1.0, embedding input truncation uses a more conservative budget for token-dense CJK and other
-full-width characters and reserves an additional safety margin. This prevents long Chinese memory entries from
-exceeding the model context window and returning HTTP 400 with combinations such as Ollama and bge-m3.
-`max_input_length` remains an approximate character budget rather than a strict token limit calculated by the model's
-tokenizer. Reduce it further when using a model with a smaller context window.
-
-Vector retrieval is enabled only when the selected backend has the minimum runnable configuration. These conditions are aligned with AgentScope credential requirements:
-
-| Backend                                         | Enable condition                              | Credential mapping              |
-| ----------------------------------------------- | --------------------------------------------- | ------------------------------- |
-| `openai` / `dashscope` / `dashscope_multimodal` | Both `model_name` and `api_key` are non-empty | `api_key`; optional `base_url`  |
-| `gemini`                                        | Both `model_name` and `api_key` are non-empty | `api_key`                       |
-| `ollama`                                        | `model_name` is non-empty                     | optional `host` from `base_url` |
-
-### Indexing Behavior
-
-The embedded ReMe configuration uses a local file store with:
-
-| Component        | Behavior                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| File store       | Local ReMe file store under `mem_metadata/`                                                      |
-| Keyword index    | BM25 keyword index enabled by default                                                            |
-| Vector index     | Enabled only when `embedding_model_config` meets the enable condition for the selected `backend` |
-| Watched dirs     | `daily_dir` and `digest_dir`                                                                     |
-| Watched suffixes | `md`                                                                                             |
+Rebuilding clears the derived index and recreates it from existing Markdown under `memory/` and `digest/`. CPU and memory usage may increase while it runs. Only one rebuild can run for an Agent at a time. `rebuild_memory_index_on_start` is no longer supported.
 
 ---
 
@@ -514,8 +475,7 @@ The full configuration can be written into `running.adbpg_memory_config` of `age
 
 ## Related Pages
 
-- [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive) — Auto-Memory, Auto-Dream, Auto-Memory-Search, Proactive complete workflow
-- [Introduction](./intro) — What this project can do
-- [Console](./console) — Manage memory and configuration in the console
-- [Skills](./skills) — Built-in and custom capabilities
-- [Configuration & Working Directory](./config) — Working directory and config
+- [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive) — Auto-Memory, Auto-Dream, Auto-Memory-Search, and Proactive workflows
+- [Embedding Models](./embedding) — Vector model capabilities, backends, configuration, and troubleshooting
+- [Console](./console) — Manage memory and configuration in the Console
+- [Configuration & Working Directory](./config) — Workspace and Agent configuration

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -1,395 +1,413 @@
 # 长期记忆
 
-**长期记忆** 让 QwenPaw 拥有跨对话的持久记忆能力。默认后端会在 QwenPaw 进程内嵌入 ReMe 应用，并通过 ReMe jobs
-完成对话事实保存、每日记忆、梦境摘要、资源文件监听和记忆检索。
+QwenPaw 的长期记忆由 [ReMe](https://github.com/agentscope-ai/ReMe) 驱动。它不是把历史对话全部塞回上下文，而是让对话与资料持续沉淀为**可读、可编辑、可检索、相互链接的 Markdown 记忆**，逐步长成一个由用户和 Agent 共同维护的自进化个人知识库。
 
-> 长期记忆机制设计受 [OpenClaw](https://github.com/openclaw/openclaw)
-> 启发，由 [ReMe](https://github.com/agentscope-ai/ReMe) 的 **ReMeLight** 实现——以文件系统为存储后端，工作记忆与长期记忆节点均为 Markdown
-> 文件，可直接读取、编辑与迁移。
-
-ReMe 的核心目标，是基于 _Memory as File, File as Memory_ 原则长出一个**自进化的个人知识库**。每个工作记忆或长期记忆节点都是一份普通 Markdown 文件——可读、可编辑、可追溯、可迁移、由你与 agent 协作维护——同时又可被索引和链接；原始来源与派生系统状态则使用适合各自职责的格式。workspace 把记忆组织为四层：
-
-| 分层     | QwenPaw 目录                | 职责                                                |
-| -------- | --------------------------- | --------------------------------------------------- |
-| 原始输入 | `mem_session/`、`resource/` | 作为证据保留的原始对话与外部资料                    |
-| 工作记忆 | `memory/`                   | daily note：事实、决策、资源解读                    |
-| 长期记忆 | `digest/`                   | 可复用知识节点（`personal` / `procedure` / `wiki`） |
-| 系统状态 | `mem_metadata/`             | 索引、wikilink 图、catalog——不手工编辑              |
-
-记忆通过 **capture → index → consolidate → recall** 闭环进化：Auto-Memory / Auto-Resource 捕获 daily note，索引让其可检索，Auto-Dream 把它们整合成带链接的 digest 节点，search / proactive 再召回。完整叙述——包括 Auto-Dream 如何对 digest 节点 corroborate、refine、correct 并织成 wikilink 图——见[智能体记忆进化与主动交互](./memory-evolving-and-proactive)。以下章节聚焦技术实现与配置。
-
----
-
-## 架构概览
+默认的 `remelight` 后端会在 QwenPaw 进程内嵌入 ReMe，并复用当前 Agent 的模型完成记忆抽取和整理。整个系统遵循下面的闭环：
 
 ```mermaid
-graph TB
-    User[用户 / Agent] --> Middleware[MemoryMiddleware]
-    Middleware --> Manager[ReMeLightMemoryManager]
-    Manager --> ReMe[嵌入式 ReMe 应用]
-    ReMe --> Jobs[ReMe Jobs]
-    Jobs --> AutoMemory[auto_memory]
-    Jobs --> AutoDream[auto_dream]
-    Jobs --> Search[search]
-    Jobs --> Resource[auto_resource]
-    Jobs --> Reindex[reindex / index_update_loop]
-    AutoMemory --> Daily[memory/YYYY-MM-DD/*.md]
-    AutoMemory --> Session[mem_session/dialog/*.jsonl]
-    AutoDream --> Digest[digest/*.md 和 interests.yaml]
-    Resource --> ResourceDir[resource/*]
-    Search --> Store[mem_metadata 文件存储 + BM25 + 可选向量]
+flowchart LR
+    A[对话与资料] --> B[Auto-Memory / Auto-Resource]
+    B --> C[每日 Markdown 记忆]
+    C --> D[Memory Index]
+    C --> E[Auto-Dream]
+    E --> F[带 Wikilink 的个人知识库]
+    F --> D
+    D --> G[memory_search]
+    G --> H[Agent 当前上下文]
+    I[Auto-Memory-Search] --> G
 ```
 
-长期记忆管理包含以下能力：
+这套框架由四项核心能力组成：
 
-| 能力               | 说明                                                                                    |
+| 能力               | 作用                                                                                    |
 | ------------------ | --------------------------------------------------------------------------------------- |
-| **嵌入式 ReMe**    | QwenPaw 在进程内启动 ReMe，并将当前 Agent 使用的 QwenPaw 模型注入到 ReMe 默认 LLM 组件  |
-| **Auto-Memory**    | 每隔可配置数量的用户回合，将对话中值得保留的事实抽取为每日 Markdown 记忆                |
-| **上下文压缩保存** | 上下文压缩前，可把尚未写入的回合先提交给同一套 `auto_memory` 流程                       |
-| **Auto-Dream**     | 定时从近期每日记忆中提取更高层的 digest 单元和主动交互兴趣主题                          |
-| **混合检索**       | `memory_search` 调用 ReMe `search` job，通过 BM25 + 可选向量检索，并使用 RRF 融合排序   |
-| **资源记忆**       | `resource/` 下的外部文件会被编目，变更后可通过 `auto_resource` 转成带来源链接的每日记忆 |
-| **Inbox 通知**     | `auto_memory`、`auto_dream`、`auto_resource` 产生结果时，会推送到 QwenPaw inbox         |
+| **Memory as File** | 以带 frontmatter 和 `[[wikilink]]` 的 Markdown 保存记忆；文件是用户可直接管理的事实来源 |
+| **Auto-Memory**    | 从对话中提取值得长期保留的事实、偏好、决策和进展，写入当天的每日记忆                    |
+| **Auto-Dream**     | 从近期每日记忆中提炼稳定知识，合并或修正长期节点，并通过 Auto-Link 建立关系             |
+| **Memory Search**  | 用 BM25 与可选的向量检索召回相关片段，经 RRF 融合后再沿 Wikilink 展开上下文             |
+
+其中 Auto-Memory 是构建个人知识库的前提：先把对话变成可靠素材；Auto-Dream 是知识库持续进化的关键：再把分散素材整合为稳定、互联的长期知识。
 
 ---
 
-## 记忆文件结构
+## Memory as File：记忆就是文件
 
-记忆以普通文件保存在 Agent 工作区中。ReMe 写出的 Markdown 是可读的记忆源数据，`mem_metadata/` 则保存搜索索引、catalog、graph
-和 embedding cache 等持久状态。
+ReMe 遵循 **Memory as File, File as Memory**：
 
-```
+- 对用户而言，记忆是工作区里的普通文件，可以直接阅读、修改、移动、删除、备份和迁移。
+- 对 Agent 而言，每个 Markdown 文件又是一个可分块、可索引、可链接、可持续演化的记忆节点。
+- 检索索引、图谱和缓存只是可以从源文件重建的派生状态；真正的记忆源数据仍由用户掌控。
+
+### 文件结构
+
+默认情况下，每个 Agent 的工作区位于 `~/.qwenpaw/workspaces/{agent_id}/`，长期记忆使用以下结构：
+
+```text
 {工作区}/
-├── memory/                         ← 每日记忆
-│   └── 2026-06-29/
-│       ├── project-plan.md          ← auto_memory 创建或更新的单条记忆
-│       └── index.md                 ← 当日记忆索引
-│
+├── memory/                              # 每日记忆：对话与资料的浅加工结果
+│   ├── 2026-08-06.md                    # 当日索引页
+│   └── 2026-08-06/
+│       ├── project-plan.md              # Auto-Memory 创建或更新的记忆卡片
+│       ├── market-report.md             # Auto-Resource 生成的资料记忆
+│       └── interests.yaml               # Auto-Dream 生成的兴趣主题
 ├── mem_session/
 │   └── dialog/
-│       └── <session_id>.jsonl       ← 作为记忆来源的对话记录
-│
-├── digest/                         ← Auto-Dream 产出的 digest 记忆和兴趣主题
-├── resource/                       ← auto_resource 监听的外部资源
-└── mem_metadata/                   ← ReMe 持久化索引、图、catalog 和缓存
-    ├── file_store/
-    │   └── file_chunks_default_v1.jsonl.zst
-    ├── file_graph/
-    │   └── default.jsonl.zst
-    ├── file_catalog/
-    │   ├── default.jsonl.zst
-    │   ├── resource.jsonl.zst
-    │   ├── digest.jsonl.zst
-    │   └── dream.jsonl.zst
-    ├── embedding_store/
-    │   └── default_v1.npz
-    └── keyword_index/
-        └── bm25_default_<tokenizer>_<fingerprint>_v1.pkl
+│       └── <session_id>.jsonl           # Auto-Memory 的来源对话
+├── digest/                              # 长期个人知识库
+│   ├── personal/                        # 用户、团队、项目事实与偏好
+│   ├── procedure/                       # 流程、runbook、可复用经验
+│   └── wiki/                            # 概念、原则、观察与决策先例
+├── resource/                            # 外部资源原文
+│   └── 2026-08-06/
+│       └── report.md
+└── mem_metadata/                        # 索引、图谱、catalog 与缓存等派生状态
 ```
 
-默认工作区下的完整路径是
-`~/.qwenpaw/workspaces/{agent_id}/mem_metadata/`。其中
-`file_store/file_chunks_default_v1.jsonl.zst` 是权威 chunk 存储，向量以 float16
-编码在压缩 JSONL 记录的 `_embedding_f16_b64` 字段中，并不会生成单独的向量数据库目录。
-`embedding_store/default_v1.npz` 是启用 `enable_cache` 后使用的本地 embedding
-缓存，不是权威索引；它可能要到缓存持久化后才出现。实际 BM25 文件名中的 tokenizer
-名称和 fingerprint 会随配置变化。
+四类用户可见目录各自承担不同职责：
 
-### memory/YYYY-MM-DD/\*.md（每日记忆）
+| 目录                         | 内容                                              | 是否直接参与 QwenPaw 记忆检索 |
+| ---------------------------- | ------------------------------------------------- | ----------------------------- |
+| `memory/YYYY-MM-DD/*.md`     | 当天事实、对话摘要、决策、进度和资源解读          | 是                            |
+| `mem_session/dialog/*.jsonl` | 经过清理的来源对话，用于追溯和后续抽取            | 否                            |
+| `digest/`                    | Auto-Dream 整合后的长期个人知识库                 | 是                            |
+| `resource/`                  | 用户放入的外部资料；由 Auto-Resource 转为每日记忆 | 不直接检索                    |
 
-每日记忆是 Auto-Memory 的默认输出。ReMe 每天会写入一到多条记忆，并通过来源会话来定位已有记忆，后续同一会话的新内容会更新既有
-note，而不是无限创建重复文件。
+> QwenPaw 的嵌入式 ReMe 只索引 `memory/` 和 `digest/` 下的 `.md` 文件。原始对话由上下文系统负责查询；资源文件要先转成 `memory/` 中的 Markdown 记忆，才会被 `memory_search` 召回。
 
-- **位置**：`{working_dir}/memory/YYYY-MM-DD/*.md`
-- **用途**：保存长期有用的对话事实、决策、偏好和工作记录
-- **更新**：ReMe `auto_memory` 通过 `daily_write`、`read`、`edit`、`frontmatter_update`、`write` 等 ReMe 文件 jobs 创建或编辑
-- **索引**：每次成功写入后，ReMe 会刷新当天的 `index.md`
+### Markdown、Frontmatter 与 Wikilink
 
-### mem_session/dialog/\*.jsonl（来源对话）
+一条记忆通常由 YAML frontmatter、正文和 Wikilink 组成：
 
-抽取记忆前，ReMe 会把相关消息保存为 session log。保存时会去掉 tool result 和 base64 数据块，避免未来的 Auto-Memory
-把“检索出来的旧记忆”或大媒体内容误当成用户新提供的事实。
+```markdown
+---
+name: 用户偏好的发布流程
+description: 用户希望先在测试环境验证，再安排生产发布。
+source_conversation: "[[mem_session/dialog/session-42.jsonl]]"
+---
 
-- **位置**：默认 `{working_dir}/mem_session/dialog/<session_id>.jsonl`
-- **用途**：为每日记忆提供可追溯的来源
-- **链接**：每日记忆 frontmatter 会通过 `[[mem_session/dialog/<session_id>.jsonl]]` 链接回来源会话
+# 发布偏好
 
-### digest/（梦境记忆）
+任何生产发布都应先执行 [[digest/procedure/staging-verification.md]]。
 
-`digest/` 是长期知识层，也是知识库真正进化的部分。Auto-Dream 读取近期每日记忆，提取可复用的 memory unit，把每个 unit
-整合进一个 digest 节点，更新 dream catalog，并写入主动交互使用的兴趣主题。
+## Sources
 
-- **位置**：`{working_dir}/digest/`
-- **Bucket**：`personal/`（用户、团队、项目身份、偏好与约定）、`procedure/`（how-to 工作流、runbook、可复用方法）、
-  `wiki/`（定义、原则、观察、作为先例的决策）
-- **进化而非追加**：每个 unit 以 `CREATE`、`CORROBORATE`、`REFINE`、`CORRECT` 之一整合，重复事实会被合并强化而非制造副本
-- **Wikilink 图**：节点带有来源边（`derived_from:: [[memory/<date>/<note>.md]]`）与关系边
-  （`relates_to:: [[digest/...]]`），让 digest 记忆保持可追溯、可连通；`memory_search` 会沿这些链接展开
-- **更新**：ReMe `auto_dream`，通常由 `dream_cron` 定时触发
-
-### resource/（资源记忆）
-
-`resource/` 下的文件会被监听和编目。支持的文件发生变化时，ReMe 可以通过 `auto_resource` 将其解释为带来源链接的每日记忆。
-
-- **位置**：`{working_dir}/resource/`
-- **默认支持后缀**：`md`、`txt`、`json`、`jsonl`、`csv`、`yaml`、`html`
-- **日期归属**：直接放在 `resource/` 下的文件归入当天；`resource/YYYY-MM-DD/`
-  下的文件归入指定日期，且可继续使用子目录
-- **输出**：生成或更新 `memory/YYYY-MM-DD/<note>.md`，frontmatter 中保留
-  `source_resource` 链接
-- **Inbox 行为**：只有实际修改记忆时，资源处理结果才会推送到 inbox
-
-```text
-resource/report.txt                    # 归入当天
-resource/2026-07-14/report.txt         # 归入 2026-07-14
-resource/2026-07-14/project/data.json  # 日期目录下可使用子目录
+- [[memory/2026-08-06/release-discussion.md]]
 ```
 
-> Auto Resource 当前按 UTF-8 文本读取资源。PDF、Word、Excel、图片等二进制文件不在监听后缀中，
-> 不会被自动解析；请先转换为上述受支持的文本格式。`yml` 也不在默认白名单中，请使用 `yaml`。
-
-> 关于 Auto-Memory、Auto-Dream、Auto-Memory-Search 和 Proactive
-> 的完整工作流介绍，请参阅 [智能体记忆进化与主动交互](./memory-evolving-and-proactive)。以下仅补充技术实现细节与配置说明。
+Frontmatter 提供节点级摘要与来源元数据；正文保存事实、条件和解释；`[[...]]` 使用工作区相对路径建立文件关系。搜索命中文件后，ReMe 可以从图索引中展开它的入链和出链，让 Agent 同时看到相关长期节点与来源。
 
 ---
 
-## 搜索记忆
+## Auto-Memory：把对话变成每日记忆
 
-Agent 有两种方式找回过去的记忆：
+Auto-Memory 是个人知识库的入口。它不会保存聊天流水账，而是提取以后仍可能有用的信息，例如：
 
-| 方式     | 工具            | 适用场景                           | 示例                                     |
-| -------- | --------------- | ---------------------------------- | ---------------------------------------- |
-| 混合检索 | `memory_search` | 不确定记在哪个文件，按意图模糊召回 | "之前关于部署流程的讨论"                 |
-| 直接读取 | 文件工具        | 已知具体日期或文件路径，精确查阅   | 读取 `memory/2026-06-29/project-plan.md` |
+- 稳定偏好和长期约定；
+- 项目背景、关键事实和限制条件；
+- 已确认的决策及其原因；
+- 当前进展、阻塞项和下一步；
+- 可复用的命令、流程和排查经验。
 
-### 混合检索原理
-
-`memory_search` 会调用 ReMe 的 `search` job。搜索始终尝试 BM25 关键词检索；当配置了 embedding 模型时，也会同时运行向量检索。
-两路都有结果时，ReMe 使用 **Reciprocal Rank Fusion（RRF）** 融合排序。
-
-#### 向量语义搜索
-
-将文本映射到高维向量空间，通过余弦相似度衡量语义距离，能捕捉意义相近但措辞不同的内容：
-
-| 查询                   | 能召回的记忆                       | 为什么能命中                     |
-| ---------------------- | ---------------------------------- | -------------------------------- |
-| "项目的数据库选型"     | "最终决定用 PostgreSQL 替换 MySQL" | 语义相关：都在讨论数据库技术选择 |
-| "怎么减少不必要的重建" | "配置了增量编译避免全量构建"       | 语义等价：减少重建 ≈ 增量编译    |
-| "上次讨论的性能问题"   | "P99 延迟从 800ms 优化到 200ms"    | 语义关联：性能问题 ≈ 延迟优化    |
-
-但向量搜索对**精确、高信号的 token** 表现较弱，因为嵌入模型倾向于捕捉整体语义而非单个 token 的精确匹配。
-
-#### BM25 关键词检索
-
-基于词频统计进行子串匹配，对精确 token 命中效果极佳，但在语义理解（同义词、改写）方面较弱。
-
-| 查询                       | BM25 能命中            | BM25 会漏掉                    |
-| -------------------------- | ---------------------- | ------------------------------ |
-| `handleWebSocketReconnect` | 包含该函数名的记忆片段 | "WebSocket 断线重连的处理逻辑" |
-| `ECONNREFUSED`             | 包含该错误码的日志记录 | "数据库连接被拒绝"             |
-
-ReMe 会为被索引文件维护本地 BM25 索引。它适合命中精确标识符、错误码、文件名和低频词；即使没有配置 embedding，也能提供关键词召回。
-
-#### 混合检索融合
-
-当向量检索和 BM25 都返回候选时，ReMe 使用加权 RRF 融合。默认向量权重为 `0.7`，剩余 `0.3` 给关键词检索。
-
-1. **扩大候选池**：将最终需要的结果数乘以 `candidate_multiplier`（默认 3 倍，上限 200），两路分别检索更多候选
-2. **独立排序**：向量和 BM25 各自返回排序后的候选列表
-3. **RRF 合并**：按 chunk id 去重，并叠加基于排名的贡献：
-   - 向量贡献：`0.7 / (60 + vector_rank)`
-   - 关键词贡献：`0.3 / (60 + keyword_rank)`
-   - 两路都命中的 chunk 会获得两份贡献
-4. **排序截断**：按 `final_score` 降序排列，返回 top-N 结果
-5. **链接展开**：搜索结果可附带相关链接文件上下文，帮助理解命中片段
-
-**示例**：查询 `"handleWebSocketReconnect 断线重连"`
-
-| 记忆片段                                               | 向量排序 | BM25 排序 | 排名靠前原因                           |
-| ------------------------------------------------------ | -------- | --------- | -------------------------------------- |
-| "handleWebSocketReconnect 函数负责 WebSocket 断线重连" | 2        | 1         | 语义匹配强，同时精确命中关键词         |
-| "网络断开后自动重试连接的逻辑"                         | 1        | -         | 语义匹配强，即使没有精确函数名也能召回 |
-| "修复了 handleWebSocketReconnect 的空指针异常"         | -        | 2         | 精确标识符命中，使其保留在候选集中     |
+### 工作原理
 
 ```mermaid
-graph LR
-    Query[搜索查询] --> Vector[向量语义搜索 x0.7]
-    Query --> BM25[BM25 关键词检索 x0.3]
-    Vector --> Merge[按 chunk 去重 + 加权 RRF]
-    BM25 --> Merge
-    Merge --> Sort[按融合分数降序排列]
-    Sort --> Results[返回 top-N 结果]
+flowchart LR
+    A[累计 N 个用户回合] --> B[筛选本批对话消息]
+    B --> C[清理工具结果与大块 Base64 数据]
+    C --> D[追加到 mem_session/dialog/session.jsonl]
+    D --> E[LLM 判断值得记住的内容]
+    E --> F[创建或更新 memory/date/note.md]
+    F --> G[刷新 date 索引并增量更新搜索索引]
 ```
 
-> **总结**：单独使用任何一种检索方式都存在盲区。混合检索让两种信号互补，无论是「自然语言提问」还是「精确查找」，都能获得可靠的召回结果。
+QwenPaw 默认每累计 5 个用户回合触发一次。触发后，ReMe 先按 `session_id` 保存来源对话，再查找当天属于该会话的已有记忆卡片；如果已有卡片则更新，否则创建新卡片。自动搜索注入的旧记忆会在抽取前移除，避免把“召回内容”误写成用户刚刚提供的新事实。
 
-### 验证向量检索是否生效
+当上下文即将压缩时，如果还有未达到触发间隔的待保存回合，`summarize_when_compact` 可以让它们提前进入同一条 Auto-Memory 流程。
 
-可以让 Agent 调用 `memory_search` 并原样返回工具结果。把 `xxx` 替换成要测试的查询：
+### 配置
+
+配置位于 `agent.json` 的 `running.reme_light_memory_config`：
+
+```json
+{
+  "running": {
+    "memory_manager_backend": "remelight",
+    "reme_light_memory_config": {
+      "auto_memory_interval": 5,
+      "summarize_when_compact": true,
+      "inbox_push_enabled": true
+    }
+  }
+}
+```
+
+| 配置项                   | 默认值 | 说明                                                       |
+| ------------------------ | ------ | ---------------------------------------------------------- |
+| `auto_memory_interval`   | `5`    | 每累计 N 个用户回合触发；`null` 或 `<= 0` 表示关闭周期触发 |
+| `summarize_when_compact` | `true` | 上下文压缩前是否保存尚未处理的回合                         |
+| `inbox_push_enabled`     | `true` | Auto-Memory 实际修改记忆后，是否把任务结果推送到 Inbox     |
+
+间隔设得越小，记忆更新越及时，但模型调用、Token 消耗和后台任务负担也越高。
+
+### Inbox
+
+开启 `inbox_push_enabled` 后，Auto-Memory 的执行结果会进入 QwenPaw Inbox。若本次判断没有值得新增或更新的内容，ReMe 会标记 `modified=false`，QwenPaw 不会为这次空变更生成 Inbox 事件。
+
+### 示例
+
+假设用户在 `session-42` 中说：
 
 ```text
-请调用 memory_search 工具搜索 "xxx"。请原样返回工具结果，包括所有分隔线以及
-score、vector、keyword 字段，不要总结或改写。
+以后所有生产发布都先跑 staging 验证；发布说明用中文，列出风险和回滚步骤。
 ```
 
-若要验证语义召回而不是关键词匹配，可以先保存一条记忆，例如
-“我首选的通勤工具是一辆轻便自行车。”，再搜索“用户平时怎样去上班？”。两句话没有明显的关键词重合，
-但语义相近，因此更容易观察向量检索是否命中。
-
-下面的分数仅用于说明输出格式：
-
-**仅向量分支命中：**
+达到触发间隔后，Auto-Memory 会保留来源对话，并生成或更新类似文件：
 
 ```text
-========== memory/2026-07-23/commute.md:1-6 [score=0.8237] ==========
-我首选的通勤工具是一辆轻便自行车。
+mem_session/dialog/session-42.jsonl
+memory/2026-08-06/release-discussion.md
 ```
 
-此时 `score` 是原始余弦相似度。
+```markdown
+---
+name: 生产发布约定
+description: 生产发布前先验证 staging，中文发布说明需包含风险和回滚步骤。
+source_conversation: "[[mem_session/dialog/session-42.jsonl]]"
+---
 
-**仅 BM25 分支命中：**
-
-```text
-========== memory/2026-07-23/commute.md:1-6 [score=3.1842] ==========
-我首选的通勤工具是一辆轻便自行车。
+- 生产发布前必须先完成 staging 验证。
+- 发布说明使用中文，并列出风险与回滚步骤。
 ```
 
-此时 `score` 是原始 BM25 分数。只有 `[score=...]` 时，单看数值不能严格判断是哪一路；
-应结合查询是否存在精确关键词，或者查看下面的检索日志。
-
-**两路均有候选的混合检索：**
-
-```text
-========== memory/2026-07-23/commute.md:1-6 [score=0.0164 vector=0.8237 keyword=3.1842] ==========
-我首选的通勤工具是一辆轻便自行车。
-
-========== memory/2026-07-20/purchase.md:3-7 [score=0.0113 vector=0.7915 keyword=-] ==========
-用户买了一辆轻便的两轮交通工具。
-
-========== memory/2026-07-18/maintenance.md:2-5 [score=0.0048 vector=- keyword=2.5176] ==========
-周末安排了自行车维护。
-```
-
-- `score`：RRF 融合分数
-- `vector`：原始向量余弦相似度；出现数值可直接确认向量分支返回了该结果
-- `keyword`：原始 BM25 分数
-- `-`：该结果没有被对应分支召回
-
-日志中的 `vector_hits=N keyword_hits=M` 可以确认每一路返回的候选数量。Embedding
-健康检查还会发送一次 `"ping"` 测试请求，并校验返回向量维度：
-
-```text
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> OK
-```
-
-`-> OK` 表示 embedding 服务可访问且返回维度与配置一致。失败时日志会包含原因，例如：
-
-```text
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL timeout(5.0s)
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL RuntimeError: embedding dimension mismatch: <actual> != <configured>
-[EMBEDDING HEALTH CHECK] name=default workspace_dir=<workspace> -> FAIL <ExceptionType>: <message>
-```
-
-健康检查会在加载持久化 chunk、发现缺失向量并需要 backfill 时运行；如果已有 chunk
-都包含有效向量，它不一定在每次启动时出现。此时搜索结果中的数值 `vector=...`
-仍是向量分支实际命中的直接证据。
+这还是“每日素材”；当相同偏好在更多对话中出现，Auto-Dream 会把它沉淀进稳定的 `digest/` 节点。
 
 ---
 
-## 记忆配置
+## Auto-Dream：让个人知识库持续进化
 
-### 配置结构
+Auto-Dream 是从每日记忆到长期知识的整合流程。它默认每天定时运行，扫描近期有变化的每日记忆，提取可长期复用的 memory unit，更新 `digest/`，同时生成可供主动交互使用的兴趣主题。
 
-记忆配置位于 `agent.json` 的 `running.reme_light_memory_config` 中：
+### 工作原理
 
-| 配置项                   | 说明                                                                                | 默认值           |
-| ------------------------ | ----------------------------------------------------------------------------------- | ---------------- |
-| `metadata_dir`           | ReMe 持久状态目录，用于保存索引、catalog、graph 和缓存                              | `"mem_metadata"` |
-| `session_dir`            | 来源对话保存目录                                                                    | `"mem_session"`  |
-| `mem_session_dir`        | ReMe 内部 memory-agent 会话目录                                                     | `"mem_agent"`    |
-| `resource_dir`           | `auto_resource` 监听的资源目录                                                      | `"resource"`     |
-| `daily_dir`              | 每日记忆目录                                                                        | `"memory"`       |
-| `digest_dir`             | dream/digest 记忆目录                                                               | `"digest"`       |
-| `summarize_when_compact` | 是否在上下文压缩前将待保存回合提交给 Auto-Memory                                    | `true`           |
-| `inbox_push_enabled`     | 是否将 `auto_memory`、`auto_dream`、`auto_resource` 的 job 结果推送到 QwenPaw inbox | `true`           |
-| `auto_memory_interval`   | 每隔 N 个用户回合触发 Auto-Memory。`None` 或 `<= 0` 表示禁用周期自动记忆            | `5`              |
-| `dream_cron_enabled`     | 是否启用按 Cron 定时执行的 Auto-Dream 任务                                          | `true`           |
-| `dream_cron`             | Auto-Dream 任务的有效 5 段 Cron 表达式（启用时必填）；触发后随机延迟 0–60 秒启动    | `"0 23 * * *"`   |
+QwenPaw 的 Auto-Dream 默认扫描目标日期及其前一天（`scan_days=2`），最多抽取 5 个 memory unit，分四个阶段执行：
 
-### 重建记忆搜索索引
+```mermaid
+flowchart LR
+    A[Extract<br/>扫描变化并提取 units/topics] --> B[Integrate + Auto-Link<br/>新建、合并、修正、连边]
+    B --> C[Topics<br/>选择非重复兴趣主题]
+    C --> D[Finish<br/>保存处理进度]
+```
 
-重建索引是一项显式维护操作，仅建议用于修复索引损坏或搜索结果异常。该操作会清空并重新创建 ReMe 搜索索引，
-执行期间 CPU 和内存占用可能明显升高。只有使用 ReMeLight 记忆后端且记忆管理器正在运行的智能体支持此操作。
+1. **Extract**：刷新日期索引，比对 dream catalog，只把新增或修改的每日记忆交给 LLM；抽取 `personal`、`procedure`、`wiki` 三类 unit 和兴趣主题候选。
+2. **Integrate + Auto-Link**：对每个 unit 调用 `node_search` 查找可能相同或相关的 digest 节点，再选择 `CREATE`、`CORROBORATE`、`REFINE` 或 `CORRECT`。
+3. **Topics**：结合最近 7 天的主题去重，默认最多写入 3 个主题到 `memory/<date>/interests.yaml`。
+4. **Finish**：把成功处理的输入写入 dream catalog；失败路径不做 checkpoint，下一次仍可重试。
 
-在控制台中，打开智能体配置，在**长期记忆**区域选择**重建记忆索引**，阅读警告后确认执行。也可以调用以下
-同步维护 API：
+Auto-Dream 不改写每日记忆正文。`memory/` 保留当时发生的事实与现场，`digest/` 保存跨时间复用的抽象。
+
+### Auto-Link 在哪里发生
+
+Auto-Link 不是独立的定时任务，而是 Auto-Dream 的 **Integrate** 阶段：
+
+- `node_search` 只召回 `digest/` 节点的 `name`、`description` 和路径，用于去重与关系发现；
+- 相同抽象会更新已有节点，而不是重复创建；
+- digest 节点的 `## Sources` 链接回 `memory/` 中的证据；
+- 相关 digest 节点通过正文中的 `[[digest/...]]` 相互连接；
+- 更新节点时保留既有来源和 Wikilink，知识图谱因此持续生长。
+
+四种整合动作的含义如下：
+
+| 动作          | 含义                                       |
+| ------------- | ------------------------------------------ |
+| `CREATE`      | 没有相同抽象，创建新的长期节点             |
+| `CORROBORATE` | 新材料再次证明已有记忆，补充来源或强化表述 |
+| `REFINE`      | 新材料增加步骤、边界、条件或细节           |
+| `CORRECT`     | 新材料修正旧节点中的错误、遗漏或冲突       |
+
+### 配置
+
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "dream_cron_enabled": true,
+      "dream_cron": "0 23 * * *",
+      "inbox_push_enabled": true
+    }
+  }
+}
+```
+
+| 配置项               | 默认值         | 说明                                                           |
+| -------------------- | -------------- | -------------------------------------------------------------- |
+| `dream_cron_enabled` | `true`         | 是否启用定时 Auto-Dream                                        |
+| `dream_cron`         | `"0 23 * * *"` | 5 段 Cron 表达式；触发后随机延迟 0–60 秒启动，避免任务集中运行 |
+| `inbox_push_enabled` | `true`         | 是否把 Auto-Dream 任务结果推送到 Inbox                         |
+
+### Inbox
+
+开启 Inbox 推送后，每次 Auto-Dream 的成功或失败摘要都会形成记忆事件，便于查看扫描、整合和主题生成结果。它只用于通知，不是记忆源数据；真正的长期知识仍保存在 `digest/` Markdown 中。
+
+### 示例
+
+假设近两天的每日记忆多次出现“发布前验证 staging”和“发布说明必须带回滚步骤”。Auto-Dream 可能：
+
+1. 通过 `node_search` 找到已有的 `digest/procedure/production-release.md`；
+2. 选择 `REFINE`，把中文说明、风险列表和回滚步骤补入该流程；
+3. 在 `## Sources` 中加入新的每日记忆链接；
+4. 链接相关的 `[[digest/personal/release-communication-preference.md]]`；
+5. 在当天 `interests.yaml` 中加入“检查生产发布流程是否覆盖回滚演练”的候选主题。
+
+结果不是又复制一份聊天摘要，而是已有长期知识被证据强化并补全关系。
+
+---
+
+## Memory Index 与 Memory Search
+
+`memory_index` 负责让文件持续可检索，`memory_search` 负责在需要时召回最相关的内容。索引是派生状态，可以从 `memory/` 与 `digest/` 的 Markdown 重新构建。
+
+### 索引能力与范围
+
+QwenPaw 启动嵌入式 ReMe 后，后台 `index_update_loop` 会：
+
+- 启动时扫描 `daily_dir`（默认 `memory`）和 `digest_dir`（默认 `digest`）；
+- 运行期间监听这两个目录下新增、修改和删除的 `.md` 文件；
+- 按 Markdown 标题与内容块进行语义分块，保留文件路径和行号；
+- 为每个 chunk 更新 BM25 索引，并在启用 Embedding 时生成向量；
+- 从 Markdown 中解析 Wikilink，更新文件节点和双向关系图；
+- 将派生状态持久化到 `mem_metadata/`。
+
+单个被索引文件上限为 10 MiB。`resource/` 与 `mem_session/` 不在这一索引监听范围内。
+
+### BM25 + Vector 混合索引如何构建
+
+```mermaid
+flowchart LR
+    A[memory/**/*.md<br/>digest/**/*.md] --> B[监听文件变化]
+    B --> C[Markdown 结构化分块]
+    C --> D[FileChunk<br/>文本 + 路径 + 行号]
+    D --> E[BM25 倒排索引]
+    D --> F[Embedding 向量<br/>可选]
+    C --> G[Wikilink 图]
+    E --> H[mem_metadata]
+    F --> H
+    G --> H
+```
+
+BM25 把每个 chunk 当作一篇文档，记录 token、词频和倒排表，适合函数名、错误码、专有名词等精确命中。启用 Embedding 后，同一 chunk 还会生成向量，用于召回措辞不同但语义相近的内容。
+
+Embedding 的支持后端、启用条件、字段含义、缓存和排查方法请参阅独立文档：[Embedding 向量模型](./embedding)。未配置 Embedding 时，BM25 和 Wikilink 展开仍可正常工作。
+
+### BM25 + Vector 如何进行混合搜索
+
+`memory_search(query, max_results, min_score)` 会调用 ReMe 的 `search` job：
+
+```mermaid
+flowchart LR
+    A[查询] --> B[扩大候选池<br/>limit × 3，最多 200]
+    B --> C[Vector 召回]
+    B --> D[BM25 召回]
+    C --> E[按 chunk id 去重并做 RRF 融合]
+    D --> E
+    E --> F[min_score 过滤并取 Top N]
+    F --> G[展开命中文件的入链与出链]
+    G --> H[片段 + 路径 + 行号 + 相关节点]
+```
+
+当两路都有结果时，默认使用加权 Reciprocal Rank Fusion（RRF）：
+
+```text
+score = 0.7 / (60 + vector_rank)
+      + 0.3 / (60 + keyword_rank)
+```
+
+RRF 比较的是各自结果列表中的排名，不直接比较数值尺度完全不同的余弦相似度和 BM25 分数。一个 chunk 同时被两路命中时会累加两份贡献；只被一路命中时仍可进入最终结果。若 Embedding 未启用或向量分支没有结果，则直接使用 BM25 排名。
+
+完成融合后，ReMe 会按命中文件从图索引中展开最多 10 条出链和 10 条入链。这样结果既包含最相关的正文片段，也能带出其来源、相关流程和相邻知识节点。
+
+> `min_score` 默认是 `0`。正常使用建议保持默认值，因为单路检索的原始分数与混合检索的 RRF 分数量纲不同，盲目提高阈值可能隐藏有效结果。
+
+### 手动搜索与 Auto-Memory-Search
+
+Agent 可以在判断需要历史信息时主动调用 `memory_search`。如果希望每个普通用户请求都先自动召回记忆，可启用 Auto-Memory-Search：
+
+```json
+{
+  "running": {
+    "reme_light_memory_config": {
+      "auto_memory_search_config": {
+        "enabled": true,
+        "max_results": 2
+      }
+    }
+  }
+}
+```
+
+启用后，QwenPaw 会在模型处理当前用户请求前，用这条请求构造查询并执行同一个 ReMe `search` job。结果以一组已完成的 `memory_search` 工具交互注入当前 live context，供本轮后续模型调用使用。自动化来源的请求不会触发；注入结果也不会被写回会话历史或 Auto-Memory，避免记忆自我复制。
+
+| 配置项        | 默认值  | 说明                               |
+| ------------- | ------- | ---------------------------------- |
+| `enabled`     | `false` | 是否为每个普通用户请求自动搜索记忆 |
+| `max_results` | `2`     | 每次自动搜索最多注入的结果数       |
+
+### 搜索示例
+
+已有记忆：
+
+```text
+memory/2026-08-06/release-discussion.md
+digest/procedure/production-release.md
+```
+
+用户问“我们上线前要做哪些检查？”时，`memory_search` 可以同时利用：
+
+- **Vector**：把“上线前检查”与“生产发布 staging 验证”按语义匹配；
+- **BM25**：精确命中 `staging`、`rollback` 等关键词；
+- **Wikilink**：从每日讨论展开到长期发布流程与相关偏好。
+
+返回结果形态类似：
+
+```text
+========== digest/procedure/production-release.md:1-18 [score=0.0162 vector=0.84 keyword=3.71] ==========
+...生产发布前先完成 staging 验证，并准备风险清单和回滚步骤...
+  outlinks (1):
+    -> digest/personal/release-communication-preference.md
+  inlinks (1):
+    <- memory/2026-08-06/release-discussion.md
+```
+
+Agent 可根据返回的路径和行号继续精确读取原文件。
+
+### ReMeLight 完整配置
+
+所有字段都位于 `running.reme_light_memory_config`：
+
+| 配置项                      | 默认值           | 说明                                                   |
+| --------------------------- | ---------------- | ------------------------------------------------------ |
+| `metadata_dir`              | `"mem_metadata"` | 索引、图谱、catalog 与缓存目录                         |
+| `session_dir`               | `"mem_session"`  | Auto-Memory 来源对话目录                               |
+| `mem_session_dir`           | `"mem_agent"`    | ReMe 内部 memory-agent 会话目录                        |
+| `resource_dir`              | `"resource"`     | Auto-Resource 监听目录                                 |
+| `daily_dir`                 | `"memory"`       | 每日记忆目录                                           |
+| `digest_dir`                | `"digest"`       | 长期知识库目录                                         |
+| `summarize_when_compact`    | `true`           | 上下文压缩前是否保存待处理回合                         |
+| `inbox_push_enabled`        | `true`           | 是否推送自动记忆任务结果到 Inbox                       |
+| `auto_memory_interval`      | `5`              | Auto-Memory 的用户回合间隔                             |
+| `dream_cron_enabled`        | `true`           | 是否启用定时 Auto-Dream                                |
+| `dream_cron`                | `"0 23 * * *"`   | Auto-Dream 的 5 段 Cron 表达式                         |
+| `auto_memory_search_config` | 见上文           | 自动记忆搜索配置                                       |
+| `embedding_model_config`    | 默认未启用       | 可选向量模型配置，见 [Embedding 向量模型](./embedding) |
+
+### 重建索引
+
+索引通常由后台增量维护。只有索引损坏或搜索结果明显异常时，才需要在 Console 的 Agent 长期记忆设置中选择**重建记忆索引**，或调用：
 
 ```http
 POST /api/agents/{agentId}/memory/reindex
 ```
 
-重建成功时返回 `{"status":"completed"}`。同一智能体同时只能执行一个重建任务；重复请求会返回 HTTP `409`。
-非 ReMeLight 后端会返回 `400`，智能体不存在时返回 `404`，ReMe 不可用时返回 `503`，重建任务失败时返回 `500`。
-
-> `rebuild_memory_index_on_start` 已不再支持，请从 `agent.json` 中删除该字段；确实需要重建索引时，请改用
-> 控制台操作或上述 API。
-
-### 自动记忆搜索配置
-
-在 `running.reme_light_memory_config.auto_memory_search_config` 中配置：
-
-启用后，搜索结果会作为已完成的 `memory_search` 交互注入当前 live context。
-同一轮工具循环里的后续模型调用仍可读取这些结果，直到常规上下文管理将其驱逐。
-
-| 配置项        | 说明                             | 默认值  |
-| ------------- | -------------------------------- | ------- |
-| `enabled`     | 是否在每次对话时自动执行记忆搜索 | `false` |
-| `max_results` | 自动搜索时最多返回的结果数       | `2`     |
-
-### Embedding 配置（可选）
-
-Embedding 配置用于向量语义搜索，位于 `running.reme_light_memory_config.embedding_model_config`：
-
-| 配置项             | 说明                                                                                  | 默认值   |
-| ------------------ | ------------------------------------------------------------------------------------- | -------- |
-| `backend`          | Embedding 后端类型：`openai`、`dashscope`、`dashscope_multimodal`、`gemini`、`ollama` | `openai` |
-| `api_key`          | Embedding 服务的 API Key。OpenAI 兼容和 Gemini 后端必填                               | ``       |
-| `base_url`         | OpenAI 兼容后端的可选自定义 API 地址；Ollama 后端会作为 host 传递                     | ``       |
-| `model_name`       | Embedding 模型名称                                                                    | ``       |
-| `dimensions`       | Embedding 向量维度                                                                    | `1024`   |
-| `enable_cache`     | 是否启用 Embedding 缓存                                                               | `true`   |
-| `use_dimensions`   | 是否在 API 请求中传递 dimensions 参数                                                 | `false`  |
-| `max_cache_size`   | Embedding 缓存最大条目数                                                              | `10000`  |
-| `max_input_length` | 单次 Embedding 的近似字符预算                                                         | `8192`   |
-| `max_batch_size`   | Embedding 批处理最大数量                                                              | `10`     |
-
-> `use_dimensions` 用于某些 vLLM 模型不支持 dimensions 参数的情况，设为 `false` 可跳过该参数。
-
-从 ReMe 0.4.1.0 开始，Embedding 输入截断会为 token 密度更高的 CJK 和其他全角字符采用更保守的预算，
-并预留安全余量。这可以避免较长的中文记忆在 Ollama + bge-m3 等组合下超过模型上下文窗口并返回 HTTP 400。
-`max_input_length` 仍是近似字符预算，并非模型 tokenizer 计算出的严格 token 上限；如果所用模型的上下文窗口更小，
-仍应相应调低该值。
-
-向量检索只有在当前后端具备最低可运行配置时才会启用；这些条件与 AgentScope credential 要求保持一致：
-
-| 后端                                            | 启用条件                         | Credential 映射                |
-| ----------------------------------------------- | -------------------------------- | ------------------------------ |
-| `openai` / `dashscope` / `dashscope_multimodal` | `model_name` 和 `api_key` 均非空 | `api_key`；可选 `base_url`     |
-| `gemini`                                        | `model_name` 和 `api_key` 均非空 | `api_key`                      |
-| `ollama`                                        | `model_name` 非空                | 可选 `host`（来自 `base_url`） |
-
-### 索引行为
-
-嵌入式 ReMe 配置使用本地 file store：
-
-| 组件       | 行为                                                              |
-| ---------- | ----------------------------------------------------------------- |
-| File store | ReMe 本地文件存储，持久状态位于 `mem_metadata/`                   |
-| 关键词索引 | 默认启用 BM25 关键词索引                                          |
-| 向量索引   | 仅当 `embedding_model_config` 满足当前 `backend` 的启用条件时启用 |
-| 监听目录   | `daily_dir` 和 `digest_dir`                                       |
-| 监听后缀   | `md`                                                              |
+重建会清空并从现有 `memory/`、`digest/` Markdown 重新生成派生索引，期间 CPU 和内存占用可能升高。同一 Agent 同时只能运行一个重建任务。`rebuild_memory_index_on_start` 已不再支持。
 
 ---
 
@@ -457,8 +475,7 @@ QwenPaw 的记忆系统采用可插拔的 Backend 架构。除了默认的 ReMeL
 
 ## 相关页面
 
-- [智能体记忆进化](./memory-evolving-and-proactive) — Auto-Memory、Auto-Dream、Auto-Memory-Search、Proactive 完整工作流
-- [项目介绍](./intro) — 这个项目可以做什么
+- [智能体记忆进化](./memory-evolving-and-proactive) — Auto-Memory、Auto-Dream、Auto-Memory-Search 与 Proactive 工作流
+- [Embedding 向量模型](./embedding) — 向量模型能力、后端、配置与排查
 - [控制台](./console) — 在控制台管理记忆与配置
-- [Skills](./skills) — 内置与自定义能力
-- [配置与工作目录](./config) — 工作目录与 config
+- [配置与工作目录](./config) — 工作目录与 Agent 配置

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -296,6 +296,7 @@
     "mcp": "MCP & Built-in Tools",
     "acpServer": "ACP Integration",
     "memory": "Memory",
+    "embedding": "Embedding Models",
     "memoryEvolvingAndProactive": "Memory-Evolving & Proactive",
     "codingMode": "Coding Mode",
     "computerUse": "Computer Use",

--- a/website/src/i18n/locales/pt-BR.json
+++ b/website/src/i18n/locales/pt-BR.json
@@ -279,6 +279,7 @@
     "mcp": "MCP e Ferramentas Integradas",
     "acpServer": "Integracao ACP",
     "memory": "Memoria",
+    "embedding": "Modelos de Embedding",
     "memoryEvolvingAndProactive": "Memoria Evolutiva e Proativa",
     "codingMode": "Modo Coding",
     "creator": "Creator: Plataforma Agentic de Criação de Vídeo",

--- a/website/src/i18n/locales/zh.json
+++ b/website/src/i18n/locales/zh.json
@@ -296,6 +296,7 @@
     "mcp": "MCP 与内置工具",
     "acpServer": "ACP 集成",
     "memory": "记忆",
+    "embedding": "Embedding 向量模型",
     "memoryEvolvingAndProactive": "记忆进化与主动交互",
     "codingMode": "Coding 模式",
     "computerUse": "电脑操作",

--- a/website/src/pages/Docs/navigation.ts
+++ b/website/src/pages/Docs/navigation.ts
@@ -28,6 +28,7 @@ export const DOC_GROUPS: DocGroup[] = [
       { slug: "cron", titleKey: "docs.cron" },
       { slug: "heartbeat", titleKey: "docs.heartbeat" },
       { slug: "memory", titleKey: "docs.memory" },
+      { slug: "embedding", titleKey: "docs.embedding" },
       {
         slug: "memory-evolving-and-proactive",
         titleKey: "docs.memoryEvolvingAndProactive",


### PR DESCRIPTION
## Description

### 背景

当前 Embedding 配置分散在通用配置与记忆文档中，部分字段的运行语义也不够明确，例如 `dimensions` 与 `use_dimensions` 的区别、输入长度的估算方式，以及配置保存后的生效时机。此次补充独立指南，帮助用户完成后端选择、凭证填写、连通性验证与常见问题排查。

### 本次改动

- 新增中英文 Embedding 模型指南，覆盖 OpenAI-compatible、DashScope、Gemini 与 Ollama 的配置示例、启用条件和排障建议。
- 详细解释 `dimensions`、`use_dimensions`、`max_input_length`、缓存和批处理参数，说明维度校验与 OpenAI 请求参数之间的差异。
- 更新中英文配置文档，补充测试服务、保存配置、热更新与自动重载的行为说明。
- 重整中英文 Memory 及 Memory-Evolving & Proactive 文档，使 Embedding、索引重建和运行时行为的描述保持一致。
- 将新页面加入文档站导航，并补充英文、中文和葡萄牙语导航标题。

### 影响范围与独立性

本 PR 仅修改 `website/**` 下的文档、文档导航和文档站翻译，不包含后端、Console 业务逻辑或测试代码。它与对应的代码功能 PR 均直接基于 `main`，可独立评审和合并，无合并顺序要求。

**Related Issue:** 无

**Security Considerations:** 仅文档改动；示例使用占位凭证，不包含真实密钥。

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

- 运行文档站 TypeScript 项目检查：`npx tsc -b --noEmit`。
- 对本 PR 修改的 12 个 Markdown、JSON 和 TypeScript 文件运行 `npx prettier --check`。
- 运行 `git diff --check`，确认无空白错误。

## Evidence

```text
npx tsc -b --noEmit
# exit code 0

npx prettier --check <12 changed documentation files>
Checking formatting...
All matched files use Prettier code style!

git diff --check
# exit code 0
```

## Additional Notes

代码功能见 #6741；本 PR 不依赖该 PR 的提交历史。