### PR TITLE
feat(chat): hide tool control during tool call streaming

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -71,12 +71,13 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
     ? `${inputProgress.truncated ? "…\n" : ""}${inputProgress.preview}`
     : "";
 
-  const showGear = content.status === "calling" && !!sessionId;
+  const isExecuting = content.status === "calling" && !inputProgress;
+  const showGear = isExecuting && !!sessionId;
 
   const control = useToolCallControl(
     sessionId,
     content.id,
-    content.status,
+    isExecuting,
     content.name || title,
   );
 

--- a/console/src/hooks/useToolCallControl.test.ts
+++ b/console/src/hooks/useToolCallControl.test.ts
@@ -59,7 +59,7 @@ describe("useToolCallControl", () => {
     }));
 
     const { result } = renderHook(() =>
-      useToolCallControl("backend-sid", "tc-1", "calling", "shell"),
+      useToolCallControl("backend-sid", "tc-1", true, "shell"),
     );
 
     await act(async () => {
@@ -103,7 +103,7 @@ describe("useToolCallControl", () => {
     });
 
     const { result } = renderHook(() =>
-      useToolCallControl("backend-sid", "tc-2", "calling"),
+      useToolCallControl("backend-sid", "tc-2", true),
     );
 
     await act(async () => {
@@ -128,7 +128,7 @@ describe("useToolCallControl", () => {
     });
 
     const { result } = renderHook(() =>
-      useToolCallControl("", "tc-retry", "calling", "shell"),
+      useToolCallControl("", "tc-retry", true, "shell"),
     );
 
     await act(async () => {
@@ -161,9 +161,9 @@ describe("useToolCallControl", () => {
     });
 
     const { rerender } = renderHook(
-      ({ status }: { status: string }) =>
-        useToolCallControl("backend-sid", "tc-fg", status, "shell"),
-      { initialProps: { status: "calling" } },
+      ({ calling }: { calling: boolean }) =>
+        useToolCallControl("backend-sid", "tc-fg", calling, "shell"),
+      { initialProps: { calling: true } },
     );
 
     await act(async () => {
@@ -172,7 +172,7 @@ describe("useToolCallControl", () => {
     });
 
     await act(async () => {
-      rerender({ status: "success" });
+      rerender({ calling: false });
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -192,7 +192,7 @@ describe("useToolCallControl", () => {
     });
 
     const { result } = renderHook(() =>
-      useToolCallControl("backend-sid", "tc-popup", "calling", "shell"),
+      useToolCallControl("backend-sid", "tc-popup", true, "shell"),
     );
 
     await act(async () => {
@@ -224,9 +224,9 @@ describe("useToolCallControl", () => {
     });
 
     const { rerender } = renderHook(
-      ({ status }: { status: string }) =>
-        useToolCallControl("backend-sid", "tc-bg-fast", status, "shell"),
-      { initialProps: { status: "calling" } },
+      ({ calling }: { calling: boolean }) =>
+        useToolCallControl("backend-sid", "tc-bg-fast", calling, "shell"),
+      { initialProps: { calling: true } },
     );
 
     await act(async () => {
@@ -235,7 +235,7 @@ describe("useToolCallControl", () => {
     });
 
     await act(async () => {
-      rerender({ status: "success" });
+      rerender({ calling: false });
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/console/src/hooks/useToolCallControl.ts
+++ b/console/src/hooks/useToolCallControl.ts
@@ -30,7 +30,7 @@ function resolveSessionId(sessionId: string): string {
 export function useToolCallControl(
   sessionId: string,
   toolCallId: string | undefined,
-  status: string,
+  isCalling: boolean,
   toolName?: string,
 ) {
   const [state, setState] = useState<ToolCallControlState>({
@@ -61,7 +61,6 @@ export function useToolCallControl(
   const toolNameRef = useRef(toolName || toolCallId || "");
   toolNameRef.current = toolName || toolCallId || "";
   const prevCallingRef = useRef(false);
-  const isCalling = status === "calling";
 
   const tryRegisterBackground = useCallback(
     (reason: string) => {


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

<img width="1758" height="288" alt="image" src="https://github.com/user-attachments/assets/64890bbb-7d2a-40ab-a1d7-828fe86247b4" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
