### PR TITLE
fix(ci): export nightly coverage artifacts even when tests fail

### DIFF
--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -108,6 +108,7 @@ jobs:
 
       - name: Upload unit coverage data
         if: |
+          always() &&
           matrix.os == 'ubuntu-latest' &&
           matrix.python-version == '3.13'
         uses: actions/upload-artifact@v4
@@ -187,6 +188,7 @@ jobs:
 
       - name: Upload contract coverage data
         if: |
+          always() &&
           matrix.os == 'ubuntu-latest' &&
           matrix.python-version == '3.13'
         uses: actions/upload-artifact@v4
@@ -299,21 +301,36 @@ jobs:
           if [ -n "$QWENPAW_INTEGRATION_COVERAGE" ]; then
             # Subprocess coverage entry. Parent process must not carry
             # --cov, hence --no-cov here.
+            #
+            # Runtime coverage is collected by the app subprocesses
+            # regardless of pass/fail, so it must be exported even when
+            # tests fail. Under the default `bash -e`, a failing pytest
+            # aborts the script right here and the cp/xml steps below
+            # never run, silently dropping the artifact. Capture the
+            # exit code, export, then restore it so failures still fail.
+            set +e
             pytest tests/integration -v --no-cov \
               -n auto --dist=loadscope --timeout=300 -m integration
-            cp .integration_coverage/integration_subproc \
-              .coverage.integration
-            # `coverage xml` honours fail_under and exits 2 when below;
-            # tolerate that — the combined value is what matters.
-            coverage xml --data-file=.coverage.integration \
-              -o coverage.integration.xml || [ "$?" -eq 2 ]
+            PYTEST_RC=$?
+            set -e
+            if [ -f .integration_coverage/integration_subproc ]; then
+              cp .integration_coverage/integration_subproc \
+                .coverage.integration
+              # `coverage xml` honours fail_under and exits 2 when below;
+              # tolerate that — the combined value is what matters.
+              coverage xml --data-file=.coverage.integration \
+                -o coverage.integration.xml || [ "$?" -eq 2 ]
+            else
+              echo "::warning::Integration coverage data file missing despite QWENPAW_INTEGRATION_COVERAGE=1 (session may have crashed before coverage flush)"
+            fi
+            exit "$PYTEST_RC"
           else
             pytest tests/integration -v \
               -n auto --dist=loadscope --timeout=300 -m integration
           fi
 
       - name: Upload integration coverage data
-        if: steps.cov_flag.outputs.enabled == '1'
+        if: always() && steps.cov_flag.outputs.enabled == '1'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-integration-${{ matrix.os }}-py${{ matrix.python-version }}


### PR DESCRIPTION
> **提交人**: 张衡·Appraiser@QPQAT

## Summary

The nightly workflow must export coverage even when tests fail. Today the `integrated-tests` coverage export/upload is chained to pytest exiting 0: on any night with ≥1 failing integration case, `bash -e` aborts the run block at the failing `pytest` line, and the upload step is then skipped (no `if: always()`), so the coverage artifact is silently dropped on the runner.

Result: **9 consecutive nights (2026-07-28 → 2026-08-05) with no integration coverage data** — the tests genuinely ran every night and runtime coverage was genuinely collected, yet nothing reached the artifacts.

## Root cause (evidence chain)

Nightly runs (`full-tests-nightly`) and their integrated-tests results, checked run by run:

| Date | run id | integrated-tests result | integration artifacts | `INTEGRATION` in Coverage Report log |
|---|---|---|---|---|
| 07-27 | 30295442263 | 4/4 success | all present | 36 |
| 07-28 | 30389112849 | 4/4 failure | none | n/a |
| 07-29 | 30480742681 | 3 fail / windows success | windows only | 0 (windows data has zero hits) |
| 07-30 | 30572037154 | 4/4 failure | none | n/a |
| 07-31 | 30656555365 | 3 fail / windows success | windows only | 0 |
| 08-01 | 30712925059 | 4/4 failure | none | n/a |
| 08-02 | 30761526176 | 4/4 failure | none | n/a |
| 08-03 | 30843414044 | 3 fail / windows success | windows only | 0 |
| 08-04 | 30940502146 | 4/4 failure | none | n/a |

Key evidence from the failing ubuntu job log of 07-29 (run 30480742681):

- `== 1 failed, 442 passed ==` (only `test_import_local_copies_source` failed)
- `[integration coverage] HTML report: /home/runner/.../htmlcov-integration/index.html` → runtime coverage **was** collected and combined by the app subprocesses
- the log ends right after the pytest summary — no `cp .integration_coverage/integration_subproc`, no `coverage xml`, no upload record → the export was aborted by `bash -e` and the upload step was skipped
- contrast: the succeeding windows job of the same run shows `Artifact coverage-data-integration-windows-latest-py3.11 ... successfully uploaded!`

Structural gap vs e2e: in `_e2e-job.yml`, both `Stop backend and collect coverage` and `Upload E2E coverage data` carry `if: always()`, so e2e coverage survives failures/cancellation. `integrated-tests` was missing exactly that.

## Changes

1. `integrated-tests` → "Run integration suite": capture the pytest exit code (`set +e` / `PYTEST_RC` / `set -e`), export coverage anyway (`cp` + `coverage xml`, tolerating the fail-under exit code 2 as before), then `exit "$PYTEST_RC"` — **a failing suite still fails the step**. Emits a `::warning` if the subprocess data file is missing despite coverage being enabled.
2. `integrated-tests` → "Upload integration coverage data": `if: always() && steps.cov_flag.outputs.enabled == '1'`.
3. `unit-tests` / `contract-tests` coverage upload steps: add `always()` to the existing matrix gate. Same latent defect (upload gated on the test step succeeding); it has not fired only because those suites are currently green.

Not changed: failure semantics — any failing suite still turns the run red. The `coverage-report` job already runs under `if: always()` and needs no change.

## Verification

After merge: trigger `workflow_dispatch` (or wait for the next nightly). On a run where integration cases fail, the Coverage Report log should show the integration data files being combined and `INTEGRATION=<non-zero>`, and `coverage-data-integration-*` artifacts should exist for the failed matrix entries.

Known remaining issue (separate track): windows subprocess coverage data currently combines to a zero-hit xml (verified from the 07-29/07-31/08-03 windows artifacts: 668 files / 91921 lines / 0 lines hit). With this PR, ubuntu/macos data backs `INTEGRATION`; the windows zero-hit needs its own investigation.
