### PR TITLE
fix(chats): handle dict-like model responses (#6813)

### DIFF
--- a/src/qwenpaw/utils/model_response.py
+++ b/src/qwenpaw/utils/model_response.py
@@ -9,6 +9,7 @@ reply needs the same handling, so it lives here once.
 """
 from __future__ import annotations
 
+from collections.abc import AsyncIterable
 from typing import Any
 
 
@@ -70,7 +71,7 @@ async def consume_model_response(
     cumulative text — the last non-empty wins); others return one response.
     """
     response = await model(messages, **call_kwargs)
-    if not hasattr(response, "__aiter__"):
+    if not isinstance(response, AsyncIterable):
         return extract_response_text(response)
     text = ""
     async for chunk in response:

--- a/tests/unit/utils/test_model_response.py
+++ b/tests/unit/utils/test_model_response.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 
 import pytest
+from agentscope.model import ChatResponse
 
 from qwenpaw.utils.model_response import (
     consume_model_response,
@@ -55,6 +56,16 @@ def test_extract_response_text(response, expected):
 async def test_consume_non_streaming():
     async def model(messages, **kw):
         return SimpleNamespace(text="done")
+
+    assert await consume_model_response(model, []) == "done"
+
+
+async def test_consume_agentscope_chat_response():
+    async def model(messages, **kw):
+        return ChatResponse(
+            content=[{"type": "text", "text": "done"}],
+            is_last=True,
+        )
 
     assert await consume_model_response(model, []) == "done"
 


### PR DESCRIPTION
## Description

`consume_model_response()` used instance-level `hasattr(response, "__aiter__")` to distinguish streaming responses. AgentScope `ChatResponse` inherits `dict` and maps `__getattr__` to `dict.__getitem__`, so that probe raises `KeyError("__aiter__")` instead of returning `False`. Background chat-title generation therefore aborts before extracting a normal non-streaming response.

This change uses the standard `collections.abc.AsyncIterable` protocol check. It reflects the protocol that `async for` actually requires without invoking the response instance's unsafe `__getattr__`. A regression uses the real AgentScope `ChatResponse`; the existing async-generator test remains the streaming negative control.

**Related Issue:** Fixes #6813

**Security Considerations:** None. This only changes response-shape detection and does not affect credentials, authorization, or request construction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no public API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```text
.venv/bin/pytest tests/unit/utils/test_model_response.py -q
13 passed

.venv/bin/pytest tests/unit/utils/ -q
173 passed

.venv/bin/pytest tests/unit/app/chats/test_manager.py -q
20 passed

.venv/bin/pre-commit run --files \
  src/qwenpaw/utils/model_response.py \
  tests/unit/utils/test_model_response.py
all applicable hooks passed
```

## Evidence

The new test fails on current `main` with the real AgentScope response:

```text
FAILED test_consume_agentscope_chat_response
E KeyError: '__aiter__'
  at if not hasattr(response, "__aiter__"):
```

After switching to `isinstance(response, AsyncIterable)`, the identical test returns `"done"`. The existing streaming test also passes, confirming an async generator is still consumed to its last non-empty chunk.

## Additional Notes

The change deliberately avoids `isinstance(response, dict)` as the primary decision. Checking the actual async-iteration protocol keeps the helper provider-agnostic and matches the operation performed immediately afterward.
