### PR TITLE
fix: use shared root profile workspace for ACL store, not per-task workspace

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -344,12 +344,10 @@ class BaseChannel(ABC):
             "id": "Anda telah diblokir dari agen ini.",
         },
         "pending": {
-            "zh": "您目前没有访问此智能体的权限，需要审批。\n"
-            "ID: {sender_id}",
+            "zh": "您目前没有访问此智能体的权限，需要审批。\n" "ID: {sender_id}",
             "en": "You do not have access to this agent. "
             "Approval required.\nID: {sender_id}",
-            "ja": "このエージェントへのアクセス権がありません。"
-            "承認が必要です。\nID: {sender_id}",
+            "ja": "このエージェントへのアクセス権がありません。" "承認が必要です。\nID: {sender_id}",
             "ru": "У вас нет доступа к этому агенту. "
             "Требуется одобрение.\nID: {sender_id}",
             "pt-BR": "Você não tem acesso a este agente. "

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -4,6 +4,7 @@
 """
 Base Channel: bound to AgentRequest/AgentResponse, unified by process.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -343,10 +344,12 @@ class BaseChannel(ABC):
             "id": "Anda telah diblokir dari agen ini.",
         },
         "pending": {
-            "zh": "您目前没有访问此智能体的权限，需要审批。\n" "ID: {sender_id}",
+            "zh": "您目前没有访问此智能体的权限，需要审批。\n"
+            "ID: {sender_id}",
             "en": "You do not have access to this agent. "
             "Approval required.\nID: {sender_id}",
-            "ja": "このエージェントへのアクセス権がありません。" "承認が必要です。\nID: {sender_id}",
+            "ja": "このエージェントへのアクセス権がありません。"
+            "承認が必要です。\nID: {sender_id}",
             "ru": "У вас нет доступа к этому агенту. "
             "Требуется одобрение.\nID: {sender_id}",
             "pt-BR": "Você não tem acesso a este agente. "
@@ -458,7 +461,27 @@ class BaseChannel(ABC):
         )
 
     def _get_acl_store(self):
-        """Get the AccessControlStore for this channel's workspace."""
+        """Get the AccessControlStore for this channel.
+
+        Uses the agent's root profile workspace directory (from global
+        config) rather than the per-task workspace, so that ACL data
+        (whitelist / blacklist / pending) is shared across all task
+        instances (e.g. multica ACP tasks).
+        """
+        if self._workspace is not None:
+            try:
+                from ...config.config import load_agent_config
+
+                profile = load_agent_config(self._workspace.agent_id)
+                workspace_dir = Path(profile.workspace_dir)
+                return get_access_control_store(workspace_dir)
+            except Exception:
+                logger.debug(
+                    "Failed to load agent config for ACL store, "
+                    "falling back to current workspace",
+                    exc_info=True,
+                )
+        # Fallback: use current workspace directory
         workspace_dir = None
         if self._workspace is not None:
             workspace_dir = Path(self._workspace.workspace_dir)

--- a/tests/unit/app/channels/test_channel_acl_workspace.py
+++ b/tests/unit/app/channels/test_channel_acl_workspace.py
@@ -12,17 +12,14 @@ directory (shared across all task instances), not the per-task directory.
 
 from __future__ import annotations
 
-# pylint: disable=protected-access,redefined-outer-name,unused-argument
+# pylint: disable=protected-access,redefined-outer-name,unused-argument,method-hidden
 
 from pathlib import Path
 from typing import Optional
 
 import pytest
 
-from qwenpaw.app.channels.access_control import (
-    ACCESS_CONTROL_FILE,
-    get_access_control_store,
-)
+from qwenpaw.app.channels.access_control import ACCESS_CONTROL_FILE
 from qwenpaw.app.channels.base import BaseChannel
 
 
@@ -50,15 +47,12 @@ class _MinimalChannel(BaseChannel):
     def _process(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
 
-    def process(self, *args, **kwargs):  # pragma: no cover
-        raise NotImplementedError
-
     def _get_agent_id(self) -> Optional[str]:
         return None
 
 
 @pytest.fixture
-def channel(monkeypatch):
+def channel():
     """A channel wired to a per-task workspace."""
     ch = _MinimalChannel()
     ch._workspace = _DummyWorkspace("default", "/tmp/per-task-ws")

--- a/tests/unit/app/channels/test_channel_acl_workspace.py
+++ b/tests/unit/app/channels/test_channel_acl_workspace.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for BaseChannel._get_acl_store workspace resolution.
+
+Regression test for:
+https://github.com/agentscope-ai/QwenPaw/issues/6786
+
+When multica starts a new task via ACP, the channel's current workspace
+points to a fresh per-task directory whose access_control.json is empty.
+The ACL store must therefore resolve to the agent's *root profile* workspace
+directory (shared across all task instances), not the per-task directory.
+"""
+
+from __future__ import annotations
+
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from qwenpaw.app.channels.access_control import (
+    ACCESS_CONTROL_FILE,
+    get_access_control_store,
+)
+from qwenpaw.app.channels.base import BaseChannel
+
+
+class _DummyWorkspace:
+    """Minimal stand-in for a Workspace with a per-task directory."""
+
+    def __init__(self, agent_id: str, workspace_dir: str):
+        self.agent_id = agent_id
+        self.workspace_dir = workspace_dir
+
+
+class _MinimalChannel(BaseChannel):
+    """Concrete BaseChannel subclass for testing _get_acl_store."""
+
+    channel = "test"
+
+    def __init__(self, *args, **kwargs):
+        # Provide a dummy ProcessHandler callable
+        if "process" not in kwargs:
+            kwargs["process"] = lambda _: (_ for _ in ()).throw(
+                StopIteration,
+            )
+        super().__init__(*args, **kwargs)
+
+    def _process(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def process(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def _get_agent_id(self) -> Optional[str]:
+        return None
+
+
+@pytest.fixture
+def channel(monkeypatch):
+    """A channel wired to a per-task workspace."""
+    ch = _MinimalChannel()
+    ch._workspace = _DummyWorkspace("default", "/tmp/per-task-ws")
+    return ch
+
+
+def test_uses_root_profile_workspace_dir_when_agent_config_loads(
+    channel,
+    monkeypatch,
+    tmp_path,
+):
+    """ACL store must point at the root profile workspace, not per-task."""
+    root_ws = tmp_path / "root-ws"
+    root_ws.mkdir()
+
+    class _FakeProfile:
+        workspace_dir = str(root_ws)
+
+    imported = {}
+
+    def fake_load_agent_config(agent_id):
+        imported["agent_id"] = agent_id
+        return _FakeProfile()
+
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        fake_load_agent_config,
+    )
+
+    store = channel._get_acl_store()
+
+    assert imported["agent_id"] == "default"
+    # Store must be keyed on the root profile workspace directory.
+    expected_key = str(root_ws.resolve())
+    assert str(store._path.parent.resolve()) == expected_key
+    assert store._path.name == ACCESS_CONTROL_FILE
+
+
+def test_falls_back_to_workspace_dir_when_config_lookup_fails(
+    channel,
+    monkeypatch,
+):
+    """If agent config lookup raises, fall back to the current workspace."""
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda agent_id: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    store = channel._get_acl_store()
+
+    expected_key = str(Path("/tmp/per-task-ws").resolve())
+    assert str(store._path.parent.resolve()) == expected_key
+
+
+def test_shared_store_across_multiple_task_workspaces(
+    monkeypatch,
+    tmp_path,
+):
+    """Two channels with different per-task dirs share one ACL store."""
+    root_ws = tmp_path / "root-ws"
+    root_ws.mkdir()
+
+    class _FakeProfile:
+        workspace_dir = str(root_ws)
+
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda agent_id: _FakeProfile(),
+    )
+
+    ch1 = _MinimalChannel()
+    ch1._workspace = _DummyWorkspace("default", "/tmp/task-1")
+    ch2 = _MinimalChannel()
+    ch2._workspace = _DummyWorkspace("default", "/tmp/task-2")
+
+    store1 = ch1._get_acl_store()
+    store2 = ch2._get_acl_store()
+
+    assert store1 is store2
+    # Approving a user on one task workspace is visible on the other.
+    store1.add_to_whitelist("test", "u1")
+    assert store2.is_whitelisted("test", "u1")

--- a/tests/unit/app/channels/test_channel_acl_workspace.py
+++ b/tests/unit/app/channels/test_channel_acl_workspace.py
@@ -12,7 +12,8 @@ directory (shared across all task instances), not the per-task directory.
 
 from __future__ import annotations
 
-# pylint: disable=protected-access,redefined-outer-name,unused-argument,method-hidden
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+# pylint: disable=method-hidden
 
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
## What Problem This Solves

When multica starts a new task via ACP protocol, the channel's current workspace points to a fresh **per-task** directory whose `access_control.json` is empty. This causes the Telegram channel to reject all previously approved users, breaking access control for every new task.

## Evidence

**Root Cause:** `_get_acl_store()` in `BaseChannel` used the (possibly per-task) `workspace_dir` to resolve the ACL store path:

```
def _get_acl_store(self):
    workspace_dir = None
    if self._workspace is not None:
        workspace_dir = Path(self._workspace.workspace_dir)
    return get_access_control_store(workspace_dir)
```

But the channel config (`access_control_dm`) is read from the **shared root profile** `agent.json`. So config says access control is on, but the ACL data lives in a fresh per-task workspace with an empty whitelist.

**Fix:** `_get_acl_store()` now resolves the ACL store path from the agent's **root profile** `workspace_dir` (via `load_agent_config`), which is shared across all task instances. Falls back to the current workspace dir if config lookup fails.

**Tests:** Added `tests/unit/app/channels/test_channel_acl_workspace.py`:
- ACL store resolves to root profile workspace, not per-task
- Falls back to current workspace when config lookup fails
- Multiple task workspaces share the same ACL store (approval visible across tasks)

Fixes #6786