### PR TITLE
fix(sandbox): guard sandbox_config against non-dataclass values from …

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -28,6 +28,7 @@ from ...config.context import (
 from ...constant import WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
 from ...sandbox import ExecutionResult
+from ...sandbox.config import SandboxConfig
 
 
 def _kill_process_tree_win32(pid: int) -> None:
@@ -798,6 +799,11 @@ async def execute_shell_command(
         env["PATH"] = python_bin_dir + os.pathsep + existing_path
     else:
         env["PATH"] = python_bin_dir
+
+    if sandbox_config is not None and not isinstance(
+        sandbox_config, SandboxConfig
+    ):
+        sandbox_config = None
 
     if sandbox_config is not None:
         # Create a copy with resolved shell and timeout to avoid mutating

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -801,7 +801,8 @@ async def execute_shell_command(
         env["PATH"] = python_bin_dir
 
     if sandbox_config is not None and not isinstance(
-        sandbox_config, SandboxConfig
+        sandbox_config,
+        SandboxConfig,
     ):
         sandbox_config = None
 

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -1723,3 +1723,33 @@ async def test_execute_shell_command_win32_uses_windows_host():
 
     mock_win.assert_awaited_once()
     assert "win-ok" in result.content[0].text
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Unix-only direct subprocess path",
+)
+async def test_non_dataclass_sandbox_config_ignored(
+    monkeypatch,
+    tmp_path,
+):
+    """Model-supplied non-SandboxConfig value must not crash replace().
+
+    Regression test for GitHub issue #6731: when a model fills the
+    ``sandbox_config`` parameter with a plain JSON value (e.g. ``{}``),
+    ``dataclasses.replace()`` raises ``TypeError``. The fix discards
+    any non-``SandboxConfig`` value and falls through to direct
+    execution.
+    """
+    from qwenpaw.agents.tools.shell import execute_shell_command
+
+    monkeypatch.setenv("SHELL", "/bin/sh")
+
+    result = await execute_shell_command(
+        "echo hello",
+        cwd=tmp_path,
+        sandbox_config={},
+    )
+
+    assert "hello" in result.content[0].text


### PR DESCRIPTION
…model

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
