### PR TITLE
fix(scripts): repair channel check environment detection

### DIFF
--- a/scripts/check-channels.sh
+++ b/scripts/check-channels.sh
@@ -29,6 +29,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # Parse arguments
 TARGET="${1:-all}"
 CHECK_CHANGED=0
+ALL_CHANGED=""
 
 if [ "$TARGET" == "--changed" ] || [ "$TARGET" == "-c" ]; then
     CHECK_CHANGED=1
@@ -89,9 +90,9 @@ if ! command -v python3 &> /dev/null; then
 fi
 
 # Check if dependencies are installed
-if ! python3 -c "import copaw" 2>/dev/null; then
+if ! python3 -c "import qwenpaw" 2>/dev/null; then
     echo -e "${YELLOW}Installing dependencies...${NC}"
-    pip install -e ".[dev]" -q
+    python3 -m pip install -e ".[dev]" -q
 fi
 
 # Run tests

--- a/tests/unit/scripts/test_check_channels_script.py
+++ b/tests/unit/scripts/test_check_channels_script.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Tests for the channel pre-commit check script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_specific_channel_uses_qwenpaw_environment(tmp_path: Path) -> None:
+    """A single-channel check should not require legacy package tooling."""
+    project_root = Path(__file__).resolve().parents[3]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    _write_executable(
+        bin_dir / "python3",
+        """#!/bin/sh
+if [ "$1" = "-c" ] && [ "$2" = "import qwenpaw" ]; then
+    exit 0
+fi
+echo "unexpected python3 invocation: $*" >&2
+exit 91
+""",
+    )
+    _write_executable(bin_dir / "pytest", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "pip",
+        "#!/bin/sh\necho 'unexpected bare pip invocation' >&2\nexit 92\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "scripts/check-channels.sh", "console"],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "unexpected" not in result.stdout + result.stderr


### PR DESCRIPTION
## Description

`scripts/check-channels.sh <channel>` currently fails in a valid QwenPaw
development environment for two independent reasons:

1. It probes the removed `copaw` package, then invokes a bare `pip` command
   even when `qwenpaw` is already installed in the active Python environment.
2. Explicit single-channel runs reference `ALL_CHANGED` without defining it,
   so `set -u` turns an otherwise successful run into an error.

This change probes `qwenpaw`, installs through the same `python3` interpreter
when needed, and initializes the changed-file state for every invocation mode.
It also adds an isolated subprocess regression test with stub executables,
proving that an installed QwenPaw environment neither invokes legacy package
tooling nor fails after the selected channel tests pass.

**Related Issue:** N/A — current `main` contributor-script regression.

**Security Considerations:** No authentication, secret, network, or runtime
channel behavior changes. Dependency installation remains the existing
editable development install and now uses the selected Python interpreter.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing behavior change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh console` and it passes
- [x] Contract test exists in `tests/contract/channels/test_console_contract.py`
- [x] Contract test implements `create_instance()`
- [x] All applicable contract verification points pass
- [x] Console unit tests pass

## Testing

```bash
.venv/bin/pytest tests/unit/scripts/test_check_channels_script.py \
  tests/contract/channels/test_console_contract.py \
  tests/unit/channels/test_console.py -q
# 60 passed, 1 skipped

PATH="/opt/homebrew/bin:$PATH" .venv/bin/pre-commit run --all-files
# all hooks passed, including mypy, black, flake8, pylint, prettier, actionlint

PATH="$PWD/.venv/bin:$PATH" bash scripts/check-channels.sh console
# contract: 20 passed, 1 skipped
# unit: 39 passed
# exit 0
```

## Evidence

Before this change, with QwenPaw importable from the active virtualenv:

```text
Installing dependencies...
scripts/check-channels.sh: line 94: pip: command not found
baseline_install_exit=127
```

After bypassing that stale package probe, the channel tests passed but the
explicit-channel path still failed:

```text
77 passed, 1 warning
scripts/check-channels.sh: line 159: ALL_CHANGED: unbound variable
baseline_unbound_exit=1
```

After this change, the real Console channel command completes:

```text
20 passed, 1 skipped
Contract tests PASSED for console
39 passed
Unit tests passed
All checks passed!
fixed_console_exit=0
```

The new regression test reproduces the contributor environment with stub
`python3`, `pytest`, and a deliberately failing bare `pip`; it exits successfully
only when the script probes `qwenpaw`, avoids bare `pip`, and defines
`ALL_CHANGED` for the explicit-channel path.

## Additional Notes

Open PR #6387 also touches the dependency setup block as part of a much larger
optional-channel installation feature, but it does not address the
single-channel `ALL_CHANGED` failure. This PR is intentionally limited to the
current script regressions and its focused test.

AI-assisted contribution: AI was used for repository analysis, implementation,
and test drafting. The behavior was manually reproduced before and after the
change, and all commands above were run locally.
