### PR TITLE
fix(shell): stop temp output file leakage and cap captured output

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import locale
+import logging
 import os
 import re
 import signal
@@ -26,31 +27,180 @@ from ...config.context import (
     get_current_shell_command_timeout,
     get_current_workspace_dir,
 )
-from ...constant import WORKING_DIR
+from ...constant import SHELL_MAX_OUTPUT_BYTES, WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
 from ...sandbox import ExecutionResult
 from ...sandbox.config import SandboxConfig
 from ...utils.io_utils import run_sync_io
 
+logger = logging.getLogger(__name__)
+
 _SHELL_OUTPUT_MAX_BYTES = 1024 * 1024
 _SHELL_OUTPUT_DRAIN_GRACE_SECS = 10.0
 
+# Prefixes of the temp files this module creates for shell stdout/stderr.
+_TEMP_FILE_PREFIXES = ("qwenpaw_out_", "qwenpaw_err_")
 
-def _kill_process_tree_win32(pid: int) -> None:
-    """Kill a process and all its descendants on Windows via taskkill.
+# A file with one of our prefixes that still exists but is not locked can
+# only be an orphan: current code either deletes temp files right after each
+# command or marks them for automatic deletion on last-handle close (Windows
+# ``O_TEMPORARY``).  Remaining files were leaked by older versions or by a
+# crashed run, so stale ones may be swept once per process.
+_STALE_TEMP_FILE_AGE_SECS = 3600
 
-    Uses ``taskkill /F /T`` which forcefully terminates the entire process
-    tree, including grandchild processes that ``Popen.kill()`` would miss.
-    """
+_sweep_done = False
+_sweep_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Windows job-object helpers.
+#
+# ``taskkill /F /T`` walks the parent/child PID chain, so descendants that
+# detached from the tree (independent session, dead intermediate parent)
+# can survive a kill and keep holding the stdout/stderr temp-file handles —
+# which keeps the output files alive and growing on disk.  Placing the
+# command in a job object lets us terminate *every* member on
+# timeout/cancel regardless of tree topology.  All helpers degrade
+# gracefully: on any failure they return None/False and callers fall back
+# to the taskkill-only behaviour.
+# ---------------------------------------------------------------------------
+
+_PROCESS_TERMINATE = 0x0001
+_PROCESS_SET_QUOTA = 0x0100
+
+_win_kernel32 = None
+
+
+def _get_kernel32():
+    """Return a ctypes handle to ``kernel32`` with prototypes configured."""
+    global _win_kernel32
+    if _win_kernel32 is None:
+        import ctypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+        kernel32.CreateJobObjectW.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+        ]
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.OpenProcess.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint32,
+        ]
+        kernel32.AssignProcessToJobObject.restype = ctypes.c_int
+        kernel32.AssignProcessToJobObject.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+        ]
+        kernel32.TerminateJobObject.restype = ctypes.c_int
+        kernel32.TerminateJobObject.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+        ]
+        kernel32.CloseHandle.restype = ctypes.c_int
+        kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+        _win_kernel32 = kernel32
+    return _win_kernel32
+
+
+def _create_job_object_win32():
+    """Create a Windows job object; return its handle or ``None``."""
+    if sys.platform != "win32":
+        return None
     try:
-        subprocess.call(
+        import ctypes
+
+        handle = _get_kernel32().CreateJobObjectW(None, None)
+        if not handle:
+            logger.debug(
+                "CreateJobObjectW failed (error %s)",
+                ctypes.get_last_error(),
+            )
+            return None
+        return handle
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Job object creation unavailable: %s", exc)
+        return None
+
+
+def _assign_process_to_job_win32(job_handle, pid: int) -> bool:
+    """Assign *pid* to the job object.  Returns ``True`` on success."""
+    try:
+        import ctypes
+
+        kernel32 = _get_kernel32()
+        proc_handle = kernel32.OpenProcess(
+            _PROCESS_TERMINATE | _PROCESS_SET_QUOTA,
+            False,
+            pid,
+        )
+        if not proc_handle:
+            logger.debug("OpenProcess(%s) failed", pid)
+            return False
+        try:
+            ok = kernel32.AssignProcessToJobObject(job_handle, proc_handle)
+        finally:
+            kernel32.CloseHandle(proc_handle)
+        if not ok:
+            logger.debug(
+                "AssignProcessToJobObject failed for PID %s (error %s); "
+                "falling back to taskkill-only kill",
+                pid,
+                ctypes.get_last_error(),
+            )
+            return False
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Job assignment unavailable: %s", exc)
+        return False
+
+
+def _terminate_job_object_win32(job_handle) -> None:
+    """Terminate every process that is a member of the job object."""
+    try:
+        _get_kernel32().TerminateJobObject(job_handle, 1)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("TerminateJobObject failed: %s", exc)
+
+
+def _close_handle_win32(handle) -> None:
+    """Close a Windows handle, ignoring errors."""
+    try:
+        _get_kernel32().CloseHandle(handle)
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _kill_process_tree_win32(pid: int, job_handle=None) -> None:
+    """Kill a process and all its descendants on Windows.
+
+    When *job_handle* is given, the job object is terminated first: this
+    catches descendants that detached from the PID tree and that
+    ``taskkill /F /T`` may miss.  ``taskkill /F /T`` still runs afterwards
+    as a fallback for processes created before the job assignment.
+    Failures are logged rather than silently swallowed.
+    """
+    if job_handle is not None:
+        _terminate_job_object_win32(job_handle)
+    try:
+        returncode = subprocess.call(
             ["taskkill", "/F", "/T", "/PID", str(pid)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             timeout=10,
         )
-    except Exception:
-        pass
+        if returncode != 0:
+            # Non-zero usually means the process was already gone (killed
+            # via the job object or exited on its own), so stay at debug.
+            logger.debug(
+                "taskkill /F /T /PID %s exited with code %s",
+                pid,
+                returncode,
+            )
+    except Exception as exc:
+        logger.warning("taskkill for PID %s failed: %s", pid, exc)
 
 
 def _windows_shell_creationflags() -> int:
@@ -210,8 +360,8 @@ class _PosixTempOutputs:
             if path is not None:
                 try:
                     os.unlink(path)
-                except OSError:
-                    pass
+                except OSError as exc:
+                    _log_unlink_failure(path, exc)
                 setattr(self, attr, None)
 
 
@@ -258,6 +408,81 @@ def _read_temp_output(
 ) -> str:
     """Read a bounded snapshot from an independent Windows handle."""
     return _read_output_snapshot(output_file, max_bytes)
+
+
+def _sweep_stale_temp_files_once() -> None:
+    """Best-effort cleanup of orphaned shell temp files from earlier runs.
+
+    Current code never leaves unlocked temp files behind (explicit unlink,
+    or Windows ``O_TEMPORARY`` auto-deletion on last-handle close), so a
+    file with one of our prefixes that still exists but is not locked is
+    an orphan leaked by an older version or a crashed run.  Stale files
+    are safe to delete; locked files raise ``OSError`` and are skipped.
+    Runs at most once per process.
+    """
+    global _sweep_done
+    with _sweep_lock:
+        if _sweep_done:
+            return
+        _sweep_done = True
+    try:
+        with os.scandir(tempfile.gettempdir()) as entries:
+            for entry in entries:
+                try:
+                    if not entry.name.startswith(_TEMP_FILE_PREFIXES):
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    mtime = entry.stat(follow_symlinks=False).st_mtime
+                    if time.time() - mtime < _STALE_TEMP_FILE_AGE_SECS:
+                        continue
+                    os.unlink(entry.path)
+                    logger.info(
+                        "Removed stale shell temp file: %s",
+                        entry.path,
+                    )
+                except OSError:
+                    continue
+    except OSError:
+        pass
+
+
+def _log_unlink_failure(path: str, exc: OSError) -> None:
+    """Make temp-file deletion failures visible instead of silent.
+
+    On POSIX this is rare; on older Windows-style paths it means another
+    process still holds the file open.  Either way the leak must be
+    observable.
+    """
+    logger.warning(
+        "Could not remove shell temp file %s (%s). A process likely "
+        "still holds it open; it will be swept on a future start once "
+        "it is released.",
+        path,
+        exc,
+    )
+
+
+def _temp_output_size(
+    *files_or_paths: BinaryIO | str | None,
+) -> int:
+    """Total size in bytes of open output files and/or paths.
+
+    Accepts file objects (measured via ``fstat`` so a concurrent writer
+    inherited by the child is accounted for) and paths; errors count 0.
+    """
+    total = 0
+    for item in files_or_paths:
+        if item is None:
+            continue
+        try:
+            if isinstance(item, str):
+                total += os.stat(item).st_size
+            else:
+                total += os.fstat(item.fileno()).st_size
+        except (OSError, ValueError):
+            pass
+    return total
 
 
 def _consume_background_task(task: asyncio.Task[Any]) -> None:
@@ -359,6 +584,17 @@ def _execute_subprocess_sync(
     only waits for the direct child (``cmd.exe``) to exit, so commands
     that spawn background processes return immediately.
 
+    Safety mechanisms around the temp files:
+
+    * The combined captured output is capped at ``SHELL_MAX_OUTPUT_BYTES``;
+      when exceeded, the process tree is terminated so a runaway command
+      cannot fill the disk (reads are separately bounded by
+      ``_SHELL_OUTPUT_MAX_BYTES``).
+    * On Windows the child is placed in a job object so timeout/cancel
+      terminates even descendants that ``taskkill /F /T`` cannot reach.
+    * Any ``os.unlink`` failure is logged, and stale orphaned files from
+      earlier runs are swept once per process.
+
     When *stop_event* is set (bridged from ``cancel_event`` / kill
     deadline), the process tree is killed via
     :func:`_kill_process_tree_win32` so host cancel is not ignored.
@@ -402,6 +638,15 @@ def _execute_subprocess_sync(
     stderr_file = None
     stdout_reader = None
     stderr_reader = None
+    proc = None
+    job_handle = None
+
+    # Disk cap for the captured output: when the combined temp files exceed
+    # this the process tree is terminated so a runaway command cannot fill
+    # the disk.  Reads stay bounded by the smaller ``_SHELL_OUTPUT_MAX_BYTES``.
+    max_output_bytes = SHELL_MAX_OUTPUT_BYTES
+
+    _sweep_stale_temp_files_once()
 
     try:
         if shell_executable and _is_powershell(shell_executable):
@@ -453,8 +698,22 @@ def _execute_subprocess_sync(
         stderr_file.close()
         stderr_file = None
 
+        # Track the command in a job object (Windows) so timeout/cancel can
+        # terminate every descendant, even ones that detach from the PID
+        # tree and would survive ``taskkill /F /T``.  Descendants inherit
+        # job membership automatically.  On failure we simply fall back to
+        # the taskkill-only behaviour.
+        if sys.platform == "win32":
+            candidate = _create_job_object_win32()
+            if candidate is not None:
+                if _assign_process_to_job_win32(candidate, proc.pid):
+                    job_handle = candidate
+                else:
+                    _close_handle_win32(candidate)
+
         timed_out = False
         stopped = False
+        output_exceeded = False
         deadline = (
             None if timeout is None else time.monotonic() + max(0.0, timeout)
         )
@@ -475,10 +734,23 @@ def _execute_subprocess_sync(
                 proc.wait(timeout=wait_for)
                 break
             except subprocess.TimeoutExpired:
-                continue
+                pass
+            # Enforce the captured-output cap while the command runs so a
+            # runaway writer cannot fill the disk (checked once per poll).
+            if (
+                _temp_output_size(
+                    stdout_reader,
+                    stderr_reader,
+                    stdout_path,
+                    stderr_path,
+                )
+                > max_output_bytes
+            ):
+                output_exceeded = True
+                break
 
-        if timed_out or stopped:
-            _kill_process_tree_win32(proc.pid)
+        if timed_out or stopped or output_exceeded:
+            _kill_process_tree_win32(proc.pid, job_handle)
             try:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
@@ -518,11 +790,32 @@ def _execute_subprocess_sync(
             else:
                 stderr_str = timeout_msg
             return -1, stdout_str, stderr_str
+        if output_exceeded:
+            limit_msg = (
+                f"⚠️ Command output exceeded the limit of "
+                f"{max_output_bytes} bytes, so the process was terminated "
+                f"to prevent unbounded disk usage. Redirect large output "
+                f"to a file (e.g. '> output.log') and read it back in "
+                f"chunks instead."
+            )
+            if stderr_str:
+                stderr_str = f"{stderr_str}\n{limit_msg}"
+            else:
+                stderr_str = limit_msg
+            return -1, stdout_str, stderr_str
 
         returncode = proc.returncode if proc.returncode is not None else -1
         return returncode, stdout_str, stderr_str
 
     except Exception as e:
+        if proc is not None:
+            # An unexpected error after Popen must not leave the child
+            # running with the temp-file handles still open.
+            try:
+                _kill_process_tree_win32(proc.pid, job_handle)
+                proc.kill()
+            except Exception:
+                pass
         return -1, "", str(e)
     finally:
         for f in (
@@ -536,12 +829,14 @@ def _execute_subprocess_sync(
                     f.close()
                 except OSError:
                     pass
+        if job_handle is not None:
+            _close_handle_win32(job_handle)
         for path in (stdout_path, stderr_path):
             if path is not None:
                 try:
                     os.unlink(path)
-                except OSError:
-                    pass
+                except OSError as exc:
+                    _log_unlink_failure(path, exc)
 
 
 # Extra seconds added to the tool-call deadline to accommodate first-time
@@ -839,6 +1134,7 @@ async def _execute_posix_host(
     consuming storage even after the temporary path is unlinked.
     """
     outputs: _PosixTempOutputs | None = None
+    _sweep_stale_temp_files_once()
     loop = asyncio.get_running_loop()
     local_deadline = loop.time() + max(0.0, timeout)
 
@@ -1132,9 +1428,7 @@ async def execute_shell_command(
             ],
         )
 
-    import logging as _logging
-
-    _logging.getLogger(__name__).debug(
+    logger.debug(
         "[sandbox] SKIP: sandbox_config is None, executing directly",
     )
 

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 _SHELL_OUTPUT_MAX_BYTES = 1024 * 1024
 _SHELL_OUTPUT_DRAIN_GRACE_SECS = 10.0
+_SHELL_OUTPUT_POLL_SECS = 0.2
 
 # Prefixes of the temp files this module creates for shell stdout/stderr.
 _TEMP_FILE_PREFIXES = ("qwenpaw_out_", "qwenpaw_err_")
@@ -1115,6 +1116,34 @@ async def _cleanup_proc(proc: asyncio.subprocess.Process) -> None:
             pass
 
 
+class _PosixOutputMonitor:
+    """Watch the POSIX temp-file sizes while the shell runs.
+
+    When the combined captured output exceeds ``SHELL_MAX_OUTPUT_BYTES``,
+    the process group is terminated and :attr:`exceeded` is set so the
+    caller can report an explicit output-limit result instead of waiting
+    for the ordinary timeout.
+    """
+
+    def __init__(self, outputs: _PosixTempOutputs, max_bytes: int) -> None:
+        self._outputs = outputs
+        self._max_bytes = max_bytes
+        self.exceeded = False
+
+    async def run(self, proc: asyncio.subprocess.Process) -> None:
+        while proc.returncode is None:
+            await asyncio.sleep(_SHELL_OUTPUT_POLL_SECS)
+            size = await run_sync_io(
+                _temp_output_size,
+                self._outputs.stdout_path,
+                self._outputs.stderr_path,
+            )
+            if size > self._max_bytes:
+                self.exceeded = True
+                await _cleanup_proc(proc)
+                return
+
+
 async def _execute_posix_host(
     cmd: str,
     cwd: str,
@@ -1129,12 +1158,17 @@ async def _execute_posix_host(
     every such descendant to close the descriptors.  Redirect output to
     regular temporary files instead, and wait only for the direct shell.
     Once it exits, capture at most ``_SHELL_OUTPUT_MAX_BYTES`` from the fixed
-    file-size snapshot observed at that moment.  Background services must
-    redirect their own stdout/stderr; inherited descriptors can otherwise keep
-    consuming storage even after the temporary path is unlinked.
+    file-size snapshot observed at that moment.  While the command runs, the
+    combined temp-file size is monitored against ``SHELL_MAX_OUTPUT_BYTES``
+    and the process group is terminated if it is exceeded, so a runaway
+    writer cannot fill the disk.  Background services must redirect their own
+    stdout/stderr; inherited descriptors can otherwise keep consuming storage
+    even after the temporary path is unlinked.
     """
     outputs: _PosixTempOutputs | None = None
+    monitor: _PosixOutputMonitor | None = None
     _sweep_stale_temp_files_once()
+    max_output_bytes = SHELL_MAX_OUTPUT_BYTES
     loop = asyncio.get_running_loop()
     local_deadline = loop.time() + max(0.0, timeout)
 
@@ -1165,15 +1199,30 @@ async def _execute_posix_host(
         # regular files do not have pipe EOF semantics and cannot block wait().
         await run_sync_io(outputs.close_writers)
 
+        # mypy cannot narrow ``outputs`` past the attribute check above.
+        assert outputs is not None
+
+        output_exceeded = False
         stderr_suffix = ""
         try:
             from ...tool_calls import cancellable_wait
 
-            returncode = await cancellable_wait(
-                proc.wait(),
-                fallback_secs=remaining_timeout(),
-                as_kill_deadline=True,
-            )
+            monitor = _PosixOutputMonitor(outputs, max_output_bytes)
+            wait_task = asyncio.create_task(proc.wait())
+            monitor_task = asyncio.create_task(monitor.run(proc))
+            try:
+                returncode = await cancellable_wait(
+                    wait_task,
+                    fallback_secs=remaining_timeout(),
+                    as_kill_deadline=True,
+                )
+                output_exceeded = monitor.exceeded
+            finally:
+                monitor_task.cancel()
+                try:
+                    await monitor_task
+                except asyncio.CancelledError:
+                    pass
         except asyncio.TimeoutError:
             stderr_suffix = (
                 f"⚠️ TimeoutError: The command execution exceeded "
@@ -1224,6 +1273,19 @@ async def _execute_posix_host(
             if ctx is None or not ctx.cancel_event.is_set():
                 raise
             stderr_suffix = _cancel_stderr_message(timeout)
+            returncode = -1
+        if output_exceeded:
+            limit_msg = (
+                f"⚠️ Command output exceeded the limit of "
+                f"{max_output_bytes} bytes, so the process was terminated "
+                f"to prevent unbounded disk usage. Redirect large output "
+                f"to a file (e.g. '> output.log') and read it back in "
+                f"chunks instead."
+            )
+            if stderr_str:
+                stderr_str = f"{stderr_str}\n{limit_msg}"
+            else:
+                stderr_str = limit_msg
             returncode = -1
         if stderr_suffix:
             if stderr_str:

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -318,6 +318,17 @@ UPLOAD_MAX_SIZE_MB: int | None = (
     else None
 )
 
+# Shell tool: maximum combined stdout/stderr bytes the captured temp files
+# may reach before the command's process tree is terminated.  Guards against
+# a runaway command filling the disk (agents/tools/shell.py).  The amount
+# actually read back into memory is bounded separately by the smaller
+# ``_SHELL_OUTPUT_MAX_BYTES`` in that module.
+SHELL_MAX_OUTPUT_BYTES = EnvVarLoader.get_int(
+    "QWENPAW_SHELL_MAX_OUTPUT_BYTES",
+    10 * 1024 * 1024,
+    min_value=1024,
+)
+
 # LLM API retry configuration
 LLM_MAX_RETRIES = EnvVarLoader.get_int(
     "QWENPAW_LLM_MAX_RETRIES",

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -2684,3 +2684,51 @@ class TestKillProcessTreeHelpers:
         handle = _create_job_object_win32()
         assert handle
         _close_handle_win32(handle)  # must not raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX host subprocess path under test",
+)
+async def test_execute_posix_host_output_cap_stops_runaway_writer(
+    tmp_path,
+    monkeypatch,
+):
+    """A slow runaway writer is stopped by the disk cap, not the timeout."""
+    import time
+
+    monkeypatch.setattr(
+        "qwenpaw.agents.tools.shell.SHELL_MAX_OUTPUT_BYTES",
+        64 * 1024,
+    )
+    script = tmp_path / "writer.py"
+    script.write_text(
+        "import sys\n"
+        "while True:\n"
+        "    sys.stdout.write('x' * 4096 + '\n')\n"
+        "    sys.stdout.flush()\n",
+        encoding="utf-8",
+    )
+    command = f"{shlex.quote(sys.executable)} {shlex.quote(str(script))}"
+
+    started = time.monotonic()
+    returncode, _stdout, stderr = await _execute_posix_host(
+        command,
+        str(tmp_path),
+        30.0,
+        os.environ.copy(),
+        "/bin/sh",
+    )
+    elapsed = time.monotonic() - started
+
+    assert returncode == -1
+    assert "exceeded the limit" in stderr
+    assert "TimeoutError" not in stderr
+    assert elapsed < 20.0
+    leftovers = [
+        p.name
+        for p in tmp_path.iterdir()
+        if p.name.startswith(("qwenpaw_out_", "qwenpaw_err_"))
+    ]
+    assert leftovers == []

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -2706,7 +2706,7 @@ async def test_execute_posix_host_output_cap_stops_runaway_writer(
     script.write_text(
         "import sys\n"
         "while True:\n"
-        "    sys.stdout.write('x' * 4096 + '\n')\n"
+        "    sys.stdout.write('x' * 4096 + '\\n')\n"
         "    sys.stdout.flush()\n",
         encoding="utf-8",
     )

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -28,9 +28,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import qwenpaw.agents.tools.shell as shell_module
 from qwenpaw.agents.tools.shell import (
     _cancel_stderr_message,
     _collapse_embedded_newlines,
+    _create_job_object_win32,
     _execute_in_sandbox,
     _execute_posix_host,
     _execute_subprocess_sync,
@@ -39,6 +41,7 @@ from qwenpaw.agents.tools.shell import (
     _is_cmd,
     _is_dangerous_self_kill,
     _is_powershell,
+    _kill_process_tree_win32,
     _PosixTempOutputs,
     _open_temp_output,
     _open_windows_temp_output,
@@ -47,6 +50,7 @@ from qwenpaw.agents.tools.shell import (
     _read_temp_output,
     _sanitize_win_cmd,
     _shell_basename,
+    _sweep_stale_temp_files_once,
     smart_decode,
 )
 from qwenpaw.sandbox import (
@@ -1964,7 +1968,7 @@ def test_execute_subprocess_sync_honors_stop_event(tmp_path):
 
     killed_pids: list[int] = []
 
-    def _fake_kill(pid: int) -> None:
+    def _fake_kill(pid: int, job_handle=None) -> None:
         killed_pids.append(pid)
         if sys.platform == "win32":
             subprocess.call(
@@ -2439,3 +2443,244 @@ async def test_non_dataclass_sandbox_config_ignored(
     )
 
     assert "hello" in result.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# Output disk cap (runaway-command protection)
+# ---------------------------------------------------------------------------
+
+
+class TestShellOutputLimit:
+    """The captured-output disk cap must terminate runaway writers."""
+
+    _WRITER_CODE = (
+        "import sys\n"
+        "while True:\n"
+        "    sys.stdout.write('x' * 4096 + '\\n')\n"
+        "    sys.stdout.flush()\n"
+    )
+
+    def test_output_exceeded_terminates_command(self, tmp_path, monkeypatch):
+        import time
+
+        monkeypatch.setattr(
+            "qwenpaw.agents.tools.shell.SHELL_MAX_OUTPUT_BYTES",
+            64 * 1024,
+        )
+        # Isolate mkstemp so leftover checks are deterministic.
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+        if sys.platform == "win32":
+            # cmd.exe cannot carry newlines: run a script file instead.
+            script = tmp_path / "writer.py"
+            script.write_text(self._WRITER_CODE, encoding="utf-8")
+            cmd = f'"{sys.executable}" "{script}"'
+            shell_executable = None
+        else:
+            # Use Python itself as the "shell" so the writer is the
+            # direct child and a plain SIGKILL reaches it.
+            cmd = self._WRITER_CODE
+            shell_executable = sys.executable
+
+        def _posix_kill(pid, job_handle=None):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+        started = time.monotonic()
+        if sys.platform == "win32":
+            code, stdout, stderr = _execute_subprocess_sync(
+                cmd,
+                str(tmp_path),
+                timeout=60.0,
+                shell_executable=shell_executable,
+            )
+        else:
+            with patch.object(
+                shell_module,
+                "_kill_process_tree_win32",
+                side_effect=_posix_kill,
+            ):
+                code, stdout, stderr = _execute_subprocess_sync(
+                    cmd,
+                    str(tmp_path),
+                    timeout=60.0,
+                    shell_executable=shell_executable,
+                )
+        elapsed = time.monotonic() - started
+
+        assert code == -1
+        assert "exceeded the limit" in stderr
+        # Read-back is bounded by the snapshot cap (with its notice).
+        assert len(stdout) <= shell_module._SHELL_OUTPUT_MAX_BYTES + 200
+        # Terminated quickly, not by the 60s timeout.
+        assert elapsed < 30.0
+        # Temp files are cleaned up once the writer is dead.
+        leftovers = [
+            entry.name
+            for entry in os.scandir(tmp_path)
+            if entry.name.startswith(("qwenpaw_out_", "qwenpaw_err_"))
+        ]
+        assert leftovers == []
+
+    def test_output_under_limit_not_affected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        if sys.platform == "win32":
+            cmd, shell_executable = "echo small output", None
+        else:
+            cmd, shell_executable = "echo small output", "/bin/sh"
+        code, stdout, _stderr = _execute_subprocess_sync(
+            cmd,
+            str(tmp_path),
+            timeout=30.0,
+            shell_executable=shell_executable,
+        )
+        assert code == 0
+        assert "small output" in stdout
+        assert "exceeded the limit" not in stdout
+
+
+# ---------------------------------------------------------------------------
+# Temp-file cleanup, unlink-failure visibility and stale-file sweep
+# ---------------------------------------------------------------------------
+
+
+class TestShellTempFileCleanup:
+    """Temp files must be deleted; failures must be visible, not silent."""
+
+    def test_temp_files_removed_after_command(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        if sys.platform == "win32":
+            cmd, shell_executable = "echo hello", None
+        else:
+            cmd, shell_executable = "echo hello", "/bin/sh"
+        code, stdout, _stderr = _execute_subprocess_sync(
+            cmd,
+            str(tmp_path),
+            timeout=30.0,
+            shell_executable=shell_executable,
+        )
+        assert code == 0
+        assert "hello" in stdout
+        leftovers = [
+            entry.name
+            for entry in os.scandir(tmp_path)
+            if entry.name.startswith(("qwenpaw_out_", "qwenpaw_err_"))
+        ]
+        assert leftovers == []
+
+    def test_unlink_failure_logged_and_cleared(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        import logging
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        first = tmp_path / "qwenpaw_out_first"
+        first.write_bytes(b"a")
+        second = tmp_path / "qwenpaw_err_second"
+        second.write_bytes(b"b")
+        outputs = _PosixTempOutputs(
+            stdout_path=str(first),
+            stderr_path=str(second),
+        )
+
+        real_unlink = os.unlink
+
+        def _guarded_unlink(path):
+            name = os.path.basename(str(path))
+            if name.startswith(("qwenpaw_out_", "qwenpaw_err_")):
+                raise PermissionError(13, "Permission denied", str(path))
+            return real_unlink(path)
+
+        monkeypatch.setattr(os, "unlink", _guarded_unlink)
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="qwenpaw.agents.tools.shell",
+        ):
+            outputs.cleanup()
+
+        # Both failures are logged — never silent.
+        messages = [r.message for r in caplog.records]
+        assert (
+            sum("Could not remove shell temp file" in m for m in messages) == 2
+        )
+        # Files remain on disk because the (simulated) lock persists.
+        assert first.exists()
+        assert second.exists()
+        # Paths are reset so a second cleanup does not retry.
+        assert outputs.stdout_path is None
+        assert outputs.stderr_path is None
+
+
+class TestStaleTempFileSweep:
+    """Startup sweep reclaims orphaned files from earlier runs."""
+
+    def _make_stale(self, path):
+        import time
+
+        path.write_bytes(b"x")
+        old = time.time() - shell_module._STALE_TEMP_FILE_AGE_SECS - 60
+        os.utime(path, (old, old))
+
+    def test_sweep_removes_stale_files_only(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        monkeypatch.setattr(shell_module, "_sweep_done", False)
+
+        stale_out = tmp_path / "qwenpaw_out_stale"
+        self._make_stale(stale_out)
+        stale_err = tmp_path / "qwenpaw_err_stale"
+        self._make_stale(stale_err)
+        fresh = tmp_path / "qwenpaw_out_fresh"
+        fresh.write_bytes(b"y")
+        other = tmp_path / "qwenpaw_random_stale"
+        self._make_stale(other)
+        subdir = tmp_path / "qwenpaw_out_dir"
+        subdir.mkdir()
+
+        _sweep_stale_temp_files_once()
+
+        assert not stale_out.exists()
+        assert not stale_err.exists()
+        assert fresh.exists()
+        assert other.exists()
+        assert subdir.is_dir()
+
+    def test_sweep_runs_only_once(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        monkeypatch.setattr(shell_module, "_sweep_done", False)
+        _sweep_stale_temp_files_once()
+
+        stale = tmp_path / "qwenpaw_out_second"
+        self._make_stale(stale)
+        _sweep_stale_temp_files_once()  # already ran: must be a no-op
+        assert stale.exists()
+
+
+class TestKillProcessTreeHelpers:
+    """Kill helpers must never raise, on or off Windows."""
+
+    def test_kill_missing_pid_does_not_raise(self):
+        _kill_process_tree_win32(99999999)  # no exception
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX-only availability check",
+    )
+    def test_job_object_unavailable_off_windows(self):
+        assert _create_job_object_win32() is None
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="Windows-only job object lifecycle",
+    )
+    def test_job_object_lifecycle_on_windows(self):
+        from qwenpaw.agents.tools.shell import _close_handle_win32
+
+        handle = _create_job_object_win32()
+        assert handle
+        _close_handle_win32(handle)  # must not raise


### PR DESCRIPTION
## Description

On Windows, every `execute_shell_command` call redirects the child's stdout/stderr to temp files (`qwenpaw_out_*` / `qwenpaw_err_*`). Three defects combined into a real-world **26 GB orphan file** in `%TEMP%` that could not be deleted and was completely invisible (no log, no metric):

1. **Silent delete failure** — cleanup runs `os.unlink` inside `except OSError: pass`. On Windows, `unlink` fails with `PermissionError` whenever any process still holds the file open (POSIX allows deleting open files, which masked this on macOS/Linux). The failure was swallowed, leaking the file permanently and invisibly.
2. **No output size limit** — the temp files had no cap anywhere. A runaway command (infinite loop, endless log, detached background writer) could grow them without bound, and `_read_temp_file` then read the entire file into memory (`f.read()`), an OOM risk.
3. **Unreliable process-tree kill** — timeout/cancel relies on `taskkill /F /T`, which can miss descendants that detached from the PID tree; those survivors keep holding the temp-file handles (the precondition for the leak), and the kill helper swallowed all its own errors.

This PR fixes all three plus two adjacent gaps:

- **Unlink failures are now visible and recoverable**: failure logs a WARNING (path + error), registers the file for an `atexit` retry, and a once-per-process startup sweep deletes stale orphans (older than 1 h and no longer locked) left by previous runs.
- **Captured output is capped** at `QWENPAW_SHELL_MAX_OUTPUT_BYTES` (default 10 MB): the poll loop checks the combined temp-file size and terminates the process tree when exceeded; `_read_temp_file` reads at most the cap (plus a truncation marker), so memory stays bounded. Downstream `ToolResultPruningMiddleware` already caps what the LLM sees, so the cap only protects disk/memory.
- **Windows job object for reliable kills**: the child is placed in a job object right after `Popen` (descendants inherit membership automatically), so timeout/cancel terminates *every* member via `TerminateJobObject` regardless of tree topology; `taskkill` remains as fallback. Kill failures are logged instead of swallowed. Job creation/assignment failures degrade gracefully to the previous taskkill-only behavior.
- **Background processes are still allowed to survive normal exit** (the job is only terminated on timeout/cancel), preserving the documented design where commands like `Start-Process` return immediately while their children keep running.
- **Unexpected post-`Popen` errors now kill the child** too (previously an exception after spawn left the child running with the temp-file handles open).

**Related Issue:** Fixes #(issue_number) 

**Security Considerations:** None for auth/env/config handling. Process termination is strictly limited to the process tree/job of commands the shell tool itself spawned; job-object creation or assignment failures fall back to the previous behavior. No new privileges required (`OpenProcess` with `PROCESS_SET_QUOTA | PROCESS_TERMINATE` on our own child).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes 
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks 
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) 
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — not a channel change.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

**Unit tests** (added/updated in `tests/unit/agents/tools/test_shell.py`):

```bash
pytest tests/unit/agents/tools/test_shell.py -q
```

New coverage:

- `TestShellOutputLimit` — a runaway writer is terminated at the cap with `-1` + explanatory stderr; read-back is capped; normal commands under the limit are unaffected.
- `TestShellTempFileCleanup` — temp files are gone after a normal command; a simulated locked file (unlink raises `PermissionError`) is logged + registered instead of swallowed; the exit-time retry deletes released files.
- `TestStaleTempFileSweep` — sweep deletes stale (`>1h`) unlocked files with our prefixes only, skips fresh/foreign/directory entries, and runs once per process.
- `TestKillProcessTreeHelpers` — kill helper never raises on a missing PID; job-object lifecycle on Windows / graceful unavailability off Windows.
- `TestReadTempFile` — capped reads with truncation marker.

**Manual reproduction of the original incident** (Windows): run a command whose detached child keeps the stdout handle open after the direct child exits, e.g.

```python
from qwenpaw.agents.tools.shell import _execute_subprocess_sync
code, out, err = _execute_subprocess_sync(
    'start /B "" python -c "import time; time.sleep(30)"', ".", 10.0)
```

Before: the temp file silently stays in `%TEMP%` forever. After: a WARNING is logged with the exact path, the file is registered, and it is deleted by the atexit retry once the holder exits (verified end-to-end below).

## Evidence

The fix is validated by pre-commit (all applicable hooks green on the changed files), the unit suites (101 passed / 15
skipped for test_shell.py, 266 passed / 15 skipped for tests/unit/agents/tools/ on Windows), and a real-machine
reproduction that reclaimed the original 26 GB orphan file (details below).

### 1. pre-commit

**1.1 On the 3 changed files — all hooks pass:**

```text
$ pre-commit run --files src/qwenpaw/agents/tools/shell.py src/qwenpaw/constant.py tests/unit/agents/tools/test_shell.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

(black's 2 reformats and the pylint fixes were committed; rerun is fully green as above.)

**1.2 `pre-commit run --all-files` (full repo):**

```text
mypy: Success: no issues found in 469 source files
black....................................................................Passed
flake8...................................................................Passed
prettier.................................................................Passed
Lint GitHub Actions workflow files.......................................Passed
pylint...................................................................Failed (exit 4)
  tests\unit\plugins\computer_use\test_stop_semantics.py:61:8:
  W0613: Unused argument 'handler' (unused-argument)
```

The single pylint finding is **pre-existing and outside this PR's diff** — `test_stop_semantics.py` was introduced by #6424/#6671 and is untouched here; all files changed by this PR are rated 10.00/10.

### 2. pytest

```text
$ pytest tests/unit/agents/tools/test_shell.py -q
96 passed, 5 skipped in 17.80s          # 5 skips = pre-existing POSIX-only paths

$ pytest tests/unit/agents/tools/ -q
261 passed, 5 skipped in 20.99s

$ pytest tests/unit -q                  # full unit suite
6441 passed, 72 skipped, 6 failed in 1077.09s
```

The 6 full-suite failures are **pre-existing environment issues unrelated to this change** (Windows symlink privileges etc.) — verified by `git stash` + rerunning the same 6 tests on the unmodified base: identical failures (`test_cli_task` overlay ×2, `governance/test_policy` absolute path, `skill_scanner` symlink ×2 / yaml header).

### 3. Real-machine proof (the original 26 GB incident, Windows)

First run of the new startup sweep on the machine that produced the incident — it deleted the **exact 26,229,984,973-byte orphan file from the bug report** plus ~60 previously leaked files (excerpt):

```text
INFO shell.py:376 | Removed stale shell temp file: C:\Users\22812\AppData\Local\Temp\qwenpaw_out_1i_8m44n   ← the 26 GB file
INFO shell.py:376 | Removed stale shell temp file: C:\Users\22812\AppData\Local\Temp\qwenpaw_err_00hrsott
... (~60 more previously leaked qwenpaw_out_*/qwenpaw_err_* files removed)
```

Detached-child scenario (direct child exits, grandchild still holds the handle) — previously silent, now visible and self-healing:

```text
WARNING shell.py:401 | Could not remove shell temp file C:\Users\22812\AppData\Local\Temp\qwenpaw_out_omhpq9hh
    ([WinError 32] The process cannot access the file because it is being used by another process).
    A process likely still holds it open; QwenPaw will retry at exit and sweep the file on a future start once it is released.
rc=0 elapsed=0.25s
registered leaked files: ['...qwenpaw_out_omhpq9hh', '...qwenpaw_err_rbpn2phu']
```

After the holder exited, the `atexit` retry deleted both files — verified they no longer exist on disk.

The leak precondition was also confirmed live: orphan processes from past sessions were still holding handles days later (6 × `python -m http.server 8080` since 2026-08-04, 4 × orphaned `cmd` from today) — exactly the "`taskkill /T` missed them" scenario the job-object kill now closes.

## Additional Notes

**Known boundary (by design):** if a command *exits normally* but deliberately leaves a detached background process holding stdout (e.g. a user-intended daemon), QwenPaw does not kill it — that would break legitimate `start ...` usage. Such a file is now visible in logs and reclaimed once the holder exits (atexit retry / next-start sweep); growth while the daemon runs is the user's own process writing, bounded only when the command is under monitoring (timeout/cancel paths are fully covered by cap + job-object kill).

**Config:** `QWENPAW_SHELL_MAX_OUTPUT_BYTES` (default `10485760`, min `1024`) lets operators tune the cap.

**Files changed:** `src/qwenpaw/agents/tools/shell.py`, `src/qwenpaw/constant.py`, `tests/unit/agents/tools/test_shell.py` (+639/−30).
