### PR TITLE
feat(sidebar): horizontal layout for mode toggle and rename desktop mode label

### DIFF
--- a/console/src/layouts/SidebarSettingsPanel.tsx
+++ b/console/src/layouts/SidebarSettingsPanel.tsx
@@ -212,7 +212,7 @@ export default function SidebarSettingsPanel({
           >
             <Monitor size={14} />
             <span className={styles.optLabel}>
-              {t("sidebar.settings.enterDesktopMode", "Enter Desktop Mode")}
+              {t("sidebar.settings.desktopMode", "Desktop Mode")}
             </span>
           </button>
         </div>

--- a/console/src/layouts/sidebarSettingsPanel.module.less
+++ b/console/src/layouts/sidebarSettingsPanel.module.less
@@ -65,10 +65,10 @@
     }
   }
 
-  /* Full-width block variant for mode toggle */
+  /* Block variant for mode toggle buttons */
   &Block {
-    width: 100%;
-    justify-content: flex-start;
+    flex: 1;
+    justify-content: center;
   }
 }
 
@@ -79,8 +79,8 @@
 
 .modeActions {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  flex-direction: row;
+  gap: 4px;
 }
 
 .desktopModeBtn {

--- a/console/src/layouts/sidebarSettingsPanel.module.less
+++ b/console/src/layouts/sidebarSettingsPanel.module.less
@@ -65,10 +65,10 @@
     }
   }
 
-  /* Block variant for mode toggle buttons */
+  /* Full-width block variant for mode toggle */
   &Block {
-    flex: 1;
-    justify-content: center;
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 
@@ -81,6 +81,12 @@
   display: flex;
   flex-direction: row;
   gap: 4px;
+
+  .optBtnBlock {
+    flex: 1;
+    width: auto;
+    justify-content: center;
+  }
 }
 
 .desktopModeBtn {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -251,7 +251,7 @@
       "language": "Language",
       "theme": "Theme",
       "mode": "Mode",
-      "enterDesktopMode": "Enter Desktop Mode"
+      "desktopMode": "Desktop Mode"
     },
     "desktopModeHint": {
       "title": "Try Desktop Mode",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -216,7 +216,7 @@
       "language": "Bahasa",
       "theme": "Tema",
       "mode": "Mode",
-      "enterDesktopMode": "Masuk ke Mode Desktop"
+      "desktopMode": "Mode Desktop"
     },
     "desktopModeHint": {
       "title": "Coba Mode Desktop",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2399,7 +2399,7 @@
       "language": "言語",
       "theme": "テーマ",
       "mode": "モード",
-      "enterDesktopMode": "デスクトップモードに入る"
+      "desktopMode": "デスクトップモード"
     },
     "desktopModeHint": {
       "title": "デスクトップモードを試す",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2643,7 +2643,7 @@
       "language": "Idioma",
       "theme": "Tema",
       "mode": "Modo",
-      "enterDesktopMode": "Entrar no Modo Desktop"
+      "desktopMode": "Modo Desktop"
     },
     "desktopModeHint": {
       "title": "Experimente o Modo Desktop",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2414,7 +2414,7 @@
       "language": "Язык",
       "theme": "Тема",
       "mode": "Режим",
-      "enterDesktopMode": "Перейти в режим рабочего стола"
+      "desktopMode": "Режим рабочего стола"
     },
     "desktopModeHint": {
       "title": "Попробуйте режим рабочего стола",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -187,7 +187,7 @@
       "language": "Ngôn ngữ",
       "theme": "Giao diện",
       "mode": "Chế độ",
-      "enterDesktopMode": "Vào Chế độ Màn hình nền"
+      "desktopMode": "Chế độ Màn hình nền"
     },
     "desktopModeHint": {
       "title": "Thử Chế độ Màn hình nền",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -251,7 +251,7 @@
       "language": "语言",
       "theme": "主题",
       "mode": "模式",
-      "enterDesktopMode": "进入桌面模式"
+      "desktopMode": "桌面模式"
     },
     "desktopModeHint": {
       "title": "试试桌面模式",


### PR DESCRIPTION
## Description

The mode toggle buttons ("Simple Mode" / "Desktop Mode") in the sidebar settings panel were stacked vertically, making them easy to misclick. This PR changes them to a horizontal (left-right) layout.

Also renames the i18n key `enterDesktopMode` → `desktopMode` across all 7 locale files, removing the redundant "Enter" prefix so the button simply reads "Desktop Mode" / "桌面模式".

<img width="408" height="326" alt="image" src="https://github.com/user-attachments/assets/ea72576d-0aac-45d6-8a6e-56ad7f3a9e0a" />


**Related Issue:** N/A

**Security Considerations:** None — UI-only change.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open the sidebar settings panel (click the gear icon)
2. Verify the "Mode" section shows two buttons side by side: "Simple Mode" | "Desktop Mode"
3. Switch language to Chinese — button should read "精简模式" | "桌面模式"
4. Verify Language and Theme sections remain unchanged (vertical layout)

## Evidence

UI-only CSS/layout change — 9 files, +13/-13 lines. No logic changes.

```
console/src/layouts/SidebarSettingsPanel.tsx         |  2 +-
console/src/layouts/sidebarSettingsPanel.module.less | 10 +++++-----
console/src/locales/en.json                          |  2 +-
console/src/locales/id.json                          |  2 +-
console/src/locales/ja.json                          |  2 +-
console/src/locales/pt-BR.json                       |  2 +-
console/src/locales/ru.json                          |  2 +-
console/src/locales/vi.json                          |  2 +-
console/src/locales/zh.json                          |  2 +-
```

## Additional Notes

N/A