### PR TITLE
feat(ci): gate main mergeability on tests (required checks ready)

### DIFF
--- a/.github/rulesets/main-required-checks.json
+++ b/.github/rulesets/main-required-checks.json
@@ -1,0 +1,34 @@
+{
+  "name": "Required status checks (main)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Test Summary", "integration_id": 15368 },
+          { "context": "Pre-commit", "integration_id": 15368 },
+          { "context": "Vitest Unit Tests", "integration_id": 15368 },
+          { "context": "console format check", "integration_id": 15368 },
+          { "context": "website format check", "integration_id": 15368 }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/main-required-checks.json
+++ b/.github/rulesets/main-required-checks.json
@@ -17,7 +17,7 @@
         "required_status_checks": [
           { "context": "Test Summary", "integration_id": 15368 },
           { "context": "Pre-commit", "integration_id": 15368 },
-          { "context": "Vitest Unit Tests", "integration_id": 15368 },
+          { "context": "Frontend Summary", "integration_id": 15368 },
           { "context": "console format check", "integration_id": 15368 },
           { "context": "website format check", "integration_id": 15368 }
         ]

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run unit tests
-        run: npm run test:run
-
-      - name: Coverage ratchet (blocks PR on regression)
+      # A single vitest pass: runs the full suite AND enforces the coverage
+      # ratchet (fails on test failures or coverage regression). The previous
+      # separate `npm run test:run` pass executed the identical suite twice.
+      - name: Run unit tests with coverage (ratchet blocks PR on regression)
         run: npm run test:coverage
 
       - name: Upload coverage report

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -8,9 +8,6 @@ on:
       - '.github/workflows/frontend-tests.yml'
   pull_request:
     branches: [main, master, dev, develop]
-    paths:
-      - 'console/**'
-      - '.github/workflows/frontend-tests.yml'
 
 jobs:
   spam-gate:
@@ -20,11 +17,32 @@ jobs:
     with:
       author: ${{ github.event.pull_request.user.login }}
 
+  # Replaces the former `on.pull_request.paths` filter: the workflow now runs
+  # (and reports a status) on every PR so `Vitest Unit Tests` can be a
+  # required check; PRs not touching the console skip the actual test run.
+  changes:
+    name: Detect console changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'console/**'
+              - '.github/workflows/frontend-tests.yml'
+
   vitest:
     name: Vitest Unit Tests
-    needs: [spam-gate]
+    needs: [spam-gate, changes]
     if: |
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,8 +18,9 @@ jobs:
       author: ${{ github.event.pull_request.user.login }}
 
   # Replaces the former `on.pull_request.paths` filter: the workflow now runs
-  # (and reports a status) on every PR so `Vitest Unit Tests` can be a
-  # required check; PRs not touching the console skip the actual test run.
+  # (and reports a status) on every PR so `Frontend Summary` can be a
+  # required check; PRs not touching the console skip the actual test run
+  # and the summary reports an explicit success instead of a skip.
   changes:
     name: Detect console changes
     runs-on: ubuntu-latest
@@ -40,8 +41,13 @@ jobs:
   vitest:
     name: Vitest Unit Tests
     needs: [spam-gate, changes]
+    # Also guard on the detection job's RESULT: if detection failed/was
+    # cancelled its `code` output is empty and this job would silently skip,
+    # which a ruleset cannot distinguish from a bypass. The frontend-summary
+    # job below turns that detection failure into a hard red.
     if: |
       always() &&
+      needs.changes.result == 'success' &&
       needs.changes.outputs.code == 'true' &&
       (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
@@ -74,3 +80,45 @@ jobs:
           name: coverage-report
           path: console/coverage/
           retention-days: 7
+
+  frontend-summary:
+    name: Frontend Summary
+    needs: [changes, spam-gate, vitest]
+    # Fail-closed gate. This job ALWAYS runs (no path condition) so the
+    # required-check context can never be satisfied by an accidental skip.
+    # Three-state decision, mirroring `Test Summary` in tests.yml:
+    #   1. change detection did not succeed -> red;
+    #   2. detection succeeded, no console changes -> explicit green;
+    #   3. console change -> vitest must be strictly `success`.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check frontend results
+        shell: bash
+        run: |
+          echo "Changes detection: ${{ needs.changes.result }}"
+          echo "Spam gate: ${{ needs.spam-gate.result }}"
+          echo "Vitest: ${{ needs.vitest.result }}"
+
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "❌ Change detection did not succeed (${{ needs.changes.result }}) — gate closed, refusing untested merge"
+            exit 1
+          fi
+
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "✅ No console changes — vitest not required"
+            exit 0
+          fi
+
+          if [ "${{ needs.spam-gate.result }}" = "success" ] && \
+             [ "${{ needs.spam-gate.outputs.blocked }}" = "true" ]; then
+            echo "❌ Spam gate blocked this PR"
+            exit 1
+          fi
+
+          if [ "${{ needs.vitest.result }}" != "success" ]; then
+            echo "❌ Vitest must be success (failure/cancelled/skipped are all rejected)"
+            exit 1
+          fi
+
+          echo "✅ Frontend tests passed"

--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -336,10 +336,11 @@ jobs:
         shell: bash
         env:
           QWENPAW_INTEGRATION_COVERAGE: ${{ steps.cov_flag.outputs.enabled }}
-          # Windows runners are 2-core and IO-bound; under xdist parallel
-          # the default 15s HTTP timeout is too tight and intermittently
-          # surfaces as ``httpx.ReadTimeout``. Lift the floor here.
-          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os == 'windows-latest' && '120' || '' }}
+          # Windows/macOS runners are slower and IO-bound; under xdist
+          # parallel the default HTTP timeouts are too tight and
+          # intermittently surface as ``httpx.ReadTimeout`` (e.g. the real
+          # plugin install on macOS). Lift the floor on non-Linux runners.
+          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os != 'ubuntu-latest' && '120' || '' }}
         run: |
           # Nightly always runs the full -m integration sweep (p0 + p1 +
           # p2), unlike tests.yml which gates by GITHUB_EVENT_NAME.

--- a/.github/workflows/pr-preview-tests.yml
+++ b/.github/workflows/pr-preview-tests.yml
@@ -171,11 +171,11 @@ jobs:
       # Upstream gates the integrated tier with `-m "integration and p0"` for
       # pull_request events (fast feedback). Fork pushes are not PR events, but
       # the intent here is the same pre-merge signal, so we hard-code p0.
-      # Windows runner gets the same lifted HTTP timeout upstream applies.
+      # Non-Linux runners get the same lifted HTTP timeout upstream applies.
       - name: Run integrated tests
         shell: bash
         env:
-          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os == 'windows-latest' && '120' || '' }}
+          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os != 'ubuntu-latest' && '120' || '' }}
         run: |
           pytest tests/integration -v \
             -n auto --dist=loadscope --timeout=300 \

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,7 @@ jobs:
       author: ${{ github.event.pull_request.user.login }}
 
   run:
+    name: Pre-commit
     needs: [spam-gate]
     if: |
       always() &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ on:
       integration_marker:
         description: >-
           Pytest marker expression for the integration tier. Leave blank
-          to keep the event-based default (PR=p0, push/dispatch=p0+p1).
-          Examples: "integration and p0", "integration and (p0 or p1)",
-          "integration".
+          to run the FULL integration suite (the default for every event).
+          Fill in to narrow a manual run, e.g. "integration and p0",
+          "integration and (p0 or p1)".
         required: false
         default: ''
 
@@ -359,15 +359,14 @@ jobs:
           DISPATCH_MARKER: ${{ inputs.integration_marker }}
         run: |
           # Manual dispatch override -> use whatever the maintainer typed.
-          # PR gate -> p0 only (fast feedback)
-          # push / workflow_dispatch (no input) -> p0 + p1 (full pre-merge gate)
-          # nightly full sweep lives in full-tests-nightly.yml
+          # Everything else (PR gate / push) -> FULL integration suite.
+          # The PR gate is the only layer that reliably runs (post-merge
+          # push runs wait on the maintainer-approved environment), so
+          # problems are blocked here rather than detected after merge.
           if [ -n "${DISPATCH_MARKER}" ]; then
             EXPR="${DISPATCH_MARKER}"
-          elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            EXPR="integration and p0"
           else
-            EXPR="integration and (p0 or p1)"
+            EXPR="integration"
           fi
           echo "expr=$EXPR" >> "$GITHUB_OUTPUT"
           echo "Selected marker expression: $EXPR"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -380,10 +380,11 @@ jobs:
           # not pay the tracer overhead. Multi-platform coverage is opt-in
           # via full-tests-nightly.yml dispatch (coverage_platforms input).
           QWENPAW_INTEGRATION_COVERAGE: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11') && '1' || '' }}
-          # Windows runners are 2-core and IO-bound; under xdist parallel
-          # the default 15s HTTP timeout is too tight and intermittently
-          # surfaces as ``httpx.ReadTimeout``. Lift the floor here.
-          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os == 'windows-latest' && '120' || '' }}
+          # Windows/macOS runners are slower and IO-bound; under xdist
+          # parallel the default HTTP timeouts are too tight and
+          # intermittently surface as ``httpx.ReadTimeout`` (e.g. the real
+          # plugin install on macOS). Lift the floor on non-Linux runners.
+          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os != 'ubuntu-latest' && '120' || '' }}
         run: |
           if [ -n "$QWENPAW_INTEGRATION_COVERAGE" ]; then
             # Subprocess coverage entry. Parent process must not carry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -563,29 +563,52 @@ jobs:
   test-summary:
     name: Test Summary
     needs: [changes, approval-gate, unit-tests, contract-tests, integrated-tests, coverage-report]
-    # Skipped (= satisfied when used as a required check) on docs-only PRs;
-    # otherwise fails unless approval was granted and every tier passed.
-    if: always() && needs.changes.outputs.code == 'true'
+    # Fail-closed gate. This job ALWAYS runs (no path condition) so the
+    # required-check context can never be satisfied by an accidental skip.
+    # Three-state decision:
+    #   1. change detection did not succeed -> red (its `code` output is
+    #      unreliable when the detection job fails/is cancelled, so the
+    #      gate must close rather than open);
+    #   2. detection succeeded and reported a docs-only PR -> explicit
+    #      green (instead of skipping, which a ruleset cannot distinguish
+    #      from a bypass);
+    #   3. code change -> approval plus EVERY test tier must be strictly
+    #      `success`; failure/cancelled/skipped are all rejected.
+    # coverage-report is intentionally observed, not enforced: a coverage
+    # tooling outage must not block an otherwise green PR.
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         shell: bash
         run: |
+          echo "Changes detection: ${{ needs.changes.result }}"
           echo "Approval gate: ${{ needs.approval-gate.result }}"
           echo "Unit tests: ${{ needs.unit-tests.result }}"
           echo "Contract tests: ${{ needs.contract-tests.result }}"
           echo "Integrated tests: ${{ needs.integrated-tests.result }}"
+          echo "Coverage report: ${{ needs.coverage-report.result }}"
+
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "❌ Change detection did not succeed (${{ needs.changes.result }}) — gate closed, refusing untested merge"
+            exit 1
+          fi
+
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "✅ Docs-only change — no test tiers required"
+            exit 0
+          fi
 
           if [ "${{ needs.approval-gate.result }}" != "success" ]; then
             echo "❌ Approval not granted"
             exit 1
           fi
 
-          if [ "${{ needs.unit-tests.result }}" = "failure" ] || \
-             [ "${{ needs.contract-tests.result }}" = "failure" ] || \
-             [ "${{ needs.integrated-tests.result }}" = "failure" ]; then
-            echo "❌ Some tests failed"
+          if [ "${{ needs.unit-tests.result }}" != "success" ] || \
+             [ "${{ needs.contract-tests.result }}" != "success" ] || \
+             [ "${{ needs.integrated-tests.result }}" != "success" ]; then
+            echo "❌ Every test tier must be success (failure/cancelled/skipped are all rejected)"
             exit 1
-          else
-            echo "✅ All tests passed"
           fi
+
+          echo "✅ All tests passed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,6 @@ on:
       - '.github/workflows/tests.yml'
   pull_request:
     branches: [main, master, dev, develop]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'setup.py'
-      - 'deploy/Dockerfile'
-      - '.github/workflows/tests.yml'
   workflow_dispatch:
     inputs:
       integration_marker:
@@ -46,11 +39,35 @@ jobs:
     with:
       author: ${{ github.event.pull_request.user.login }}
 
+  # Replaces the former `on.pull_request.paths` filter: the workflow now runs
+  # (and reports a status) on every PR so `Test Summary` can be a required
+  # check, but docs-only PRs skip the approval gate and every test tier.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'setup.py'
+              - '.github/workflows/tests.yml'
+
   approval-gate:
     name: Maintainer Approval
-    needs: [spam-gate]
+    needs: [spam-gate, changes]
     if: |
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     environment: maintainer-approved
@@ -545,8 +562,10 @@ jobs:
 
   test-summary:
     name: Test Summary
-    needs: [approval-gate, unit-tests, contract-tests, integrated-tests, coverage-report]
-    if: always()
+    needs: [changes, approval-gate, unit-tests, contract-tests, integrated-tests, coverage-report]
+    # Skipped (= satisfied when used as a required check) on docs-only PRs;
+    # otherwise fails unless approval was granted and every tier passed.
+    if: always() && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check test results


### PR DESCRIPTION
> **Submitted by**: 秦琼·CIOps@QPQAT

> **Plain-language summary**: This PR fixes the "no gate on `main`" problem. In short: previously `main` had no required status checks, so code could be merged even when tests were all red — this already happened (#6418 was merged with three failing test jobs). This PR: (1) adds required-check rules to `main` (tests, frontend tests, and code-style checks must all be green before merging); (2) resolves the trap where path filtering causes checks to stay pending forever (docs-only PRs will not be stuck); (3) since the PR tier is the only reliable execution layer (push-triggered runs are never actually approved in practice), the PR stage runs the full integration test suite. Note: merging this PR does **not** automatically enable the gate — a repository admin must manually import the ruleset configuration file.

> **Merging this PR does not enable the gate.** The ruleset must be imported by a repository admin, and there is a prerequisite to clear first — see [Before importing the ruleset](#before-importing-the-ruleset).

## Problem

Two independent gaps mean a red test run does not stop anything today.

**1. `main` has no `required_status_checks`.** Tests, frontend vitest and pre-commit all turn red without blocking a merge. Concretely: #6418 was merged with three failing test jobs.

**2. The push tier never actually runs.** The tiered plan assumed post-merge push runs provide deeper coverage (PR=p0, push=p0+p1, nightly=full). But push-triggered runs wait on the maintainer-approved environment and are never approved in practice — **the last 40 push runs on `main` all expired in `waiting`**. The PR gate is the only layer that reliably executes.

## Changes

**1. Required checks that cannot deadlock a PR.** `tests.yml` and `frontend-tests.yml` drop the `pull_request` `paths` filter and replace it with an in-workflow `changes` job (dorny/paths-filter, same path list). A path-filtered workflow that never triggers leaves its required check pending forever, which blocks the PR permanently — the classic trap. With the filter moved inside, a docs-only PR reports the checks as *skipped*, which satisfies a required check. Push triggers are unchanged, and docs-only PRs also stop pinging the maintainer-approved environment.

**2. Readable check contexts.** `pre-commit.yml`'s bare `run` job is named `Pre-commit`.

**3. Importable ruleset.** `.github/rulesets/main-required-checks.json` requires Test Summary, Pre-commit, Vitest Unit Tests and both npm format checks (GitHub Actions app pinned), with repository admins as bypass actors for emergencies.

**4. PR gate runs the full integration suite** instead of p0 only, compensating for the dead push tier. The `workflow_dispatch` marker input remains as a manual override to narrow a run.

**5. macOS integration HTTP timeout floor.** The 120s floor was applied to Windows only; extended to every non-Linux runner. Nightly evidence: `test_plugins_install_real_via_agentscoped` hit `httpx.ReadTimeout` on macOS 2 nights in 10.

## Fail-closed revision (head 7fa21070)

Addresses the review finding that the required-check design fails open when a path-detection job fails:

- `Test Summary` (tests.yml) and the new `Frontend Summary` (frontend-tests.yml) now run with `if: always()` and make a three-state decision: detection not `success` → fail; docs-only → explicit pass; tests required → every tier must be strictly `success` (`failure`/`cancelled`/`skipped` all rejected).
- Ruleset required check `Vitest Unit Tests` → `Frontend Summary`.
- Verified with 7 canary scenarios against the real Actions state machine on the fork (docs-only, all-green, detection failed, detection cancelled, test failed, test cancelled mid-run, test unexpectedly skipped): only the first two are mergeable; every failure mode is blocked.

## Verification

Verified on a fork via a real `pull_request` event (not `workflow_dispatch`), so the actual gate path was exercised — `changes` job filtering, full integration selection, and the job names used as check contexts.

- Rebased onto latest `main` with no conflicts; confirmed the `playwright install` step added by #6678 survives in both workflows, and the PR-gate marker resolves to `integration`.
- `check yaml`, `check json` and `actionlint` all pass.
- Earlier rounds used two canary branches to close the loop both ways: a deliberately failing unit test (red is actually blocked) and a docs-only change (docs-only PRs are not left hanging).

## Before importing the ruleset

Because the PR gate now runs the full suite, **any pre-existing failure on `main` will block every PR once the ruleset is active.** As of this PR there is one, and it must be fixed first:

`tests/integration/test_fork_and_coding_mode.py::test_coding_mode_get_default_disabled` — fails on all four platforms.

It is a test-side adaptation gap, not a regression: #6504 intentionally removed `project_dir` from the `GET /api/coding-mode` response (`- "project_dir": cm.project_dir,` in `src/qwenpaw/app/routers/coding_mode.py`), while the test still asserts `"project_dir" in body`. Response is now `{'enabled': False, 'agent_id': 'default'}`. Reported separately for the integration test owner.

Two notes on things that look alarming in this PR's own CI but are not caused by it:

- The same `test_coding_mode_get_default_disabled` failure appears here. It arrived with the rebase: `#6504` is in this branch's base but not in the 8/05 nightly base, which is why nightly showed a different failure set.
- `Coverage Report` fails with `Couldn't combine from non-existent path '.coverage.integration'` — a cascade of the integration job failing, so the artifact was never uploaded. #6743 is already addressing artifact export on failure.

Recommended sequence: merge this PR, land the `test_coding_mode_get_default_disabled` fix, confirm a green run on `main`, then import the ruleset.
