### PR TITLE
fix(chat): restore rich input message queue

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1996,13 +1996,8 @@ export default function ChatPage() {
       if (!hasCtrl && e.altKey) return;
       if (isComposingRef.current || (e as any).isComposing) return;
       const textarea = hasCtrl
-        ? (document
-            .querySelector('[class*="sender"]')
-            ?.querySelector("textarea") as HTMLTextAreaElement | null)
-        : e.target instanceof HTMLTextAreaElement &&
-          e.target.closest('[class*="sender"]')
-        ? e.target
-        : null;
+        ? getActiveSenderTextarea()
+        : getSenderTextareaFromTarget(e.target);
       if (!textarea) return;
       const val = textarea.value.trim();
       if (!val) return;

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -141,6 +141,34 @@ describe("getSenderTextareaFromTarget", () => {
     document.body.innerHTML = "";
   });
 
+  it("resolves the hidden textarea from a rich-editor Enter event", () => {
+    document.body.innerHTML = `
+      <div class="qwenpaw-sender">
+        <div id="editor" contenteditable="true"></div>
+        <textarea id="bridge">queued message</textarea>
+      </div>
+    `;
+    const editor = document.querySelector("#editor") as HTMLElement;
+    const textarea = document.querySelector("#bridge");
+    let resolved: HTMLTextAreaElement | null = null;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      resolved = getSenderTextareaFromTarget(event.target);
+    };
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    editor.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(resolved).toBe(textarea);
+    document.removeEventListener("keydown", handleKeyDown, true);
+    document.body.innerHTML = "";
+  });
+
   it("rejects contenteditable elements outside a sender", () => {
     document.body.innerHTML = `<div id="editor" contenteditable="true"></div>`;
 


### PR DESCRIPTION
## Summary

- Restore message queue submission while an assistant response is still running.
- Resolve Enter events from the Lexical `contenteditable` editor to its hidden textarea bridge.
- Preserve Ctrl/Cmd+Enter behavior by resolving the currently active sender.
- Add regression coverage for Enter events originating from the rich-text editor.

## Root Cause

After the chat input was migrated from a native textarea to the Lexical-based rich input, keyboard events originated from a `contenteditable` element. The queue handler only accepted `HTMLTextAreaElement` targets, so it returned without enqueueing the message.

## Testing

- Chat and message queue tests: 234 passed
- TypeScript type checking passed
- Prettier formatting check passed
- Git diff validation passed

Fixes #6796

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
