### PR TITLE
fix(prompt): refresh current date for long-lived sessions

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -63,10 +63,10 @@ class CurrentDateMiddleware(MiddlewareBase):
 
     async def on_system_prompt(
         self,
+        # pylint: disable=unused-argument
         agent: "Agent",
         current_prompt: str,
     ) -> str:
-        del agent
         timezone_name = self._timezone_name
         try:
             tz = ZoneInfo(timezone_name)

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -16,9 +16,12 @@ Currently provided:
 
 import asyncio
 import logging
+import re
 from contextlib import contextmanager
 from contextvars import ContextVar
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Iterator, Set
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from agentscope.middleware import MiddlewareBase
 from agentscope.message import Msg
@@ -40,10 +43,47 @@ logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
 _AUTOMATION_MEMORY_SKIP_SOURCES = frozenset({"cron", "heartbeat"})
 _TOOL_RESULT_METADATA_KEY = "qwenpaw_tool_result_metadata"
+_CURRENT_DATE_LINE = re.compile(r"^- Current date: .*$", re.MULTILINE)
 _MANUAL_COMPACT_MEMORY_BY_HANDLER: ContextVar[bool] = ContextVar(
     "manual_compact_memory_by_handler",
     default=False,
 )
+
+
+class CurrentDateMiddleware(MiddlewareBase):
+    """Refresh the environment date before every model call."""
+
+    def __init__(
+        self,
+        timezone_name: str,
+        clock: Callable[[Any], datetime] = datetime.now,
+    ) -> None:
+        self._timezone_name = timezone_name or "UTC"
+        self._clock = clock
+
+    async def on_system_prompt(
+        self,
+        agent: "Agent",
+        current_prompt: str,
+    ) -> str:
+        del agent
+        timezone_name = self._timezone_name
+        try:
+            tz = ZoneInfo(timezone_name)
+        except (ZoneInfoNotFoundError, KeyError):
+            logger.warning(
+                "Invalid timezone %r, falling back to UTC",
+                timezone_name,
+            )
+            timezone_name = "UTC"
+            tz = timezone.utc
+
+        now = self._clock(tz)
+        current_date = (
+            f"- Current date: {now.strftime('%Y-%m-%d')} "
+            f"{timezone_name} ({now.strftime('%A')})"
+        )
+        return _CURRENT_DATE_LINE.sub(current_date, current_prompt, count=1)
 
 
 @contextmanager

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -1125,7 +1125,12 @@ class AgentBuilder:
         3. Plugin-registered middlewares (sorted by priority)
         4. VisualCompressionMiddleware — innermost pre-provider transform
         """
-        mws: list[Any] = []
+        from ..agents.middlewares import CurrentDateMiddleware
+        from ..config.utils import load_config
+
+        mws: list[Any] = [
+            CurrentDateMiddleware(load_config().user_timezone),
+        ]
 
         pruning_middleware = None
         try:

--- a/tests/unit/agents/test_current_date_middleware.py
+++ b/tests/unit/agents/test_current_date_middleware.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Tests for refreshing the date in long-lived agent prompts."""
+
+from datetime import datetime
+
+import pytest
+
+from qwenpaw.agents.middlewares import CurrentDateMiddleware
+
+
+@pytest.mark.asyncio
+async def test_refreshes_stale_date_with_configured_timezone() -> None:
+    prompt = (
+        "====================\n"
+        "- Session ID: long-lived\n"
+        "- Current date: 2026-08-05 Asia/Shanghai (Wednesday)\n"
+        "- Important: keep this line\n"
+        "===================="
+    )
+    middleware = CurrentDateMiddleware(
+        "Asia/Shanghai",
+        clock=lambda tz: datetime(2026, 8, 6, 9, 30, tzinfo=tz),
+    )
+
+    result = await middleware.on_system_prompt(None, prompt)
+
+    assert "- Current date: 2026-08-06 Asia/Shanghai (Thursday)" in result
+    assert "- Current date: 2026-08-05" not in result
+    assert "- Important: keep this line" in result
+
+
+@pytest.mark.asyncio
+async def test_invalid_timezone_falls_back_to_utc() -> None:
+    middleware = CurrentDateMiddleware(
+        "Invalid/Timezone",
+        clock=lambda tz: datetime(2026, 8, 6, 1, 30, tzinfo=tz),
+    )
+
+    result = await middleware.on_system_prompt(
+        None,
+        "- Current date: 2026-08-05 Invalid/Timezone (Wednesday)",
+    )
+
+    assert result == "- Current date: 2026-08-06 UTC (Thursday)"
+
+
+@pytest.mark.asyncio
+async def test_prompt_without_current_date_is_unchanged() -> None:
+    middleware = CurrentDateMiddleware(
+        "UTC",
+        clock=lambda tz: datetime(2026, 8, 6, tzinfo=tz),
+    )
+    prompt = "System prompt without an environment date."
+
+    assert await middleware.on_system_prompt(None, prompt) == prompt


### PR DESCRIPTION
## Description

Fixes #6755.

The environment context records `Current date` when an agent is built. A
long-lived session keeps that frozen system prompt across midnight, so later
model calls can receive yesterday's date and weekday and schedule tasks on the
wrong day.

This PR adds a system-prompt middleware that refreshes only the existing
`- Current date:` line whenever AgentScope assembles the prompt for a model
call. It uses the configured user timezone, preserves every other prompt line,
and falls back to UTC if a persisted timezone becomes invalid.

**Related Issue:** Fixes #6755

**Security Considerations:** None. The change updates non-sensitive runtime
environment metadata already present in the prompt.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] Relevant tests pass
- [x] Documentation updated (not needed; runtime correctness fix)
- [x] Ready for review

## Testing

The regression freezes the middleware clock before and after the reported
date boundary and verifies the exact Asia/Shanghai date/weekday pair. It also
covers invalid timezone fallback and prompts without an environment date.

## Evidence

Before the fix, an agent built on August 5 retained:

```text
- Current date: 2026-08-05 Asia/Shanghai (Wednesday)
```

for model calls made on August 6.

After the fix:

```bash
.venv/bin/pytest \
  tests/unit/agents/test_current_date_middleware.py \
  tests/unit/workspace/test_prompt.py \
  tests/unit/runtime/test_builder_scroll_migration.py -q
# 9 passed in 2.92s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/agents/middlewares.py \
  src/qwenpaw/runtime/builder.py \
  tests/unit/agents/test_current_date_middleware.py
# Python AST, encoding, private-key detection, whitespace, trailing commas,
# mypy, black, flake8, and pylint: Passed
```

`actionlint` is not applicable to the changed Python files.

## Additional Notes

The implementation was AI-assisted and personally verified after rebasing onto
current `main` (`9ad8166b`), against Issue #6755, AgentScope's per-call
`_get_system_prompt()` middleware pipeline, and semantic searches across open
issues and PRs.
