### PR TITLE
feat(acp): support portable runtime sessions

### DIFF
--- a/src/qwenpaw/agents/acp/meta.py
+++ b/src/qwenpaw/agents/acp/meta.py
@@ -5,12 +5,12 @@ This module is intentionally lightweight so CLI code can import constants
 without importing the ACP server implementation.
 """
 
-ACP_CODING_PROJECT_META_KEY = "qwenpaw.coding_project_dir"
+ACP_PROJECT_DIR_META_KEY = "qwenpaw.project_dir"
 ACP_EPHEMERAL_META_KEY = "qwenpaw.ephemeral"
 ACP_APPROVAL_EXPIRES_AT_META_KEY = "qwenpaw.approval_expires_at"
 
 __all__ = [
     "ACP_APPROVAL_EXPIRES_AT_META_KEY",
-    "ACP_CODING_PROJECT_META_KEY",
     "ACP_EPHEMERAL_META_KEY",
+    "ACP_PROJECT_DIR_META_KEY",
 ]

--- a/src/qwenpaw/agents/acp/runtime_provider.py
+++ b/src/qwenpaw/agents/acp/runtime_provider.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""Ephemeral model providers for headless ACP runtimes."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+from urllib.parse import urlparse
+
+from ...config.config import ModelSlotConfig
+from ...providers.openai_provider import OpenAIProvider
+from ...providers.provider import ModelInfo
+
+RUNTIME_OPENAI_PROVIDER_ID = "runtime-openai"
+
+
+@dataclass(frozen=True)
+class OpenAIRuntimeProviderConfig:
+    """One process-scoped OpenAI-compatible model connection."""
+
+    base_url: str
+    api_key: str
+    model: str
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+    ) -> "OpenAIRuntimeProviderConfig":
+        """Load and validate the runtime provider environment."""
+        source = os.environ if environ is None else environ
+        names = (
+            "OPENAI_BASE_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_MODEL",
+        )
+        values = {name: str(source.get(name, "")).strip() for name in names}
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            missing_text = ", ".join(missing)
+            raise ValueError(
+                f"Missing runtime provider environment: {missing_text}",
+            )
+
+        base_url = values["OPENAI_BASE_URL"].rstrip("/")
+        parsed = urlparse(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(
+                "OPENAI_BASE_URL must be an absolute HTTP(S) URL",
+            )
+
+        return cls(
+            base_url=base_url,
+            api_key=values["OPENAI_API_KEY"],
+            model=values["OPENAI_MODEL"],
+        )
+
+    @property
+    def model_slot(self) -> ModelSlotConfig:
+        """Return the per-request model selection."""
+        return ModelSlotConfig(
+            provider_id=RUNTIME_OPENAI_PROVIDER_ID,
+            model=self.model,
+        )
+
+    def build_provider(self) -> OpenAIProvider:
+        """Create the in-memory provider without writing credentials."""
+        return OpenAIProvider(
+            id=RUNTIME_OPENAI_PROVIDER_ID,
+            name="ACP Runtime OpenAI",
+            base_url=self.base_url,
+            api_key=self.api_key,
+            models=[
+                ModelInfo(
+                    id=self.model,
+                    name=self.model,
+                ),
+            ],
+            require_api_key=True,
+            support_connection_check=False,
+            support_model_discovery=False,
+            is_custom=True,
+        )

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -24,6 +24,7 @@ from acp import (
     LoadSessionResponse,
     NewSessionResponse,
     PromptResponse,
+    RequestError,
     SetSessionModelResponse,
     run_agent,
     start_tool_call,
@@ -43,11 +44,10 @@ from acp.schema import (
     ClientCapabilities,
     CloseSessionResponse,
     EmbeddedResourceContentBlock,
-    HttpMcpServer,
     ImageContentBlock,
     Implementation,
     ListSessionsResponse,
-    McpServerStdio,
+    McpCapabilities,
     ModelInfo as ACPModelInfo,
     PermissionOption,
     ResourceContentBlock,
@@ -61,7 +61,6 @@ from acp.schema import (
     SessionModelState,
     SessionResumeCapabilities,
     SetSessionConfigOptionResponse,
-    SseMcpServer,
     TextContentBlock,
     ToolCallUpdate,
     UsageUpdate,
@@ -76,18 +75,29 @@ from qwenpaw.schemas import (
 from ...__version__ import __version__
 from ...constant import WORKING_DIR
 from ...config.config import ModelSlotConfig, load_agent_config
+from ...drivers.constants import DRIVER_SCOPE_CONTEXT_KEY
 from ...exceptions import AppBaseException
 from ...providers.provider_manager import ProviderManager
 from .meta import (
     ACP_APPROVAL_EXPIRES_AT_META_KEY,
-    ACP_CODING_PROJECT_META_KEY,
     ACP_EPHEMERAL_META_KEY,
+    ACP_PROJECT_DIR_META_KEY,
+)
+from .runtime_provider import (
+    RUNTIME_OPENAI_PROVIDER_ID,
+    OpenAIRuntimeProviderConfig,
+)
+from .session_mcp import (
+    ACP_MCP_SERVER_TYPES,
+    acp_mcp_scope_id,
+    build_acp_mcp_driver_cards,
 )
 
 logger = logging.getLogger(__name__)
 
 ACP_ERROR_META_KEY = "qwenpaw.error"
 ACP_AGENT_META_KEY = "qwenpaw.agent"
+_ACP_RUNTIME_MODEL_SLOT_KEY = "qwenpaw.runtime_model_slot"
 
 _GENERIC_PROMPT_ERROR = (
     "QwenPaw failed to process the request. Check server logs for details."
@@ -147,6 +157,19 @@ class _EnvelopeTracker:
             except ValueError:
                 return stripped
         return arguments
+
+    @staticmethod
+    def _tool_result_status(data: dict[str, Any]) -> str:
+        state = str(data.get("state") or "").strip().lower()
+        if state in {
+            "cancelled",
+            "denied",
+            "error",
+            "failed",
+            "interrupted",
+        }:
+            return "failed"
+        return "completed"
 
     # pylint: disable=too-many-return-statements, too-many-branches
     def process(
@@ -209,7 +232,7 @@ class _EnvelopeTracker:
                                     str(
                                         data.get("call_id") or uuid4().hex[:8],
                                     ),
-                                    status="completed",
+                                    status=self._tool_result_status(data),
                                     content=[
                                         tool_content(
                                             text_block(
@@ -217,6 +240,7 @@ class _EnvelopeTracker:
                                             ),
                                         ),
                                     ],
+                                    raw_output=data.get("output"),
                                 ),
                             ]
                 return []
@@ -246,12 +270,18 @@ class QwenPawACPAgent(Agent):
         agent_id: str | None = None,
         workspace_dir: Path | None = None,
         local_diagnostics: bool = False,
+        runtime_provider: OpenAIRuntimeProviderConfig | None = None,
     ):
         self._agent_id = agent_id
         self._workspace_dir = workspace_dir
         self._local_diagnostics = local_diagnostics
+        self._runtime_provider = runtime_provider
+        self._runtime_provider_manager: ProviderManager | None = None
+        self._runtime_provider_instance: Any | None = None
+        self._previous_active_model: ModelSlotConfig | None = None
         self._sessions: dict[str, dict[str, Any]] = {}
         self._cancel_events: dict[str, asyncio.Event] = {}
+        self._prompt_tasks: dict[str, asyncio.Task[Any]] = {}
         self._workspace: Any | None = None
         self._workspace_ready = False
         self._workspace_lock = asyncio.Lock()
@@ -289,8 +319,8 @@ class QwenPawACPAgent(Agent):
             return self._workspace_dir
         return WORKING_DIR / "workspaces" / agent_id
 
-    @staticmethod
     def _session_info(
+        self,
         *,
         cwd: str,
         session_id: str,
@@ -300,15 +330,64 @@ class QwenPawACPAgent(Agent):
             "cwd": cwd,
             "user_id": f"acp_{session_id[:8]}",
             "mode": QwenPawACPAgent.MODE_DEFAULT,
+            DRIVER_SCOPE_CONTEXT_KEY: acp_mcp_scope_id(session_id),
         }
-        project_dir = meta.get(ACP_CODING_PROJECT_META_KEY)
+        project_dir = meta.get(ACP_PROJECT_DIR_META_KEY)
+        if project_dir is None:
+            project_dir = cwd
         if isinstance(project_dir, str):
             project_dir = project_dir.strip()
             if project_dir:
-                info[ACP_CODING_PROJECT_META_KEY] = project_dir
-        if meta.get(ACP_EPHEMERAL_META_KEY) is True:
+                info[ACP_PROJECT_DIR_META_KEY] = project_dir
+        if (
+            meta.get(ACP_EPHEMERAL_META_KEY) is True
+            or self._runtime_provider is not None
+        ):
             info[ACP_EPHEMERAL_META_KEY] = True
+        if self._runtime_provider is not None:
+            info[
+                _ACP_RUNTIME_MODEL_SLOT_KEY
+            ] = self._runtime_provider.model_slot
         return info
+
+    def _install_runtime_provider(self) -> None:
+        """Register the process-scoped provider without persisting it."""
+        if self._runtime_provider is None:
+            return
+        if self._runtime_provider_manager is not None:
+            return
+
+        manager = ProviderManager.get_instance()
+        if manager.get_provider(RUNTIME_OPENAI_PROVIDER_ID) is not None:
+            raise RuntimeError(
+                f"Provider {RUNTIME_OPENAI_PROVIDER_ID!r} already exists",
+            )
+
+        provider = self._runtime_provider.build_provider()
+        self._previous_active_model = manager.active_model
+        manager.custom_providers[RUNTIME_OPENAI_PROVIDER_ID] = provider
+        manager.active_model = self._runtime_provider.model_slot
+        self._runtime_provider_manager = manager
+        self._runtime_provider_instance = provider
+
+    def _remove_runtime_provider(self) -> None:
+        """Remove the process-scoped provider and its credentials."""
+        manager = self._runtime_provider_manager
+        if manager is None:
+            return
+
+        provider = manager.custom_providers.get(
+            RUNTIME_OPENAI_PROVIDER_ID,
+        )
+        if provider is self._runtime_provider_instance:
+            manager.custom_providers.pop(
+                RUNTIME_OPENAI_PROVIDER_ID,
+                None,
+            )
+        manager.active_model = self._previous_active_model
+        self._runtime_provider_manager = None
+        self._runtime_provider_instance = None
+        self._previous_active_model = None
 
     async def _ensure_app_services(self) -> Any:
         """Create and start ACP-local cross-workspace services."""
@@ -411,6 +490,7 @@ class QwenPawACPAgent(Agent):
             except Exception:
                 logger.exception("Error stopping ACP app services")
             self._app_services_started = False
+        self._remove_runtime_provider()
 
     # ------------------------------------------------------------------
     # ACP protocol methods
@@ -432,6 +512,10 @@ class QwenPawACPAgent(Agent):
             protocol_version=protocol_version,
             agent_capabilities=AgentCapabilities(
                 load_session=True,
+                mcp_capabilities=McpCapabilities(
+                    http=True,
+                    sse=True,
+                ),
                 session_capabilities=SessionCapabilities(
                     close=SessionCloseCapabilities(),
                     list=SessionListCapabilities(),
@@ -448,8 +532,7 @@ class QwenPawACPAgent(Agent):
     async def new_session(  # pylint: disable=unused-argument
         self,
         cwd: str,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio]
-        | None = None,
+        mcp_servers: list[ACP_MCP_SERVER_TYPES] | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
         session_id = uuid4().hex
@@ -458,6 +541,12 @@ class QwenPawACPAgent(Agent):
             session_id=session_id,
             meta=kwargs,
         )
+        try:
+            await self._sync_session_mcp(session_id, mcp_servers)
+        except BaseException:
+            self._sessions.pop(session_id, None)
+            await self._remove_session_mcp(session_id)
+            raise
         logger.info(
             "ACP new_session: id=%s cwd=%s",
             session_id,
@@ -475,15 +564,23 @@ class QwenPawACPAgent(Agent):
         self,
         cwd: str,
         session_id: str,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio]
-        | None = None,
+        mcp_servers: list[ACP_MCP_SERVER_TYPES] | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
+        previous_session = self._sessions.get(session_id)
         self._sessions[session_id] = self._session_info(
             cwd=cwd,
             session_id=session_id,
             meta=kwargs,
         )
+        try:
+            await self._sync_session_mcp(session_id, mcp_servers)
+        except BaseException:
+            if previous_session is None:
+                self._sessions.pop(session_id, None)
+            else:
+                self._sessions[session_id] = previous_session
+            raise
         logger.info(
             "ACP load_session: id=%s cwd=%s",
             session_id,
@@ -520,21 +617,14 @@ class QwenPawACPAgent(Agent):
 
         cancel_event = asyncio.Event()
         self._cancel_events[session_id] = cancel_event
+        prompt_task = asyncio.current_task()
+        if prompt_task is not None:
+            self._prompt_tasks[session_id] = prompt_task
         approval_bridge = asyncio.create_task(
             self._bridge_approval_requests(session_id),
         )
 
-        session_mode = session_info.get("mode", self.MODE_DEFAULT)
-        request_context: dict[str, Any] = {}
-        if session_mode == self.MODE_BYPASS:
-            request_context["_headless_tool_guard"] = "false"
-        project_dir = session_info.get(ACP_CODING_PROJECT_META_KEY)
-        if isinstance(project_dir, str):
-            project_dir = project_dir.strip()
-            if project_dir:
-                request_context[ACP_CODING_PROJECT_META_KEY] = project_dir
-        if session_info.get(ACP_EPHEMERAL_META_KEY) is True:
-            request_context[ACP_EPHEMERAL_META_KEY] = True
+        request_context = self._build_request_context(session_info)
 
         request = AgentRequest(
             input=[
@@ -549,13 +639,18 @@ class QwenPawACPAgent(Agent):
             user_id=user_id,
             agent_id=self._resolve_agent_id(),
             request_context=request_context or None,
+            model_slot_override=session_info.get(
+                _ACP_RUNTIME_MODEL_SLOT_KEY,
+            ),
         )
 
         tracker = _EnvelopeTracker()
+        was_cancelled = False
 
         try:
             async for event in workspace.stream_query(request):
                 if cancel_event.is_set():
+                    was_cancelled = True
                     logger.info(
                         "ACP prompt cancelled: session=%s",
                         session_id,
@@ -570,19 +665,30 @@ class QwenPawACPAgent(Agent):
                     )
 
                 await self._emit_usage_if_available(session_id)
+        except asyncio.CancelledError:
+            was_cancelled = True
+            logger.info(
+                "ACP prompt task cancelled: session=%s",
+                session_id,
+            )
         except Exception as exc:
             logger.exception(
                 "ACP prompt error: session=%s",
                 session_id,
             )
             await self._report_prompt_error(session_id, exc)
+            raise RequestError.internal_error(
+                {"details": "QwenPaw runtime failed"},
+            ) from None
         finally:
             await self._stop_approval_bridge(approval_bridge)
             self._cancel_events.pop(session_id, None)
+            self._prompt_tasks.pop(session_id, None)
 
         await self._emit_usage_if_available(session_id)
 
-        return PromptResponse(stop_reason="end_turn")
+        stop_reason = "cancelled" if was_cancelled else "end_turn"
+        return PromptResponse(stop_reason=stop_reason)
 
     async def close_session(  # pylint: disable=unused-argument
         self,
@@ -590,9 +696,12 @@ class QwenPawACPAgent(Agent):
         **kwargs: Any,
     ) -> CloseSessionResponse | None:
         logger.info("ACP close_session: session=%s", session_id)
+        await self._cancel_active_prompt(session_id)
         await self._cancel_pending_approvals(session_id)
+        await self._remove_session_mcp(session_id)
         self._sessions.pop(session_id, None)
         self._cancel_events.pop(session_id, None)
+        self._prompt_tasks.pop(session_id, None)
         return CloseSessionResponse()
 
     async def list_sessions(  # pylint: disable=unused-argument
@@ -620,8 +729,7 @@ class QwenPawACPAgent(Agent):
         self,
         cwd: str,
         session_id: str,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio]
-        | None = None,
+        mcp_servers: list[ACP_MCP_SERVER_TYPES] | None = None,
         **kwargs: Any,
     ) -> ResumeSessionResponse:
         logger.info(
@@ -629,21 +737,30 @@ class QwenPawACPAgent(Agent):
             session_id,
             cwd,
         )
-        if session_id not in self._sessions:
-            self._sessions[session_id] = self._session_info(
+        previous_session = self._sessions.get(session_id)
+        if previous_session is None:
+            candidate_session = self._session_info(
                 cwd=cwd,
                 session_id=session_id,
                 meta=kwargs,
             )
         else:
-            self._sessions[session_id]["cwd"] = cwd
-            project_dir = kwargs.get(ACP_CODING_PROJECT_META_KEY)
+            candidate_session = dict(previous_session)
+            candidate_session["cwd"] = cwd
+            project_dir = kwargs.get(ACP_PROJECT_DIR_META_KEY)
             if isinstance(project_dir, str):
                 project_dir = project_dir.strip()
                 if project_dir:
-                    self._sessions[session_id][
-                        ACP_CODING_PROJECT_META_KEY
-                    ] = project_dir
+                    candidate_session[ACP_PROJECT_DIR_META_KEY] = project_dir
+        self._sessions[session_id] = candidate_session
+        try:
+            await self._sync_session_mcp(session_id, mcp_servers)
+        except BaseException:
+            if previous_session is None:
+                self._sessions.pop(session_id, None)
+            else:
+                self._sessions[session_id] = previous_session
+            raise
         return ResumeSessionResponse()
 
     async def set_session_model(  # pylint: disable=unused-argument
@@ -658,13 +775,21 @@ class QwenPawACPAgent(Agent):
             model_id,
         )
         try:
-            await self._switch_model(model_id)
-        except Exception:
+            model_slot = await self._switch_model(model_id)
+        except Exception as exc:
             logger.exception(
                 "Failed to switch model to %s",
                 model_id,
             )
-            return None
+            raise RequestError.invalid_params(
+                {
+                    "model_id": model_id,
+                    "details": str(exc),
+                },
+            ) from None
+        session_info = self._sessions.get(session_id)
+        if session_info is not None:
+            session_info[_ACP_RUNTIME_MODEL_SLOT_KEY] = model_slot
         logger.info(
             "Model switched to %s for agent %s",
             model_id,
@@ -715,14 +840,96 @@ class QwenPawACPAgent(Agent):
             "ACP cancel: session=%s",
             session_id,
         )
-        event = self._cancel_events.get(session_id)
-        if event is not None:
-            event.set()
+        await self._cancel_active_prompt(session_id)
         await self._cancel_pending_approvals(session_id)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    async def _cancel_active_prompt(self, session_id: str) -> None:
+        """Cancel and await the active prompt for one ACP session."""
+        event = self._cancel_events.get(session_id)
+        if event is not None:
+            event.set()
+
+        prompt_task = self._prompt_tasks.get(session_id)
+        current_task = asyncio.current_task()
+        if (
+            prompt_task is None
+            or prompt_task is current_task
+            or prompt_task.done()
+        ):
+            return
+
+        prompt_task.cancel()
+        try:
+            await prompt_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception(
+                "ACP prompt failed while cancelling session=%s",
+                session_id,
+            )
+
+    def _build_request_context(
+        self,
+        session_info: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build the runtime request context for one ACP session."""
+        request_context: dict[str, Any] = {}
+        if session_info.get("mode", self.MODE_DEFAULT) == self.MODE_BYPASS:
+            request_context["_headless_tool_guard"] = "false"
+
+        project_dir = session_info.get(ACP_PROJECT_DIR_META_KEY)
+        if isinstance(project_dir, str):
+            project_dir = project_dir.strip()
+            if project_dir:
+                request_context["project_dir"] = project_dir
+
+        if session_info.get(ACP_EPHEMERAL_META_KEY) is True:
+            request_context[ACP_EPHEMERAL_META_KEY] = True
+
+        driver_scope_id = session_info.get(DRIVER_SCOPE_CONTEXT_KEY)
+        if isinstance(driver_scope_id, str) and driver_scope_id:
+            request_context[DRIVER_SCOPE_CONTEXT_KEY] = driver_scope_id
+        return request_context
+
+    async def _sync_session_mcp(
+        self,
+        session_id: str,
+        mcp_servers: list[ACP_MCP_SERVER_TYPES] | None,
+    ) -> None:
+        """Replace the transient MCP Drivers owned by one ACP session."""
+        scope_id = acp_mcp_scope_id(session_id)
+        session_info = self._sessions.get(session_id)
+        if session_info is not None:
+            session_info[DRIVER_SCOPE_CONTEXT_KEY] = scope_id
+
+        cards = build_acp_mcp_driver_cards(session_id, mcp_servers)
+        if not cards and self._workspace is None:
+            return
+
+        workspace = await self._ensure_workspace()
+        driver_manager = getattr(workspace, "driver_manager", None)
+        if driver_manager is None:
+            raise RuntimeError(
+                "QwenPaw workspace has no DriverManager for ACP MCP",
+            )
+        await driver_manager.replace_transient_drivers(scope_id, cards)
+
+    async def _remove_session_mcp(self, session_id: str) -> None:
+        """Remove transient MCP Drivers for one ACP session if initialized."""
+        workspace = self._workspace
+        if workspace is None:
+            return
+        driver_manager = getattr(workspace, "driver_manager", None)
+        if driver_manager is None:
+            return
+        await driver_manager.remove_transient_drivers(
+            acp_mcp_scope_id(session_id),
+        )
 
     async def _bridge_approval_requests(
         self,
@@ -1090,6 +1297,19 @@ class QwenPawACPAgent(Agent):
         selector to users.
         """
         try:
+            if self._runtime_provider is not None:
+                slot = self._runtime_provider.model_slot
+                model_id = f"{slot.provider_id}:{slot.model}"
+                return SessionModelState(
+                    available_models=[
+                        ACPModelInfo(
+                            model_id=model_id,
+                            name=slot.model,
+                        ),
+                    ],
+                    current_model_id=model_id,
+                )
+
             manager = ProviderManager.get_instance()
             provider_infos = await manager.list_provider_info()
 
@@ -1257,7 +1477,7 @@ class QwenPawACPAgent(Agent):
     async def _switch_model(
         self,
         model_spec: str,
-    ) -> None:
+    ) -> ModelSlotConfig:
         """Switch the active model for the current agent.
 
         Validates the provider/model pair exists, then writes the
@@ -1270,6 +1490,15 @@ class QwenPawACPAgent(Agent):
         Falls back to treating the whole string as *model_id* with
         an automatic provider search.
         """
+        if self._runtime_provider is not None:
+            expected = self._runtime_provider.model
+            qualified = f"{RUNTIME_OPENAI_PROVIDER_ID}:{expected}"
+            if model_spec not in {expected, qualified}:
+                raise ValueError(
+                    f"Runtime model must be {expected!r}",
+                )
+            return self._runtime_provider.model_slot
+
         if ":" in model_spec:
             provider_id, model_id = model_spec.split(":", 1)
         else:
@@ -1315,20 +1544,24 @@ class QwenPawACPAgent(Agent):
             model=model_id,
         )
         save_agent_config(agent_id, agent_config)
+        return agent_config.active_model
 
 
 async def run_qwenpaw_agent(
     agent_id: str | None = None,
     workspace_dir: Path | None = None,
     local_diagnostics: bool = False,
+    runtime_provider: OpenAIRuntimeProviderConfig | None = None,
 ) -> None:
     """Entry point: run QwenPaw as an ACP agent over stdio."""
     agent = QwenPawACPAgent(
         agent_id=agent_id,
         workspace_dir=workspace_dir,
         local_diagnostics=local_diagnostics,
+        runtime_provider=runtime_provider,
     )
     try:
+        agent._install_runtime_provider()  # pylint: disable=protected-access
         await run_agent(agent, use_unstable_protocol=True)
     finally:
         await agent._shutdown_workspace()  # pylint: disable=protected-access

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -336,10 +336,8 @@ class QwenPawACPAgent(Agent):
         project_dir = meta.get(ACP_PROJECT_DIR_META_KEY)
         if project_dir is None:
             project_dir = cwd
-        if isinstance(project_dir, str):
-            project_dir = project_dir.strip()
-            if project_dir:
-                info[ACP_PROJECT_DIR_META_KEY] = project_dir
+        if isinstance(project_dir, str) and project_dir.strip():
+            info[ACP_PROJECT_DIR_META_KEY] = project_dir
         if (
             meta.get(ACP_EPHEMERAL_META_KEY) is True
             or self._runtime_provider is not None
@@ -749,10 +747,8 @@ class QwenPawACPAgent(Agent):
             candidate_session = dict(previous_session)
             candidate_session["cwd"] = cwd
             project_dir = kwargs.get(ACP_PROJECT_DIR_META_KEY)
-            if isinstance(project_dir, str):
-                project_dir = project_dir.strip()
-                if project_dir:
-                    candidate_session[ACP_PROJECT_DIR_META_KEY] = project_dir
+            if isinstance(project_dir, str) and project_dir.strip():
+                candidate_session[ACP_PROJECT_DIR_META_KEY] = project_dir
         self._sessions[session_id] = candidate_session
         try:
             await self._sync_session_mcp(session_id, mcp_servers)
@@ -884,10 +880,8 @@ class QwenPawACPAgent(Agent):
             request_context["_headless_tool_guard"] = "false"
 
         project_dir = session_info.get(ACP_PROJECT_DIR_META_KEY)
-        if isinstance(project_dir, str):
-            project_dir = project_dir.strip()
-            if project_dir:
-                request_context["project_dir"] = project_dir
+        if isinstance(project_dir, str) and project_dir.strip():
+            request_context["project_dir"] = project_dir
 
         if session_info.get(ACP_EPHEMERAL_META_KEY) is True:
             request_context[ACP_EPHEMERAL_META_KEY] = True

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -78,6 +78,7 @@ from ...config.config import ModelSlotConfig, load_agent_config
 from ...drivers.constants import DRIVER_SCOPE_CONTEXT_KEY
 from ...exceptions import AppBaseException
 from ...providers.provider_manager import ProviderManager
+from ...utils.io_utils import run_sync_io
 from .meta import (
     ACP_APPROVAL_EXPIRES_AT_META_KEY,
     ACP_EPHEMERAL_META_KEY,
@@ -350,14 +351,14 @@ class QwenPawACPAgent(Agent):
             ] = self._runtime_provider.model_slot
         return info
 
-    def _install_runtime_provider(self) -> None:
+    async def _install_runtime_provider(self) -> None:
         """Register the process-scoped provider without persisting it."""
         if self._runtime_provider is None:
             return
         if self._runtime_provider_manager is not None:
             return
 
-        manager = ProviderManager.get_instance()
+        manager = await run_sync_io(ProviderManager.get_instance)
         if manager.get_provider(RUNTIME_OPENAI_PROVIDER_ID) is not None:
             raise RuntimeError(
                 f"Provider {RUNTIME_OPENAI_PROVIDER_ID!r} already exists",
@@ -907,7 +908,18 @@ class QwenPawACPAgent(Agent):
         if session_info is not None:
             session_info[DRIVER_SCOPE_CONTEXT_KEY] = scope_id
 
-        cards = build_acp_mcp_driver_cards(session_id, mcp_servers)
+        if session_info is None:
+            raise RuntimeError(
+                f"ACP session {session_id!r} is not registered",
+            )
+        session_cwd = session_info.get("cwd")
+        if not isinstance(session_cwd, str):
+            raise ValueError("ACP session cwd must be a string")
+        cards = build_acp_mcp_driver_cards(
+            session_id,
+            mcp_servers,
+            session_cwd=session_cwd,
+        )
         if not cards and self._workspace is None:
             return
 
@@ -1561,7 +1573,8 @@ async def run_qwenpaw_agent(
         runtime_provider=runtime_provider,
     )
     try:
-        agent._install_runtime_provider()  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        await agent._install_runtime_provider()
         await run_agent(agent, use_unstable_protocol=True)
     finally:
         await agent._shutdown_workspace()  # pylint: disable=protected-access

--- a/src/qwenpaw/agents/acp/session_mcp.py
+++ b/src/qwenpaw/agents/acp/session_mcp.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""ACP session MCP normalization for QwenPaw transient Drivers."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, TypeAlias
+
+from acp.schema import HttpMcpServer, McpServerStdio, SseMcpServer
+
+from ...drivers.constants import POLICY_EFFECT_ASK, PROTOCOL_MCP
+from ...drivers.contracts import DriverCard
+from ...drivers.policy_types import DriverPolicy
+
+ACP_MCP_SCOPE_PREFIX = "acp-session:"
+
+ACP_MCP_SERVER_TYPES: TypeAlias = HttpMcpServer | SseMcpServer | McpServerStdio
+
+
+def acp_mcp_scope_id(session_id: str) -> str:
+    """Return the transient Driver scope for one ACP session."""
+    if not session_id.strip():
+        raise ValueError("ACP session id must be non-empty")
+    return f"{ACP_MCP_SCOPE_PREFIX}{session_id}"
+
+
+def build_acp_mcp_driver_cards(
+    session_id: str,
+    mcp_servers: list[ACP_MCP_SERVER_TYPES] | None,
+) -> list[DriverCard]:
+    """Convert ACP MCP records into non-persistent QwenPaw DriverCards."""
+    cards: list[DriverCard] = []
+    seen_names: set[str] = set()
+    for server in mcp_servers or []:
+        name = _required_text(server, "name")
+        if name in seen_names:
+            raise ValueError(
+                f"Duplicate ACP MCP server name in session: {name}",
+            )
+        seen_names.add(name)
+
+        if isinstance(server, McpServerStdio):
+            endpoint = {
+                "transport": "stdio",
+                "command": _required_text(server, "command"),
+                "args": [str(item) for item in server.args],
+                "env": _named_values(server.env, label="environment"),
+            }
+        elif isinstance(server, SseMcpServer):
+            endpoint = {
+                "transport": "sse",
+                "url": _required_text(server, "url"),
+                "headers": _named_values(
+                    server.headers,
+                    label="HTTP header",
+                    case_insensitive=True,
+                ),
+            }
+        elif isinstance(server, HttpMcpServer):
+            endpoint = {
+                "transport": "streamable_http",
+                "url": _required_text(server, "url"),
+                "headers": _named_values(
+                    server.headers,
+                    label="HTTP header",
+                    case_insensitive=True,
+                ),
+            }
+        else:
+            raise TypeError(
+                f"Unsupported ACP MCP server type: "
+                f"{type(server).__name__}",
+            )
+
+        cards.append(
+            DriverCard(
+                name=_transient_driver_name(session_id, name),
+                protocol=PROTOCOL_MCP,
+                endpoint=endpoint,
+                config={
+                    "display_name": name,
+                    "description": "MCP server supplied by the ACP client.",
+                    "acp_server_name": name,
+                    "transient": True,
+                },
+                policy=DriverPolicy(default_effect=POLICY_EFFECT_ASK),
+            ),
+        )
+    return cards
+
+
+def _transient_driver_name(session_id: str, server_name: str) -> str:
+    raw = f"{session_id}\0{server_name}".encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()[:20]
+    return f"acp_{digest}"
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if isinstance(value, dict):
+        raw = value.get(field_name)
+    else:
+        raw = getattr(value, field_name, None)
+    text = str(raw or "").strip()
+    if not text:
+        raise ValueError(f"ACP MCP server {field_name} must be non-empty")
+    return text
+
+
+def _named_values(
+    values: list[Any],
+    *,
+    label: str,
+    case_insensitive: bool = False,
+) -> dict[str, str]:
+    result: dict[str, str] = {}
+    seen: set[str] = set()
+    for item in values:
+        name = _required_text(item, "name")
+        compare_name = name.lower() if case_insensitive else name
+        if compare_name in seen:
+            raise ValueError(f"Duplicate ACP MCP {label}: {name}")
+        seen.add(compare_name)
+        if isinstance(item, dict):
+            raw_value = item.get("value")
+        else:
+            raw_value = getattr(item, "value", None)
+        if raw_value is None:
+            raise ValueError(f"ACP MCP {label} '{name}' has no value")
+        result[name] = str(raw_value)
+    return result
+
+
+__all__ = [
+    "ACP_MCP_SCOPE_PREFIX",
+    "ACP_MCP_SERVER_TYPES",
+    "acp_mcp_scope_id",
+    "build_acp_mcp_driver_cards",
+]

--- a/src/qwenpaw/agents/acp/session_mcp.py
+++ b/src/qwenpaw/agents/acp/session_mcp.py
@@ -27,6 +27,8 @@ def acp_mcp_scope_id(session_id: str) -> str:
 def build_acp_mcp_driver_cards(
     session_id: str,
     mcp_servers: list[ACP_MCP_SERVER_TYPES] | None,
+    *,
+    session_cwd: str,
 ) -> list[DriverCard]:
     """Convert ACP MCP records into non-persistent QwenPaw DriverCards."""
     cards: list[DriverCard] = []
@@ -44,7 +46,12 @@ def build_acp_mcp_driver_cards(
                 "transport": "stdio",
                 "command": _required_text(server, "command"),
                 "args": [str(item) for item in server.args],
-                "env": _named_values(server.env, label="environment"),
+                "cwd": _required_session_cwd(session_cwd),
+                "env": _named_values(
+                    server.env,
+                    label="environment",
+                    case_insensitive=True,
+                ),
             }
         elif isinstance(server, SseMcpServer):
             endpoint = {
@@ -116,7 +123,7 @@ def _named_values(
     seen: set[str] = set()
     for item in values:
         name = _required_text(item, "name")
-        compare_name = name.lower() if case_insensitive else name
+        compare_name = name.casefold() if case_insensitive else name
         if compare_name in seen:
             raise ValueError(f"Duplicate ACP MCP {label}: {name}")
         seen.add(compare_name)
@@ -128,6 +135,12 @@ def _named_values(
             raise ValueError(f"ACP MCP {label} '{name}' has no value")
         result[name] = str(raw_value)
     return result
+
+
+def _required_session_cwd(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("ACP session cwd must be non-empty")
+    return value.strip()
 
 
 __all__ = [

--- a/src/qwenpaw/agents/acp/session_mcp.py
+++ b/src/qwenpaw/agents/acp/session_mcp.py
@@ -140,7 +140,7 @@ def _named_values(
 def _required_session_cwd(value: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError("ACP session cwd must be non-empty")
-    return value.strip()
+    return value
 
 
 __all__ = [

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -1436,9 +1436,9 @@ async def _spawn_forked_subagent(
     fork_scope_id = ""
     if worktree_path:
         # ``fork_project_dir`` is the spawn-level key; also set the ACP
-        # coding-project meta key so AgentBuilder / ContextVars rebind
+        # project-directory meta key so AgentBuilder / ContextVars rebind
         # tools/cwd to the worktree.
-        from ..acp.meta import ACP_CODING_PROJECT_META_KEY
+        from ..acp.meta import ACP_PROJECT_DIR_META_KEY
 
         workspace_dir = get_current_workspace_dir()
         registered = await asyncio.to_thread(
@@ -1457,7 +1457,7 @@ async def _spawn_forked_subagent(
         fork_scope_id = get_active_fork_scope(workspace_dir)
         fork_extra = {
             "fork_project_dir": worktree_path,
-            ACP_CODING_PROJECT_META_KEY: worktree_path,
+            ACP_PROJECT_DIR_META_KEY: worktree_path,
             "fork_worktree_branch": worktree_branch,
             "fork_scope_id": fork_scope_id,
         }

--- a/src/qwenpaw/cli/acp_cmd.py
+++ b/src/qwenpaw/cli/acp_cmd.py
@@ -35,11 +35,21 @@ import click
         "local clients that own this ACP subprocess, such as the TUI."
     ),
 )
+@click.option(
+    "--runtime-provider",
+    type=click.Choice(["openai-env"], case_sensitive=False),
+    default=None,
+    help=(
+        "Use an ephemeral provider from OPENAI_BASE_URL, "
+        "OPENAI_API_KEY, and OPENAI_MODEL."
+    ),
+)
 def acp_cmd(
     agent: str | None,
     workspace: str | None,
     debug: bool,
     local_diagnostics: bool,
+    runtime_provider: str | None,
 ) -> None:
     """Start QwenPaw as an ACP agent (stdio)."""
     from pathlib import Path
@@ -51,6 +61,16 @@ def acp_cmd(
     )
 
     workspace_dir = Path(workspace) if workspace else None
+    provider_config = None
+    if runtime_provider == "openai-env":
+        from ..agents.acp.runtime_provider import (
+            OpenAIRuntimeProviderConfig,
+        )
+
+        try:
+            provider_config = OpenAIRuntimeProviderConfig.from_env()
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
 
     from ..agents.acp.server import run_qwenpaw_agent
 
@@ -59,5 +79,6 @@ def acp_cmd(
             agent_id=agent,
             workspace_dir=workspace_dir,
             local_diagnostics=local_diagnostics,
+            runtime_provider=provider_config,
         ),
     )

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -38,7 +38,7 @@ from acp.schema import (
 
 from ....agents.acp.meta import (
     ACP_APPROVAL_EXPIRES_AT_META_KEY,
-    ACP_CODING_PROJECT_META_KEY,
+    ACP_PROJECT_DIR_META_KEY,
     ACP_EPHEMERAL_META_KEY,
 )
 from ..__version__ import __version__
@@ -402,7 +402,7 @@ class AcpTransport:
     def _session_kwargs(self) -> dict[str, str]:
         if not self._project_dir:
             return {}
-        return {ACP_CODING_PROJECT_META_KEY: self._project_dir}
+        return {ACP_PROJECT_DIR_META_KEY: self._project_dir}
 
     async def start(self) -> Connected:
         self._stack = AsyncExitStack()

--- a/src/qwenpaw/drivers/constants.py
+++ b/src/qwenpaw/drivers/constants.py
@@ -35,3 +35,8 @@ PRINCIPAL_SOURCE_CHANNEL: Final = "channel"
 PRINCIPAL_SUBJECT_ALL: Final = "all"
 PRINCIPAL_SUBJECT_USER: Final = "user"
 PRINCIPAL_SUBJECT_SESSION: Final = "session"
+
+# Request-scoped Driver capabilities, such as MCP servers supplied by an ACP
+# client, use this key to prevent one session from seeing another session's
+# transient handlers.
+DRIVER_SCOPE_CONTEXT_KEY: Final = "driver_scope_id"

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -19,6 +19,7 @@ from .capabilities import (
 from .constants import (
     CREDENTIAL_ALIAS_DEFAULT,
     CREDENTIAL_KIND_NONE,
+    DRIVER_SCOPE_CONTEXT_KEY,
 )
 from .credentials.providers import build_provider
 from .credentials.store import AsyncCredentialStore
@@ -67,6 +68,8 @@ class DriverManager:
         self._handler_types: dict[str, type[DriverHandler]] = {}
         self._endpoint_validators: dict[str, EndpointValidator] = {}
         self._handlers: dict[str, DriverHandler] = {}
+        self._handler_scopes: dict[str, str] = {}
+        self._scope_handlers: dict[str, set[str]] = {}
         self._lock = asyncio.Lock()
 
     def register_handler_type(
@@ -117,11 +120,32 @@ class DriverManager:
                     exc_info=True,
                 )
 
+        collisions: set[str] = set()
+        old_handlers: list[DriverHandler] = []
         async with self._lock:
-            old_handlers = self._handlers
-            self._handlers = built
+            transient = {
+                name: handler
+                for name, handler in self._handlers.items()
+                if name in self._handler_scopes
+            }
+            collisions = set(built) & set(transient)
+            if not collisions:
+                old_handlers = [
+                    handler
+                    for name, handler in self._handlers.items()
+                    if name not in self._handler_scopes
+                ]
+                self._handlers = {**built, **transient}
 
-        await self._shutdown_handlers(old_handlers.values())
+        if collisions:
+            await self._shutdown_handlers(built.values())
+            names = ", ".join(sorted(collisions))
+            raise ValueError(
+                f"Persistent Drivers collide with transient Drivers: "
+                f"{names}",
+            )
+
+        await self._shutdown_handlers(old_handlers)
 
     async def upsert_driver(
         self,
@@ -137,15 +161,33 @@ class DriverManager:
     async def register_driver(self, card: DriverCard) -> None:
         """Persist card, build handler, then publish after init success."""
         card = self._validate_card_for_registered_protocol(card)
-        await self._card_store.save(card)
+        async with self._lock:
+            if card.name in self._handler_scopes:
+                raise ValueError(
+                    f"Persistent Driver '{card.name}' collides with "
+                    f"a transient Driver",
+                )
+            await self._card_store.save(card)
+
         handler = None
         if card.enabled:
             handler = await self._build_and_init_handler(card)
 
-        async with self._lock:
-            old = self._handlers.pop(card.name, None)
+        old = None
+        try:
+            async with self._lock:
+                if card.name in self._handler_scopes:
+                    raise ValueError(
+                        f"Persistent Driver '{card.name}' collides with "
+                        f"a transient Driver",
+                    )
+                old = self._handlers.pop(card.name, None)
+                if handler is not None:
+                    self._handlers[card.name] = handler
+        except BaseException:
             if handler is not None:
-                self._handlers[card.name] = handler
+                await self._shutdown_handler(handler)
+            raise
 
         if old is not None:
             await self._shutdown_handler(old)
@@ -160,14 +202,24 @@ class DriverManager:
         handler = None
         if card.enabled:
             handler = await self._build_and_init_handler(card)
-        await self._card_store.save(card)
-
-        async with self._lock:
-            old = self._handlers.get(name)
-            if handler is None:
-                old = self._handlers.pop(name, None)
-            else:
-                self._handlers[name] = handler
+        old = None
+        try:
+            async with self._lock:
+                if name in self._handler_scopes:
+                    raise ValueError(
+                        f"Persistent Driver '{name}' collides with "
+                        f"a transient Driver",
+                    )
+                await self._card_store.save(card)
+                old = self._handlers.get(name)
+                if handler is None:
+                    old = self._handlers.pop(name, None)
+                else:
+                    self._handlers[name] = handler
+        except BaseException:
+            if handler is not None:
+                await self._shutdown_handler(handler)
+            raise
 
         if old is not None:
             await self._shutdown_handler(old)
@@ -200,6 +252,11 @@ class DriverManager:
         """
         card = self._validate_card_for_registered_protocol(card)
         async with self._lock:
+            if card.name in self._handler_scopes:
+                raise ValueError(
+                    f"Persistent Driver '{card.name}' collides with "
+                    f"a transient Driver",
+                )
             await self._card_store.save(card)
             handler = self._handlers.get(card.name)
             if handler is None or handler.card.protocol != card.protocol:
@@ -218,17 +275,104 @@ class DriverManager:
 
     async def delete_driver(self, name: str) -> None:
         """Delete persisted card and shutdown a published handler."""
-        await self._card_store.delete(name)
         async with self._lock:
+            if name in self._handler_scopes:
+                raise ValueError(
+                    f"Transient Driver '{name}' must be removed by scope",
+                )
+            await self._card_store.delete(name)
             old = self._handlers.pop(name, None)
         if old is not None:
             await self._shutdown_handler(old)
+
+    async def replace_transient_drivers(
+        self,
+        scope_id: str,
+        cards: list[DriverCard],
+    ) -> None:
+        """Atomically replace all non-persistent Drivers for one scope.
+
+        Every new handler is initialized before publication. Failure leaves
+        the previous scope untouched and shuts down any newly built handlers.
+        Transient cards and credentials are never written to persistent stores.
+        """
+        if not scope_id.strip():
+            raise ValueError("Transient Driver scope must be non-empty")
+
+        names = [card.name for card in cards]
+        if len(names) != len(set(names)):
+            raise ValueError(
+                f"Transient Driver names must be unique in scope "
+                f"'{scope_id}'",
+            )
+
+        built: dict[str, DriverHandler] = {}
+        try:
+            for card in cards:
+                built[card.name] = await self._build_and_init_handler(card)
+        except BaseException:
+            await self._shutdown_handlers(built.values())
+            raise
+
+        old_handlers: list[DriverHandler] = []
+        try:
+            async with self._lock:
+                owned_names = self._scope_handlers.get(scope_id, set())
+                persistent_names = {
+                    name
+                    for name in built
+                    if await self._card_store.stored_path(name) is not None
+                }
+                unavailable = {
+                    name
+                    for name in built
+                    if name in self._handlers and name not in owned_names
+                } | persistent_names
+                if unavailable:
+                    joined = ", ".join(sorted(unavailable))
+                    raise ValueError(
+                        f"Transient Driver names already exist: {joined}",
+                    )
+
+                for name in owned_names:
+                    old = self._handlers.pop(name, None)
+                    if old is not None:
+                        old_handlers.append(old)
+                    self._handler_scopes.pop(name, None)
+
+                for name, handler in built.items():
+                    self._handlers[name] = handler
+                    self._handler_scopes[name] = scope_id
+
+                if built:
+                    self._scope_handlers[scope_id] = set(built)
+                else:
+                    self._scope_handlers.pop(scope_id, None)
+        except BaseException:
+            await self._shutdown_handlers(built.values())
+            raise
+
+        await self._shutdown_handlers(old_handlers)
+
+    async def remove_transient_drivers(self, scope_id: str) -> None:
+        """Remove and shut down all transient Drivers owned by one scope."""
+        async with self._lock:
+            names = self._scope_handlers.pop(scope_id, set())
+            handlers = []
+            for name in names:
+                handler = self._handlers.pop(name, None)
+                self._handler_scopes.pop(name, None)
+                if handler is not None:
+                    handlers.append(handler)
+        await self._shutdown_handlers(handlers)
 
     async def shutdown_all(self) -> None:
         """Shutdown all handlers and clear manager state."""
         async with self._lock:
             handlers = list(self._handlers.values())
             self._handlers.clear()
+            self._handler_scopes.clear()
+            self._scope_handlers.clear()
         await self._shutdown_handlers(handlers)
 
     async def list_drivers(
@@ -262,7 +406,10 @@ class DriverManager:
         request_context: dict[str, str] | None = None,
     ) -> list[DriverCapability]:
         """Return capabilities exposed by active handlers."""
-        handlers = self._iter_handlers(protocol)
+        scope_id = str(
+            (request_context or {}).get(DRIVER_SCOPE_CONTEXT_KEY) or "",
+        )
+        handlers = self._iter_handlers(protocol, scope_id=scope_id)
         capabilities: list[DriverCapability] = []
         for handler in handlers:
             for capability in await handler.list_capabilities(
@@ -281,6 +428,12 @@ class DriverManager:
     ) -> list[DriverCapability]:
         """Return capabilities from one active Driver only."""
         handler = self._get_handler(name)
+        scope_id = self._handler_scopes.get(name)
+        request_scope = str(
+            (request_context or {}).get(DRIVER_SCOPE_CONTEXT_KEY) or "",
+        )
+        if scope_id is not None and request_scope != scope_id:
+            raise DriverNotFoundError(name)
         capabilities = await handler.list_capabilities(
             request_context=request_context,
         )
@@ -317,6 +470,20 @@ class DriverManager:
                 message=str(exc),
                 metadata={"driver_name": exc.name},
             )
+        scope_id = self._handler_scopes.get(driver_name)
+        request_scope = str(
+            invocation.request_context.get(DRIVER_SCOPE_CONTEXT_KEY) or "",
+        )
+        if scope_id is not None and request_scope != scope_id:
+            return DriverInvocationResult(
+                ok=False,
+                error_type="driver_scope_mismatch",
+                message=(
+                    f"Driver '{driver_name}' is not available in the "
+                    f"current request scope"
+                ),
+                metadata={"driver_name": driver_name},
+            )
         return await handler.invoke_capability(invocation)
 
     def _get_handler(self, name: str) -> DriverHandler:
@@ -328,8 +495,15 @@ class DriverManager:
     def _iter_handlers(
         self,
         protocol: str | None = None,
+        *,
+        scope_id: str = "",
     ) -> list[DriverHandler]:
-        handlers = list(self._handlers.values())
+        handlers = [
+            handler
+            for name, handler in self._handlers.items()
+            if name not in self._handler_scopes
+            or self._handler_scopes[name] == scope_id
+        ]
         if protocol is not None:
             handlers = [
                 handler

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 from .approval import ApprovalGate
@@ -70,6 +70,8 @@ class DriverManager:
         self._handlers: dict[str, DriverHandler] = {}
         self._handler_scopes: dict[str, str] = {}
         self._scope_handlers: dict[str, set[str]] = {}
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
+        self._cleanup_handler_ids: set[int] = set()
         self._lock = asyncio.Lock()
 
     def register_handler_type(
@@ -292,9 +294,11 @@ class DriverManager:
     ) -> None:
         """Atomically replace all non-persistent Drivers for one scope.
 
-        Every new handler is initialized before publication. Failure leaves
-        the previous scope untouched and shuts down any newly built handlers.
-        Transient cards and credentials are never written to persistent stores.
+        Every new handler is initialized before publication. Failure before
+        publication leaves the previous scope untouched and shuts down any
+        newly built handlers. After publication, retired handlers are cleaned
+        up by managed tasks. Transient cards and credentials are never written
+        to persistent stores.
         """
         if not scope_id.strip():
             raise ValueError("Transient Driver scope must be non-empty")
@@ -352,10 +356,10 @@ class DriverManager:
             await self._shutdown_handlers(built.values())
             raise
 
-        await self._shutdown_handlers(old_handlers)
+        self._schedule_handler_cleanup(old_handlers)
 
     async def remove_transient_drivers(self, scope_id: str) -> None:
-        """Remove and shut down all transient Drivers owned by one scope."""
+        """Unpublish a scope and wait for its managed handler cleanup."""
         async with self._lock:
             names = self._scope_handlers.pop(scope_id, set())
             handlers = []
@@ -364,16 +368,19 @@ class DriverManager:
                 self._handler_scopes.pop(name, None)
                 if handler is not None:
                     handlers.append(handler)
-        await self._shutdown_handlers(handlers)
+        cleanup_task = self._schedule_handler_cleanup(handlers)
+        if cleanup_task is not None:
+            await asyncio.shield(cleanup_task)
 
     async def shutdown_all(self) -> None:
-        """Shutdown all handlers and clear manager state."""
+        """Unpublish all handlers and wait for every managed cleanup."""
         async with self._lock:
             handlers = list(self._handlers.values())
             self._handlers.clear()
             self._handler_scopes.clear()
             self._scope_handlers.clear()
-        await self._shutdown_handlers(handlers)
+        self._schedule_handler_cleanup(handlers)
+        await self._wait_for_handler_cleanups()
 
     async def list_drivers(
         self,
@@ -597,13 +604,63 @@ class DriverManager:
         return self._card_store
 
     async def _shutdown_handlers(self, handlers) -> None:
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[
                 self._shutdown_handler_with_timeout(handler)
                 for handler in handlers
             ],
             return_exceptions=True,
         )
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Managed Driver handler cleanup returned an error: %s",
+                    result,
+                )
+
+    def _schedule_handler_cleanup(
+        self,
+        handlers: Iterable[DriverHandler],
+    ) -> asyncio.Task[None] | None:
+        retired = [
+            handler
+            for handler in handlers
+            if id(handler) not in self._cleanup_handler_ids
+        ]
+        if not retired:
+            return None
+        handler_ids = {id(handler) for handler in retired}
+        self._cleanup_handler_ids.update(handler_ids)
+        task = asyncio.create_task(
+            self._shutdown_handlers(retired),
+            name="driver-handler-cleanup",
+        )
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(
+            lambda done: self._finish_handler_cleanup(done, handler_ids),
+        )
+        return task
+
+    def _finish_handler_cleanup(
+        self,
+        task: asyncio.Task[None],
+        handler_ids: set[int],
+    ) -> None:
+        self._cleanup_tasks.discard(task)
+        self._cleanup_handler_ids.difference_update(handler_ids)
+        if task.cancelled():
+            logger.warning("Managed Driver handler cleanup was cancelled")
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error("Managed Driver handler cleanup failed: %s", error)
+
+    async def _wait_for_handler_cleanups(self) -> None:
+        while self._cleanup_tasks:
+            tasks = tuple(self._cleanup_tasks)
+            await asyncio.shield(
+                asyncio.gather(*tasks, return_exceptions=True),
+            )
 
     @staticmethod
     async def _shutdown_handler(handler: DriverHandler) -> None:

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Callable
 
+from agentscope.message import ToolCallBlock
 from agentscope.model import OpenAIChatModel
 from agentscope.model._model_response import ChatResponse
 
@@ -733,9 +734,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         response: Any,
     ) -> AsyncGenerator[ChatResponse, None]:
         sanitized_response = _SanitizedStream(response)
-
-        _think_tool_calls: dict[str, dict] = {}
-        _text_tool_calls: dict[str, dict] = {}
+        next_think_tool_call_id = 0
+        next_text_tool_call_id = 0
 
         async for parsed in super()._parse_stream_response(
             start_datetime=start_datetime,
@@ -807,10 +807,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                 for b in parsed.content
             )
 
-            if has_tool_use:
-                _think_tool_calls.clear()
-                _text_tool_calls.clear()
-            else:
+            recovered_tool_calls: list[ToolCallBlock] = []
+            if not has_tool_use:
                 # --- 1. Scan thinking blocks ---
                 for block in parsed.content:
                     btype = _battr(block, "type")
@@ -826,16 +824,15 @@ class OpenAIChatModelCompat(OpenAIChatModel):
 
                     _bset(block, "thinking", think_parsed.text_before.strip())
 
-                    _think_tool_calls = {
-                        f"thinking_{i}": {
-                            "type": "tool_use",
-                            "id": f"think_call_{i}",
-                            "name": ptc.name,
-                            "input": ptc.arguments,
-                            "raw_input": ptc.raw_arguments,
-                        }
-                        for i, ptc in enumerate(think_parsed.tool_calls)
-                    }
+                    for tool_call in think_parsed.tool_calls:
+                        recovered_tool_calls.append(
+                            ToolCallBlock(
+                                id=f"think_call_{next_think_tool_call_id}",
+                                name=tool_call.name,
+                                input=tool_call.raw_arguments,
+                            ),
+                        )
+                        next_think_tool_call_id += 1
 
                 # --- 2. Scan text/content blocks ---
                 new_content: list | None = None
@@ -851,16 +848,15 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                     _bset(block, "text", clean_text)
 
                     if text_parsed.tool_calls:
-                        _text_tool_calls = {
-                            f"text_{j}": {
-                                "type": "tool_use",
-                                "id": f"text_call_{j}",
-                                "name": ptc.name,
-                                "input": ptc.arguments,
-                                "raw_input": ptc.raw_arguments,
-                            }
-                            for j, ptc in enumerate(text_parsed.tool_calls)
-                        }
+                        for tool_call in text_parsed.tool_calls:
+                            recovered_tool_calls.append(
+                                ToolCallBlock(
+                                    id=f"text_call_{next_text_tool_call_id}",
+                                    name=tool_call.name,
+                                    input=tool_call.raw_arguments,
+                                ),
+                            )
+                            next_text_tool_call_id += 1
 
                     # If the text block is now empty, mark it for removal.
                     if not clean_text:
@@ -871,10 +867,9 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                 if new_content is not None:
                     parsed.content = [b for b in new_content if b is not None]
 
-                extra = list(_think_tool_calls.values()) + list(
-                    _text_tool_calls.values(),
-                )
-                if extra:
-                    parsed.content = list(parsed.content) + extra
+                if recovered_tool_calls:
+                    parsed.content = (
+                        list(parsed.content) + recovered_tool_calls
+                    )
 
             yield parsed

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
-from ..agents.acp.meta import ACP_CODING_PROJECT_META_KEY
+from ..agents.acp.meta import ACP_PROJECT_DIR_META_KEY
 from ..utils.io_utils import run_sync_io
 
 if TYPE_CHECKING:
@@ -628,7 +628,7 @@ class AgentBuilder:
         if not isinstance(raw_project_dir, str) or not raw_project_dir.strip():
             raw_project_dir = request_context.get("project_dir")
         if not isinstance(raw_project_dir, str) or not raw_project_dir.strip():
-            raw_project_dir = request_context.get(ACP_CODING_PROJECT_META_KEY)
+            raw_project_dir = request_context.get(ACP_PROJECT_DIR_META_KEY)
         fork_raw = request_context.get("fork_project_dir")
         if not isinstance(raw_project_dir, str) or not raw_project_dir.strip():
             # spawn_subagent(fork=True) places the worktree here.
@@ -636,7 +636,7 @@ class AgentBuilder:
         if not isinstance(raw_project_dir, str) or not raw_project_dir.strip():
             return agent_config
 
-        # When fork_project_dir is present, the final coding project MUST be
+        # When fork_project_dir is present, the final project directory MUST be
         # the validated worktree — never fall through to an unchecked ACP path.
         if isinstance(fork_raw, str) and fork_raw.strip():
             existing_pd = getattr(agent_config, "project_dir", None)

--- a/tests/integration/test_acp_mcp_driver_flow.py
+++ b/tests/integration/test_acp_mcp_driver_flow.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Integration coverage for ACP MCP cards through DriverManager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from acp.schema import EnvVariable, McpServerStdio
+
+from qwenpaw.agents.acp.session_mcp import (
+    acp_mcp_scope_id,
+    build_acp_mcp_driver_cards,
+)
+from qwenpaw.drivers.capabilities import DriverInvocation
+from qwenpaw.drivers.constants import DRIVER_SCOPE_CONTEXT_KEY
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.handlers.mcp import (
+    MCPDriverHandler,
+    validate_mcp_endpoint,
+)
+from qwenpaw.drivers.manager import DriverManager
+from qwenpaw.drivers.policy import DriverInvocationContext
+from tests.integration.driver_mcp_fakes import (
+    FakeStdIOClient,
+    patch_mcp_runtime_clients,
+)
+
+
+class _AutoApprovalGate:
+    def __init__(self) -> None:
+        self.contexts: list[DriverInvocationContext] = []
+
+    async def request_approval(
+        self,
+        context: DriverInvocationContext,
+    ) -> None:
+        self.contexts.append(context)
+
+
+@pytest.mark.asyncio
+async def test_acp_mcp_card_discovers_approves_and_invokes_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    gate = _AutoApprovalGate()
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+        approval_gate=gate,
+    )
+    manager.register_handler_type(
+        "mcp",
+        MCPDriverHandler,
+        validate_mcp_endpoint,
+    )
+    session_id = "session-1"
+    scope_id = acp_mcp_scope_id(session_id)
+    cards = build_acp_mcp_driver_cards(
+        session_id,
+        [
+            McpServerStdio(
+                name="benchmark",
+                command="python",
+                args=["server.py"],
+                env=[
+                    EnvVariable(
+                        name="ECHO_SECRET",
+                        value="session-secret",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    await manager.replace_transient_drivers(scope_id, cards)
+    request_context = {
+        DRIVER_SCOPE_CONTEXT_KEY: scope_id,
+        "approval_level": "smart",
+        "session_id": session_id,
+        "user_id": "user:test",
+    }
+    capabilities = await manager.list_capabilities(
+        kind="tool",
+        request_context=request_context,
+    )
+    capability = next(
+        item for item in capabilities if item.name == "get_secret_status"
+    )
+
+    result = await manager.invoke_capability(
+        DriverInvocation(
+            capability_id=capability.capability_id,
+            payload={},
+            request_context=request_context,
+        ),
+    )
+
+    assert result.ok is True
+    assert result.value == {"has_secret": True}
+    assert len(gate.contexts) == 1
+    assert gate.contexts[0].target.name == "get_secret_status"
+    assert FakeStdIOClient.instances[0].kwargs["env"] == {
+        "ECHO_SECRET": "session-secret",
+    }
+    assert await manager.card_store.list_paths() == []
+
+
+@pytest.mark.asyncio
+async def test_acp_mcp_tool_cannot_be_invoked_without_session_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+    )
+    manager.register_handler_type(
+        "mcp",
+        MCPDriverHandler,
+        validate_mcp_endpoint,
+    )
+    scope_id = acp_mcp_scope_id("session-1")
+    cards = build_acp_mcp_driver_cards(
+        "session-1",
+        [
+            McpServerStdio(
+                name="benchmark",
+                command="python",
+                args=["server.py"],
+                env=[],
+            ),
+        ],
+    )
+    await manager.replace_transient_drivers(scope_id, cards)
+    capability = (
+        await manager.list_capabilities(
+            kind="tool",
+            request_context={DRIVER_SCOPE_CONTEXT_KEY: scope_id},
+        )
+    )[0]
+
+    result = await manager.invoke_capability(
+        DriverInvocation(
+            capability_id=capability.capability_id,
+            payload={"value": "blocked"},
+            request_context={},
+        ),
+    )
+
+    assert result.ok is False
+    assert result.error_type == "driver_scope_mismatch"

--- a/tests/integration/test_acp_mcp_driver_flow.py
+++ b/tests/integration/test_acp_mcp_driver_flow.py
@@ -72,6 +72,7 @@ async def test_acp_mcp_card_discovers_approves_and_invokes_tool(
                 ],
             ),
         ],
+        session_cwd=str(tmp_path),
     )
 
     await manager.replace_transient_drivers(scope_id, cards)
@@ -133,6 +134,7 @@ async def test_acp_mcp_tool_cannot_be_invoked_without_session_scope(
                 env=[],
             ),
         ],
+        session_cwd=str(tmp_path),
     )
     await manager.replace_transient_drivers(scope_id, cards)
     capability = (

--- a/tests/unit/agents/test_acp_project_context.py
+++ b/tests/unit/agents/test_acp_project_context.py
@@ -57,15 +57,16 @@ async def test_acp_project_dir_flows_to_request_context(tmp_path):
     assert workspace.requests[0].request_context["project_dir"] == project_dir
 
 
-async def test_acp_project_dir_is_stripped(tmp_path):
+async def test_acp_project_dir_preserves_trailing_space(tmp_path):
     project_dir = str(tmp_path)
+    provided_project_dir = f"{project_dir} "
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
     agent.on_connect(_FakeConn())
 
     response = await agent.new_session(
         cwd=project_dir,
-        **{ACP_PROJECT_DIR_META_KEY: f"  {project_dir}  "},
+        **{ACP_PROJECT_DIR_META_KEY: provided_project_dir},
     )
 
     await agent.prompt(
@@ -73,11 +74,15 @@ async def test_acp_project_dir_is_stripped(tmp_path):
         session_id=response.session_id,
     )
 
-    assert workspace.requests[0].request_context["project_dir"] == project_dir
+    assert (
+        workspace.requests[0].request_context["project_dir"]
+        == provided_project_dir
+    )
 
 
-async def test_acp_resume_project_dir_is_stripped(tmp_path):
+async def test_acp_resume_project_dir_preserves_trailing_space(tmp_path):
     project_dir = str(tmp_path)
+    provided_project_dir = f"{project_dir} "
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
     agent.on_connect(_FakeConn())
@@ -86,7 +91,7 @@ async def test_acp_resume_project_dir_is_stripped(tmp_path):
     await agent.resume_session(
         cwd=project_dir,
         session_id=response.session_id,
-        **{ACP_PROJECT_DIR_META_KEY: f"  {project_dir}  "},
+        **{ACP_PROJECT_DIR_META_KEY: provided_project_dir},
     )
 
     await agent.prompt(
@@ -94,7 +99,10 @@ async def test_acp_resume_project_dir_is_stripped(tmp_path):
         session_id=response.session_id,
     )
 
-    assert workspace.requests[0].request_context["project_dir"] == project_dir
+    assert (
+        workspace.requests[0].request_context["project_dir"]
+        == provided_project_dir
+    )
 
 
 async def test_acp_ephemeral_metadata_flows_to_request_context(tmp_path):

--- a/tests/unit/agents/test_acp_project_context.py
+++ b/tests/unit/agents/test_acp_project_context.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-"""ACP session metadata for TUI Coding Mode projects."""
+"""ACP session project context metadata."""
 
 from __future__ import annotations
 
 from acp import text_block
 
 from qwenpaw.agents.acp.meta import (
-    ACP_CODING_PROJECT_META_KEY,
     ACP_EPHEMERAL_META_KEY,
+    ACP_PROJECT_DIR_META_KEY,
 )
 from qwenpaw.agents.acp.server import QwenPawACPAgent
 
@@ -37,7 +37,7 @@ class _TestACPAgent(QwenPawACPAgent):
         return self._fake_workspace
 
 
-async def test_acp_project_metadata_flows_to_request_context(tmp_path):
+async def test_acp_project_dir_flows_to_request_context(tmp_path):
     project_dir = str(tmp_path)
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
@@ -45,7 +45,7 @@ async def test_acp_project_metadata_flows_to_request_context(tmp_path):
 
     response = await agent.new_session(
         cwd=project_dir,
-        **{ACP_CODING_PROJECT_META_KEY: project_dir},
+        **{ACP_PROJECT_DIR_META_KEY: project_dir},
     )
 
     await agent.prompt(
@@ -54,13 +54,10 @@ async def test_acp_project_metadata_flows_to_request_context(tmp_path):
     )
 
     assert workspace.requests
-    assert (
-        workspace.requests[0].request_context[ACP_CODING_PROJECT_META_KEY]
-        == project_dir
-    )
+    assert workspace.requests[0].request_context["project_dir"] == project_dir
 
 
-async def test_acp_project_metadata_is_stripped(tmp_path):
+async def test_acp_project_dir_is_stripped(tmp_path):
     project_dir = str(tmp_path)
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
@@ -68,7 +65,7 @@ async def test_acp_project_metadata_is_stripped(tmp_path):
 
     response = await agent.new_session(
         cwd=project_dir,
-        **{ACP_CODING_PROJECT_META_KEY: f"  {project_dir}  "},
+        **{ACP_PROJECT_DIR_META_KEY: f"  {project_dir}  "},
     )
 
     await agent.prompt(
@@ -76,13 +73,10 @@ async def test_acp_project_metadata_is_stripped(tmp_path):
         session_id=response.session_id,
     )
 
-    assert (
-        workspace.requests[0].request_context[ACP_CODING_PROJECT_META_KEY]
-        == project_dir
-    )
+    assert workspace.requests[0].request_context["project_dir"] == project_dir
 
 
-async def test_acp_resume_project_metadata_is_stripped(tmp_path):
+async def test_acp_resume_project_dir_is_stripped(tmp_path):
     project_dir = str(tmp_path)
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
@@ -92,7 +86,7 @@ async def test_acp_resume_project_metadata_is_stripped(tmp_path):
     await agent.resume_session(
         cwd=project_dir,
         session_id=response.session_id,
-        **{ACP_CODING_PROJECT_META_KEY: f"  {project_dir}  "},
+        **{ACP_PROJECT_DIR_META_KEY: f"  {project_dir}  "},
     )
 
     await agent.prompt(
@@ -100,10 +94,7 @@ async def test_acp_resume_project_metadata_is_stripped(tmp_path):
         session_id=response.session_id,
     )
 
-    assert (
-        workspace.requests[0].request_context[ACP_CODING_PROJECT_META_KEY]
-        == project_dir
-    )
+    assert workspace.requests[0].request_context["project_dir"] == project_dir
 
 
 async def test_acp_ephemeral_metadata_flows_to_request_context(tmp_path):

--- a/tests/unit/agents/test_acp_runtime_provider.py
+++ b/tests/unit/agents/test_acp_runtime_provider.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ephemeral ACP OpenAI-compatible provider."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from acp import RequestError, text_block
+
+from qwenpaw.agents.acp.runtime_provider import (
+    RUNTIME_OPENAI_PROVIDER_ID,
+    OpenAIRuntimeProviderConfig,
+)
+from qwenpaw.agents.acp.server import QwenPawACPAgent
+from qwenpaw.config.config import ModelSlotConfig
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self.custom_providers = {}
+        self.active_model = ModelSlotConfig(
+            provider_id="original",
+            model="original-model",
+        )
+
+    def get_provider(self, provider_id):  # noqa: ANN001
+        return self.custom_providers.get(provider_id)
+
+    async def list_provider_info(self):
+        return [
+            SimpleNamespace(
+                id=provider.id,
+                models=[
+                    SimpleNamespace(id=model.id, name=model.name)
+                    for model in provider.models
+                ],
+                extra_models=[],
+            )
+            for provider in self.custom_providers.values()
+        ]
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.updates = []
+
+    async def session_update(self, session_id, update):  # noqa: ANN001
+        self.updates.append((session_id, update))
+
+
+class _FakeWorkspace:
+    def __init__(self) -> None:
+        self.requests = []
+
+    async def stream_query(self, request):  # noqa: ANN001
+        self.requests.append(request)
+        for event in ():
+            yield event
+
+
+def _config() -> OpenAIRuntimeProviderConfig:
+    return OpenAIRuntimeProviderConfig(
+        base_url="https://policy.example.test/v1",
+        api_key="execution-secret",
+        model="policy",
+    )
+
+
+def test_runtime_provider_requires_complete_environment():
+    with pytest.raises(ValueError) as exc_info:
+        OpenAIRuntimeProviderConfig.from_env(
+            {
+                "OPENAI_BASE_URL": "https://policy.example.test/v1",
+                "OPENAI_API_KEY": "execution-secret",
+            },
+        )
+
+    assert "OPENAI_MODEL" in str(exc_info.value)
+    assert "execution-secret" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "policy.example.test/v1",
+        "file:///tmp/policy.sock",
+        "",
+    ],
+)
+def test_runtime_provider_rejects_invalid_base_url(base_url):
+    with pytest.raises(ValueError):
+        OpenAIRuntimeProviderConfig.from_env(
+            {
+                "OPENAI_BASE_URL": base_url,
+                "OPENAI_API_KEY": "execution-secret",
+                "OPENAI_MODEL": "policy",
+            },
+        )
+
+
+def test_runtime_provider_builds_openai_provider():
+    provider = _config().build_provider()
+
+    assert provider.id == RUNTIME_OPENAI_PROVIDER_ID
+    assert provider.base_url == "https://policy.example.test/v1"
+    assert provider.api_key == "execution-secret"
+    assert provider.has_model("policy")
+
+
+def test_runtime_provider_is_registered_only_in_memory(monkeypatch):
+    manager = _FakeManager()
+    original_model = manager.active_model
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.acp.server.ProviderManager.get_instance",
+        lambda: manager,
+    )
+
+    agent._install_runtime_provider()
+
+    provider = manager.custom_providers[RUNTIME_OPENAI_PROVIDER_ID]
+    assert provider.api_key == "execution-secret"
+    assert manager.active_model == _config().model_slot
+
+    agent._remove_runtime_provider()
+
+    assert not manager.custom_providers
+    assert manager.active_model is original_model
+
+
+def test_runtime_provider_credentials_are_not_persisted(
+    isolated_secret_dir,
+):
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+
+    agent._install_runtime_provider()
+
+    stored_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in isolated_secret_dir.rglob("*")
+        if path.is_file()
+    )
+    assert "execution-secret" not in stored_text
+    assert "policy.example.test" not in stored_text
+
+    agent._remove_runtime_provider()
+
+
+async def test_runtime_provider_forces_model_override(monkeypatch):
+    manager = _FakeManager()
+    workspace = _FakeWorkspace()
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    agent.on_connect(_FakeConn())
+    monkeypatch.setattr(
+        "qwenpaw.agents.acp.server.ProviderManager.get_instance",
+        lambda: manager,
+    )
+
+    async def _fake_workspace():
+        return workspace
+
+    monkeypatch.setattr(agent, "_ensure_workspace", _fake_workspace)
+    agent._install_runtime_provider()
+    response = await agent.new_session(cwd="/task")
+
+    await agent.set_session_model(
+        model_id="policy",
+        session_id=response.session_id,
+    )
+    await agent.prompt(
+        prompt=[text_block("hello")],
+        session_id=response.session_id,
+    )
+
+    assert workspace.requests
+    assert workspace.requests[0].model_slot_override == _config().model_slot
+
+
+async def test_runtime_provider_is_advertised_as_current_model(monkeypatch):
+    manager = _FakeManager()
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.acp.server.ProviderManager.get_instance",
+        lambda: manager,
+    )
+    agent._install_runtime_provider()
+
+    model_state = await agent._build_model_state()
+
+    assert model_state is not None
+    assert model_state.current_model_id == "runtime-openai:policy"
+    assert [model.model_id for model in model_state.available_models] == [
+        "runtime-openai:policy"
+    ]
+
+
+async def test_runtime_provider_rejects_other_model():
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    response = await agent.new_session(cwd="/task")
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.set_session_model(
+            model_id="fallback-model",
+            session_id=response.session_id,
+        )
+
+    assert exc_info.value.code == -32602
+    assert exc_info.value.data == {
+        "model_id": "fallback-model",
+        "details": "Runtime model must be 'policy'",
+    }
+
+
+async def test_runtime_failure_is_an_acp_request_error(monkeypatch):
+    async def _raise_runtime_error():
+        raise RuntimeError("upstream returned secret-token")
+
+    class _FailingWorkspace:
+        async def stream_query(self, request):  # noqa: ANN001
+            del request
+            yield await _raise_runtime_error()
+
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    conn = _FakeConn()
+    agent.on_connect(conn)
+
+    async def _fake_workspace():
+        return _FailingWorkspace()
+
+    monkeypatch.setattr(agent, "_ensure_workspace", _fake_workspace)
+    response = await agent.new_session(cwd="/task")
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.prompt(
+            prompt=[text_block("hello")],
+            session_id=response.session_id,
+        )
+
+    assert exc_info.value.code == -32603
+    assert exc_info.value.data == {
+        "details": "QwenPaw runtime failed",
+    }
+    assert "secret-token" not in str(conn.updates)
+
+
+async def test_cancel_stops_active_prompt(monkeypatch):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class _BlockingWorkspace:
+        async def stream_query(self, request):  # noqa: ANN001
+            del request
+            started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            yield
+
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+    agent.on_connect(_FakeConn())
+
+    async def _fake_workspace():
+        return _BlockingWorkspace()
+
+    monkeypatch.setattr(agent, "_ensure_workspace", _fake_workspace)
+    response = await agent.new_session(cwd="/task")
+    prompt_task = asyncio.create_task(
+        agent.prompt(
+            prompt=[text_block("hello")],
+            session_id=response.session_id,
+        ),
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await agent.cancel(session_id=response.session_id)
+    result = await asyncio.wait_for(prompt_task, timeout=1)
+
+    assert cancelled.is_set()
+    assert result.stop_reason == "cancelled"

--- a/tests/unit/agents/test_acp_runtime_provider.py
+++ b/tests/unit/agents/test_acp_runtime_provider.py
@@ -111,7 +111,7 @@ def test_runtime_provider_builds_openai_provider():
     assert provider.has_model("policy")
 
 
-def test_runtime_provider_is_registered_only_in_memory(monkeypatch):
+async def test_runtime_provider_is_registered_only_in_memory(monkeypatch):
     manager = _FakeManager()
     original_model = manager.active_model
     agent = QwenPawACPAgent(
@@ -123,7 +123,7 @@ def test_runtime_provider_is_registered_only_in_memory(monkeypatch):
         lambda: manager,
     )
 
-    agent._install_runtime_provider()
+    await agent._install_runtime_provider()
 
     provider = manager.custom_providers[RUNTIME_OPENAI_PROVIDER_ID]
     assert provider.api_key == "execution-secret"
@@ -135,7 +135,36 @@ def test_runtime_provider_is_registered_only_in_memory(monkeypatch):
     assert manager.active_model is original_model
 
 
-def test_runtime_provider_credentials_are_not_persisted(
+async def test_runtime_provider_initialization_uses_sync_io(monkeypatch):
+    manager = _FakeManager()
+    operations = []
+    agent = QwenPawACPAgent(
+        agent_id="default",
+        runtime_provider=_config(),
+    )
+
+    def get_manager():
+        return manager
+
+    async def fake_run_sync_io(operation):
+        operations.append(operation)
+        return operation()
+
+    monkeypatch.setattr(
+        "qwenpaw.agents.acp.server.ProviderManager.get_instance",
+        get_manager,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.acp.server.run_sync_io",
+        fake_run_sync_io,
+    )
+
+    await agent._install_runtime_provider()
+
+    assert operations == [get_manager]
+
+
+async def test_runtime_provider_credentials_are_not_persisted(
     isolated_secret_dir,
 ):
     agent = QwenPawACPAgent(
@@ -143,7 +172,7 @@ def test_runtime_provider_credentials_are_not_persisted(
         runtime_provider=_config(),
     )
 
-    agent._install_runtime_provider()
+    await agent._install_runtime_provider()
 
     stored_text = "\n".join(
         path.read_text(encoding="utf-8")
@@ -173,7 +202,7 @@ async def test_runtime_provider_forces_model_override(monkeypatch):
         return workspace
 
     monkeypatch.setattr(agent, "_ensure_workspace", _fake_workspace)
-    agent._install_runtime_provider()
+    await agent._install_runtime_provider()
     response = await agent.new_session(cwd="/task")
 
     await agent.set_session_model(
@@ -199,14 +228,14 @@ async def test_runtime_provider_is_advertised_as_current_model(monkeypatch):
         "qwenpaw.agents.acp.server.ProviderManager.get_instance",
         lambda: manager,
     )
-    agent._install_runtime_provider()
+    await agent._install_runtime_provider()
 
     model_state = await agent._build_model_state()
 
     assert model_state is not None
     assert model_state.current_model_id == "runtime-openai:policy"
     assert [model.model_id for model in model_state.available_models] == [
-        "runtime-openai:policy"
+        "runtime-openai:policy",
     ]
 
 

--- a/tests/unit/agents/test_acp_session_mcp.py
+++ b/tests/unit/agents/test_acp_session_mcp.py
@@ -29,6 +29,8 @@ from qwenpaw.drivers.constants import (
     DRIVER_SCOPE_CONTEXT_KEY,
     POLICY_EFFECT_ASK,
 )
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.manager import DriverManager
 
 
 def _stdio_server(name: str = "tools") -> McpServerStdio:
@@ -77,6 +79,16 @@ def test_build_acp_mcp_driver_cards_normalizes_all_transports() -> None:
     )
     assert all(card.config["transient"] is True for card in cards)
     assert len({card.name for card in cards}) == len(cards)
+
+
+def test_build_acp_mcp_driver_cards_preserves_session_cwd() -> None:
+    cards = build_acp_mcp_driver_cards(
+        "session-1",
+        [_stdio_server()],
+        session_cwd="/workspace ",
+    )
+
+    assert cards[0].endpoint["cwd"] == "/workspace "
 
 
 def test_build_acp_mcp_driver_cards_rejects_duplicate_names() -> None:
@@ -244,6 +256,96 @@ async def test_acp_session_mcp_lifecycle_and_request_scope(tmp_path) -> None:
 
     await agent.close_session(session_id=response.session_id)
     assert workspace.driver_manager.removals[-1] == scope_id
+
+
+# pylint: disable-next=too-many-statements
+async def test_acp_session_cleanup_cancellation_preserves_committed_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    old_cwd = tmp_path / "old"
+    new_cwd = tmp_path / "new"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    teardown_started = asyncio.Event()
+    allow_teardown = asyncio.Event()
+    close_started = asyncio.Event()
+    allow_close = asyncio.Event()
+    close_finished = asyncio.Event()
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+    )
+
+    class _BlockingHandler:
+        def __init__(self, card) -> None:
+            self.card = card
+            self.name = card.name
+
+        async def shutdown(self) -> None:
+            if self.card.endpoint["cwd"] == str(old_cwd):
+                teardown_started.set()
+                await allow_teardown.wait()
+            else:
+                close_started.set()
+                await allow_close.wait()
+                close_finished.set()
+
+    async def build_handler(card):
+        return _BlockingHandler(card)
+
+    monkeypatch.setattr(manager, "_build_and_init_handler", build_handler)
+    workspace = _FakeWorkspace()
+    workspace.driver_manager = manager
+    agent = _TestACPAgent(workspace)
+    response = await agent.new_session(
+        cwd=str(old_cwd),
+        mcp_servers=[_stdio_server()],
+    )
+    scope_id = acp_mcp_scope_id(response.session_id)
+    load_task = asyncio.create_task(
+        agent.load_session(
+            cwd=str(new_cwd),
+            session_id=response.session_id,
+            mcp_servers=[_stdio_server()],
+        ),
+    )
+    try:
+        await asyncio.wait_for(teardown_started.wait(), timeout=1)
+
+        assert load_task.done()
+        load_task.cancel()
+        await load_task
+        assert agent._sessions[response.session_id]["cwd"] == str(new_cwd)
+        handler_name = next(iter(manager._scope_handlers[scope_id]))
+        assert manager._handlers[handler_name].card.endpoint["cwd"] == str(
+            new_cwd,
+        )
+
+        allow_teardown.set()
+        await manager._wait_for_handler_cleanups()
+        close_task = asyncio.create_task(
+            agent.close_session(session_id=response.session_id),
+        )
+        await asyncio.wait_for(close_started.wait(), timeout=1)
+
+        assert scope_id not in manager._scope_handlers
+        assert handler_name not in manager._handlers
+        assert not close_task.done()
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+        assert response.session_id in agent._sessions
+
+        allow_close.set()
+        await manager._wait_for_handler_cleanups()
+        assert close_finished.is_set()
+        await agent.close_session(session_id=response.session_id)
+        assert response.session_id not in agent._sessions
+    finally:
+        allow_teardown.set()
+        allow_close.set()
+        await manager.shutdown_all()
 
 
 async def test_acp_new_session_rolls_back_failed_mcp_registration(

--- a/tests/unit/agents/test_acp_session_mcp.py
+++ b/tests/unit/agents/test_acp_session_mcp.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+"""Tests for ACP session-scoped MCP Driver registration."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from acp import text_block
+from acp.schema import (
+    EnvVariable,
+    HttpHeader,
+    HttpMcpServer,
+    McpServerStdio,
+    SseMcpServer,
+)
+
+from qwenpaw.agents.acp.server import QwenPawACPAgent
+from qwenpaw.agents.acp.session_mcp import (
+    acp_mcp_scope_id,
+    build_acp_mcp_driver_cards,
+)
+from qwenpaw.drivers.constants import (
+    DRIVER_SCOPE_CONTEXT_KEY,
+    POLICY_EFFECT_ASK,
+)
+
+
+def _stdio_server(name: str = "tools") -> McpServerStdio:
+    return McpServerStdio(
+        name=name,
+        command="python",
+        args=["server.py"],
+        env=[EnvVariable(name="TOKEN", value="secret")],
+    )
+
+
+def test_build_acp_mcp_driver_cards_normalizes_all_transports() -> None:
+    cards = build_acp_mcp_driver_cards(
+        "session-1",
+        [
+            _stdio_server(),
+            SseMcpServer(
+                type="sse",
+                name="events",
+                url="https://example.test/sse",
+                headers=[HttpHeader(name="X-Test", value="sse")],
+            ),
+            HttpMcpServer(
+                type="http",
+                name="api",
+                url="https://example.test/mcp",
+                headers=[HttpHeader(name="Authorization", value="token")],
+            ),
+        ],
+    )
+
+    assert [card.endpoint["transport"] for card in cards] == [
+        "stdio",
+        "sse",
+        "streamable_http",
+    ]
+    assert cards[0].endpoint["env"] == {"TOKEN": "secret"}
+    assert cards[1].endpoint["headers"] == {"X-Test": "sse"}
+    assert cards[2].endpoint["headers"] == {
+        "Authorization": "token",
+    }
+    assert all(
+        card.policy.default_effect == POLICY_EFFECT_ASK for card in cards
+    )
+    assert all(card.config["transient"] is True for card in cards)
+    assert len({card.name for card in cards}) == len(cards)
+
+
+def test_build_acp_mcp_driver_cards_rejects_duplicate_names() -> None:
+    with pytest.raises(ValueError, match="Duplicate ACP MCP server name"):
+        build_acp_mcp_driver_cards(
+            "session-1",
+            [_stdio_server(), _stdio_server()],
+        )
+
+
+def test_build_acp_mcp_driver_cards_rejects_duplicate_headers() -> None:
+    server = HttpMcpServer(
+        type="http",
+        name="api",
+        url="https://example.test/mcp",
+        headers=[
+            HttpHeader(name="Authorization", value="one"),
+            HttpHeader(name="authorization", value="two"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Duplicate ACP MCP HTTP header"):
+        build_acp_mcp_driver_cards("session-1", [server])
+
+
+async def test_acp_advertises_supported_remote_mcp_transports() -> None:
+    agent = QwenPawACPAgent(agent_id="default")
+
+    response = await agent.initialize(protocol_version=1)
+
+    capabilities = response.agent_capabilities.mcp_capabilities
+    assert capabilities is not None
+    assert capabilities.http is True
+    assert capabilities.sse is True
+
+
+class _FakeConn:
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+    ) -> None:
+        del session_id, update
+
+
+class _FakeDriverManager:
+    def __init__(self) -> None:
+        self.replacements: list[tuple[str, list[Any]]] = []
+        self.removals: list[str] = []
+        self.fail_replacement = False
+
+    async def replace_transient_drivers(
+        self,
+        scope_id: str,
+        cards: list[Any],
+    ) -> None:
+        if self.fail_replacement:
+            raise RuntimeError("registration failed")
+        self.replacements.append((scope_id, cards))
+
+    async def remove_transient_drivers(self, scope_id: str) -> None:
+        self.removals.append(scope_id)
+
+
+class _FakeWorkspace:
+    def __init__(self) -> None:
+        self.driver_manager = _FakeDriverManager()
+        self.requests: list[Any] = []
+
+    async def stream_query(
+        self,
+        request: Any,
+    ) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        for event in ():
+            yield event
+
+
+class _TestACPAgent(QwenPawACPAgent):
+    def __init__(self, workspace: _FakeWorkspace) -> None:
+        super().__init__(agent_id="default")
+        self._fake_workspace = workspace
+
+    async def _ensure_workspace(self) -> _FakeWorkspace:
+        self._workspace = self._fake_workspace
+        return self._fake_workspace
+
+
+async def test_acp_session_mcp_lifecycle_and_request_scope(tmp_path) -> None:
+    workspace = _FakeWorkspace()
+    agent = _TestACPAgent(workspace)
+    agent.on_connect(_FakeConn())
+
+    response = await agent.new_session(
+        cwd=str(tmp_path),
+        mcp_servers=[_stdio_server()],
+    )
+    scope_id = acp_mcp_scope_id(response.session_id)
+
+    assert workspace.driver_manager.replacements[0][0] == scope_id
+    assert len(workspace.driver_manager.replacements[0][1]) == 1
+
+    await agent.prompt(
+        prompt=[text_block("hello")],
+        session_id=response.session_id,
+    )
+    request_context = workspace.requests[0].request_context
+    assert request_context[DRIVER_SCOPE_CONTEXT_KEY] == scope_id
+
+    await agent.resume_session(
+        cwd=str(tmp_path),
+        session_id=response.session_id,
+        mcp_servers=[],
+    )
+    assert workspace.driver_manager.replacements[-1] == (scope_id, [])
+
+    await agent.close_session(session_id=response.session_id)
+    assert workspace.driver_manager.removals[-1] == scope_id
+
+
+async def test_acp_new_session_rolls_back_failed_mcp_registration(
+    tmp_path: Path,
+) -> None:
+    workspace = _FakeWorkspace()
+    workspace.driver_manager.fail_replacement = True
+    agent = _TestACPAgent(workspace)
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        await agent.new_session(
+            cwd=str(tmp_path),
+            mcp_servers=[_stdio_server()],
+        )
+
+    assert not agent._sessions
+    assert len(workspace.driver_manager.removals) == 1
+
+
+async def test_acp_load_session_restores_metadata_on_mcp_failure(
+    tmp_path: Path,
+) -> None:
+    workspace = _FakeWorkspace()
+    agent = _TestACPAgent(workspace)
+    await agent.load_session(
+        cwd=str(tmp_path),
+        session_id="session-1",
+        mcp_servers=[],
+    )
+    previous = dict(agent._sessions["session-1"])
+    workspace.driver_manager.fail_replacement = True
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        await agent.load_session(
+            cwd="/replacement",
+            session_id="session-1",
+            mcp_servers=[_stdio_server()],
+        )
+
+    assert agent._sessions["session-1"] == previous
+
+
+async def test_acp_resume_session_removes_new_metadata_on_mcp_failure(
+    tmp_path: Path,
+) -> None:
+    workspace = _FakeWorkspace()
+    workspace.driver_manager.fail_replacement = True
+    agent = _TestACPAgent(workspace)
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        await agent.resume_session(
+            cwd=str(tmp_path),
+            session_id="session-1",
+            mcp_servers=[_stdio_server()],
+        )
+
+    assert not agent._sessions
+
+
+async def test_acp_close_waits_for_prompt_before_removing_mcp(
+    tmp_path: Path,
+) -> None:
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+
+    class _OrderedDriverManager(_FakeDriverManager):
+        async def remove_transient_drivers(self, scope_id: str) -> None:
+            assert stopped.is_set()
+            await super().remove_transient_drivers(scope_id)
+
+    class _BlockingWorkspace(_FakeWorkspace):
+        def __init__(self) -> None:
+            super().__init__()
+            self.driver_manager = _OrderedDriverManager()
+
+        async def stream_query(
+            self,
+            request: Any,
+        ) -> AsyncIterator[Any]:
+            del request
+            started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                stopped.set()
+            yield
+
+    workspace = _BlockingWorkspace()
+    agent = _TestACPAgent(workspace)
+    agent.on_connect(_FakeConn())
+    response = await agent.new_session(
+        cwd=str(tmp_path),
+        mcp_servers=[_stdio_server()],
+    )
+    prompt_task = asyncio.create_task(
+        agent.prompt(
+            prompt=[text_block("hello")],
+            session_id=response.session_id,
+        ),
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await agent.close_session(session_id=response.session_id)
+    prompt_response = await asyncio.wait_for(prompt_task, timeout=1)
+
+    assert prompt_response.stop_reason == "cancelled"
+    assert stopped.is_set()

--- a/tests/unit/agents/test_acp_session_mcp.py
+++ b/tests/unit/agents/test_acp_session_mcp.py
@@ -58,6 +58,7 @@ def test_build_acp_mcp_driver_cards_normalizes_all_transports() -> None:
                 headers=[HttpHeader(name="Authorization", value="token")],
             ),
         ],
+        session_cwd="/workspace",
     )
 
     assert [card.endpoint["transport"] for card in cards] == [
@@ -66,6 +67,7 @@ def test_build_acp_mcp_driver_cards_normalizes_all_transports() -> None:
         "streamable_http",
     ]
     assert cards[0].endpoint["env"] == {"TOKEN": "secret"}
+    assert cards[0].endpoint["cwd"] == "/workspace"
     assert cards[1].endpoint["headers"] == {"X-Test": "sse"}
     assert cards[2].endpoint["headers"] == {
         "Authorization": "token",
@@ -82,6 +84,7 @@ def test_build_acp_mcp_driver_cards_rejects_duplicate_names() -> None:
         build_acp_mcp_driver_cards(
             "session-1",
             [_stdio_server(), _stdio_server()],
+            session_cwd="/workspace",
         )
 
 
@@ -97,7 +100,30 @@ def test_build_acp_mcp_driver_cards_rejects_duplicate_headers() -> None:
     )
 
     with pytest.raises(ValueError, match="Duplicate ACP MCP HTTP header"):
-        build_acp_mcp_driver_cards("session-1", [server])
+        build_acp_mcp_driver_cards(
+            "session-1",
+            [server],
+            session_cwd="/workspace",
+        )
+
+
+def test_build_acp_mcp_driver_cards_rejects_duplicate_environment() -> None:
+    server = McpServerStdio(
+        name="tools",
+        command="python",
+        args=["server.py"],
+        env=[
+            EnvVariable(name="PATH", value="one"),
+            EnvVariable(name="Path", value="two"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Duplicate ACP MCP environment"):
+        build_acp_mcp_driver_cards(
+            "session-1",
+            [server],
+            session_cwd="/workspace",
+        )
 
 
 async def test_acp_advertises_supported_remote_mcp_transports() -> None:
@@ -167,6 +193,10 @@ async def test_acp_session_mcp_lifecycle_and_request_scope(tmp_path) -> None:
     workspace = _FakeWorkspace()
     agent = _TestACPAgent(workspace)
     agent.on_connect(_FakeConn())
+    load_cwd = tmp_path / "loaded"
+    resume_cwd = tmp_path / "resumed"
+    load_cwd.mkdir()
+    resume_cwd.mkdir()
 
     response = await agent.new_session(
         cwd=str(tmp_path),
@@ -176,6 +206,27 @@ async def test_acp_session_mcp_lifecycle_and_request_scope(tmp_path) -> None:
 
     assert workspace.driver_manager.replacements[0][0] == scope_id
     assert len(workspace.driver_manager.replacements[0][1]) == 1
+    assert workspace.driver_manager.replacements[0][1][0].endpoint[
+        "cwd"
+    ] == str(tmp_path)
+
+    await agent.load_session(
+        cwd=str(load_cwd),
+        session_id=response.session_id,
+        mcp_servers=[_stdio_server()],
+    )
+    assert workspace.driver_manager.replacements[-1][1][0].endpoint[
+        "cwd"
+    ] == str(load_cwd)
+
+    await agent.resume_session(
+        cwd=str(resume_cwd),
+        session_id=response.session_id,
+        mcp_servers=[_stdio_server()],
+    )
+    assert workspace.driver_manager.replacements[-1][1][0].endpoint[
+        "cwd"
+    ] == str(resume_cwd)
 
     await agent.prompt(
         prompt=[text_block("hello")],
@@ -185,7 +236,7 @@ async def test_acp_session_mcp_lifecycle_and_request_scope(tmp_path) -> None:
     assert request_context[DRIVER_SCOPE_CONTEXT_KEY] == scope_id
 
     await agent.resume_session(
-        cwd=str(tmp_path),
+        cwd=str(resume_cwd),
         session_id=response.session_id,
         mcp_servers=[],
     )

--- a/tests/unit/agents/test_acp_tool_capture.py
+++ b/tests/unit/agents/test_acp_tool_capture.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Tests for QwenPaw envelope to ACP tool-call capture."""
+
+from __future__ import annotations
+
+from qwenpaw.agents.acp.server import _EnvelopeTracker
+from qwenpaw.schemas import (
+    ContentType,
+    DataContent,
+    FunctionCall,
+    FunctionCallOutput,
+    Message,
+    MessageType,
+    Role,
+    RunStatus,
+)
+
+
+def _tool_call_message() -> Message:
+    message = Message(
+        id="message-call",
+        type=MessageType.PLUGIN_CALL,
+        role=Role.ASSISTANT,
+        status=RunStatus.Completed,
+        content=[
+            DataContent(
+                type=ContentType.DATA,
+                data=FunctionCall(
+                    call_id="call-1",
+                    name="benchmark__lookup",
+                    arguments='{"query": "documentation"}',
+                ).model_dump(),
+            ),
+        ],
+    )
+    message.object = "message"
+    return message
+
+
+def _tool_result_message(state: str) -> Message:
+    data = FunctionCallOutput(
+        call_id="call-1",
+        name="benchmark__lookup",
+        output='{"answer": "found"}',
+    ).model_dump()
+    data["state"] = state
+    message = Message(
+        id="message-result",
+        type=MessageType.PLUGIN_CALL_OUTPUT,
+        role=Role.TOOL,
+        status=RunStatus.Completed,
+        content=[
+            DataContent(
+                type=ContentType.DATA,
+                data=data,
+            ),
+        ],
+    )
+    message.object = "message"
+    return message
+
+
+def test_acp_tool_capture_preserves_id_name_arguments_and_output() -> None:
+    tracker = _EnvelopeTracker()
+
+    [start] = tracker.process(_tool_call_message())
+    [result] = tracker.process(_tool_result_message("success"))
+
+    assert start.tool_call_id == "call-1"
+    assert start.title == "benchmark__lookup"
+    assert start.status == "in_progress"
+    assert start.raw_input == {"query": "documentation"}
+    assert result.tool_call_id == "call-1"
+    assert result.status == "completed"
+    assert result.raw_output == '{"answer": "found"}'
+    assert result.content[0].content.text == '{"answer": "found"}'
+
+
+def test_acp_tool_capture_marks_unsuccessful_results_failed() -> None:
+    tracker = _EnvelopeTracker()
+
+    for state in ("error", "denied", "interrupted"):
+        [result] = tracker.process(_tool_result_message(state))
+        assert result.tool_call_id == "call-1"
+        assert result.status == "failed"

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -16,7 +16,7 @@ import pytest
 
 from qwenpaw.agents.acp.meta import (
     ACP_APPROVAL_EXPIRES_AT_META_KEY,
-    ACP_CODING_PROJECT_META_KEY,
+    ACP_PROJECT_DIR_META_KEY,
 )
 from qwenpaw.cli.tui.events import (
     BackendWarmed,
@@ -47,7 +47,7 @@ def test_session_kwargs_include_project_dir():
         project_dir="/tmp/project",
     )
     assert transport._session_kwargs() == {
-        ACP_CODING_PROJECT_META_KEY: "/tmp/project",
+        ACP_PROJECT_DIR_META_KEY: "/tmp/project",
     }
 
 

--- a/tests/unit/drivers/test_transient_scopes.py
+++ b/tests/unit/drivers/test_transient_scopes.py
@@ -3,6 +3,10 @@
 
 from __future__ import annotations
 
+# Tests verify managed cleanup ownership directly.
+# pylint: disable=protected-access
+
+import asyncio
 from pathlib import Path
 from typing import ClassVar
 
@@ -191,6 +195,50 @@ async def test_transient_replace_is_atomic_on_init_failure(
     assert "broken" in _FakeHandler.shutdown_names
 
 
+async def test_transient_replace_commits_before_retired_cleanup(
+    tmp_path: Path,
+) -> None:
+    teardown_started = asyncio.Event()
+    allow_teardown = asyncio.Event()
+
+    class _BlockingHandler(_FakeHandler):
+        async def _teardown(self) -> None:
+            if self.name == "old":
+                teardown_started.set()
+                await allow_teardown.wait()
+            await super()._teardown()
+
+    manager = _manager(tmp_path)
+    manager.register_handler_type("fake", _BlockingHandler)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("old")],
+    )
+
+    replace_task = asyncio.create_task(
+        manager.replace_transient_drivers(
+            "scope-a",
+            [_card("new")],
+        ),
+    )
+    try:
+        await asyncio.wait_for(teardown_started.wait(), timeout=1)
+
+        assert replace_task.done()
+        replace_task.cancel()
+        await replace_task
+        names = {
+            item.driver_name
+            for item in await manager.list_capabilities(
+                request_context=_scope_context("scope-a"),
+            )
+        }
+        assert names == {"new"}
+    finally:
+        allow_teardown.set()
+        await manager.shutdown_all()
+
+
 async def test_transient_remove_shuts_down_without_persisting(
     tmp_path: Path,
 ) -> None:
@@ -210,6 +258,55 @@ async def test_transient_remove_shuts_down_without_persisting(
         )
         == []
     )
+    await manager.shutdown_all()
+    assert _FakeHandler.shutdown_names == ["transient-a"]
+
+
+async def test_transient_remove_commits_before_handler_cleanup(
+    tmp_path: Path,
+) -> None:
+    teardown_started = asyncio.Event()
+    allow_teardown = asyncio.Event()
+
+    class _BlockingHandler(_FakeHandler):
+        async def _teardown(self) -> None:
+            teardown_started.set()
+            await allow_teardown.wait()
+            await super()._teardown()
+
+    manager = _manager(tmp_path)
+    manager.register_handler_type("fake", _BlockingHandler)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("transient-a")],
+    )
+    handler = manager._handlers["transient-a"]
+
+    remove_task = asyncio.create_task(
+        manager.remove_transient_drivers("scope-a"),
+    )
+    try:
+        await asyncio.wait_for(teardown_started.wait(), timeout=1)
+
+        assert not remove_task.done()
+        assert (
+            manager._schedule_handler_cleanup(
+                [handler],
+            )
+            is None
+        )
+        remove_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await remove_task
+        assert (
+            await manager.list_capabilities(
+                request_context=_scope_context("scope-a"),
+            )
+            == []
+        )
+    finally:
+        allow_teardown.set()
+        await manager.shutdown_all()
     assert _FakeHandler.shutdown_names == ["transient-a"]
 
 

--- a/tests/unit/drivers/test_transient_scopes.py
+++ b/tests/unit/drivers/test_transient_scopes.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+"""Tests for transient Driver scope isolation and lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from qwenpaw.drivers.capabilities import (
+    CapabilityExposure,
+    DriverCapability,
+    DriverInvocation,
+    DriverInvocationResult,
+    format_capability_id,
+)
+from qwenpaw.drivers.constants import DRIVER_SCOPE_CONTEXT_KEY
+from qwenpaw.drivers.contracts import DriverCard
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.handler import DriverHandler
+from qwenpaw.drivers.manager import DriverManager
+
+
+class _FakeHandler(DriverHandler):
+    shutdown_names: ClassVar[list[str]] = []
+
+    async def _setup(self) -> None:
+        if self.card.endpoint.get("fail"):
+            raise RuntimeError(f"Failed to initialize {self.name}")
+
+    async def _teardown(self) -> None:
+        self.shutdown_names.append(self.name)
+
+    async def list_capabilities(
+        self,
+        request_context: dict[str, str] | None = None,
+    ) -> list[DriverCapability]:
+        del request_context
+        capability_id = format_capability_id(
+            "fake",
+            self.name,
+            "tool",
+            "invoke",
+            "echo",
+        )
+        return [
+            DriverCapability(
+                capability_id=capability_id,
+                driver_name=self.name,
+                protocol="fake",
+                kind="tool",
+                action="invoke",
+                name="echo",
+                exposure=CapabilityExposure(
+                    as_tool=True,
+                    tool_name=f"{self.name}__echo",
+                ),
+            ),
+        ]
+
+    async def invoke_capability(
+        self,
+        invocation: DriverInvocation,
+    ) -> DriverInvocationResult:
+        return DriverInvocationResult(
+            ok=True,
+            value={
+                "driver": self.name,
+                "payload": invocation.payload,
+            },
+        )
+
+
+def _card(
+    name: str,
+    *,
+    fail: bool = False,
+    enabled: bool = True,
+) -> DriverCard:
+    return DriverCard(
+        name=name,
+        protocol="fake",
+        endpoint={"fail": fail},
+        enabled=enabled,
+    )
+
+
+def _manager(tmp_path: Path) -> DriverManager:
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+    )
+    manager.register_handler_type("fake", _FakeHandler)
+    return manager
+
+
+def _scope_context(scope_id: str) -> dict[str, str]:
+    return {DRIVER_SCOPE_CONTEXT_KEY: scope_id}
+
+
+@pytest.fixture(autouse=True)
+def _reset_handler_state() -> None:
+    _FakeHandler.shutdown_names = []
+
+
+async def test_transient_drivers_are_additive_and_scope_isolated(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.register_driver(_card("persistent"))
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("transient-a")],
+    )
+    await manager.replace_transient_drivers(
+        "scope-b",
+        [_card("transient-b")],
+    )
+
+    names_without_scope = {
+        item.driver_name for item in await manager.list_capabilities()
+    }
+    names_in_a = {
+        item.driver_name
+        for item in await manager.list_capabilities(
+            request_context=_scope_context("scope-a"),
+        )
+    }
+    names_in_b = {
+        item.driver_name
+        for item in await manager.list_capabilities(
+            request_context=_scope_context("scope-b"),
+        )
+    }
+
+    assert names_without_scope == {"persistent"}
+    assert names_in_a == {"persistent", "transient-a"}
+    assert names_in_b == {"persistent", "transient-b"}
+
+
+async def test_transient_invocation_rejects_another_scope(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("transient-a")],
+    )
+    capability = (
+        await manager.list_capabilities(
+            request_context=_scope_context("scope-a"),
+        )
+    )[0]
+
+    result = await manager.invoke_capability(
+        DriverInvocation(
+            capability_id=capability.capability_id,
+            payload={"value": "hello"},
+            request_context=_scope_context("scope-b"),
+        ),
+    )
+
+    assert result.ok is False
+    assert result.error_type == "driver_scope_mismatch"
+
+
+async def test_transient_replace_is_atomic_on_init_failure(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("old")],
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to initialize broken"):
+        await manager.replace_transient_drivers(
+            "scope-a",
+            [_card("new"), _card("broken", fail=True)],
+        )
+
+    names = {
+        item.driver_name
+        for item in await manager.list_capabilities(
+            request_context=_scope_context("scope-a"),
+        )
+    }
+    assert names == {"old"}
+    assert "new" in _FakeHandler.shutdown_names
+    assert "broken" in _FakeHandler.shutdown_names
+
+
+async def test_transient_remove_shuts_down_without_persisting(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("transient-a")],
+    )
+
+    assert await manager.card_store.list_paths() == []
+
+    await manager.remove_transient_drivers("scope-a")
+
+    assert (
+        await manager.list_capabilities(
+            request_context=_scope_context("scope-a"),
+        )
+        == []
+    )
+    assert _FakeHandler.shutdown_names == ["transient-a"]
+
+
+async def test_persistent_registration_rejects_transient_name(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.replace_transient_drivers(
+        "scope-a",
+        [_card("shared")],
+    )
+
+    with pytest.raises(ValueError, match="collides with a transient"):
+        await manager.register_driver(_card("shared"))
+
+    assert await manager.card_store.stored_path("shared") is None
+    capabilities = await manager.list_capabilities(
+        request_context=_scope_context("scope-a"),
+    )
+    assert [item.driver_name for item in capabilities] == ["shared"]
+
+
+async def test_transient_registration_rejects_disabled_persistent_name(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.register_driver(_card("shared", enabled=False))
+
+    with pytest.raises(ValueError, match="already exist"):
+        await manager.replace_transient_drivers(
+            "scope-a",
+            [_card("shared")],
+        )
+
+    assert await manager.card_store.stored_path("shared") is not None
+    assert (
+        await manager.list_capabilities(
+            request_context=_scope_context("scope-a"),
+        )
+        == []
+    )

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -6,7 +6,10 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from agentscope.credential import OpenAICredential
+from agentscope.message import ToolCallBlock
+from agentscope.model._model_response import ChatResponse
 
 from qwenpaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
@@ -52,13 +55,18 @@ class FakeAsyncStream:
             raise StopAsyncIteration from exc
 
 
-def _make_chunk(tool_calls: list[Any]) -> Any:
+def _make_chunk(
+    tool_calls: list[Any] | None = None,
+    *,
+    content: str | None = None,
+    reasoning_content: str | None = None,
+) -> Any:
     delta = SimpleNamespace(
-        reasoning_content=None,
-        content=None,
+        reasoning_content=reasoning_content,
+        content=content,
         tool_calls=tool_calls,
     )
-    choice = SimpleNamespace(delta=delta)
+    choice = SimpleNamespace(delta=delta, finish_reason=None)
     return SimpleNamespace(usage=None, choices=[choice])
 
 
@@ -178,3 +186,88 @@ def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:
     assert sanitized_missing_name_and_arguments is not None
     assert sanitized_missing_name_and_arguments.function.name == ""
     assert sanitized_missing_name_and_arguments.function.arguments == ""
+
+
+@pytest.mark.parametrize(
+    ("use_reasoning", "id_prefix"),
+    [
+        (False, "text_call_"),
+        (True, "think_call_"),
+    ],
+)
+async def test_tagged_tool_calls_use_agentscope_blocks_once(
+    use_reasoning: bool,
+    id_prefix: str,
+) -> None:
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    tagged = '<tool_call>{"name":"ping","arguments":{"x":1}}</tool_call>'
+    if use_reasoning:
+        tagged_chunk = _make_chunk(reasoning_content=tagged)
+        following_chunk = _make_chunk(reasoning_content="done")
+    else:
+        tagged_chunk = _make_chunk(content=tagged)
+        following_chunk = _make_chunk(content="done")
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        FakeAsyncStream([tagged_chunk, following_chunk]),
+    )
+
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0].id.startswith(id_prefix)
+    assert tool_blocks[0].name == "ping"
+    assert json.loads(tool_blocks[0].input) == {"x": 1}
+
+    accumulated = ChatResponse(content=[], is_last=True)
+    for response in responses:
+        accumulated.append_chat_response(response)
+
+    accumulated_tools = [
+        block
+        for block in accumulated.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert len(accumulated_tools) == 1
+    assert json.loads(accumulated_tools[0].input) == {"x": 1}
+
+
+async def test_multiple_tagged_tool_calls_have_unique_ids() -> None:
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    tagged = (
+        '<tool_call>{"name":"first","arguments":{}}</tool_call>'
+        '<tool_call>{"name":"second","arguments":{}}</tool_call>'
+    )
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        FakeAsyncStream([_make_chunk(content=tagged)]),
+    )
+
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert [block.name for block in tool_blocks] == ["first", "second"]
+    assert len({block.id for block in tool_blocks}) == 2

--- a/tests/unit/runtime/test_project_dir_override.py
+++ b/tests/unit/runtime/test_project_dir_override.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from qwenpaw.agents.acp.meta import ACP_CODING_PROJECT_META_KEY
+from qwenpaw.agents.acp.meta import ACP_PROJECT_DIR_META_KEY
 from qwenpaw.config.config import AgentProfileConfig
 from qwenpaw.runtime.builder import AgentBuilder
 from qwenpaw.runtime.prompt_contributors import CodingModeContributor
@@ -21,7 +21,7 @@ def test_request_project_override_does_not_enable_coding_tools(tmp_path):
 
     updated = AgentBuilder._apply_request_project(
         config,
-        {ACP_CODING_PROJECT_META_KEY: str(tmp_path)},
+        {ACP_PROJECT_DIR_META_KEY: str(tmp_path)},
     )
 
     assert updated is not config
@@ -62,12 +62,12 @@ def test_active_mode_project_precedes_session_project(tmp_path):
     assert updated.project_dir == str(active_dir.resolve())
 
 
-def test_request_coding_project_ignores_non_directory(tmp_path):
+def test_request_project_ignores_non_directory(tmp_path):
     config = AgentProfileConfig(id="default", name="Default")
 
     updated = AgentBuilder._apply_request_project(
         config,
-        {ACP_CODING_PROJECT_META_KEY: str(tmp_path / "missing")},
+        {ACP_PROJECT_DIR_META_KEY: str(tmp_path / "missing")},
     )
 
     assert updated is config
@@ -75,7 +75,7 @@ def test_request_coding_project_ignores_non_directory(tmp_path):
 
 
 @pytest.mark.usefixtures("capture_qwenpaw_logs")
-def test_request_coding_project_warns_for_unsupported_config(
+def test_request_project_warns_for_unsupported_config(
     caplog,
     tmp_path,
 ):
@@ -83,7 +83,7 @@ def test_request_coding_project_warns_for_unsupported_config(
 
     updated = AgentBuilder._apply_request_project(
         config,
-        {ACP_CODING_PROJECT_META_KEY: str(tmp_path)},
+        {ACP_PROJECT_DIR_META_KEY: str(tmp_path)},
     )
 
     assert updated is config


### PR DESCRIPTION
## Summary

- add an ephemeral OpenAI-compatible provider for headless ACP runtimes
- use the ACP session `cwd` as the runtime project context
- connect client-provided stdio, HTTP, and SSE MCP servers with session-scoped Driver lifecycles
- isolate transient Driver discovery and invocation by request scope
- expose typed tagged tool calls and complete ACP tool results
- make cancellation wait for active prompts before session resources are released

## Why this belongs in core

These are protocol and runtime capabilities that apply to any ACP client, not one frontend or launcher.

The ACP session setup contract defines `cwd` as the primary filesystem context and requires it to be used independently of the directory where the Agent subprocess was spawned. The same contract allows clients to provide MCP servers on session creation, load, and resume. Stdio MCP is required for all Agents, while HTTP and SSE support is advertised through `mcpCapabilities`.

Other ACP implementations follow the same architecture:

- Gemini CLI creates per-session configuration from `cwd`, merges client-provided MCP servers, and binds stdio MCP processes to the session directory.
- Codex ACP keeps the working directory, MCP servers, model, and active prompt lifecycle in session state.
- GitHub Copilot CLI documents the working directory and MCP servers as core `session/new` inputs and supports process-level BYOK configuration for headless ACP runtimes.

This change makes QwenPaw behave consistently with those clients while reusing the existing Provider, Workspace, Driver, policy, and approval infrastructure.

References:

- https://agentclientprotocol.com/protocol/v1/session-setup
- https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/acp/acpSessionManager.ts
- https://github.com/agentclientprotocol/codex-acp/blob/main/src/CodexAcpServer.ts
- https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server

## Design

### Ephemeral runtime provider

`qwenpaw acp --runtime-provider openai-env` reads `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and `OPENAI_MODEL`.

The provider exists only in memory for the ACP process:

- credentials are not written to provider configuration or secret storage
- every runtime-backed session receives an explicit model override
- ACP model state exposes only the runtime model, matching actual execution
- the previous process model state is restored during shutdown

### Session project context

The ACP `cwd` becomes the default `project_dir` request context. A controlled explicit project override still takes precedence.

This gives prompts, tools, file operations, and runtime context one session directory without modifying the Agent default.

### Session-scoped MCP

ACP MCP definitions are normalized into transient Driver cards:

- stdio, HTTP, and SSE transports are supported
- transient cards and credentials are never persisted
- every session receives a distinct Driver scope
- persistent Drivers remain available to all sessions
- transient Drivers are discoverable and invokable only from their owning scope
- replacement is build-before-publish and rolls back on initialization failure
- close removes and shuts down the session MCP handlers

The Agent now advertises `mcpCapabilities.http` and `mcpCapabilities.sse`, so compliant clients can use the implemented remote transports.

### Tool-call compatibility

Tagged tool calls recovered from OpenAI-compatible model text are emitted as typed AgentScope `ToolCallBlock` values with stable unique IDs. ACP tool result updates also preserve raw output and map unsuccessful states to `failed`.

## Merge blockers addressed

This version resolves the issues identified during review of the earlier follow-up:

- remote MCP transports are now declared during ACP initialization
- runtime model state matches the forced runtime model and does not advertise unusable alternatives
- transient and persistent Driver names cannot overwrite each other, including disabled persistent cards
- `session/close` waits for the active prompt to stop before MCP resources are removed
- session MCP replacement and metadata updates roll back together on failure
- direct unit and integration coverage has been restored and expanded

## Security

- client-provided MCP tools retain the default `ask` policy
- request scope checks apply to capability listing, direct Driver listing, and invocation
- MCP environment values and HTTP headers remain in memory and are not written to Driver storage
- runtime provider credentials remain in memory and are removed on shutdown
- unexpected prompt failures return a generic ACP error unless local diagnostics are explicitly enabled

## Validation

```text
Focused new runtime/session tests:
41 passed

ACP, Driver, provider compatibility, and Driver integration tests:
247 passed, 2 skipped

pre-commit on all changed Python files:
AST, encoding, trailing commas, mypy, black, flake8, and pylint passed

git diff --check:
passed
```

## Scope

This PR intentionally does not add persistent runtime-provider configuration or a new compatibility layer. It uses the existing Provider and Driver contracts and keeps all client-supplied runtime state ephemeral.
