### PR TITLE
fix(providers): sanitize Chat Completions content for strict providers

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -86,7 +86,7 @@ class _ChatCompletionFormatterWrapper:
         self._inner_formatter = formatter
 
     async def format(self, *args: Any, **kwargs: Any) -> list[Any]:
-        """Format messages and remove fields unsupported by Chat Completions."""
+        """Format messages and strip Chat Completions-unsupported fields."""
         formatted_messages = await self._inner_formatter.format(
             *args,
             **kwargs,
@@ -732,8 +732,10 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         self._extra_generate_kwargs = extra_generate_kwargs or {}
         self._output_token_param = output_token_param
         super().__init__(**kwargs)
-        if not isinstance(self.formatter, _ChatCompletionFormatterWrapper):
-            self.formatter = _ChatCompletionFormatterWrapper(self.formatter)
+        # AgentScope sets self.formatter in OpenAIChatModel.__init__.
+        current_formatter = getattr(self, "formatter", None)
+        if not isinstance(current_formatter, _ChatCompletionFormatterWrapper):
+            self.formatter = _ChatCompletionFormatterWrapper(current_formatter)
         credential_id = str(getattr(self.credential, "id", "") or "")
         credential_provider_id = credential_id.removeprefix("qwenpaw-")
         if (

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -79,6 +79,24 @@ def _sanitize_chat_completion_messages(messages: Any) -> list[Any]:
     return sanitized_messages
 
 
+class _ChatCompletionFormatterWrapper:
+    """Sanitize the wire messages returned by an OpenAI formatter."""
+
+    def __init__(self, formatter: Any) -> None:
+        self._inner_formatter = formatter
+
+    async def format(self, *args: Any, **kwargs: Any) -> list[Any]:
+        """Format messages and remove fields unsupported by Chat Completions."""
+        formatted_messages = await self._inner_formatter.format(
+            *args,
+            **kwargs,
+        )
+        return _sanitize_chat_completion_messages(formatted_messages)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner_formatter, name)
+
+
 def _battr(block: Any, key: str, default: Any = None) -> Any:
     """Read an attribute from a dict *or* Pydantic block."""
     if isinstance(block, dict):
@@ -714,6 +732,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         self._extra_generate_kwargs = extra_generate_kwargs or {}
         self._output_token_param = output_token_param
         super().__init__(**kwargs)
+        if not isinstance(self.formatter, _ChatCompletionFormatterWrapper):
+            self.formatter = _ChatCompletionFormatterWrapper(self.formatter)
         credential_id = str(getattr(self.credential, "id", "") or "")
         credential_provider_id = credential_id.removeprefix("qwenpaw-")
         if (
@@ -807,7 +827,6 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         tool_choice: Any | None = None,
         **generate_kwargs: Any,
     ) -> Any:
-        messages = _sanitize_chat_completion_messages(messages)
         merged = {**self._extra_generate_kwargs, **generate_kwargs}
         self._consume_disable_thinking(merged)
         if self._output_token_param != "max_tokens":

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -27,6 +27,58 @@ from qwenpaw.utils.tool_call_extra import (
 logger = logging.getLogger(__name__)
 
 
+_CHAT_COMPLETION_RUNTIME_KEYS = frozenset(
+    {"delta", "index", "status", "object", "msg_id"},
+)
+
+
+def _sanitize_chat_completion_messages(messages: Any) -> list[Any]:
+    """Remove non-Chat-Completions fields from message content parts."""
+    sanitized_messages: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            sanitized_messages.append(message)
+            continue
+
+        sanitized_message = dict(message)
+        content = message.get("content")
+        if isinstance(content, list):
+            sanitized_content = []
+            for item in content:
+                if not isinstance(item, dict):
+                    sanitized_content.append(item)
+                    continue
+
+                item_type = item.get("type")
+                if item_type in ("input_text", "output_text"):
+                    sanitized_item = {"type": "text"}
+                    if "text" in item:
+                        sanitized_item["text"] = item["text"]
+                    sanitized_content.append(sanitized_item)
+                elif item_type == "text":
+                    sanitized_content.append(
+                        {
+                            key: value
+                            for key, value in item.items()
+                            if key in ("type", "text")
+                        },
+                    )
+                else:
+                    sanitized_content.append(
+                        {
+                            key: value
+                            for key, value in item.items()
+                            if key not in _CHAT_COMPLETION_RUNTIME_KEYS
+                        },
+                    )
+
+            sanitized_message["content"] = sanitized_content
+
+        sanitized_messages.append(sanitized_message)
+
+    return sanitized_messages
+
+
 def _battr(block: Any, key: str, default: Any = None) -> Any:
     """Read an attribute from a dict *or* Pydantic block."""
     if isinstance(block, dict):
@@ -755,6 +807,7 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         tool_choice: Any | None = None,
         **generate_kwargs: Any,
     ) -> Any:
+        messages = _sanitize_chat_completion_messages(messages)
         merged = {**self._extra_generate_kwargs, **generate_kwargs}
         self._consume_disable_thinking(merged)
         if self._output_token_param != "max_tokens":

--- a/tests/unit/providers/test_openai_chat_content_sanitize.py
+++ b/tests/unit/providers/test_openai_chat_content_sanitize.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from __future__ import annotations
 
 from copy import deepcopy
@@ -135,7 +136,9 @@ def test_sanitizing_does_not_mutate_original_messages() -> None:
     assert sanitized[0] is not messages[0]
     assert sanitized[0]["content"] is not messages[0]["content"]
     assert messages == original
-    assert messages[0]["content"][0]["delta"] is True
+    original_content = messages[0]["content"]
+    assert isinstance(original_content, list)
+    assert original_content[0]["delta"] is True
 
 
 async def test_call_api_passes_sanitized_messages_to_base(monkeypatch) -> None:
@@ -168,4 +171,6 @@ async def test_call_api_passes_sanitized_messages_to_base(monkeypatch) -> None:
             "content": [{"type": "text", "text": "system prompt"}],
         },
     ]
-    assert messages[0]["content"][0]["type"] == "input_text"
+    original_content = messages[0]["content"]
+    assert isinstance(original_content, list)
+    assert original_content[0]["type"] == "input_text"

--- a/tests/unit/providers/test_openai_chat_content_sanitize.py
+++ b/tests/unit/providers/test_openai_chat_content_sanitize.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from agentscope.model import OpenAIChatModel
+
+from qwenpaw.providers.openai_chat_model_compat import (
+    OpenAIChatModelCompat,
+    _sanitize_chat_completion_messages,
+)
+
+
+def test_polluted_text_content_keeps_only_wire_fields() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "delta": False,
+                    "index": None,
+                    "status": "created",
+                    "object": "content",
+                    "msg_id": None,
+                    "text": "测试",
+                    "runtime_extra": "drop me",
+                },
+            ],
+        },
+    ]
+
+    assert _sanitize_chat_completion_messages(messages) == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "测试"}],
+        },
+    ]
+
+
+@pytest.mark.parametrize("content_type", ["input_text", "output_text"])
+def test_response_text_types_become_chat_completion_text(
+    content_type: str,
+) -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": content_type,
+                    "text": "history",
+                    "status": "completed",
+                    "extra": "drop me",
+                },
+            ],
+        },
+    ]
+
+    assert _sanitize_chat_completion_messages(messages)[0]["content"] == [
+        {"type": "text", "text": "history"},
+    ]
+
+
+def test_mixed_content_is_sanitized_item_by_item() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "prompt"},
+                {
+                    "type": "text",
+                    "text": "reply",
+                    "index": 1,
+                    "internal": True,
+                },
+                {"type": "input_audio", "input_audio": {"data": "abc"}},
+            ],
+        },
+    ]
+
+    assert _sanitize_chat_completion_messages(messages)[0]["content"] == [
+        {"type": "text", "text": "prompt"},
+        {"type": "text", "text": "reply"},
+        {"type": "input_audio", "input_audio": {"data": "abc"}},
+    ]
+
+
+def test_image_url_content_is_preserved_without_runtime_fields() -> None:
+    image = {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/image.png"},
+        "delta": False,
+        "index": 0,
+        "status": "created",
+        "object": "content",
+        "msg_id": "message-id",
+    }
+    messages = [{"role": "user", "content": [image]}]
+
+    assert _sanitize_chat_completion_messages(messages)[0]["content"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/image.png"},
+        },
+    ]
+
+
+def test_plain_string_content_is_preserved() -> None:
+    messages = [{"role": "user", "content": "hello"}]
+
+    sanitized = _sanitize_chat_completion_messages(messages)
+
+    assert sanitized[0]["content"] == "hello"
+
+
+def test_sanitizing_does_not_mutate_original_messages() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "hello",
+                    "delta": True,
+                },
+            ],
+        },
+    ]
+    original = deepcopy(messages)
+
+    sanitized = _sanitize_chat_completion_messages(messages)
+
+    assert sanitized is not messages
+    assert sanitized[0] is not messages[0]
+    assert sanitized[0]["content"] is not messages[0]["content"]
+    assert messages == original
+    assert messages[0]["content"][0]["delta"] is True
+
+
+async def test_call_api_passes_sanitized_messages_to_base(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_call_api(self, *args, **kwargs):
+        del self, kwargs
+        captured["messages"] = args[1]
+        return "ok"
+
+    monkeypatch.setattr(OpenAIChatModel, "_call_api", fake_call_api)
+
+    model = object.__new__(OpenAIChatModelCompat)
+    model._default_headers = None
+    model._extra_generate_kwargs = {}
+    model._output_token_param = "max_tokens"
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "input_text", "text": "system prompt"},
+            ],
+        },
+    ]
+
+    assert await model._call_api("model", messages) == "ok"
+    assert captured["messages"] == [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "system prompt"}],
+        },
+    ]
+    assert messages[0]["content"][0]["type"] == "input_text"

--- a/tests/unit/providers/test_openai_chat_content_sanitize.py
+++ b/tests/unit/providers/test_openai_chat_content_sanitize.py
@@ -179,7 +179,9 @@ async def test_formatter_wrapper_sanitizes_without_mutating() -> None:
     assert sanitized == [
         {"role": "user", "content": [{"type": "text", "text": "hello"}]},
     ]
-    assert polluted[0]["content"][0]["delta"] is True
+    original_content = polluted[0]["content"]
+    assert isinstance(original_content, list)
+    assert original_content[0]["delta"] is True
     assert wrapper.relay_reasoning_content is True
 
 
@@ -282,5 +284,9 @@ async def test_call_api_sanitizes_formatted_messages_at_transport() -> None:
             "stream": False,
         },
     ]
-    assert polluted[0]["content"][0]["type"] == "input_text"
-    assert polluted[1]["content"][0]["msg_id"] == "message-id"
+    system_content = polluted[0]["content"]
+    user_content = polluted[1]["content"]
+    assert isinstance(system_content, list)
+    assert isinstance(user_content, list)
+    assert system_content[0]["type"] == "input_text"
+    assert user_content[0]["msg_id"] == "message-id"

--- a/tests/unit/providers/test_openai_chat_content_sanitize.py
+++ b/tests/unit/providers/test_openai_chat_content_sanitize.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
+from typing import Any
 
+import httpx
 import pytest
-from agentscope.model import OpenAIChatModel
+from agentscope.credential import OpenAICredential
+from agentscope.message import Msg, TextBlock
 
 from qwenpaw.providers.openai_chat_model_compat import (
+    _ChatCompletionFormatterWrapper,
     OpenAIChatModelCompat,
     _sanitize_chat_completion_messages,
 )
@@ -141,36 +146,141 @@ def test_sanitizing_does_not_mutate_original_messages() -> None:
     assert original_content[0]["delta"] is True
 
 
-async def test_call_api_passes_sanitized_messages_to_base(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+class _PollutedFormatter:
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self.messages = messages
+        self.received_messages: list[Msg] | None = None
+        self.relay_reasoning_content = True
 
-    async def fake_call_api(self, *args, **kwargs):
-        del self, kwargs
-        captured["messages"] = args[1]
-        return "ok"
+    async def format(self, messages: list[Msg]) -> list[dict[str, Any]]:
+        self.received_messages = messages
+        return self.messages
 
-    monkeypatch.setattr(OpenAIChatModel, "_call_api", fake_call_api)
 
-    model = object.__new__(OpenAIChatModelCompat)
-    model._default_headers = None
-    model._extra_generate_kwargs = {}
-    model._output_token_param = "max_tokens"
-    messages = [
+async def test_formatter_wrapper_sanitizes_without_mutating() -> None:
+    polluted = [
         {
-            "role": "system",
+            "role": "user",
             "content": [
-                {"type": "input_text", "text": "system prompt"},
+                {
+                    "type": "text",
+                    "text": "hello",
+                    "delta": True,
+                    "index": 0,
+                },
             ],
         },
     ]
+    formatter = _PollutedFormatter(polluted)
+    wrapper = _ChatCompletionFormatterWrapper(formatter)
 
-    assert await model._call_api("model", messages) == "ok"
-    assert captured["messages"] == [
+    sanitized = await wrapper.format([])
+
+    assert sanitized == [
+        {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+    ]
+    assert polluted[0]["content"][0]["delta"] is True
+    assert wrapper.relay_reasoning_content is True
+
+
+async def test_call_api_sanitizes_formatted_messages_at_transport() -> None:
+    polluted = [
         {
             "role": "system",
-            "content": [{"type": "text", "text": "system prompt"}],
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "system prompt",
+                    "status": "completed",
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "user prompt",
+                    "delta": "user prompt",
+                    "index": 0,
+                    "status": "completed",
+                    "object": "content",
+                    "msg_id": "message-id",
+                },
+            ],
         },
     ]
-    original_content = messages[0]["content"]
-    assert isinstance(original_content, list)
-    assert original_content[0]["type"] == "input_text"
+    formatter = _PollutedFormatter(polluted)
+    request_bodies: list[dict[str, Any]] = []
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        request_bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    },
+                ],
+            },
+        )
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handle_request),
+    )
+    messages = [
+        Msg(
+            name="system",
+            role="system",
+            content=[TextBlock(text="system prompt")],
+        ),
+        Msg(
+            name="user",
+            role="user",
+            content=[TextBlock(text="user prompt")],
+        ),
+    ]
+    model = OpenAIChatModelCompat(
+        credential=OpenAICredential(
+            api_key="test-key",
+            base_url="https://test.invalid/v1",
+        ),
+        model="test-model",
+        stream=False,
+        formatter=formatter,
+        client_kwargs={"http_client": http_client},
+    )
+
+    try:
+        response = await model._call_api("test-model", messages)
+    finally:
+        await http_client.aclose()
+
+    assert response.is_last is True
+    assert formatter.received_messages == messages
+    assert request_bodies == [
+        {
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "system prompt"}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "user prompt"}],
+                },
+            ],
+            "stream": False,
+        },
+    ]
+    assert polluted[0]["content"][0]["type"] == "input_text"
+    assert polluted[1]["content"][0]["msg_id"] == "message-id"


### PR DESCRIPTION
## Description

Strict OpenAI-compatible Chat Completions providers (for example StepFun) reject QwenPaw requests when message content parts include internal runtime envelope fields or Responses API text types.

Observed on the wire:

1. Text content parts can carry runtime fields such as delta, index, status, object, and msg_id from the streaming envelope.
2. Chat Completions requests can include input_text (Responses API) instead of text.

This PR sanitizes Chat Completions message content in OpenAIChatModelCompat._call_api before the request is sent:

- rewrite input_text / output_text to text
- keep only type and text for text parts
- strip known runtime envelope keys from non-text multimodal parts
- leave plain string content unchanged
- do not mutate the original messages object

Responses API providers and formatters are intentionally unchanged.

**Related Issue:** Fixes #6803

**Security Considerations:** None. Wire-format cleanup only; no auth, secrets, or channel changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran black (line-length 79) and flake8 on touched files locally and they pass
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran targeted unit tests locally and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Focused unit tests cover polluted text parts, input_text/output_text rewrite, mixed content lists, image_url preservation, plain string content, immutability of the original messages object, and that _call_api forwards sanitized messages to the base model.

## Evidence

Local unit proof for the Chat Completions sanitizer path:

- test file: tests/unit/providers/test_openai_chat_content_sanitize.py
- result: 8 passed
- black --line-length=79 on touched files: clean
- flake8 --extend-ignore=E203 on touched files: clean

Commands used:

pytest tests/unit/providers/test_openai_chat_content_sanitize.py -q
black --line-length=79 src/qwenpaw/providers/openai_chat_model_compat.py tests/unit/providers/test_openai_chat_content_sanitize.py
flake8 --extend-ignore=E203 src/qwenpaw/providers/openai_chat_model_compat.py tests/unit/providers/test_openai_chat_content_sanitize.py

## Additional Notes

Defensive sanitization on the Chat Completions wire path only. Does not change Responses API content types.
