### PR TITLE
fix(os): restore text selection and copy in OS desktop window content

### DIFF
--- a/console/src/os/osWindowBody.css
+++ b/console/src/os/osWindowBody.css
@@ -29,3 +29,10 @@
 .os-window-overlay-root > .ant-drawer {
   position: absolute;
 }
+
+/* Restore text selection inside OS window content (desktop shell sets
+ * user-select: none on the root to prevent drag interference). */
+.os-window-body {
+  user-select: text;
+  -webkit-user-select: text;
+}


### PR DESCRIPTION
## Problem

In QwenPaw OS desktop mode (`/os` route), users cannot select text with mouse or copy with Ctrl/Cmd+C inside window content (chat messages, code blocks, tool output). The classic browser layout works fine.

**Root cause:** `useOsStyles.ts` sets `user-select: none` on the desktop root container to prevent accidental selection during window drag / icon click. This inherits into all window content, and no override exists for the content area.

## Fix

Add `user-select: text` on `.os-window-body` in `osWindowBody.css` to restore text selection inside OS window content while keeping the desktop shell (icons, Dock, MenuBar, title bar) non-selectable.

## Changes

- `console/src/os/osWindowBody.css` — add `user-select: text` + `-webkit-user-select: text` for `.os-window-body`

## Testing

- ✅ Text selection with mouse works in OS window content
- ✅ Ctrl/Cmd+C copy works in OS window content
- ✅ Desktop icons, Dock, MenuBar remain non-selectable
- ✅ Window title bar drag unaffected
- ✅ Classic layout unaffected

Closes #6797