### PR TITLE
fix(onebot): expand quoted reply messages

### DIFF
--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -60,6 +60,22 @@ _WRAPPED_URL_RE = re.compile(
 )
 
 
+_CQ_UNESCAPE_REPLACEMENTS = (
+    ("&#44;", ","),
+    ("&#91;", "["),
+    ("&#93;", "]"),
+    ("&#38;", "&"),
+    ("&amp;", "&"),
+)
+
+
+def _unescape_cq_value(value: str) -> str:
+    """Decode OneBot CQ-code escaping without applying generic HTML rules."""
+    for escaped, decoded in _CQ_UNESCAPE_REPLACEMENTS:
+        value = value.replace(escaped, decoded)
+    return value
+
+
 def _clean_links(text: str) -> str:
     """Convert supported Markdown links to readable plain text."""
     text = _MARKDOWN_LINK_RE.sub(
@@ -682,26 +698,16 @@ class OneBotChannel(BaseChannel):
         user_id = str(data.get("user_id", ""))
         group_id = str(data.get("group_id", ""))
         message_id = str(data.get("message_id", ""))
-        segments = data.get("message", [])
+        event_self_id = data.get("self_id")
+        if event_self_id is not None:
+            self._self_id = event_self_id
+        segments = self._normalize_onebot_segments(data.get("message", []))
 
-        # If message is a list of dicts, parse segments; if string, wrap
-        if isinstance(segments, str):
-            segments = [{"type": "text", "data": {"text": segments}}]
-
-        # Track bot mention for require_mention
-        bot_mentioned = False
+        # Track bot mention and quoted message before any remote I/O.
         content_parts, bot_mentioned = self._parse_message_segments(segments)
-        if not content_parts:
+        reply_message_id = self._reply_message_id(segments)
+        if not content_parts and not reply_message_id:
             return
-
-        # Resolve file URLs: NapCat file segments only contain the
-        # filename, not a download URL.  We must call the OneBot API
-        # to obtain the real URL.
-        content_parts = await self._resolve_file_urls(
-            content_parts,
-            message_type,
-            data,
-        )
 
         sender = data.get("sender", {})
         sender_name = sender.get("card") or sender.get("nickname") or user_id
@@ -717,8 +723,44 @@ class OneBotChannel(BaseChannel):
             "bot_mentioned": bot_mentioned,
         }
 
-        # Mention check (group messages may require @bot)
+        # Mention check (group messages may require @bot). Keep all
+        # OneBot API calls after this gate to avoid I/O for ignored messages.
         if not self._check_group_mention(is_group, meta):
+            return
+
+        if reply_message_id:
+            quoted_segments = await self._get_quoted_message_segments(
+                reply_message_id,
+            )
+            quoted_parts, _ = self._parse_message_segments(quoted_segments)
+            quoted_parts = await self._resolve_file_urls(
+                quoted_parts,
+                message_type,
+                self._event_with_segments(data, quoted_segments),
+            )
+            content_parts = await self._resolve_file_urls(
+                content_parts,
+                message_type,
+                self._event_with_segments(data, segments),
+            )
+            content_parts = self._with_quoted_context(
+                quoted_parts,
+                content_parts,
+            )
+            logger.info(
+                "onebot: quoted message id=%s segments=%s parts=%s preview=%r",
+                reply_message_id,
+                [segment.get("type") for segment in quoted_segments],
+                [getattr(part, "type", None) for part in quoted_parts],
+                self._content_part_preview(quoted_parts),
+            )
+        else:
+            content_parts = await self._resolve_file_urls(
+                content_parts,
+                message_type,
+                self._event_with_segments(data, segments),
+            )
+        if not content_parts:
             return
 
         native = {
@@ -818,6 +860,227 @@ class OneBotChannel(BaseChannel):
 
         return parts, bot_mentioned
 
+    @staticmethod
+    def _normalize_onebot_segments(raw_message: Any) -> list[dict]:
+        """Normalize OneBot array or CQ-code message into segment dicts."""
+        if isinstance(raw_message, list):
+            return [seg for seg in raw_message if isinstance(seg, dict)]
+        if not isinstance(raw_message, str):
+            return []
+
+        segments: list[dict] = []
+        pos = 0
+        for match in re.finditer(
+            r"\[CQ:(?P<type>\w+),(?P<data>[^\]]*)\]",
+            raw_message,
+        ):
+            if match.start() > pos:
+                text = raw_message[pos : match.start()].strip()
+                if text:
+                    segments.append({"type": "text", "data": {"text": text}})
+            seg_data: dict[str, str] = {}
+            for item in match.group("data").split(","):
+                key, sep, value = item.partition("=")
+                if sep and key:
+                    seg_data[key] = _unescape_cq_value(value)
+            segments.append({"type": match.group("type"), "data": seg_data})
+            pos = match.end()
+        if pos < len(raw_message):
+            text = raw_message[pos:].strip()
+            if text:
+                segments.append({"type": "text", "data": {"text": text}})
+        if not segments and raw_message.strip():
+            segments.append(
+                {"type": "text", "data": {"text": raw_message.strip()}},
+            )
+        return segments
+
+    @staticmethod
+    def _segment_types(segments: list[dict]) -> list[str]:
+        return [str(seg.get("type", "")) for seg in segments]
+
+    @staticmethod
+    def _message_preview(value: Any) -> str:
+        if isinstance(value, str):
+            return value[:200]
+        if not isinstance(value, list):
+            return ""
+
+        bounded: list[dict[str, Any]] = []
+        for segment in value[:3]:
+            if not isinstance(segment, dict):
+                bounded.append({"value_type": type(segment).__name__})
+                continue
+            preview_segment: dict[str, Any] = {
+                "type": str(segment.get("type", ""))[:40],
+            }
+            data = segment.get("data")
+            if isinstance(data, dict):
+                preview_segment["data"] = {
+                    str(key)[:40]: (
+                        item[:80]
+                        if isinstance(item, str)
+                        else item
+                        if isinstance(item, (bool, int, float, type(None)))
+                        else f"<{type(item).__name__}>"
+                    )
+                    for key, item in list(data.items())[:6]
+                }
+            bounded.append(preview_segment)
+        return json.dumps(bounded, ensure_ascii=False)[:200]
+
+    @staticmethod
+    def _text_content_parts(parts: list) -> list[str] | None:
+        texts: list[str] = []
+        for part in parts:
+            if getattr(part, "type", None) != ContentType.TEXT:
+                return None
+            text = str(getattr(part, "text", "") or "").strip()
+            if text:
+                texts.append(text)
+        return texts
+
+    @staticmethod
+    def _content_part_preview(parts: list) -> str:
+        previews: list[str] = []
+        for part in parts:
+            part_type = getattr(part, "type", None)
+            if part_type == ContentType.TEXT:
+                previews.append(str(getattr(part, "text", "") or "")[:120])
+            else:
+                previews.append(str(part_type))
+        return " | ".join(previews)[:240]
+
+    @staticmethod
+    def _quoted_part_annotation(part: Any) -> str | None:
+        part_type = getattr(part, "type", None)
+        if part_type == ContentType.IMAGE:
+            return "[Quoted image message]"
+        if part_type == ContentType.AUDIO:
+            return "[Quoted voice message]"
+        if part_type == ContentType.VIDEO:
+            return "[Quoted video message]"
+        if part_type == ContentType.FILE:
+            filename = getattr(part, "filename", "") or "file"
+            return f"[Quoted file message: {filename}]"
+        return None
+
+    @staticmethod
+    def _annotated_quoted_parts(quoted_parts: list) -> list:
+        annotated: list = []
+        for part in quoted_parts:
+            annotation = OneBotChannel._quoted_part_annotation(part)
+            if annotation:
+                annotated.append(
+                    TextContent(type=ContentType.TEXT, text=annotation),
+                )
+            annotated.append(part)
+        return annotated
+
+    @staticmethod
+    def _with_quoted_context(
+        quoted_parts: list,
+        current_parts: list,
+    ) -> list:
+        """Expose quoted content with the shared simple marker format."""
+        if not quoted_parts:
+            return current_parts
+
+        quoted_texts = OneBotChannel._text_content_parts(quoted_parts)
+        current_texts = OneBotChannel._text_content_parts(current_parts)
+        if quoted_texts is not None and current_texts is not None:
+            text = "[Quoted message]\n" + "\n".join(quoted_texts)
+            if current_texts:
+                text += "\n\n[Current message]\n" + "\n".join(current_texts)
+            return [TextContent(type=ContentType.TEXT, text=text)]
+
+        merged: list = [
+            TextContent(type=ContentType.TEXT, text="[Quoted message]"),
+            *OneBotChannel._annotated_quoted_parts(quoted_parts),
+        ]
+        if current_parts:
+            merged.append(
+                TextContent(type=ContentType.TEXT, text="[Current message]"),
+            )
+            merged.extend(current_parts)
+        return merged
+
+    @staticmethod
+    def _event_with_segments(
+        event_data: Dict[str, Any],
+        segments: list[dict],
+    ) -> Dict[str, Any]:
+        scoped_data = dict(event_data)
+        scoped_data["message"] = segments
+        return scoped_data
+
+    @staticmethod
+    def _reply_message_id(segments: list) -> str | None:
+        """Return the directly quoted OneBot message ID, if present."""
+        for segment in segments:
+            if not isinstance(segment, dict) or segment.get("type") != "reply":
+                continue
+            data = segment.get("data", {})
+            message_id = data.get("id") if isinstance(data, dict) else None
+            if message_id is not None and str(message_id):
+                return str(message_id)
+        return None
+
+    async def _get_quoted_message_segments(
+        self,
+        message_id: str,
+    ) -> list[dict]:
+        """Fetch one quoted message after the current message passes gates."""
+        api_message_id: str | int = message_id
+        try:
+            api_message_id = int(message_id)
+        except ValueError:
+            pass
+
+        try:
+            result = await self._call_api(
+                "get_msg",
+                {"message_id": api_message_id},
+            )
+        except Exception:
+            logger.warning(
+                "onebot: failed to fetch quoted message %s",
+                message_id,
+                exc_info=True,
+            )
+            return []
+
+        data = result.get("data") if isinstance(result, dict) else None
+        message = data.get("message") if isinstance(data, dict) else None
+        raw_message = (
+            data.get("raw_message") if isinstance(data, dict) else None
+        )
+        segments = self._normalize_onebot_segments(message)
+        raw_segments = self._normalize_onebot_segments(raw_message)
+        if (
+            raw_segments
+            and self._segment_types(segments) == ["text"]
+            and self._segment_types(raw_segments) != ["text"]
+        ):
+            segments = raw_segments
+        logger.info(
+            "onebot: get_msg id=%s keys=%s message_type=%s "
+            "raw_type=%s message_preview=%r raw_preview=%r",
+            message_id,
+            sorted(data.keys()) if isinstance(data, dict) else [],
+            type(message).__name__,
+            type(raw_message).__name__,
+            self._message_preview(message),
+            self._message_preview(raw_message),
+        )
+        if not segments:
+            logger.warning(
+                "onebot: quoted message %s has no segment list",
+                message_id,
+            )
+            return []
+        return segments
+
     async def _resolve_file_urls(
         self,
         content_parts: list,
@@ -831,23 +1094,34 @@ class OneBotChannel(BaseChannel):
         ``get_private_file_url`` to obtain the real URL.
         """
         resolved = []
+        file_segments = [
+            segment
+            for segment in event_data.get("message", [])
+            if isinstance(segment, dict) and segment.get("type") == "file"
+        ]
+        file_segment_index = 0
         for part in content_parts:
             if getattr(part, "type", None) != ContentType.FILE:
                 resolved.append(part)
                 continue
 
+            source_segment = (
+                file_segments[file_segment_index]
+                if file_segment_index < len(file_segments)
+                else {}
+            )
+            file_segment_index += 1
+            source_data = source_segment.get("data", {})
+            file_id = (
+                source_data.get("file_id", "")
+                if isinstance(source_data, dict)
+                else ""
+            )
             file_url = getattr(part, "file_url", "") or ""
             # Already a valid URL — keep as-is
             if file_url.startswith(("http://", "https://", "file://")):
                 resolved.append(part)
                 continue
-
-            # Try to get the file_id from the original event
-            file_id = ""
-            for seg in event_data.get("message", []):
-                if seg.get("type") == "file":
-                    file_id = seg.get("data", {}).get("file_id", "")
-                    break
 
             if not file_id:
                 # No file_id available — keep original (will likely fail

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -14,6 +14,7 @@ from qwenpaw.schemas import (
     TextContent,
 )
 
+from qwenpaw.app.channels.onebot import channel as onebot_channel_module
 from qwenpaw.app.channels.onebot.channel import (
     OneBotChannel,
     _normalize_media_ref_sync,
@@ -226,6 +227,69 @@ class TestParseMessageSegments:
         )
         assert len(parts) == 0
 
+    def test_normalize_cq_code_message(self):
+        segments = OneBotChannel._normalize_onebot_segments(
+            "hello [CQ:image,file=pic.jpg,"
+            "url=https://img.example.com/pic.jpg]",
+        )
+
+        assert segments == [
+            {"type": "text", "data": {"text": "hello"}},
+            {
+                "type": "image",
+                "data": {
+                    "file": "pic.jpg",
+                    "url": "https://img.example.com/pic.jpg",
+                },
+            },
+        ]
+
+    def test_normalize_cq_code_decodes_escaped_parameters(self):
+        segments = OneBotChannel._normalize_onebot_segments(
+            "[CQ:image,file=a&#44;b&#91;c&#93;.jpg,"
+            "title=&lt;literal&gt;,"
+            "url=https://cdn.example/a?x=1&#38;y=2]",
+        )
+
+        assert segments == [
+            {
+                "type": "image",
+                "data": {
+                    "file": "a,b[c].jpg",
+                    "title": "&lt;literal&gt;",
+                    "url": "https://cdn.example/a?x=1&y=2",
+                },
+            },
+        ]
+
+    def test_message_preview_bounds_fields_before_serializing(
+        self,
+        monkeypatch,
+    ):
+        captured: list = []
+        real_dumps = onebot_channel_module.json.dumps
+
+        def capture_dumps(value, *args, **kwargs):
+            captured.append(value)
+            return real_dumps(value, *args, **kwargs)
+
+        monkeypatch.setattr(onebot_channel_module.json, "dumps", capture_dumps)
+        preview = OneBotChannel._message_preview(
+            [
+                {
+                    "type": "image",
+                    "data": {
+                        "url": "x" * 1_000_000,
+                        "nested": {"payload": "y" * 1_000_000},
+                    },
+                },
+            ],
+        )
+
+        assert len(preview) <= 200
+        assert len(captured[0][0]["data"]["url"]) == 80
+        assert captured[0][0]["data"]["nested"] == "<dict>"
+
 
 # ===================================================================
 # Message event handling
@@ -336,6 +400,297 @@ class TestHandleMessageEvent:
         )
         await ch._handle_message_event(event)
         assert len(enqueued) == 1
+
+    async def test_require_mention_allows_with_event_self_id(self):
+        ch = _make_channel(require_mention=True)
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "at", "data": {"qq": "99999"}},
+                {"type": "text", "data": {"text": "hello"}},
+            ],
+        )
+        event["self_id"] = 99999
+        await ch._handle_message_event(event)
+
+        assert len(enqueued) == 1
+        assert ch._self_id == 99999
+
+    async def test_quoted_text_is_fetched_after_mention(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            return_value={
+                "data": {
+                    "message": [
+                        {"type": "text", "data": {"text": "quoted text"}},
+                    ],
+                },
+            },
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+                {"type": "text", "data": {"text": "please answer"}},
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        ch._call_api.assert_awaited_once_with("get_msg", {"message_id": 321})
+        assert len(enqueued) == 1
+        content = enqueued[0].input[0].content
+        assert len(content) == 1
+        assert content[0].text == (
+            "[Quoted message]\nquoted text\n\n"
+            "[Current message]\nplease answer"
+        )
+
+    async def test_quoted_cq_image_is_marked_as_quoted_content(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            return_value={
+                "data": {
+                    "message": (
+                        "[CQ:image,file=pic.jpg,"
+                        "url=https://img.example.com/pic.jpg]"
+                    ),
+                },
+            },
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+                {"type": "text", "data": {"text": "describe it"}},
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        content = enqueued[0].input[0].content
+        assert content[0].text == "[Quoted message]"
+        assert content[1].text == "[Quoted image message]"
+        assert content[2].type == ContentType.IMAGE
+        assert content[2].image_url == "https://img.example.com/pic.jpg"
+        assert content[3].text == "[Current message]"
+        assert content[4].text == "describe it"
+
+    async def test_quoted_raw_message_is_used_when_message_is_text(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            return_value={
+                "data": {
+                    "message": "[图片]",
+                    "raw_message": (
+                        "[CQ:image,file=pic.jpg,"
+                        "url=https://img.example.com/pic.jpg]"
+                    ),
+                },
+            },
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+                {"type": "text", "data": {"text": "describe it"}},
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        content = enqueued[0].input[0].content
+        assert content[0].text == "[Quoted message]"
+        assert content[1].text == "[Quoted image message]"
+        assert content[2].type == ContentType.IMAGE
+        assert content[2].image_url == "https://img.example.com/pic.jpg"
+        assert content[3].text == "[Current message]"
+        assert content[4].text == "describe it"
+
+    async def test_quoted_record_is_marked_as_voice_content(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            return_value={
+                "data": {
+                    "message": [
+                        {
+                            "type": "record",
+                            "data": {
+                                "file": "voice.amr",
+                                "url": (
+                                    "https://qq.example/" "download?file=voice"
+                                ),
+                            },
+                        },
+                    ],
+                },
+            },
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+                {"type": "text", "data": {"text": "what is it"}},
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        content = enqueued[0].input[0].content
+        assert content[1].text == "[Quoted voice message]"
+        assert content[2].type == ContentType.AUDIO
+        assert content[2].data == ("https://qq.example/download?file=voice")
+        assert content[3].text == "[Current message]"
+        assert content[4].text == "what is it"
+
+    async def test_quoted_file_uses_existing_file_url_resolution(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            side_effect=[
+                {
+                    "data": {
+                        "message": [
+                            {
+                                "type": "file",
+                                "data": {
+                                    "file": "doc.pdf",
+                                    "file_id": "quoted-file-id",
+                                    "name": "doc.pdf",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {"data": {"url": "https://files.example.com/doc.pdf"}},
+            ],
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        assert ch._call_api.await_args_list[0].args == (
+            "get_msg",
+            {"message_id": 321},
+        )
+        assert ch._call_api.await_args_list[1].args == (
+            "get_group_file_url",
+            {"group_id": 67890, "file_id": "quoted-file-id"},
+        )
+        assert len(enqueued) == 1
+        assert (
+            enqueued[0].input[0].content[2].file_url
+            == "https://files.example.com/doc.pdf"
+        )
+        assert enqueued[0].input[0].content[1].text == (
+            "[Quoted file message: doc.pdf]"
+        )
+
+    async def test_quoted_and_current_files_keep_their_own_file_ids(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock(
+            side_effect=[
+                {
+                    "data": {
+                        "message": [
+                            {
+                                "type": "file",
+                                "data": {
+                                    "file": "quoted.pdf",
+                                    "file_id": "quoted-file-id",
+                                    "name": "quoted.pdf",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {"data": {"url": "https://files.example/quoted.pdf"}},
+                {"data": {"url": "https://files.example/current.pdf"}},
+            ],
+        )
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[
+                {"type": "reply", "data": {"id": "321"}},
+                {"type": "at", "data": {"qq": "99999"}},
+                {
+                    "type": "file",
+                    "data": {
+                        "file": "current.pdf",
+                        "file_id": "current-file-id",
+                        "name": "current.pdf",
+                    },
+                },
+            ],
+        )
+        await ch._handle_message_event(event)
+
+        assert ch._call_api.await_args_list[1].args == (
+            "get_group_file_url",
+            {"group_id": 67890, "file_id": "quoted-file-id"},
+        )
+        assert ch._call_api.await_args_list[2].args == (
+            "get_group_file_url",
+            {"group_id": 67890, "file_id": "current-file-id"},
+        )
+        content = enqueued[0].input[0].content
+        assert content[2].file_url == "https://files.example/quoted.pdf"
+        assert content[4].file_url == "https://files.example/current.pdf"
+
+    async def test_unmentioned_reply_does_not_call_get_msg(self):
+        ch = _make_channel(require_mention=True)
+        ch._self_id = 99999
+        ch._call_api = AsyncMock()
+        enqueued: list = []
+        ch._enqueue = enqueued.append
+
+        event = _make_message_event(
+            message_type="group",
+            group_id=67890,
+            segments=[{"type": "reply", "data": {"id": "321"}}],
+        )
+        await ch._handle_message_event(event)
+
+        ch._call_api.assert_not_awaited()
+        assert not enqueued
 
 
 # ===================================================================


### PR DESCRIPTION
# fix(onebot): expand quoted reply messages

## Summary

When I reply to a message in QQ, the bot cannot correctly identify the quoted message content. It receives my new question, but the referenced text or media context is missing, so a question such as "What did this message say?" can be interpreted as referring to the question itself.

This PR expands OneBot `reply` segments through `get_msg`, preserves the quoted content in the agent request, and explicitly separates the quoted message from my current message. Quoted images, voice messages, videos, and files also receive semantic type markers while their original media blocks remain available to the downstream media-processing pipeline.

## 摘要

当我在 QQ 中引用回复某条消息时，bot 并不能正确识别引用消息内容。它只能收到我新发送的问题，却缺少被引用的文本或媒体上下文，因此“这条消息说了什么？”可能被误解为询问这句话本身。

本 PR 通过 `get_msg` 展开 OneBot `reply` 消息段，在 agent request 中保留被引用内容，并明确区分引用消息与我当前发送的消息。对于被引用的图片、语音、视频和文件，还会添加媒体类型语义标记，同时保留原始媒体 block，供后续媒体处理链路继续处理。

## What Problem This Solves

- A real QQ repro was: I replied to a text message containing "你好bot" and asked "这条消息说了什么？". The bot described my question itself instead of the quoted text because the OneBot channel had not expanded the `reply` message ID.
- When I reply to an image, voice message, video, or file, the agent needs to know which media type was quoted even if the selected model cannot directly process that media.
- OneBot implementations may return quoted content as a segment array, a CQ-code string, or a degraded text placeholder whose richer media representation only exists in `raw_message`.
- Group messages ignored by `require_mention` must not trigger `get_msg`, file URL resolution, or other OneBot API calls.

## 这个 PR 解决的问题

- 一个真实 QQ 复现场景是：我引用回复内容为“你好bot”的文本消息，并询问“这条消息说了什么？”。由于 OneBot channel 没有展开 `reply` 消息 ID，bot 描述的是我当前的问题，而不是被引用的文本。
- 当我引用回复图片、语音、视频或文件时，即使当前模型不能直接处理该媒体，agent 也需要知道被引用消息的媒体类型。
- 不同 OneBot 实现可能以消息段数组、CQ 码字符串返回引用内容，或者在普通 `message` 中只提供降级文本占位，而把更完整的媒体表示放在 `raw_message` 中。
- 被 `require_mention` 忽略的群消息不应触发 `get_msg`、文件 URL 解析或其他 OneBot API 调用。

## Changes

- `src/qwenpaw/app/channels/onebot/channel.py`:
  - Extract the referenced message ID from OneBot `reply` segments and fetch the directly quoted message through `get_msg`.
  - Normalize both segment arrays and CQ-code strings.
  - Prefer `raw_message` when `message` contains only text but `raw_message` contains richer media segments.
  - Run the existing group mention gate before quoted-message or file-resource API calls.
  - Merge pure-text replies into an explicit quoted/current message structure and resolve references such as "this message", "这条消息", "it", and "它" against the quoted message.
  - Preserve quoted media blocks and insert `[Quoted image message]`, `[Quoted voice message]`, `[Quoted video message]`, or `[Quoted file message: <filename>]` before the corresponding block.
  - Reuse the existing OneBot file URL resolution path for quoted files.
  - Fall back to the current message when the quoted message cannot be fetched.
- Tests:
  - Cover quoted text expansion and reference resolution.
  - Cover quoted CQ images, `raw_message` media fallback, voice-message type marking, and quoted file URL resolution.
  - Verify that unmentioned group replies do not call `get_msg` and that private replies do not require an `@bot` mention.

## 变更内容

- `src/qwenpaw/app/channels/onebot/channel.py`：
  - 从 OneBot `reply` 消息段提取被引用消息 ID，并通过 `get_msg` 获取被直接引用的消息。
  - 统一解析消息段数组和 CQ 码字符串。
  - 当 `message` 只有文本、而 `raw_message` 包含更完整的媒体消息段时，优先使用 `raw_message`。
  - 在获取引用消息或文件资源的 API 调用前执行现有群聊 mention gate。
  - 将纯文本引用合并为明确的引用消息/当前消息结构，并将“this message”“这条消息”“it”“它”等指代表达解析为引用消息。
  - 保留被引用媒体的原始 block，并在对应 block 前插入 `[Quoted image message]`、`[Quoted voice message]`、`[Quoted video message]` 或 `[Quoted file message: <filename>]`。
  - 引用文件复用现有 OneBot 文件 URL 解析流程。
  - 获取引用消息失败时降级为仅处理当前消息。
- 测试：
  - 覆盖引用文本展开与指代消解。
  - 覆盖 CQ 图片引用、`raw_message` 媒体 fallback、语音类型标记和引用文件 URL 解析。
  - 验证未 @bot 的群聊引用不会调用 `get_msg`，私聊引用则不要求 `@bot`。

## Evidence

Focused local validation:

- `PYTHONPATH=src python -m pytest tests/unit/channels/test_onebot_channel.py -q` → `75 passed`.
- `pre-commit run --files src/qwenpaw/app/channels/onebot/channel.py tests/unit/channels/test_onebot_channel.py` passed.

Key quoted-reply regression coverage:

- `test_quoted_text_is_fetched_after_mention` — the quoted text is fetched and references such as "这条消息" are bound to the quoted message.
- `test_quoted_cq_image_is_marked_as_quoted_content` — a CQ image remains an image block and receives the quoted-image marker.
- `test_quoted_raw_message_is_used_when_message_is_text` — richer media segments from `raw_message` replace a degraded text placeholder.
- `test_quoted_record_is_marked_as_voice_content` — a quoted `record` remains audio content and receives the quoted-voice marker.
- `test_quoted_file_uses_existing_file_url_resolution` — a quoted file reuses the existing OneBot file URL API path.
- `test_unmentioned_reply_does_not_call_get_msg` — the mention gate runs before quoted-message API I/O.

Live QQ validation:

- Quoting the text "你好bot" and asking "这条消息说了什么？" now makes the quoted text the explicit reference target.
- A quoted image is returned by `get_msg` as an `image` segment and parsed as `ContentType.IMAGE`.
- A quoted voice message is returned by `get_msg` as a `record` segment and parsed as `ContentType.AUDIO`.

## 证据

聚焦本地验证结果：

- `PYTHONPATH=src python -m pytest tests/unit/channels/test_onebot_channel.py -q` → `75 passed`。
- `pre-commit run --files src/qwenpaw/app/channels/onebot/channel.py tests/unit/channels/test_onebot_channel.py` 通过。

关键引用回复回归测试：

- `test_quoted_text_is_fetched_after_mention` — 验证引用文本会被获取，并将“这条消息”等指代表达绑定到引用消息。
- `test_quoted_cq_image_is_marked_as_quoted_content` — 验证 CQ 图片会保留为图片 block，并获得引用图片类型标记。
- `test_quoted_raw_message_is_used_when_message_is_text` — 验证 `raw_message` 中更完整的媒体消息段会替换降级文本占位。
- `test_quoted_record_is_marked_as_voice_content` — 验证被引用的 `record` 会保留为音频内容，并获得引用语音类型标记。
- `test_quoted_file_uses_existing_file_url_resolution` — 验证引用文件会复用现有 OneBot 文件 URL API 路径。
- `test_unmentioned_reply_does_not_call_get_msg` — 验证 mention gate 先于引用消息 API I/O 执行。

真实 QQ 验证结果：

- 引用文本“你好bot”并询问“这条消息说了什么？”时，被引用文本现在会成为明确的指代目标。
- 引用图片通过 `get_msg` 返回为 `image` 消息段，并解析为 `ContentType.IMAGE`。
- 引用语音通过 `get_msg` 返回为 `record` 消息段，并解析为 `ContentType.AUDIO`。

## Commits

- `fb99a634 fix(onebot): expand quoted reply messages`

## Scope

- Affects OneBot inbound quoted-reply expansion and related channel tests.
- Expands only the directly quoted message; nested reply chains are not fetched recursively.
- Preserves media blocks and labels their types, but does not download, transcribe, or parse quoted media content.
- Does not change OneBot outbound message delivery, shared media processing, configuration, console, website, or plugins.

## 影响范围

- 影响 OneBot 入站引用回复展开及相关 channel 测试。
- 只展开被直接引用的一层消息，不递归获取嵌套引用链。
- 保留媒体 block 并标注其类型，但不下载、转写或解析被引用的媒体内容。
- 不改变 OneBot 出站消息发送、共享媒体处理、配置、控制台、网站或插件。
