### PR TITLE
fix(ci): target rich chat input in desktop verification

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -162,7 +162,7 @@ jobs:
             dist/tauri-windows-x86_64-updater.json
 
   build-tauri-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -162,7 +162,7 @@ jobs:
             dist/tauri-windows-x86_64-updater.json
 
   build-tauri-macos:
-    runs-on: macos-15
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -300,7 +300,7 @@ jobs:
       always() &&
       (needs.check-release-secrets.result == 'success' ||
        needs.check-release-secrets.result == 'skipped')
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -300,7 +300,7 @@ jobs:
       always() &&
       (needs.check-release-secrets.result == 'success' ||
        needs.check-release-secrets.result == 'skipped')
-    runs-on: macos-15
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -38,7 +38,7 @@ jobs:
       inputs.platforms == 'all' ||
       inputs.platforms == 'tauri-only' ||
       inputs.platforms == 'macos-only'
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -38,7 +38,7 @@ jobs:
       inputs.platforms == 'all' ||
       inputs.platforms == 'tauri-only' ||
       inputs.platforms == 'macos-only'
-    runs-on: macos-15
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -7,7 +7,6 @@ import {
   clearLastEditorCopy,
   setLastEditorCopy,
 } from "../Coding/lastEditorCopy";
-import { setTextareaValue } from "./utils";
 import { useState } from "react";
 import "../../i18n";
 
@@ -73,21 +72,6 @@ describe("RichFileReferenceInput", () => {
       container.querySelector('[contenteditable="true"]'),
     ).toHaveTextContent("");
     expect(container.querySelector("textarea")).toHaveValue("");
-  });
-
-  it("syncs native textarea input into the visible editor", async () => {
-    const { container } = render(<ControlledRichInput />);
-    const textarea = container.querySelector("textarea");
-    expect(textarea).not.toBeNull();
-
-    setTextareaValue(textarea as HTMLTextAreaElement, "hello from automation");
-
-    await waitFor(() => {
-      expect(screen.getByTestId("qwenpaw-chat-input")).toHaveTextContent(
-        "hello from automation",
-      );
-    });
-    expect(textarea).toHaveValue("hello from automation");
   });
 
   it("turns a whole-line Monaco paste into an atomic line reference", async () => {

--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -41,7 +41,7 @@ describe("RichFileReferenceInput", () => {
       screen.getByRole("button", { name: /Code snippet · 1 line/i }),
     ).toBeInTheDocument();
 
-    const editor = screen.getByTestId("qwenpaw-chat-input");
+    const editor = screen.getByRole("textbox");
     expect(editor).toHaveAttribute("contenteditable", "true");
     expect(editor).not.toHaveTextContent("/work/app.ts");
     expect(container.querySelector("textarea")).toHaveValue(raw);

--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -41,7 +41,8 @@ describe("RichFileReferenceInput", () => {
       screen.getByRole("button", { name: /Code snippet · 1 line/i }),
     ).toBeInTheDocument();
 
-    const editor = container.querySelector('[contenteditable="true"]');
+    const editor = screen.getByTestId("qwenpaw-chat-input");
+    expect(editor).toHaveAttribute("contenteditable", "true");
     expect(editor).not.toHaveTextContent("/work/app.ts");
     expect(container.querySelector("textarea")).toHaveValue(raw);
   });

--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -7,6 +7,7 @@ import {
   clearLastEditorCopy,
   setLastEditorCopy,
 } from "../Coding/lastEditorCopy";
+import { setTextareaValue } from "./utils";
 import { useState } from "react";
 import "../../i18n";
 
@@ -72,6 +73,21 @@ describe("RichFileReferenceInput", () => {
       container.querySelector('[contenteditable="true"]'),
     ).toHaveTextContent("");
     expect(container.querySelector("textarea")).toHaveValue("");
+  });
+
+  it("syncs native textarea input into the visible editor", async () => {
+    const { container } = render(<ControlledRichInput />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    setTextareaValue(textarea as HTMLTextAreaElement, "hello from automation");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("qwenpaw-chat-input")).toHaveTextContent(
+        "hello from automation",
+      );
+    });
+    expect(textarea).toHaveValue("hello from automation");
   });
 
   it("turns a whole-line Monaco paste into an atomic line reference", async () => {

--- a/console/src/pages/Chat/RichFileReferenceInput.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.tsx
@@ -579,7 +579,7 @@ function EditableSurface({
   return (
     <ContentEditable
       className={styles.richEditor}
-      data-testid="qwenpaw-chat-input"
+      role="textbox"
       aria-multiline="true"
       spellCheck={false}
       onKeyDown={(event) => {

--- a/console/src/pages/Chat/RichFileReferenceInput.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.tsx
@@ -579,6 +579,7 @@ function EditableSurface({
   return (
     <ContentEditable
       className={styles.richEditor}
+      data-testid="qwenpaw-chat-input"
       aria-multiline="true"
       spellCheck={false}
       onKeyDown={(event) => {

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -417,7 +417,7 @@ class ChatPage(BasePage):
 
         # ---- Fill the input box ----
         input_box = self.page.locator(self.CHAT_INPUT)
-        input_box.click()
+        input_box.focus()
         self.wait(300)
         input_box.fill("")
         self.wait(200)
@@ -450,7 +450,7 @@ class ChatPage(BasePage):
         except (TimeoutError, AssertionError, Exception):
             logger.warning("[send_message] user bubble missing, retrying with Enter")
             input_box = self.page.locator(self.CHAT_INPUT)
-            input_box.click()
+            input_box.focus()
             self.wait(200)
             input_box.press("Enter")
             # Verify again after retry; if still failing, raise for real

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -43,7 +43,7 @@ class ChatPage(BasePage):
     SESSION_LIST_BTN = 'button:has(.spark-icon-spark-history-line), button:has(.anticon-history), button:has([class*="history"])'
 
     # Input area
-    CHAT_INPUT = '[data-testid="qwenpaw-chat-input"]'
+    CHAT_INPUT = '.qwenpaw-sender [role="textbox"][contenteditable="true"]:visible'
     SEND_BTN = 'button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary'
     FILE_INPUT = 'input[type="file"]'
     UPLOAD_WRAPPER = 'span.qwenpaw-upload-wrapper'
@@ -55,7 +55,7 @@ class ChatPage(BasePage):
     MESSAGE_LIST = '.qwenpaw-bubble-list-scroll'
 
     # Welcome screen (check input visibility)
-    WELCOME_TEXT = '[data-testid="qwenpaw-chat-input"]'
+    WELCOME_TEXT = CHAT_INPUT
     QUICK_ACTIONS = '.quick-action'
 
     # Session management (right-side "All Chats" drawer).

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -43,7 +43,7 @@ class ChatPage(BasePage):
     SESSION_LIST_BTN = 'button:has(.spark-icon-spark-history-line), button:has(.anticon-history), button:has([class*="history"])'
 
     # Input area
-    CHAT_INPUT = 'textarea.qwenpaw-sender-input'
+    CHAT_INPUT = '[data-testid="qwenpaw-chat-input"]'
     SEND_BTN = 'button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary'
     FILE_INPUT = 'input[type="file"]'
     UPLOAD_WRAPPER = 'span.qwenpaw-upload-wrapper'
@@ -55,7 +55,7 @@ class ChatPage(BasePage):
     MESSAGE_LIST = '.qwenpaw-bubble-list-scroll'
 
     # Welcome screen (check input visibility)
-    WELCOME_TEXT = 'textarea.qwenpaw-sender-input'
+    WELCOME_TEXT = '[data-testid="qwenpaw-chat-input"]'
     QUICK_ACTIONS = '.quick-action'
 
     # Session management (right-side "All Chats" drawer).

--- a/e2e/tests/test_coding.py
+++ b/e2e/tests/test_coding.py
@@ -256,7 +256,7 @@ class TestChatInCodingMode:
 
             log_test_step("3. Send a question that mentions README.md")
             chat_input = coding_page.page.locator(
-                "textarea.qwenpaw-sender-input"
+                '[data-testid="qwenpaw-chat-input"]'
             ).first
             expect(chat_input).to_be_visible(timeout=coding_page.timeout)
             chat_input.fill(

--- a/e2e/tests/test_coding.py
+++ b/e2e/tests/test_coding.py
@@ -256,7 +256,7 @@ class TestChatInCodingMode:
 
             log_test_step("3. Send a question that mentions README.md")
             chat_input = coding_page.page.locator(
-                '[data-testid="qwenpaw-chat-input"]'
+                '.qwenpaw-sender [role="textbox"][contenteditable="true"]:visible'
             ).first
             expect(chat_input).to_be_visible(timeout=coding_page.timeout)
             chat_input.fill(

--- a/e2e/tests/test_memory.py
+++ b/e2e/tests/test_memory.py
@@ -167,7 +167,7 @@ class TestMemorySearchRecall:
             timeout=memory_page.timeout,
         )
         chat_input = memory_page.page.locator(
-            "textarea.qwenpaw-sender-input"
+            '[data-testid="qwenpaw-chat-input"]'
         ).first
         expect(chat_input).to_be_visible(timeout=memory_page.timeout)
         chat_input.fill(

--- a/e2e/tests/test_memory.py
+++ b/e2e/tests/test_memory.py
@@ -167,7 +167,7 @@ class TestMemorySearchRecall:
             timeout=memory_page.timeout,
         )
         chat_input = memory_page.page.locator(
-            '[data-testid="qwenpaw-chat-input"]'
+            '.qwenpaw-sender [role="textbox"][contenteditable="true"]:visible'
         ).first
         expect(chat_input).to_be_visible(timeout=memory_page.timeout)
         chat_input.fill(

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -69,6 +69,7 @@ SEL_INPUT = '[data-testid="qwenpaw-chat-input"]'
 SEL_SEND_BTN = "button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary"
 SEL_USER_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-end"
 SEL_AI_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-start"
+SEL_TOUR_NEXT = "button.qwenpaw-tour-next-btn"
 
 
 # =============================================================================
@@ -521,14 +522,31 @@ class PlaywrightDriver(UIDriver):
             except Exception:  # noqa: BLE001
                 pass
 
+    def _dismiss_open_tour(self) -> None:
+        """Complete any active product tour before driving the chat UI."""
+        dismissed_steps = 0
+        for _ in range(10):
+            next_button = self._page.locator(SEL_TOUR_NEXT).first
+            if not next_button.is_visible():
+                break
+            next_button.click(timeout=5_000)
+            dismissed_steps += 1
+            time.sleep(0.2)
+
+        if self._page.locator(SEL_TOUR_NEXT).first.is_visible():
+            raise RuntimeError("Product tour did not close after 10 steps")
+        if dismissed_steps:
+            print(f"INFO  dismissed product tour ({dismissed_steps} step(s))")
+
     def chat_one_round(self, message: str, timeout: int) -> str:
+        self._dismiss_open_tour()
         self._wait_previous_round_idle()
 
         ai_count_before = self._page.locator(SEL_AI_BUBBLE).count()
         user_count_before = self._page.locator(SEL_USER_BUBBLE).count()
 
         # Defensive input flow borrowed from e2e/pages/chat_page.py:
-        # focus the textarea, clear any leftover text, fill the new
+        # focus the chat input, clear any leftover text, fill the new
         # message, then click send (or fall back to Enter).
         input_box = self._page.locator(SEL_INPUT).first
         input_box.click()

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -545,15 +545,16 @@ class PlaywrightDriver(UIDriver):
         ai_count_before = self._page.locator(SEL_AI_BUBBLE).count()
         user_count_before = self._page.locator(SEL_USER_BUBBLE).count()
 
-        # Defensive input flow borrowed from e2e/pages/chat_page.py:
-        # focus the chat input, clear any leftover text, fill the new
-        # message, then click send (or fall back to Enter).
+        # Drive the contenteditable through keyboard events.  Playwright's
+        # click() and fill() can hang against Lexical on WebKit even after
+        # completing their actionability checks.
         input_box = self._page.locator(SEL_INPUT).first
         input_box.focus()
         time.sleep(0.2)
-        input_box.fill("")
-        time.sleep(0.2)
-        input_box.fill(message)
+        select_all = "Meta+A" if sys.platform == "darwin" else "Control+A"
+        self._page.keyboard.press(select_all)
+        self._page.keyboard.press("Backspace")
+        self._page.keyboard.insert_text(message)
         time.sleep(0.5)
 
         # Reset Gate 2 state-machine caches so a fresh round starts
@@ -571,7 +572,7 @@ class PlaywrightDriver(UIDriver):
         if send_btn.is_visible() and send_btn.is_enabled():
             send_btn.click()
         else:
-            input_box.press("Enter")
+            self._page.keyboard.press("Enter")
 
         # Gold-standard "message actually sent" check: a new user bubble
         # must appear. Treating button-disabled as the signal turns out
@@ -596,7 +597,7 @@ class PlaywrightDriver(UIDriver):
             try:
                 input_box.focus()
                 time.sleep(0.2)
-                input_box.press("Enter")
+                self._page.keyboard.press("Enter")
                 self._page.wait_for_function(
                     """(expected) => {
                       const msgs = document.querySelectorAll(

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -65,7 +65,7 @@ HANG_DUMP_SECONDS = 540
 
 # Selectors come straight from e2e/pages/chat_page.py so they stay in sync
 # with what the real UI tests expect.
-SEL_INPUT = "textarea.qwenpaw-sender-input"
+SEL_INPUT = '[data-testid="qwenpaw-chat-input"]'
 SEL_SEND_BTN = "button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary"
 SEL_USER_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-end"
 SEL_AI_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-start"

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -65,7 +65,7 @@ HANG_DUMP_SECONDS = 540
 
 # Selectors come straight from e2e/pages/chat_page.py so they stay in sync
 # with what the real UI tests expect.
-SEL_INPUT = '[data-testid="qwenpaw-chat-input"]'
+SEL_INPUT = '.qwenpaw-sender [role="textbox"][contenteditable="true"]:visible'
 SEL_SEND_BTN = "button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary"
 SEL_USER_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-end"
 SEL_AI_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-start"

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -272,7 +272,6 @@ class PlaywrightDriver(UIDriver):
         cdp_url: str = "",
     ) -> None:
         self._screenshot_dir = screenshot_dir
-        self._browser_name = browser
         if screenshot_dir:
             os.makedirs(screenshot_dir, exist_ok=True)
 
@@ -539,38 +538,6 @@ class PlaywrightDriver(UIDriver):
         if dismissed_steps:
             print(f"INFO  dismissed product tour ({dismissed_steps} step(s))")
 
-    def _replace_webkit_input(self, message: str) -> None:
-        """Replace Lexical content without WebKit's hanging input protocol."""
-        print("INFO  replacing WebKit rich-editor content", flush=True)
-        self._page.locator(SEL_INPUT).first.evaluate(
-            """(editor, value) => {
-              const textarea = editor.parentElement?.querySelector('textarea');
-              if (!(textarea instanceof HTMLTextAreaElement)) {
-                throw new Error('Hidden chat textarea was not found');
-              }
-              const setter = Object.getOwnPropertyDescriptor(
-                HTMLTextAreaElement.prototype,
-                'value',
-              )?.set;
-              if (setter) setter.call(textarea, value);
-              else textarea.value = value;
-              textarea.selectionStart = textarea.selectionEnd = value.length;
-              textarea.dispatchEvent(new Event('input', { bubbles: true }));
-            }""",
-            message,
-            timeout=5_000,
-        )
-        self._page.wait_for_function(
-            """({ selector, value }) => {
-              const editor = document.querySelector(selector);
-              const textarea = editor?.parentElement?.querySelector('textarea');
-              return editor?.textContent === value && textarea?.value === value;
-            }""",
-            arg={"selector": SEL_INPUT, "value": message},
-            timeout=5_000,
-        )
-        print("INFO  WebKit rich-editor content synchronized", flush=True)
-
     def chat_one_round(self, message: str, timeout: int) -> str:
         self._dismiss_open_tour()
         self._wait_previous_round_idle()
@@ -578,17 +545,15 @@ class PlaywrightDriver(UIDriver):
         ai_count_before = self._page.locator(SEL_AI_BUBBLE).count()
         user_count_before = self._page.locator(SEL_USER_BUBBLE).count()
 
+        # Defensive input flow borrowed from e2e/pages/chat_page.py:
+        # focus the chat input, clear any leftover text, fill the new
+        # message, then click send (or fall back to Enter).
         input_box = self._page.locator(SEL_INPUT).first
-        if self._browser_name == "webkit":
-            # WebKit v2251 on macos-14 can hang indefinitely in Playwright's
-            # click(), fill(), and keyboard input protocols for Lexical.
-            self._replace_webkit_input(message)
-        else:
-            input_box.focus()
-            time.sleep(0.2)
-            input_box.fill("")
-            time.sleep(0.2)
-            input_box.fill(message)
+        input_box.focus()
+        time.sleep(0.2)
+        input_box.fill("")
+        time.sleep(0.2)
+        input_box.fill(message)
         time.sleep(0.5)
 
         # Reset Gate 2 state-machine caches so a fresh round starts
@@ -603,12 +568,10 @@ class PlaywrightDriver(UIDriver):
             pass
 
         send_btn = self._page.locator(SEL_SEND_BTN).first
-        if self._browser_name == "webkit":
-            send_btn.evaluate("element => element.click()", timeout=5_000)
-        elif send_btn.is_visible() and send_btn.is_enabled():
+        if send_btn.is_visible() and send_btn.is_enabled():
             send_btn.click()
         else:
-            self._page.keyboard.press("Enter")
+            input_box.press("Enter")
 
         # Gold-standard "message actually sent" check: a new user bubble
         # must appear. Treating button-disabled as the signal turns out
@@ -631,28 +594,9 @@ class PlaywrightDriver(UIDriver):
             # Fall back to pressing Enter — some layouts ignore the
             # send button click but accept Enter on the chat input.
             try:
-                if self._browser_name == "webkit":
-                    input_box.evaluate(
-                        """element => {
-                          const options = {
-                            key: 'Enter',
-                            code: 'Enter',
-                            bubbles: true,
-                            cancelable: true,
-                          };
-                          element.dispatchEvent(
-                            new KeyboardEvent('keydown', options),
-                          );
-                          element.dispatchEvent(
-                            new KeyboardEvent('keyup', options),
-                          );
-                        }""",
-                        timeout=5_000,
-                    )
-                else:
-                    input_box.focus()
-                    time.sleep(0.2)
-                    self._page.keyboard.press("Enter")
+                input_box.focus()
+                time.sleep(0.2)
+                input_box.press("Enter")
                 self._page.wait_for_function(
                     """(expected) => {
                       const msgs = document.querySelectorAll(

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -539,22 +539,23 @@ class PlaywrightDriver(UIDriver):
         if dismissed_steps:
             print(f"INFO  dismissed product tour ({dismissed_steps} step(s))")
 
-    def _replace_webkit_input(self, input_box, message: str) -> None:
+    def _replace_webkit_input(self, message: str) -> None:
         """Replace Lexical content without WebKit's hanging input protocol."""
         print("INFO  replacing WebKit rich-editor content", flush=True)
-        input_box.evaluate(
-            """(element, value) => {
-              element.focus();
-              const selection = window.getSelection();
-              if (!selection) throw new Error('Selection API is unavailable');
-              const range = document.createRange();
-              range.selectNodeContents(element);
-              selection.removeAllRanges();
-              selection.addRange(range);
-              document.execCommand('insertText', false, value);
-              if (element.textContent !== value) {
-                throw new Error('insertText did not update the rich editor');
+        self._page.locator(SEL_INPUT).first.evaluate(
+            """(editor, value) => {
+              const textarea = editor.parentElement?.querySelector('textarea');
+              if (!(textarea instanceof HTMLTextAreaElement)) {
+                throw new Error('Hidden chat textarea was not found');
               }
+              const setter = Object.getOwnPropertyDescriptor(
+                HTMLTextAreaElement.prototype,
+                'value',
+              )?.set;
+              if (setter) setter.call(textarea, value);
+              else textarea.value = value;
+              textarea.selectionStart = textarea.selectionEnd = value.length;
+              textarea.dispatchEvent(new Event('input', { bubbles: true }));
             }""",
             message,
             timeout=5_000,
@@ -581,7 +582,7 @@ class PlaywrightDriver(UIDriver):
         if self._browser_name == "webkit":
             # WebKit v2251 on macos-14 can hang indefinitely in Playwright's
             # click(), fill(), and keyboard input protocols for Lexical.
-            self._replace_webkit_input(input_box, message)
+            self._replace_webkit_input(message)
         else:
             input_box.focus()
             time.sleep(0.2)
@@ -602,7 +603,9 @@ class PlaywrightDriver(UIDriver):
             pass
 
         send_btn = self._page.locator(SEL_SEND_BTN).first
-        if send_btn.is_visible() and send_btn.is_enabled():
+        if self._browser_name == "webkit":
+            send_btn.evaluate("element => element.click()", timeout=5_000)
+        elif send_btn.is_visible() and send_btn.is_enabled():
             send_btn.click()
         else:
             self._page.keyboard.press("Enter")
@@ -628,9 +631,28 @@ class PlaywrightDriver(UIDriver):
             # Fall back to pressing Enter — some layouts ignore the
             # send button click but accept Enter on the chat input.
             try:
-                input_box.focus()
-                time.sleep(0.2)
-                self._page.keyboard.press("Enter")
+                if self._browser_name == "webkit":
+                    input_box.evaluate(
+                        """element => {
+                          const options = {
+                            key: 'Enter',
+                            code: 'Enter',
+                            bubbles: true,
+                            cancelable: true,
+                          };
+                          element.dispatchEvent(
+                            new KeyboardEvent('keydown', options),
+                          );
+                          element.dispatchEvent(
+                            new KeyboardEvent('keyup', options),
+                          );
+                        }""",
+                        timeout=5_000,
+                    )
+                else:
+                    input_box.focus()
+                    time.sleep(0.2)
+                    self._page.keyboard.press("Enter")
                 self._page.wait_for_function(
                     """(expected) => {
                       const msgs = document.querySelectorAll(

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -549,7 +549,7 @@ class PlaywrightDriver(UIDriver):
         # focus the chat input, clear any leftover text, fill the new
         # message, then click send (or fall back to Enter).
         input_box = self._page.locator(SEL_INPUT).first
-        input_box.click()
+        input_box.focus()
         time.sleep(0.2)
         input_box.fill("")
         time.sleep(0.2)
@@ -592,9 +592,9 @@ class PlaywrightDriver(UIDriver):
             )
         except Exception:  # noqa: BLE001
             # Fall back to pressing Enter — some layouts ignore the
-            # send button click but accept Enter on the textarea.
+            # send button click but accept Enter on the chat input.
             try:
-                input_box.click()
+                input_box.focus()
                 time.sleep(0.2)
                 input_box.press("Enter")
                 self._page.wait_for_function(

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -272,6 +272,7 @@ class PlaywrightDriver(UIDriver):
         cdp_url: str = "",
     ) -> None:
         self._screenshot_dir = screenshot_dir
+        self._browser_name = browser
         if screenshot_dir:
             os.makedirs(screenshot_dir, exist_ok=True)
 
@@ -538,6 +539,37 @@ class PlaywrightDriver(UIDriver):
         if dismissed_steps:
             print(f"INFO  dismissed product tour ({dismissed_steps} step(s))")
 
+    def _replace_webkit_input(self, input_box, message: str) -> None:
+        """Replace Lexical content without WebKit's hanging input protocol."""
+        print("INFO  replacing WebKit rich-editor content", flush=True)
+        input_box.evaluate(
+            """(element, value) => {
+              element.focus();
+              const selection = window.getSelection();
+              if (!selection) throw new Error('Selection API is unavailable');
+              const range = document.createRange();
+              range.selectNodeContents(element);
+              selection.removeAllRanges();
+              selection.addRange(range);
+              document.execCommand('insertText', false, value);
+              if (element.textContent !== value) {
+                throw new Error('insertText did not update the rich editor');
+              }
+            }""",
+            message,
+            timeout=5_000,
+        )
+        self._page.wait_for_function(
+            """({ selector, value }) => {
+              const editor = document.querySelector(selector);
+              const textarea = editor?.parentElement?.querySelector('textarea');
+              return editor?.textContent === value && textarea?.value === value;
+            }""",
+            arg={"selector": SEL_INPUT, "value": message},
+            timeout=5_000,
+        )
+        print("INFO  WebKit rich-editor content synchronized", flush=True)
+
     def chat_one_round(self, message: str, timeout: int) -> str:
         self._dismiss_open_tour()
         self._wait_previous_round_idle()
@@ -545,16 +577,17 @@ class PlaywrightDriver(UIDriver):
         ai_count_before = self._page.locator(SEL_AI_BUBBLE).count()
         user_count_before = self._page.locator(SEL_USER_BUBBLE).count()
 
-        # Drive the contenteditable through keyboard events.  Playwright's
-        # click() and fill() can hang against Lexical on WebKit even after
-        # completing their actionability checks.
         input_box = self._page.locator(SEL_INPUT).first
-        input_box.focus()
-        time.sleep(0.2)
-        select_all = "Meta+A" if sys.platform == "darwin" else "Control+A"
-        self._page.keyboard.press(select_all)
-        self._page.keyboard.press("Backspace")
-        self._page.keyboard.insert_text(message)
+        if self._browser_name == "webkit":
+            # WebKit v2251 on macos-14 can hang indefinitely in Playwright's
+            # click(), fill(), and keyboard input protocols for Lexical.
+            self._replace_webkit_input(input_box, message)
+        else:
+            input_box.focus()
+            time.sleep(0.2)
+            input_box.fill("")
+            time.sleep(0.2)
+            input_box.fill(message)
         time.sleep(0.5)
 
         # Reset Gate 2 state-machine caches so a fresh round starts


### PR DESCRIPTION
## Description

Fixes the Windows and macOS desktop verification failure in [release run 31093606793](https://github.com/agentscope-ai/QwenPaw/actions/runs/31093606793).

`RichFileReferenceInput` replaced the visible sender textarea with a Lexical contenteditable editor, but desktop verification and several E2E tests still waited for `textarea.qwenpaw-sender-input`. This PR gives the visible editor explicit textbox semantics and updates all remaining consumers to locate the visible contenteditable within `.qwenpaw-sender`. The desktop verifier also completes any open product tour before typing, and active macOS desktop checks use the supported `macos-15` runner instead of the frozen WebKit shipped for `macos-14`.

**Related Issue:** N/A — regression found in release run 31093606793.

**Security Considerations:** None; this only changes test/verification targeting and CI runner configuration.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
cd console
node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run src/pages/Chat/RichFileReferenceInput.test.tsx --pool=threads --maxWorkers=1
npx prettier --check src/pages/Chat/RichFileReferenceInput.tsx src/pages/Chat/RichFileReferenceInput.test.tsx

cd ..
python -m py_compile scripts/verify/desktop_verify.py e2e/pages/chat_page.py e2e/tests/test_coding.py e2e/tests/test_memory.py
git diff --check
```

## Evidence

- Focused Vitest: 1 test file passed, 4 tests passed.
- Targeted Prettier check: both modified TSX files passed.
- Python compilation: all four modified verification/E2E modules passed.
- `git diff --check`: passed.
- Original failure on both platforms: Playwright timed out waiting for `textarea.qwenpaw-sender-input` after the visible editor changed to contenteditable.
- [Origin desktop build 31145565283](https://github.com/jinglinpeng/CoPaw/actions/runs/31145565283) passed for commit `f6545a0d9`: Windows and macOS package builds, sender-scoped semantic input smoke verification, screenshots, and installer artifact uploads all succeeded.

## Additional Notes

The change is limited to the sender-scoped semantic locator and its consumers, the product-tour blocker in the same verifier, and the supported macOS runner needed to exercise that verification reliably.
