### PR TITLE
fix(console): show custom profile markdown files

### DIFF
--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -38,6 +38,7 @@ import SessionProjectDirectory from "../project-directory/SessionProjectDirector
 import { getPendingProjectDirectory } from "../project-directory/pendingProjectDirectory";
 import { directoriesMatch, workspaceRoots } from "./directorySources";
 import FileGlyph from "./FileGlyph";
+import { isWorkspaceMarkdown } from "./defaultWorkspaceMarkdown";
 import {
   filesWorkspaceScopeKey,
   type FilesWorkspaceScope,
@@ -482,14 +483,16 @@ export default function FilesNavigator({
         workspaceApi.getSystemPromptFiles(),
       ]);
       const order = Array.isArray(enabled) ? enabled : [];
-      const mappedFiles = files.map((file) => ({
-        name: file.filename.split("/").pop() ?? file.filename,
-        path: file.filename,
-        kind: "file" as const,
-        size: file.size,
-        modified_at: file.modified_time,
-        preview_kind: "text" as const,
-      }));
+      const mappedFiles = files
+        .filter((file) => isWorkspaceMarkdown(file.filename))
+        .map((file) => ({
+          name: file.filename.split("/").pop() ?? file.filename,
+          path: file.filename,
+          kind: "file" as const,
+          size: file.size,
+          modified_at: file.modified_time,
+          preview_kind: "text" as const,
+        }));
       setEnabledFiles(order);
       setAllProfileFiles(mappedFiles);
     } finally {

--- a/console/src/features/files-workspace/defaultWorkspaceMarkdown.test.ts
+++ b/console/src/features/files-workspace/defaultWorkspaceMarkdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKSPACE_MARKDOWN_FILENAMES,
-  isDefaultWorkspaceMarkdown,
+  isWorkspaceMarkdown,
 } from "./defaultWorkspaceMarkdown";
 
 describe("defaultWorkspaceMarkdown", () => {
@@ -15,14 +15,17 @@ describe("defaultWorkspaceMarkdown", () => {
       "BOOTSTRAP.md",
     ]);
     expect(
-      DEFAULT_WORKSPACE_MARKDOWN_FILENAMES.every(isDefaultWorkspaceMarkdown),
+      DEFAULT_WORKSPACE_MARKDOWN_FILENAMES.every(isWorkspaceMarkdown),
     ).toBe(true);
   });
 
-  it("rejects user-created Markdown files", () => {
-    expect(isDefaultWorkspaceMarkdown("analysis.md")).toBe(false);
-    expect(isDefaultWorkspaceMarkdown("xiaomi_stock_analysis_2026.md")).toBe(
-      false,
-    );
+  it("recognizes user-created workspace Markdown files", () => {
+    expect(isWorkspaceMarkdown("FILES.md")).toBe(true);
+    expect(isWorkspaceMarkdown("WORKFLOW.md")).toBe(true);
+  });
+
+  it("rejects non-Markdown files", () => {
+    expect(isWorkspaceMarkdown("avatar.png")).toBe(false);
+    expect(isWorkspaceMarkdown("notes.txt")).toBe(false);
   });
 });

--- a/console/src/features/files-workspace/defaultWorkspaceMarkdown.ts
+++ b/console/src/features/files-workspace/defaultWorkspaceMarkdown.ts
@@ -7,10 +7,6 @@ export const DEFAULT_WORKSPACE_MARKDOWN_FILENAMES = [
   "BOOTSTRAP.md",
 ] as const;
 
-const defaultWorkspaceMarkdownFilenames = new Set<string>(
-  DEFAULT_WORKSPACE_MARKDOWN_FILENAMES,
-);
-
-export function isDefaultWorkspaceMarkdown(filename: string): boolean {
-  return defaultWorkspaceMarkdownFilenames.has(filename);
+export function isWorkspaceMarkdown(filename: string): boolean {
+  return filename.endsWith(".md");
 }


### PR DESCRIPTION
## Description

The Files workspace Profile category filtered the backend `/workspace/files` response through the six built-in persona filenames. The backend already returns every workspace-root Markdown file, so custom persona files were hidden even when listed in `system_prompt_files`.

This change keeps the built-in filename list for features that need it, while allowing every returned `.md` file into the Profile category. Custom files can therefore be opened, toggled, and ordered alongside the built-ins.

**Related Issue:** Fixes #6785

**Security Considerations:** None. This only changes client-side filtering of files already returned by the workspace API.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran focused tests locally and they pass
- [x] Documentation updated (not needed; behavior restores the existing backend contract)
- [ ] Ready for review

## Testing

- Executed a focused Node smoke against the actual TypeScript module. It checks all six built-ins, custom `FILES.md`, `INFRA.md`, and `WORKFLOW.md`, plus two non-Markdown rejections: 11 assertions passed.
- `git diff --check` passed.
- A full Vitest invocation could not start locally because npm 10.8.2 crashed during `npm ci` with its known `Exit handler never called` error before linking binaries. The Draft PR leaves the repository CI suite to validate the lockfile environment.

## Evidence

```text
workspace Markdown profile smoke: 11 assertions passed
```

```text
git diff --check
# no output (passed)
```

## Additional Notes

The patch is intentionally limited to the Profile category filter and its focused unit expectations. Language switching still uses the unchanged official six-file constant.