### PR TITLE
feat(wechat): accept Chinese approval replies (#6728)

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -58,6 +58,12 @@ _WECHAT_PROCESSED_IDS_MAX = 2000
 # Time window (seconds) for content-based dedup (same user + same text)
 _TEXT_DEDUP_TTL = 30.0
 
+# Exact replies accepted while this WeChat session has a pending approval.
+_APPROVAL_REPLY_ACTIONS = {
+    "允许": "approve",
+    "拒绝": "deny",
+}
+
 # Default token file path
 _DEFAULT_TOKEN_FILE = WORKING_DIR / "wechat_bot_token"
 
@@ -325,6 +331,30 @@ class WeChatChannel(BaseChannel):
             getattr(request, "user_id", "") or "",
             getattr(request, "session_id", "") or "",
         )
+
+    @staticmethod
+    async def _normalize_approval_reply(text: str, session_id: str) -> str:
+        """Translate exact Chinese approval replies for pending sessions."""
+        action = _APPROVAL_REPLY_ACTIONS.get(text)
+        if action is None:
+            return text
+
+        try:
+            from ...approvals import get_approval_service
+
+            pending = await get_approval_service().get_pending_by_root_session(
+                session_id,
+            )
+        except Exception:
+            logger.debug(
+                "wechat: failed to inspect pending approvals",
+                exc_info=True,
+            )
+            return text
+
+        if not pending:
+            return text
+        return f"/approval {action}"
 
     def build_agent_request_from_native(
         self,
@@ -834,14 +864,6 @@ class WeChatChannel(BaseChannel):
                     )
 
             text = "\n".join(text_parts).strip()
-            if text:
-                content_parts.insert(
-                    0,
-                    TextContent(type=ContentType.TEXT, text=text),
-                )
-            if not content_parts:
-                return
-
             is_group = bool(group_id)
             meta: Dict[str, Any] = {
                 "wechat_from_user_id": from_user_id,
@@ -850,6 +872,15 @@ class WeChatChannel(BaseChannel):
                 "wechat_group_id": group_id,
                 "is_group": is_group,
             }
+            session_id = self.resolve_session_id(from_user_id, meta)
+            text = await self._normalize_approval_reply(text, session_id)
+            if text:
+                content_parts.insert(
+                    0,
+                    TextContent(type=ContentType.TEXT, text=text),
+                )
+            if not content_parts:
+                return
 
             # Save latest context_token for proactive sends (heartbeat/cron)
             if from_user_id and context_token:
@@ -882,7 +913,6 @@ class WeChatChannel(BaseChannel):
                     description="start typing indicator",
                 )
 
-            session_id = self.resolve_session_id(from_user_id, meta)
             native = {
                 "channel_id": self.channel,
                 "sender_id": from_user_id,

--- a/tests/contract/channels/test_wechat_contract.py
+++ b/tests/contract/channels/test_wechat_contract.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""WeChat channel contract tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+
+from tests.contract.channels import ChannelContractTest
+
+if TYPE_CHECKING:
+    from qwenpaw.app.channels.base import BaseChannel
+
+
+class TestWeChatChannelContract(ChannelContractTest):
+    """Ensure WeChatChannel satisfies the BaseChannel contract."""
+
+    def create_instance(self) -> "BaseChannel":
+        """Provide a configured WeChat channel instance."""
+        from qwenpaw.app.channels.wechat.channel import WeChatChannel
+
+        return WeChatChannel(
+            process=AsyncMock(),
+            enabled=True,
+            bot_token="test_token",
+            bot_prefix="[Test]",
+            display_config=ChannelDisplayConfig(
+                show_tool_calls=False,
+                show_tool_results=False,
+            ),
+        )

--- a/tests/unit/channels/test_wechat.py
+++ b/tests/unit/channels/test_wechat.py
@@ -1159,6 +1159,79 @@ class TestWeChatOnMessage:
         call_args = wechat_channel._enqueue.call_args[0][0]
         assert call_args["sender_id"] == "user123"
 
+    @pytest.mark.parametrize(
+        ("reply", "action"),
+        [("允许", "approve"), ("拒绝", "deny")],
+    )
+    async def test_on_message_maps_chinese_pending_approval_reply(
+        self,
+        wechat_channel,
+        mock_ilink_client,
+        reply,
+        action,
+    ):
+        """Exact Chinese replies resolve the current approval queue head."""
+        wechat_channel._client = mock_ilink_client
+        wechat_channel._enqueue = MagicMock()
+        approval_service = MagicMock()
+        approval_service.get_pending_by_root_session = AsyncMock(
+            return_value=[MagicMock()],
+        )
+
+        with patch(
+            "qwenpaw.app.approvals.get_approval_service",
+            return_value=approval_service,
+        ):
+            await wechat_channel._on_message(
+                {
+                    "from_user_id": "user123",
+                    "context_token": f"ctx_{action}",
+                    "message_type": 1,
+                    "item_list": [
+                        {"type": 1, "text_item": {"text": reply}},
+                    ],
+                },
+                mock_ilink_client,
+            )
+
+        payload = wechat_channel._enqueue.call_args[0][0]
+        assert payload["content_parts"][0].text == f"/approval {action}"
+        approval_service.get_pending_by_root_session.assert_awaited_once_with(
+            "wechat:user123",
+        )
+
+    async def test_on_message_preserves_chinese_reply_without_pending_approval(
+        self,
+        wechat_channel,
+        mock_ilink_client,
+    ):
+        """Approval words remain normal chat when no approval is pending."""
+        wechat_channel._client = mock_ilink_client
+        wechat_channel._enqueue = MagicMock()
+        approval_service = MagicMock()
+        approval_service.get_pending_by_root_session = AsyncMock(
+            return_value=[],
+        )
+
+        with patch(
+            "qwenpaw.app.approvals.get_approval_service",
+            return_value=approval_service,
+        ):
+            await wechat_channel._on_message(
+                {
+                    "from_user_id": "user123",
+                    "context_token": "ctx_no_pending",
+                    "message_type": 1,
+                    "item_list": [
+                        {"type": 1, "text_item": {"text": "允许"}},
+                    ],
+                },
+                mock_ilink_client,
+            )
+
+        payload = wechat_channel._enqueue.call_args[0][0]
+        assert payload["content_parts"][0].text == "允许"
+
     async def test_on_message_skip_non_user_message(
         self,
         wechat_channel,


### PR DESCRIPTION
## Description

Fixes #6728.

WeChat users can now reply with the exact Chinese actions `允许` or `拒绝`
while their root session has a pending approval. The channel translates those
replies to the existing `/approval approve` or `/approval deny` control
commands.

Outside an active approval flow, the same words remain ordinary chat messages.
This keeps the change channel-local and avoids adding ambiguous global command
aliases.

**Related Issue:** Fixes #6728

**Security Considerations:** Translation is gated on a pending approval for the
same WeChat root session. It does not bypass the existing approval service,
change approval scope, or grant permissions directly.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] If pre-commit auto-fixed files, changes were rechecked
- [x] Relevant tests pass
- [x] Documentation updated (not needed; the approval prompt already presents the actions)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] `./scripts/check-channels.sh wechat` contract and unit stages pass
- [x] Contract test exists in `tests/contract/channels/test_wechat_contract.py`
- [x] Contract test implements `create_instance()`
- [x] All 19 contract verification points pass
- [x] Unit tests cover pending and no-pending behavior

## Testing

- Chinese `允许` maps to `/approval approve` with a pending approval.
- Chinese `拒绝` maps to `/approval deny` with a pending approval.
- `允许` remains unchanged when no approval is pending.
- The approval lookup uses the WeChat root session ID.

## Evidence

```bash
.venv/bin/pytest tests/unit/channels/test_wechat.py -q
# 80 passed, 1 pre-existing warning

.venv/bin/pytest tests/contract/channels/test_wechat_contract.py -q
# 19 passed

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/app/channels/wechat/channel.py \
  tests/unit/channels/test_wechat.py \
  tests/contract/channels/test_wechat_contract.py
# Python AST, encoding, private-key detection, whitespace, mypy,
# black, flake8, and pylint: Passed
```

## Additional Notes

The implementation was AI-assisted and personally verified against current
`main`, Issue #6728, the approval service root-session semantics, duplicate PR
searches, and the focused test suites above.
