### PR TITLE
fix: preserve tool call extra content across context lifecycle

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -388,6 +388,8 @@ class HistoryStore:
                     (seq,),
                 ).fetchone()
                 old_content = r["content"] if r else None
+            # Keep every column name below as a hard-coded literal. Only
+            # values are parameterized; never add caller-controlled names.
             assignments = [
                 "content = ?",
                 "headline = ?",
@@ -408,6 +410,8 @@ class HistoryStore:
             ]
             if metadata is not _UNSET:
                 assignments.append("metadata = ?")
+                # The history schema canonically represents empty metadata
+                # as SQL NULL, matching the initial insert path.
                 values.append(_to_json(metadata or None))
             values.append(seq)
             self._conn.execute(

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -18,6 +18,7 @@ from ..types import LogEntry
 logger = logging.getLogger(__name__)
 
 _BUSY_TIMEOUT_MS = 5000
+_UNSET = object()
 
 # The recall tool's own turns — the model's ``ms.*`` Python source and its
 # printed stdout/stderr — are written through to history like any turn, but
@@ -363,6 +364,7 @@ class HistoryStore:
         name: str | None = None,
         tool_state: str | None = None,
         tool_input: Any = None,
+        metadata: Any = _UNSET,
     ) -> None:
         """Refresh an already-appended row in place (keeping FTS in sync).
 
@@ -370,9 +372,10 @@ class HistoryStore:
         accumulates a whole reply into a single assistant Msg, so the durable
         row must end up with every cell's blocks and any later-emitted
         headline. The scalar ``tool_call_id``/``name``/``tool_state``/
-        ``tool_input`` are refreshed too, so a turn that grows a *later* tool
-        call doesn't leave them frozen at their first-write values. ``seq`` is
-        unchanged.
+        ``tool_input`` and message ``metadata`` are refreshed too, so a turn
+        that grows a *later* tool call doesn't leave them frozen at their
+        first-write values. ``seq`` is unchanged. Omitting ``metadata`` keeps
+        the stored value unchanged for backwards-compatible direct callers.
         """
         # Recall-tool rows are never FTS-indexed (see ``_RECALL_TOOL_NAMES``),
         # so don't touch the index for them on update either.
@@ -385,20 +388,33 @@ class HistoryStore:
                     (seq,),
                 ).fetchone()
                 old_content = r["content"] if r else None
+            assignments = [
+                "content = ?",
+                "headline = ?",
+                "blocks = ?",
+                "tool_call_id = ?",
+                "name = ?",
+                "tool_state = ?",
+                "tool_input = ?",
+            ]
+            values: list[Any] = [
+                content,
+                headline,
+                _to_json(blocks),
+                tool_call_id,
+                name,
+                tool_state,
+                _to_json(tool_input),
+            ]
+            if metadata is not _UNSET:
+                assignments.append("metadata = ?")
+                values.append(_to_json(metadata or None))
+            values.append(seq)
             self._conn.execute(
-                "UPDATE conversation_history SET content = ?, headline = ?, "
-                "blocks = ?, tool_call_id = ?, name = ?, tool_state = ?, "
-                "tool_input = ? WHERE seq = ?",
-                (
-                    content,
-                    headline,
-                    _to_json(blocks),
-                    tool_call_id,
-                    name,
-                    tool_state,
-                    _to_json(tool_input),
-                    seq,
-                ),
+                "UPDATE conversation_history SET "
+                + ", ".join(assignments)
+                + " WHERE seq = ?",
+                values,
             )
             if fts_sync:
                 if old_content is not None:

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -1627,6 +1627,7 @@ class ScrollContextManager:
                             name=entry.name,
                             tool_state=entry.tool_state,
                             tool_input=entry.tool_input,
+                            metadata=entry.metadata,
                         )
                         self._model_turn_nblk[mid] = nblk
                         if new_headline:

--- a/src/qwenpaw/agents/context/scroll/serialize.py
+++ b/src/qwenpaw/agents/context/scroll/serialize.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
 from agentscope.message import Msg
 
 from ....constant import QWENPAW_MESSAGE_TAG_KEY
+from ....utils.tool_call_extra import TOOL_CALL_EXTRAS_METADATA_KEY
 from ..types import LogEntry
 
 # The model echoes a milestone as a fenced single line: ``⟦ text ⟧`` (rare
@@ -287,14 +289,22 @@ def msg_to_entries(msg: Msg) -> list[LogEntry]:
         if media:
             joined = "\n".join(media)
             text = f"{text}\n{joined}".strip() if text else joined
-        # Persist the runtime tag (loop_continuation / auto_continue / …) so
-        # durable rows keep the "this user msg is a synthetic stub, not a
-        # request" signal — the recall layer's active-turn floor anchors on
-        # real requests only and needs it in SQL.
-        tag = None
+        # Persist only protocol metadata required to reconstruct the turn:
+        # runtime tags distinguish synthetic stubs from real requests, while
+        # provider tool-call extras preserve signatures for exact archives.
+        persisted_metadata: dict[str, Any] = {}
         msg_meta = getattr(msg, "metadata", None)
         if isinstance(msg_meta, dict):
             tag = msg_meta.get(QWENPAW_MESSAGE_TAG_KEY)
+            if tag:
+                persisted_metadata[QWENPAW_MESSAGE_TAG_KEY] = str(tag)
+            tool_call_extras = msg_meta.get(
+                TOOL_CALL_EXTRAS_METADATA_KEY,
+            )
+            if isinstance(tool_call_extras, dict):
+                persisted_metadata[TOOL_CALL_EXTRAS_METADATA_KEY] = deepcopy(
+                    tool_call_extras,
+                )
         entries.append(
             LogEntry(
                 kind="model_turn"
@@ -307,7 +317,7 @@ def msg_to_entries(msg: Msg) -> list[LogEntry]:
                 tool_input=tool_input,
                 headline=headline,
                 blocks=dumped or None,
-                metadata=({QWENPAW_MESSAGE_TAG_KEY: str(tag)} if tag else {}),
+                metadata=persisted_metadata,
                 created_at=created_at,
             ),
         )

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1374,22 +1374,20 @@ def _resolve_model_slot_override(model_slot_override: Any):
     return slot
 
 
-def _canonical_provider_id_for_model(
+def _bind_provider_id_to_model(
     model: ChatModelBase,
-    configured_provider_id: str,
+    provider_id: str,
 ) -> str:
-    """Prefer the provider identity explicitly bound to the model."""
-    model_provider_id = getattr(model, "qwenpaw_provider_id", None)
-    if not isinstance(model_provider_id, str) or not model_provider_id:
-        return configured_provider_id
-    if model_provider_id != configured_provider_id:
-        logger.warning(
-            "Configured provider id %r differs from the model's canonical "
-            "id %r; using the model id for formatter scope.",
-            configured_provider_id,
-            model_provider_id,
-        )
-    return model_provider_id
+    """Bind the provider identity resolved by ``ProviderManager``."""
+    bind_provider_id = getattr(model, "bind_qwenpaw_provider_id", None)
+    if callable(bind_provider_id):
+        bind_provider_id(provider_id)
+    return provider_id
+
+
+def _resolved_provider_id(provider: Any, configured_provider_id: str) -> str:
+    """Return the canonical ID exposed by a resolved provider instance."""
+    return str(getattr(provider, "id", "") or configured_provider_id)
 
 
 def create_model_and_formatter(
@@ -1472,7 +1470,7 @@ def create_model_and_formatter(
             )
 
         model = provider.get_chat_model_instance(model_slot.model)
-        provider_id = model_slot.provider_id
+        provider_id = _resolved_provider_id(provider, model_slot.provider_id)
     else:
         # Fallback to global active model
         model = ProviderManager.get_active_chat_model()
@@ -1485,9 +1483,14 @@ def create_model_and_formatter(
                     "or set an agent-specific model."
                 ),
             )
-        provider_id = global_model.provider_id
+        provider_id = _resolved_provider_id(
+            ProviderManager.get_instance().get_provider(
+                global_model.provider_id,
+            ),
+            global_model.provider_id,
+        )
 
-    provider_id = _canonical_provider_id_for_model(model, provider_id)
+    provider_id = _bind_provider_id_to_model(model, provider_id)
 
     # Create the formatter based on the model's native one.  In 2.0 every
     # ``ChatModelBase`` carries its own ``self.formatter`` (set by its

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1374,6 +1374,24 @@ def _resolve_model_slot_override(model_slot_override: Any):
     return slot
 
 
+def _canonical_provider_id_for_model(
+    model: ChatModelBase,
+    configured_provider_id: str,
+) -> str:
+    """Prefer the provider identity explicitly bound to the model."""
+    model_provider_id = getattr(model, "qwenpaw_provider_id", None)
+    if not isinstance(model_provider_id, str) or not model_provider_id:
+        return configured_provider_id
+    if model_provider_id != configured_provider_id:
+        logger.warning(
+            "Configured provider id %r differs from the model's canonical "
+            "id %r; using the model id for formatter scope.",
+            configured_provider_id,
+            model_provider_id,
+        )
+    return model_provider_id
+
+
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
     model_slot_override: Any = None,
@@ -1468,6 +1486,8 @@ def create_model_and_formatter(
                 ),
             )
         provider_id = global_model.provider_id
+
+    provider_id = _canonical_provider_id_for_model(model, provider_id)
 
     # Create the formatter based on the model's native one.  In 2.0 every
     # ``ChatModelBase`` carries its own ``self.formatter`` (set by its

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -10,6 +10,7 @@ Example:
 """
 
 import base64
+from collections import defaultdict, deque
 import hashlib
 import logging
 import os
@@ -39,6 +40,7 @@ from .utils.message_request_normalizer import (
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
+from ..utils.tool_call_extra import tool_call_extras_for_provider
 from ..providers.retry_chat_model import (
     RetryChatModel,
     RetryConfig,
@@ -977,6 +979,7 @@ def _fixup_media_list(items: list) -> None:
 # pylint: disable-next=too-many-statements
 def _create_file_block_support_formatter(
     base_formatter_class: Type[FormatterBase],
+    provider_id: str | None = None,
 ) -> Type[FormatterBase]:
     """Create a formatter class with file block support.
 
@@ -984,7 +987,10 @@ def _create_file_block_support_formatter(
     in tool results, which are not natively supported by AgentScope.
 
     Args:
-        base_formatter_class: Base formatter class to extend
+        base_formatter_class: Base formatter class to extend.
+        provider_id: Provider owning the formatter. Provider-specific
+            tool-call metadata is relayed only when this matches the
+            provider that originally emitted it.
 
     Returns:
         Enhanced formatter class with file block support
@@ -1075,10 +1081,14 @@ def _create_file_block_support_formatter(
             )
 
             has_reasoning = False
-            extra_contents: dict[str, Any] = {}
+            extra_contents: dict[str, deque[Any]] = defaultdict(deque)
             for msg in normalized_msgs:
                 if msg.role != "assistant":
                     continue
+                persisted_extras = tool_call_extras_for_provider(
+                    msg,
+                    provider_id,
+                )
                 for block in msg.content or []:
                     if _battr(block, "type") == "thinking":
                         thinking = _battr(block, "thinking", "")
@@ -1088,9 +1098,13 @@ def _create_file_block_support_formatter(
                     btype = _battr(block, "type")
                     if btype in ("tool_use", "tool_call"):
                         ec = _battr(block, "extra_content")
+                        if ec is None:
+                            ec = persisted_extras.get(
+                                _battr(block, "id", ""),
+                            )
                         if ec is not None:
                             bid = _battr(block, "id", "")
-                            extra_contents[bid] = ec
+                            extra_contents[bid].append(ec)
 
             # Convert file:// URLs to paths for all media blocks,
             # and replace deleted local files with text placeholders.
@@ -1135,11 +1149,15 @@ def _create_file_block_support_formatter(
             messages = _reorder_tool_and_promoted_messages(messages)
             _fix_image_mime_types(messages)
 
-            if extra_contents and _is_gemini_formatter:
+            if extra_contents and issubclass(
+                base_formatter_class,
+                OpenAIChatFormatter,
+            ):
                 for message in messages:
                     for tc in message.get("tool_calls", []):
-                        ec = extra_contents.get(tc.get("id"))
-                        if ec:
+                        queued = extra_contents.get(tc.get("id"))
+                        if queued:
+                            ec = queued.popleft()
                             tc["extra_content"] = ec
 
             relay_reasoning = getattr(
@@ -1448,7 +1466,7 @@ def create_model_and_formatter(
     # ``ChatModelBase`` carries its own ``self.formatter`` (set by its
     # ``__init__``), so we just wrap that one with file-block support
     # instead of class-resolving via a brittle map.
-    formatter = _create_formatter_instance(model)
+    formatter = _create_formatter_instance(model, provider_id=provider_id)
     # Keep the provider model and the separately returned formatter on the
     # same instance.  AgentScope formats ``Msg`` objects through
     # ``model.formatter`` inside every API call, while QwenPaw's retry layer
@@ -1483,6 +1501,7 @@ def create_model_and_formatter(
 
 def _create_formatter_instance(
     model: ChatModelBase,
+    provider_id: str | None = None,
 ) -> FormatterBase:
     """Wrap the model's native formatter with file-block support.
 
@@ -1516,6 +1535,7 @@ def _create_formatter_instance(
     base_formatter_class = type(base_formatter)
     formatter_class = _create_file_block_support_formatter(
         base_formatter_class,
+        provider_id=provider_id,
     )
     # Carry over all Pydantic field values (max_bytes,
     # relay_reasoning_content, etc.) from the provider-constructed

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1081,6 +1081,9 @@ def _create_file_block_support_formatter(
             )
 
             has_reasoning = False
+            # Tool-call IDs are required to be unique within one assistant
+            # response. A deque still preserves FIFO order when historical
+            # messages from separate turns happen to reuse the same ID.
             extra_contents: dict[str, deque[Any]] = defaultdict(deque)
             for msg in normalized_msgs:
                 if msg.role != "assistant":
@@ -1149,6 +1152,10 @@ def _create_file_block_support_formatter(
             messages = _reorder_tool_and_promoted_messages(messages)
             _fix_image_mime_types(messages)
 
+            # ``extra_content`` is an OpenAI-chat wire extension. Persisted
+            # values entered ``extra_contents`` only when ``provider_id``
+            # matched their origin, so other compatible providers never see
+            # the field merely because they share this formatter family.
             if extra_contents and issubclass(
                 base_formatter_class,
                 OpenAIChatFormatter,

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -240,9 +240,21 @@ class QwenPawAgent(CodingModeMixin, Agent):
 
     def _save_to_context(self, blocks: Any, usage: Any = None) -> None:
         """Append blocks, then let the context manager write them through."""
-        super()._save_to_context(blocks, usage)
+        from ..utils.tool_call_extra import (
+            collect_transient_tool_call_extras,
+            persist_tool_call_extras,
+        )
+
+        block_list = list(blocks or [])
+        tool_call_extras = collect_transient_tool_call_extras(block_list)
+
+        super()._save_to_context(block_list, usage)
+        if tool_call_extras:
+            last_msg = self._get_last_msg()
+            if last_msg is not None and last_msg.role == "assistant":
+                persist_tool_call_extras(last_msg, tool_call_extras)
         if self._context_manager is not None:
-            self._context_manager.on_save(self, blocks)
+            self._context_manager.on_save(self, block_list)
 
     # Session persistence calls state_dict/load_state_dict on the agent;
     # these round-trip through self.state (AgentState pydantic model).

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -41,6 +41,10 @@ from ..constant import (
 from ..loop.gates import StopAction, StopHandlerResult
 from ..providers.error_utils import extract_status_code
 from ..providers.model_capability_cache import get_capability_cache
+from ..utils.tool_call_extra import (
+    collect_transient_tool_call_extras,
+    persist_tool_call_extras,
+)
 
 if TYPE_CHECKING:
     from ..agents.memory import BaseMemoryManager
@@ -240,11 +244,6 @@ class QwenPawAgent(CodingModeMixin, Agent):
 
     def _save_to_context(self, blocks: Any, usage: Any = None) -> None:
         """Append blocks, then let the context manager write them through."""
-        from ..utils.tool_call_extra import (
-            collect_transient_tool_call_extras,
-            persist_tool_call_extras,
-        )
-
         block_list = list(blocks or [])
         tool_call_extras = collect_transient_tool_call_extras(block_list)
 

--- a/src/qwenpaw/providers/ollama_provider.py
+++ b/src/qwenpaw/providers/ollama_provider.py
@@ -91,6 +91,7 @@ class OllamaProvider(OpenAIProvider):
         )
         return OpenAIChatModelCompat(
             credential=credential,
+            provider_id=self.id,
             model=model_id,
             parameters=parameters,
             stream=True,

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -17,6 +17,7 @@ from qwenpaw.local_models.tag_parser import (
     parse_tool_calls_from_text,
     text_contains_tool_call_tag,
 )
+from qwenpaw.utils.tool_call_extra import attach_transient_tool_call_extra
 
 logger = logging.getLogger(__name__)
 
@@ -647,6 +648,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         self._extra_generate_kwargs = extra_generate_kwargs or {}
         self._output_token_param = output_token_param
         super().__init__(**kwargs)
+        credential_id = str(getattr(self.credential, "id", "") or "")
+        self._qwenpaw_provider_id = credential_id.removeprefix("qwenpaw-")
 
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         try:
@@ -792,10 +795,11 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                         continue
                     ec = sanitized_response.extra_contents.get(tool_id)
                     if ec:
-                        if isinstance(block, dict):
-                            block["extra_content"] = ec
-                        else:
-                            block.extra_content = ec
+                        attach_transient_tool_call_extra(
+                            block,
+                            provider_id=self._qwenpaw_provider_id,
+                            extra_content=ec,
+                        )
 
             has_tool_use = any(
                 (

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -681,6 +681,17 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         """Canonical provider ID used for provider-scoped metadata."""
         return self._qwenpaw_provider_id
 
+    def bind_qwenpaw_provider_id(self, provider_id: str) -> None:
+        """Bind the provider identity resolved by ``ProviderManager``.
+
+        Credential-derived IDs are only a fallback for models constructed
+        outside QwenPaw's factory.  Inside the factory, the resolved provider
+        instance is authoritative for metadata, accounting, and retry keys.
+        """
+        if not provider_id:
+            raise ValueError("provider_id must not be empty")
+        self._qwenpaw_provider_id = provider_id
+
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         try:
             from ..observability.langfuse import (
@@ -715,22 +726,25 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         reattach its records to the final accumulated response.
         """
         extras: dict[str, dict[str, Any]] = {}
-        async for chunk in response:
-            extras.update(
-                collect_transient_tool_call_extras(chunk.content),
-            )
-            if chunk.is_last and extras:
-                for block in chunk.content:
-                    tool_id = _battr(block, "id")
-                    record = extras.get(tool_id)
-                    if not record:
-                        continue
-                    attach_transient_tool_call_extra(
-                        block,
-                        provider_id=str(record.get("provider_id") or ""),
-                        extra_content=record["extra_content"],
-                    )
-            yield chunk
+        try:
+            async for chunk in response:
+                extras.update(
+                    collect_transient_tool_call_extras(chunk.content),
+                )
+                if chunk.is_last and extras:
+                    for block in chunk.content:
+                        tool_id = _battr(block, "id")
+                        record = extras.get(tool_id)
+                        if not record:
+                            continue
+                        attach_transient_tool_call_extra(
+                            block,
+                            provider_id=str(record.get("provider_id") or ""),
+                            extra_content=record["extra_content"],
+                        )
+                yield chunk
+        finally:
+            await response.aclose()
 
     async def _call_api(
         self,

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import re
@@ -17,7 +18,10 @@ from qwenpaw.local_models.tag_parser import (
     parse_tool_calls_from_text,
     text_contains_tool_call_tag,
 )
-from qwenpaw.utils.tool_call_extra import attach_transient_tool_call_extra
+from qwenpaw.utils.tool_call_extra import (
+    attach_transient_tool_call_extra,
+    collect_transient_tool_call_extras,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +167,7 @@ class _SanitizedStream:
         self._stream = stream
         self._ctx_stream: Any | None = None
         self.extra_contents: dict[str, Any] = {}
+        self._tool_call_ids: dict[int, str] = {}
 
     async def __aenter__(self) -> "_SanitizedStream":
         self._ctx_stream = await self._stream.__aenter__()
@@ -196,6 +201,11 @@ class _SanitizedStream:
                 continue
             for tc in getattr(delta, "tool_calls", None) or []:
                 tc_id = getattr(tc, "id", None)
+                index = getattr(tc, "index", None)
+                if tc_id and isinstance(index, int):
+                    self._tool_call_ids[index] = tc_id
+                elif not tc_id and isinstance(index, int):
+                    tc_id = self._tool_call_ids.get(index)
                 if not tc_id:
                     continue
                 extra = getattr(tc, "extra_content", None)
@@ -628,8 +638,10 @@ class OpenAIChatModelCompat(OpenAIChatModel):
     """OpenAIChatModel with robust parsing for malformed tool-call chunks
     and transparent ``extra_content`` (Gemini thought_signature) relay.
 
-    Accepts two extra constructor kwargs that ``OpenAIChatModel`` does not:
+    Accepts extra constructor kwargs that ``OpenAIChatModel`` does not:
 
+    * ``provider_id`` — canonical QwenPaw provider identity used to scope
+      persisted tool-call metadata.
     * ``default_headers`` — injected as ``extra_headers`` on every API call
       (used for DashScope tracking headers, etc.).
     * ``extra_generate_kwargs`` — merged into every ``_call_api`` invocation
@@ -639,6 +651,7 @@ class OpenAIChatModelCompat(OpenAIChatModel):
     def __init__(
         self,
         *,
+        provider_id: str | None = None,
         default_headers: dict[str, str] | None = None,
         extra_generate_kwargs: dict[str, Any] | None = None,
         output_token_param: str = "max_tokens",
@@ -649,7 +662,24 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         self._output_token_param = output_token_param
         super().__init__(**kwargs)
         credential_id = str(getattr(self.credential, "id", "") or "")
-        self._qwenpaw_provider_id = credential_id.removeprefix("qwenpaw-")
+        credential_provider_id = credential_id.removeprefix("qwenpaw-")
+        if (
+            provider_id
+            and credential_provider_id
+            and provider_id != credential_provider_id
+        ):
+            logger.warning(
+                "Explicit provider id %r differs from credential-derived "
+                "id %r; using the explicit id for tool-call metadata.",
+                provider_id,
+                credential_provider_id,
+            )
+        self._qwenpaw_provider_id = provider_id or credential_provider_id
+
+    @property
+    def qwenpaw_provider_id(self) -> str:
+        """Canonical provider ID used for provider-scoped metadata."""
+        return self._qwenpaw_provider_id
 
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         try:
@@ -668,7 +698,39 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                     "langfuse generation kwargs failed",
                     exc_info=True,
                 )
-        return await super().__call__(*args, **kwargs)
+        response = await super().__call__(*args, **kwargs)
+        if not inspect.isasyncgen(response):
+            return response
+        return self._relay_stream_tool_call_extras(response)
+
+    async def _relay_stream_tool_call_extras(
+        self,
+        response: AsyncGenerator[ChatResponse, None],
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Carry delta-only tool metadata onto the accumulated response.
+
+        AgentScope copies ``model_extra`` while merging an existing
+        ``ToolCallBlock``, but QwenPaw's transient attribute intentionally is
+        not a Pydantic field. Keep a sidecar local to this model call and
+        reattach its records to the final accumulated response.
+        """
+        extras: dict[str, dict[str, Any]] = {}
+        async for chunk in response:
+            extras.update(
+                collect_transient_tool_call_extras(chunk.content),
+            )
+            if chunk.is_last and extras:
+                for block in chunk.content:
+                    tool_id = _battr(block, "id")
+                    record = extras.get(tool_id)
+                    if not record:
+                        continue
+                    attach_transient_tool_call_extra(
+                        block,
+                        provider_id=str(record.get("provider_id") or ""),
+                        extra_content=record["extra_content"],
+                    )
+            yield chunk
 
     async def _call_api(
         self,

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -506,6 +506,7 @@ class OpenAIProvider(Provider):
 
         return OpenAIChatModelCompat(
             credential=credential,
+            provider_id=self.id,
             model=model_id,
             parameters=parameters,
             stream=True,

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -452,6 +452,7 @@ class OpenRouterProvider(Provider):
         )
         return OpenAIChatModelCompat(
             credential=credential,
+            provider_id=self.id,
             model=model_id,
             stream=True,
             default_headers=self._build_default_headers() or None,

--- a/src/qwenpaw/utils/tool_call_extra.py
+++ b/src/qwenpaw/utils/tool_call_extra.py
@@ -33,9 +33,11 @@ def attach_transient_tool_call_extra(
         return
 
     # ``ToolCallBlock`` rejects unknown fields through Pydantic's normal
-    # setattr path.  This attribute is deliberately transient: the agent
-    # consumes it before state serialization and persists the value in the
-    # owning Msg.metadata instead.
+    # setattr path. This deliberately relies on the current Pydantic model
+    # layout accepting transient attributes through ``object.__setattr__``;
+    # the lifecycle tests should fail loudly if a future AgentScope/Pydantic
+    # release changes that contract. The agent consumes the attribute before
+    # state serialization and persists the value in the owning Msg.metadata.
     object.__setattr__(block, _TRANSIENT_TOOL_CALL_EXTRA_ATTR, record)
 
 
@@ -53,10 +55,19 @@ def collect_transient_tool_call_extras(
             block_type = getattr(block, "type", None)
             tool_id = getattr(block, "id", None)
             record = getattr(block, _TRANSIENT_TOOL_CALL_EXTRA_ATTR, None)
-            getattr(block, "__dict__", {}).pop(
-                _TRANSIENT_TOOL_CALL_EXTRA_ATTR,
-                None,
-            )
+            try:
+                object.__delattr__(
+                    block,
+                    _TRANSIENT_TOOL_CALL_EXTRA_ATTR,
+                )
+            except AttributeError:
+                # Current Pydantic models store the transient attribute in
+                # ``__dict__``. Keep this fallback for compatible wrappers;
+                # slot-only models are covered by ``object.__delattr__``.
+                getattr(block, "__dict__", {}).pop(
+                    _TRANSIENT_TOOL_CALL_EXTRA_ATTR,
+                    None,
+                )
 
         if (
             block_type not in ("tool_use", "tool_call")

--- a/src/qwenpaw/utils/tool_call_extra.py
+++ b/src/qwenpaw/utils/tool_call_extra.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Persist provider-specific tool-call fields without extending AgentScope.
+
+AgentScope's ``ToolCallBlock`` is a strict Pydantic model, so provider
+extensions such as Gemini's ``extra_content`` cannot be assigned as normal
+fields.  The stream parser attaches the extension transiently, and
+``QwenPawAgent._save_to_context`` moves it into the owning ``Msg.metadata``
+before session state is serialized.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Iterable
+
+TOOL_CALL_EXTRAS_METADATA_KEY = "_qwenpaw_tool_call_extras"
+_TRANSIENT_TOOL_CALL_EXTRA_ATTR = "_qwenpaw_tool_call_extra"
+
+
+def attach_transient_tool_call_extra(
+    block: Any,
+    *,
+    provider_id: str,
+    extra_content: Any,
+) -> None:
+    """Attach an extension to a parsed block until it enters message state."""
+    record = {
+        "provider_id": provider_id,
+        "extra_content": extra_content,
+    }
+    if isinstance(block, dict):
+        block[_TRANSIENT_TOOL_CALL_EXTRA_ATTR] = record
+        return
+
+    # ``ToolCallBlock`` rejects unknown fields through Pydantic's normal
+    # setattr path.  This attribute is deliberately transient: the agent
+    # consumes it before state serialization and persists the value in the
+    # owning Msg.metadata instead.
+    object.__setattr__(block, _TRANSIENT_TOOL_CALL_EXTRA_ATTR, record)
+
+
+def collect_transient_tool_call_extras(
+    blocks: Iterable[Any],
+) -> dict[str, dict[str, Any]]:
+    """Remove and return transient extensions keyed by tool-call id."""
+    collected: dict[str, dict[str, Any]] = {}
+    for block in blocks:
+        if isinstance(block, dict):
+            block_type = block.get("type")
+            tool_id = block.get("id")
+            record = block.pop(_TRANSIENT_TOOL_CALL_EXTRA_ATTR, None)
+        else:
+            block_type = getattr(block, "type", None)
+            tool_id = getattr(block, "id", None)
+            record = getattr(block, _TRANSIENT_TOOL_CALL_EXTRA_ATTR, None)
+            getattr(block, "__dict__", {}).pop(
+                _TRANSIENT_TOOL_CALL_EXTRA_ATTR,
+                None,
+            )
+
+        if (
+            block_type not in ("tool_use", "tool_call")
+            or not isinstance(tool_id, str)
+            or not tool_id
+            or not isinstance(record, dict)
+            or "extra_content" not in record
+        ):
+            continue
+        collected[tool_id] = deepcopy(record)
+    return collected
+
+
+def persist_tool_call_extras(
+    msg: Any,
+    extras: dict[str, dict[str, Any]],
+) -> None:
+    """Merge tool-call extensions into an assistant message's metadata."""
+    if not extras:
+        return
+    metadata = dict(getattr(msg, "metadata", None) or {})
+    existing = metadata.get(TOOL_CALL_EXTRAS_METADATA_KEY)
+    persisted = dict(existing) if isinstance(existing, dict) else {}
+    persisted.update(deepcopy(extras))
+    metadata[TOOL_CALL_EXTRAS_METADATA_KEY] = persisted
+    msg.metadata = metadata
+
+
+def tool_call_extras_for_provider(
+    msg: Any,
+    provider_id: str | None,
+) -> dict[str, Any]:
+    """Return extensions that originated from the current provider only."""
+    if not provider_id:
+        return {}
+    metadata = getattr(msg, "metadata", None) or {}
+    raw = metadata.get(TOOL_CALL_EXTRAS_METADATA_KEY)
+    if not isinstance(raw, dict):
+        return {}
+
+    matched: dict[str, Any] = {}
+    for tool_id, record in raw.items():
+        if (
+            isinstance(tool_id, str)
+            and isinstance(record, dict)
+            and record.get("provider_id") == provider_id
+            and "extra_content" in record
+        ):
+            matched[tool_id] = record["extra_content"]
+    return matched
+
+
+__all__ = [
+    "TOOL_CALL_EXTRAS_METADATA_KEY",
+    "attach_transient_tool_call_extra",
+    "collect_transient_tool_call_extras",
+    "persist_tool_call_extras",
+    "tool_call_extras_for_provider",
+]

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -40,6 +40,10 @@ from qwenpaw.constant import (
     QWENPAW_MESSAGE_TAG_KEY,
     SCROLL_MEMORY_MESSAGE_TAG,
 )
+from qwenpaw.utils.tool_call_extra import (
+    TOOL_CALL_EXTRAS_METADATA_KEY,
+    persist_tool_call_extras,
+)
 
 # -- fixtures ---------------------------------------------------------------
 
@@ -233,6 +237,18 @@ def auto_memory_search_msg(*, query: str, max_results: int, text: str) -> Msg:
     )
 
 
+def _persist_signature(msg: Msg, tool_id: str) -> None:
+    persist_tool_call_extras(
+        msg,
+        {
+            tool_id: {
+                "provider_id": "example",
+                "extra_content": {"thought_signature": "signature-abc"},
+            },
+        },
+    )
+
+
 # -- write-through dedup -----------------------------------------------------
 
 
@@ -253,6 +269,47 @@ def test_persist_new_records_seq_and_headline_leaf(store: HistoryStore):
     assert a.id in mgr._leaf_by_id
     assert mgr._leaf_by_id[a.id].headline == "milestone"
     assert a.id in mgr._seq_by_id
+
+
+def test_persist_new_refreshes_late_tool_call_metadata(store: HistoryStore):
+    """A streamed assistant row must gain metadata when its tool call lands."""
+    mgr = make_manager(store)
+    turn = assistant("starting")
+    agent = FakeAgent([turn])
+    mgr._persist_new(agent)
+
+    turn.content.extend(
+        [
+            ToolCallBlock(
+                type="tool_call",
+                id="call-late",
+                name="grep",
+                input="{}",
+            ),
+            ToolResultBlock(
+                type="tool_result",
+                id="call-late",
+                name="grep",
+                output="done",
+            ),
+        ],
+    )
+    _persist_signature(turn, "call-late")
+    mgr._persist_new(agent)
+
+    row = store._conn.execute(
+        "SELECT blocks, metadata FROM conversation_history "
+        "WHERE kind='model_turn' AND dedup_key = ?",
+        (turn.id,),
+    ).fetchone()
+    stored_blocks = json.loads(row["blocks"])
+    assert any(block["id"] == "call-late" for block in stored_blocks)
+    assert json.loads(row["metadata"])[TOOL_CALL_EXTRAS_METADATA_KEY] == {
+        "call-late": {
+            "provider_id": "example",
+            "extra_content": {"thought_signature": "signature-abc"},
+        },
+    }
 
 
 def test_tool_result_persisted_under_tool_call_id(store: HistoryStore):
@@ -554,6 +611,7 @@ async def test_compress_restores_complete_non_active_tool_boundary(
     old_u = user("older question")
     old_a = assistant("older reply", headline="OLD")
     boundary = assistant_with_tool("call-boundary")
+    _persist_signature(boundary, "call-boundary")
     cur_u = user("current request")
     cur_a = assistant("current reply")
     ctx = [old_u, old_a, boundary, cur_u, cur_a]
@@ -581,6 +639,9 @@ async def test_compress_restores_complete_non_active_tool_boundary(
         "tool_call",
         "tool_result",
     ]
+    assert retained.metadata[TOOL_CALL_EXTRAS_METADATA_KEY] == (
+        boundary.metadata[TOOL_CALL_EXTRAS_METADATA_KEY]
+    )
 
 
 async def test_compress_keeps_active_turn_live(store: HistoryStore):
@@ -2124,6 +2185,24 @@ def test_serialize_persists_runtime_tag():
     }
     (plain,) = msg_to_entries(user("hello"))
     assert not plain.metadata
+
+
+def test_serialize_persists_tool_call_extras():
+    """The exact Scroll archive retains provider tool-call protocol data."""
+    from qwenpaw.agents.context.scroll.serialize import msg_to_entries
+
+    msg = assistant_with_tool("call-signed")
+    _persist_signature(msg, "call-signed")
+
+    model_turn = next(
+        entry for entry in msg_to_entries(msg) if entry.kind == "model_turn"
+    )
+    assert model_turn.metadata[TOOL_CALL_EXTRAS_METADATA_KEY] == {
+        "call-signed": {
+            "provider_id": "example",
+            "extra_content": {"thought_signature": "signature-abc"},
+        },
+    }
 
 
 def test_serialize_captures_tool_input():

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -19,6 +19,11 @@ class _FakeChatModel:
         self.identifier = identifier
         self.formatter = SimpleNamespace()
         self.max_retries = 3
+        self.qwenpaw_provider_id = "credential-derived"
+
+    def bind_qwenpaw_provider_id(self, provider_id: str) -> None:
+        """Record the provider identity selected by the factory."""
+        self.qwenpaw_provider_id = provider_id
 
 
 def _patched_load_agent_config(_agent_id):  # noqa: ARG001
@@ -60,7 +65,7 @@ def _patch_dependencies(monkeypatch):
         SimpleNamespace(
             get_instance=lambda: SimpleNamespace(
                 get_provider=lambda provider_id: SimpleNamespace(
-                    provider_id=provider_id,
+                    id=provider_id,
                     get_chat_model_instance=(
                         lambda model_name: _FakeChatModel(
                             f"{provider_id}/{model_name}",
@@ -119,15 +124,16 @@ def test_factory_binds_returned_formatter_to_provider_model():
     assert model.formatter is fmt
 
 
-def test_factory_uses_model_canonical_provider_id(
+def test_factory_uses_resolved_provider_id(
     monkeypatch,
     _patch_dependencies,
 ):
-    """Formatter scope follows the provider ID bound to the model."""
+    """Resolved provider identity overrides credential-derived fallback."""
     canonical_model = _FakeChatModel("canonical-provider/model")
-    canonical_model.qwenpaw_provider_id = "canonical-provider"
+    wrapper_provider_ids = []
     manager = SimpleNamespace(
         get_provider=lambda _provider_id: SimpleNamespace(
+            id="canonical-provider",
             get_chat_model_instance=lambda _model_name: canonical_model,
         ),
     )
@@ -135,6 +141,13 @@ def test_factory_uses_model_canonical_provider_id(
         model_factory,
         "ProviderManager",
         SimpleNamespace(get_instance=lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "TokenRecordingModelWrapper",
+        lambda provider_id, model, **_kwargs: (
+            wrapper_provider_ids.append(provider_id) or model
+        ),
     )
 
     with patch.object(model_factory, "RetryConfig") as retry_cls:
@@ -145,6 +158,8 @@ def test_factory_uses_model_canonical_provider_id(
         )
 
     assert _patch_dependencies == ["canonical-provider"]
+    assert wrapper_provider_ids == ["canonical-provider"]
+    assert canonical_model.qwenpaw_provider_id == "canonical-provider"
 
 
 def test_override_with_dict():

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -48,6 +48,7 @@ def _patched_load_agent_config(_agent_id):  # noqa: ARG001
 @pytest.fixture(autouse=True)
 def _patch_dependencies(monkeypatch):
     """Avoid touching the real provider manager / retry wrappers."""
+    formatter_provider_ids = []
     monkeypatch.setattr(
         config_module,
         "load_agent_config",
@@ -74,7 +75,9 @@ def _patch_dependencies(monkeypatch):
     monkeypatch.setattr(
         model_factory,
         "_create_formatter_instance",
-        lambda _model: "formatter",
+        lambda _model, provider_id=None: (
+            formatter_provider_ids.append(provider_id) or "formatter"
+        ),
     )
     monkeypatch.setattr(
         model_factory,
@@ -86,9 +89,10 @@ def _patch_dependencies(monkeypatch):
         "RetryChatModel",
         lambda model, **_kwargs: model,
     )
+    return formatter_provider_ids
 
 
-def test_override_with_model_slot_config():
+def test_override_with_model_slot_config(_patch_dependencies):
     """Passing a ``ModelSlotConfig`` instance overrides ``active_model``."""
     override = ModelSlotConfig(provider_id="p", model="m")
 
@@ -101,6 +105,7 @@ def test_override_with_model_slot_config():
 
     assert model.identifier == "p/m"
     assert fmt == "formatter"
+    assert _patch_dependencies == ["p"]
 
 
 def test_factory_binds_returned_formatter_to_provider_model():
@@ -112,6 +117,34 @@ def test_factory_binds_returned_formatter_to_provider_model():
         )
 
     assert model.formatter is fmt
+
+
+def test_factory_uses_model_canonical_provider_id(
+    monkeypatch,
+    _patch_dependencies,
+):
+    """Formatter scope follows the provider ID bound to the model."""
+    canonical_model = _FakeChatModel("canonical-provider/model")
+    canonical_model.qwenpaw_provider_id = "canonical-provider"
+    manager = SimpleNamespace(
+        get_provider=lambda _provider_id: SimpleNamespace(
+            get_chat_model_instance=lambda _model_name: canonical_model,
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "ProviderManager",
+        SimpleNamespace(get_instance=lambda: manager),
+    )
+
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override="configured-alias:model",
+        )
+
+    assert _patch_dependencies == ["canonical-provider"]
 
 
 def test_override_with_dict():

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -32,6 +32,7 @@ except ImportError:
 from qwenpaw.agents import model_factory
 from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
 from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
+from qwenpaw.utils.tool_call_extra import persist_tool_call_extras
 
 
 def _data_block(media_type: str, url: str) -> DataBlock:
@@ -530,6 +531,96 @@ def _messages_with_extra_content() -> list[Msg]:
             ],
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_relays_persisted_tool_call_extra() -> None:
+    msg = _messages_with_extra_content()[0]
+    persist_tool_call_extras(
+        msg,
+        {
+            "call_ec": {
+                "provider_id": "example",
+                "extra_content": {"thought_signature": "signature-abc"},
+            },
+        },
+    )
+    # Exercise the session persistence boundary, not just the live Msg.
+    restored = Msg.model_validate(msg.model_dump(mode="json"))
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id="example",
+    )
+
+    formatted = await formatter_class().format([restored])
+
+    tool_call = formatted[0]["tool_calls"][0]
+    assert tool_call["id"] == "call_ec"
+    assert tool_call["extra_content"] == {
+        "thought_signature": "signature-abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_does_not_relay_other_provider_extra() -> None:
+    msg = _messages_with_extra_content()[0]
+    persist_tool_call_extras(
+        msg,
+        {
+            "call_ec": {
+                "provider_id": "source-provider",
+                "extra_content": {"thought_signature": "signature-abc"},
+            },
+        },
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id="target-provider",
+    )
+
+    formatted = await formatter_class().format([msg])
+
+    assert "extra_content" not in formatted[0]["tool_calls"][0]
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_isolates_reused_ids_between_requests() -> None:
+    first = _messages_with_extra_content()[0]
+    second = _messages_with_extra_content()[0]
+    persist_tool_call_extras(
+        first,
+        {
+            "call_ec": {
+                "provider_id": "example",
+                "extra_content": {"thought_signature": "signature-1"},
+            },
+        },
+    )
+    persist_tool_call_extras(
+        second,
+        {
+            "call_ec": {
+                "provider_id": "example",
+                "extra_content": {"thought_signature": "signature-2"},
+            },
+        },
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id="example",
+    )
+
+    formatter = formatter_class()
+    formatted_first = await formatter.format([first])
+    formatted_second = await formatter.format([second])
+
+    first_call = formatted_first[0]["tool_calls"][0]
+    second_call = formatted_second[0]["tool_calls"][0]
+    relayed = [
+        first_call["extra_content"]["thought_signature"],
+        second_call["extra_content"]["thought_signature"],
+    ]
+    assert relayed == ["signature-1", "signature-2"]
 
 
 def test_openai_formatter_strips_extra_content(monkeypatch) -> None:

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -12,6 +12,7 @@ from qwenpaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
     _sanitize_tool_call,
 )
+from qwenpaw.utils.tool_call_extra import collect_transient_tool_call_extras
 
 
 class CompatHarnessOpenAIChatModel(OpenAIChatModelCompat):
@@ -115,6 +116,45 @@ async def test_stream_parser_skips_tool_call_without_function() -> None:
     if isinstance(block_input, str):
         block_input = json.loads(block_input)
     assert block_input == {"x": 1}
+
+
+async def test_stream_parser_carries_extra_content_on_strict_block() -> None:
+    """Gemini thought signatures survive strict ToolCallBlock parsing."""
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            id="qwenpaw-example",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    tool_call = SimpleNamespace(
+        index=0,
+        id="call_sig",
+        function=SimpleNamespace(name="ping", arguments='{"x":1}'),
+        extra_content={"thought_signature": "signature-abc"},
+    )
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        FakeAsyncStream([_make_chunk([tool_call])]),
+    )
+
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if getattr(block, "type", None) in ("tool_use", "tool_call")
+    ]
+    assert tool_blocks
+    assert not hasattr(tool_blocks[0], "extra_content")
+    assert collect_transient_tool_call_extras(tool_blocks) == {
+        "call_sig": {
+            "provider_id": "example",
+            "extra_content": {"thought_signature": "signature-abc"},
+        },
+    }
 
 
 def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -44,6 +44,10 @@ class CompatHarnessOpenAIChatModel(OpenAIChatModelCompat):
         finally:
             object.__delattr__(self, "_test_stream")
 
+    def relay_stream_for_test(self, response: Any) -> Any:
+        """Expose the compatibility relay for lifecycle assertions."""
+        return self._relay_stream_tool_call_extras(response)
+
 
 class FakeAsyncStream:
     def __init__(self, items: list[Any]):
@@ -217,6 +221,34 @@ async def test_full_stream_preserves_extra_from_later_chunk(
             "extra_content": {"thought_signature": "signature-late"},
         },
     }
+
+
+async def test_stream_relay_closes_inner_generator_immediately() -> None:
+    """Closing the public stream promptly releases the provider stream."""
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    inner_closed = False
+
+    async def inner_stream():
+        nonlocal inner_closed
+        try:
+            yield SimpleNamespace(content=[], is_last=False)
+            yield SimpleNamespace(content=[], is_last=True)
+        finally:
+            inner_closed = True
+
+    response = inner_stream()
+    relay = model.relay_stream_for_test(response)
+    await anext(relay)
+    await relay.aclose()
+
+    assert inner_closed
 
 
 def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from agentscope.credential import OpenAICredential
 
 from qwenpaw.providers.openai_chat_model_compat import (
@@ -16,6 +17,12 @@ from qwenpaw.utils.tool_call_extra import collect_transient_tool_call_extras
 
 
 class CompatHarnessOpenAIChatModel(OpenAIChatModelCompat):
+    async def _call_api(self, *args: Any, **kwargs: Any) -> Any:
+        stream = getattr(self, "_test_stream", None)
+        if stream is not None:
+            return self._parse_stream_response(datetime.now(), stream)
+        return await super()._call_api(*args, **kwargs)
+
     async def parse_stream_for_test(
         self,
         start_datetime: datetime,
@@ -28,6 +35,14 @@ class CompatHarnessOpenAIChatModel(OpenAIChatModelCompat):
         ):
             responses.append(response)
         return responses
+
+    async def call_stream_for_test(self, stream: Any) -> list[Any]:
+        object.__setattr__(self, "_test_stream", stream)
+        try:
+            response = await self(messages=[])
+            return [chunk async for chunk in response]
+        finally:
+            object.__delattr__(self, "_test_stream")
 
 
 class FakeAsyncStream:
@@ -153,6 +168,53 @@ async def test_stream_parser_carries_extra_content_on_strict_block() -> None:
         "call_sig": {
             "provider_id": "example",
             "extra_content": {"thought_signature": "signature-abc"},
+        },
+    }
+
+
+@pytest.mark.parametrize("repeat_tool_id", [True, False])
+async def test_full_stream_preserves_extra_from_later_chunk(
+    repeat_tool_id: bool,
+) -> None:
+    """The final AgentScope accumulator receives late thought signatures."""
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            id="qwenpaw-credential-name",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        provider_id="configured-name",
+        model="dummy",
+        stream=True,
+    )
+    first = SimpleNamespace(
+        index=0,
+        id="call_sig",
+        function=SimpleNamespace(name="ping", arguments='{"x":'),
+    )
+    second = SimpleNamespace(
+        index=0,
+        id="call_sig" if repeat_tool_id else None,
+        function=SimpleNamespace(name=None, arguments="1}"),
+        extra_content={"thought_signature": "signature-late"},
+    )
+
+    responses = await model.call_stream_for_test(
+        FakeAsyncStream([_make_chunk([first]), _make_chunk([second])]),
+    )
+
+    final = responses[-1]
+    assert final.is_last
+    tool_block = next(
+        block
+        for block in final.content
+        if getattr(block, "type", None) in ("tool_use", "tool_call")
+    )
+    assert tool_block.input == '{"x":1}'
+    assert collect_transient_tool_call_extras([tool_block]) == {
+        "call_sig": {
+            "provider_id": "configured-name",
+            "extra_content": {"thought_signature": "signature-late"},
         },
     }
 


### PR DESCRIPTION
## Description

Preserve provider-specific tool call metadata, such as Gemini thought signatures, without modifying AgentScope's strict `ToolCallBlock`.

The metadata is persisted with assistant messages, survives session restoration and context compression, and is only restored for the originating OpenAI-compatible provider. This also avoids process-global state and cross-session tool-call ID collisions.

Closes #6619.

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
