### PR TITLE
fix(modes): honor in_loop_modes for goal and mission gates

### DIFF
--- a/src/qwenpaw/modes/goal/helpers.py
+++ b/src/qwenpaw/modes/goal/helpers.py
@@ -3,6 +3,7 @@
 
 Separated from goal_mode.py for maintainability.
 """
+
 from __future__ import annotations
 
 import logging
@@ -56,17 +57,17 @@ def register_goal_tools_governance() -> None:
 def create_doom_loop_gate(
     workspace: object,
 ) -> Any:
-    """Create DoomLoopGate from agent config.
+    """Create DoomLoopGate from workspace config.
 
     Returns None if doom loop detection is disabled
-    or config is unavailable.
+    or not enabled for in-loop modes.
     """
     try:
         from ...loop.gates import DoomLoopGate
 
         agent_cfg = getattr(
             workspace,
-            "agent_config",
+            "config",
             None,
         )
         if agent_cfg is None:
@@ -82,7 +83,11 @@ def create_doom_loop_gate(
             "doom_loop",
             None,
         )
-        if doom_cfg is None or not doom_cfg.enabled:
+        if (
+            doom_cfg is None
+            or not doom_cfg.enabled
+            or not doom_cfg.in_loop_modes
+        ):
             return None
 
         return DoomLoopGate(
@@ -101,10 +106,10 @@ def create_doom_loop_gate(
 def create_completion_gate(
     workspace: object,
 ) -> Any:
-    """Create QualitativeRubricGate from config.
+    """Create QualitativeRubricGate from workspace config.
 
     Returns None when the rubric completion check
-    is disabled or the config is missing.
+    is disabled, not enabled for in-loop modes, or missing.
     """
     try:
         from ...loop.gates import (
@@ -113,7 +118,7 @@ def create_completion_gate(
 
         agent_cfg = getattr(
             workspace,
-            "agent_config",
+            "config",
             None,
         )
         if agent_cfg is None:
@@ -129,7 +134,11 @@ def create_completion_gate(
             "rubric",
             None,
         )
-        if rubric_cfg is None or not rubric_cfg.enabled:
+        if (
+            rubric_cfg is None
+            or not rubric_cfg.enabled
+            or not rubric_cfg.in_loop_modes
+        ):
             return None
 
         return QualitativeRubricGate(

--- a/src/qwenpaw/modes/mission/__init__.py
+++ b/src/qwenpaw/modes/mission/__init__.py
@@ -19,6 +19,10 @@ from typing import TYPE_CHECKING, Optional
 from agentscope.message import Msg, TextBlock
 
 from ..base import AgentMode, find_active_explicit_mode
+from ..goal.helpers import (
+    create_completion_gate,
+    create_doom_loop_gate,
+)
 from ...runtime.hooks import HookBase, HookContext
 from ...runtime.slash_command_registry import CommandSpec
 
@@ -102,6 +106,12 @@ class MissionMode(AgentMode):
         handler = StopHandler()
         gate = _MG()
         handler.register(gate)
+        doom_gate = create_doom_loop_gate(workspace)
+        if doom_gate is not None:
+            handler.register(doom_gate)
+        completion_gate = create_completion_gate(workspace)
+        if completion_gate is not None:
+            handler.register(completion_gate)
         self._gate = gate
 
         plugins = getattr(workspace, "plugins", None)

--- a/tests/unit/loop/test_loop_mode_gate_helpers.py
+++ b/tests/unit/loop/test_loop_mode_gate_helpers.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Tests for loop gates shared by explicit loop modes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from qwenpaw.loop.gates.doom_loop import DoomLoopGate
+from qwenpaw.loop.gates.rubric import QualitativeRubricGate
+from qwenpaw.modes.goal.helpers import (
+    create_completion_gate,
+    create_doom_loop_gate,
+)
+
+
+def _workspace(
+    *,
+    doom_enabled: bool = True,
+    doom_in_loop_modes: bool = True,
+    rubric_enabled: bool = True,
+    rubric_in_loop_modes: bool = True,
+    include_config: bool = True,
+) -> SimpleNamespace:
+    doom_loop = SimpleNamespace(
+        enabled=doom_enabled,
+        in_loop_modes=doom_in_loop_modes,
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[
+            SimpleNamespace(
+                after=3,
+                action="stop",
+                prompt="doom",
+            ),
+        ],
+    )
+    rubric = SimpleNamespace(
+        enabled=rubric_enabled,
+        in_loop_modes=rubric_in_loop_modes,
+        prompt="continue",
+        max_interventions=1,
+    )
+    config = SimpleNamespace(
+        running=SimpleNamespace(
+            loop=SimpleNamespace(
+                doom_loop=doom_loop,
+                rubric=rubric,
+            ),
+        ),
+    )
+    if include_config:
+        return SimpleNamespace(config=config)
+    return SimpleNamespace()
+
+
+def test_create_doom_loop_gate_requires_enabled_in_loop_config() -> None:
+    """Doom gate requires workspace config and in-loop opt-in."""
+    assert create_doom_loop_gate(SimpleNamespace()) is None
+    assert (
+        create_doom_loop_gate(
+            _workspace(include_config=False),
+        )
+        is None
+    )
+    assert (
+        create_doom_loop_gate(
+            _workspace(doom_enabled=False),
+        )
+        is None
+    )
+    assert (
+        create_doom_loop_gate(
+            _workspace(doom_in_loop_modes=False),
+        )
+        is None
+    )
+
+    gate = create_doom_loop_gate(_workspace())
+
+    assert isinstance(gate, DoomLoopGate)
+
+
+def test_create_completion_gate_requires_enabled_in_loop_config() -> None:
+    """Completion gate requires workspace config and in-loop opt-in."""
+    assert create_completion_gate(SimpleNamespace()) is None
+    assert (
+        create_completion_gate(
+            _workspace(include_config=False),
+        )
+        is None
+    )
+    assert (
+        create_completion_gate(
+            _workspace(rubric_enabled=False),
+        )
+        is None
+    )
+    assert (
+        create_completion_gate(
+            _workspace(rubric_in_loop_modes=False),
+        )
+        is None
+    )
+
+    gate = create_completion_gate(_workspace())
+
+    assert isinstance(gate, QualitativeRubricGate)


### PR DESCRIPTION
## Description

Fixes #6773.

/goal and /mission never registered doom-loop or rubric completion gates because the helpers read workspace.agent_config, which does not exist on Workspace (only workspace.config does). They also ignored the in_loop_modes flag on DoomLoopConfig and RubricGateConfig. Mission mode only registered MissionGate.

This change:
- reads workspace.config in create_doom_loop_gate / create_completion_gate
- requires enabled and in_loop_modes before creating either gate
- registers those gates on the mission StopHandler after MissionGate

Related Issue: Fixes #6773

Security Considerations: None. Loop safety gates only; no auth, channel, or env handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit style checks on changed files locally (black --line-length=79, flake8 --extend-ignore=E203)
- [x] I ran targeted unit tests locally and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Covered by unit tests that build a minimal workspace.config and assert gate creation when enabled+in_loop_modes is true, and None when config is missing, disabled, or in_loop_modes is false. Also re-ran existing doom loop gate unit tests.

## Evidence

Local unit proof for the touched path:

- test file: tests/unit/loop/test_loop_mode_gate_helpers.py and tests/unit/loop/test_doom_loop_gate.py
- result: 9 passed in 0.48s
- black --line-length=79 --check on changed files: clean
- flake8 --extend-ignore=E203 on changed files: clean

Commands used:

```bash
black --line-length=79 --check src/qwenpaw/modes/goal/helpers.py src/qwenpaw/modes/mission/__init__.py tests/unit/loop/test_loop_mode_gate_helpers.py
flake8 --extend-ignore=E203 src/qwenpaw/modes/goal/helpers.py src/qwenpaw/modes/mission/__init__.py tests/unit/loop/test_loop_mode_gate_helpers.py
pytest tests/unit/loop/test_loop_mode_gate_helpers.py tests/unit/loop/test_doom_loop_gate.py -q
# 9 passed in 0.48s
```

## Additional Notes

Default in_loop_modes remains false, so /goal and /mission only get these gates when the user opts in via config, matching the documented contract.
