### PR TITLE
feat: integrate AnySearch web search (SearchProvider + MCP)

### DIFF
--- a/src/qwenpaw/agents/tools/web_search.py
+++ b/src/qwenpaw/agents/tools/web_search.py
@@ -3,7 +3,8 @@
 # pylint: disable=line-too-long
 """Web search and fetch tools.
 
-web_search uses Tavily keyless API.
+web_search delegates to a pluggable search provider (AnySearch by
+default, Tavily when QWENPAW_WEBSEARCH_PROVIDER=tavily).
 web_fetch uses direct HTTP GET + html2text.
 """
 
@@ -21,12 +22,11 @@ from agentscope.tool import ToolChunk
 from agentscope.message import ToolResultState
 
 from ...runtime.tool_registry import tool_descriptor
+from .websearch import format_search_results, get_search_provider
 
 logger = logging.getLogger(__name__)
 
-_TAVILY_SEARCH_URL = "https://api.tavily.com/search"
 _DEFAULT_TIMEOUT = 30
-_DEFAULT_MAX_RESULTS = 5
 
 _SEARCH_FALLBACK_HINT = (
     "This tool uses a free API with rate limits. "
@@ -64,57 +64,6 @@ def _is_ssl_error(exc: BaseException) -> bool:
             return True
         cur = cur.__cause__
     return False
-
-
-async def _post(
-    url: str,
-    headers: dict,
-    payload: dict,
-) -> dict:
-    """Async HTTP POST with SSL-verification fallback."""
-    try:
-        async with httpx.AsyncClient(
-            timeout=_DEFAULT_TIMEOUT,
-        ) as client:
-            resp = await client.post(
-                url,
-                headers=headers,
-                json=payload,
-            )
-    except Exception as first_exc:
-        if not _is_ssl_error(first_exc):
-            raise
-        logger.warning(
-            f"SSL verify failed for {url}, retrying",
-        )
-        async with httpx.AsyncClient(
-            timeout=_DEFAULT_TIMEOUT,
-            verify=False,
-        ) as client:
-            resp = await client.post(
-                url,
-                headers=headers,
-                json=payload,
-            )
-    resp.raise_for_status()
-    return resp.json()
-
-
-def _format_search_results(results: list[dict]) -> str:
-    """Format Tavily search results into readable text."""
-    if not results:
-        return "No results found."
-    lines: list[str] = []
-    for i, r in enumerate(results, 1):
-        title = r.get("title", "")
-        url = r.get("url", "")
-        content = r.get("content", "")
-        lines.append(f"[{i}] {title}")
-        lines.append(f"    URL: {url}")
-        if content:
-            lines.append(f"    {content}")
-        lines.append("")
-    return "\n".join(lines).rstrip()
 
 
 async def _fetch_html(url: str) -> str:
@@ -225,20 +174,12 @@ async def web_search(search_term: str) -> ToolChunk:
         )
 
     try:
-        data = await _post(
-            _TAVILY_SEARCH_URL,
-            headers={
-                "Content-Type": "application/json",
-                "X-Tavily-Access-Mode": "keyless",
-            },
-            payload={
-                "query": query,
-                "max_results": _DEFAULT_MAX_RESULTS,
-                "search_depth": "basic",
-            },
+        provider = get_search_provider()
+        results = await provider.search(
+            query,
+            max_results=5,
         )
-        results = data.get("results", [])
-        text = _format_search_results(results)
+        text = format_search_results(results)
         if not text:
             text = "No content searched."
         return ToolChunk(

--- a/src/qwenpaw/agents/tools/websearch/__init__.py
+++ b/src/qwenpaw/agents/tools/websearch/__init__.py
@@ -6,8 +6,8 @@
 ``SearchProvider`` is the abstraction that lets QwenPaw swap the search
 backend without touching the tool surface.  The active provider is chosen
 via the ``QWENPAW_WEBSEARCH_PROVIDER`` environment variable
-(``anysearch`` by default, ``tavily`` to fall back to the legacy
-keyless backend).
+(``tavily`` by default for backward compatibility, ``anysearch`` as an
+explicit opt-in).
 """
 
 from __future__ import annotations

--- a/src/qwenpaw/agents/tools/websearch/__init__.py
+++ b/src/qwenpaw/agents/tools/websearch/__init__.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa: E501
+# pylint: disable=line-too-long
+"""Pluggable web search providers for the ``web_search`` tool.
+
+``SearchProvider`` is the abstraction that lets QwenPaw swap the search
+backend without touching the tool surface.  The active provider is chosen
+via the ``QWENPAW_WEBSEARCH_PROVIDER`` environment variable
+(``anysearch`` by default, ``tavily`` to fall back to the legacy
+keyless backend).
+"""
+
+from __future__ import annotations
+
+import os
+
+from abc import ABC, abstractmethod
+
+import httpx
+
+_TIMEOUT = 30
+
+
+async def _post(
+    url: str,
+    headers: dict,
+    payload: dict,
+) -> dict:
+    """Async HTTP POST with certificate validation always on."""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(url, headers=headers, json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def format_search_results(results: list[dict]) -> str:
+    """Format search results into readable text."""
+    if not results:
+        return "No results found."
+    lines: list[str] = []
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "")
+        url = r.get("url", "")
+        content = r.get("content", "")
+        lines.append(f"[{i}] {title}")
+        lines.append(f"    URL: {url}")
+        if content:
+            lines.append(f"    {content}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+class SearchProvider(ABC):
+    """Abstract web search backend."""
+
+    name = ""
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        max_results: int = 5,
+    ) -> list[dict]:
+        """Return a list of ``{title, url, snippet, content}`` dicts."""
+        raise NotImplementedError
+
+
+class TavilyProvider(SearchProvider):
+    """Legacy Tavily keyless search backend."""
+
+    name = "tavily"
+
+    _SEARCH_URL = "https://api.tavily.com/search"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 5,
+    ) -> list[dict]:
+        payload = {
+            "query": query,
+            "max_results": max_results,
+            "search_depth": "basic",
+        }
+        data = await _post(
+            self._SEARCH_URL,
+            headers={
+                "Content-Type": "application/json",
+                "X-Tavily-Access-Mode": "keyless",
+            },
+            payload=payload,
+        )
+        return list(data.get("results") or [])
+
+
+class AnySearchProvider(SearchProvider):
+    """AnySearch REST search backend (https://api.anysearch.com)."""
+
+    name = "anysearch"
+
+    _SEARCH_URL = "https://api.anysearch.com/v1/search"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 5,
+    ) -> list[dict]:
+        headers = {"Content-Type": "application/json"}
+        api_key = os.environ.get("ANYSEARCH_API_KEY", "")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        payload = {
+            "query": query,
+            "max_results": max_results,
+        }
+        data = await _post(
+            self._SEARCH_URL,
+            headers=headers,
+            payload=payload,
+        )
+        return list((data.get("data") or {}).get("results") or [])
+
+
+def get_search_provider() -> SearchProvider:
+    """Return the active search provider selected by env var.
+
+    Defaults to ``tavily`` (the legacy keyless backend). Set
+    ``QWENPAW_WEBSEARCH_PROVIDER=anysearch`` to use AnySearch.
+    Unknown values raise ``ValueError`` instead of silently routing.
+    """
+    choice = os.environ.get("QWENPAW_WEBSEARCH_PROVIDER", "").strip().lower()
+    if choice in {"", "tavily"}:
+        return TavilyProvider()
+    if choice == "anysearch":
+        return AnySearchProvider()
+    raise ValueError(
+        f"Unknown QWENPAW_WEBSEARCH_PROVIDER: {choice!r} "
+        "(expected 'tavily' or 'anysearch')",
+    )
+
+
+__all__ = [
+    "SearchProvider",
+    "TavilyProvider",
+    "AnySearchProvider",
+    "get_search_provider",
+    "format_search_results",
+]

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2002,17 +2002,20 @@ class MCPConfig(BaseModel):
     """MCP clients configuration.
 
     Uses a dict to allow dynamic client definitions.
-    Default tavily_search client is created and auto-enabled if API key exists.
+    Default anysearch client is provided but disabled by default; enable it
+    in the Console to use AnySearch through MCP. Access follows the default
+    ask policy (no blanket allow).
     """
 
     clients: Dict[str, MCPClientConfig] = Field(
         default_factory=lambda: {
-            "tavily_search": MCPClientConfig(
-                name="tavily_mcp",
+            "anysearch": MCPClientConfig(
+                name="anysearch_mcp",
                 enabled=False,
-                command="npx",
-                args=["-y", "tavily-mcp@latest"],
-                env={"TAVILY_API_KEY": ""},
+                transport="streamable_http",
+                url="https://api.anysearch.com/mcp",
+                headers={"Authorization": "Bearer ${ANYSEARCH_API_KEY}"},
+                description="AnySearch web search via MCP",
             ),
         },
     )

--- a/src/qwenpaw/drivers/adapters/mcp_binding.py
+++ b/src/qwenpaw/drivers/adapters/mcp_binding.py
@@ -144,6 +144,7 @@ def plan_env_ref_bindings(secrets: dict[str, str]) -> EnvRefPlan:
     migration can warn about them.
     """
     plan = EnvRefPlan()
+    used_aliases: set[str] = set()
     for raw_key, raw_value in dict(secrets or {}).items():
         key = str(raw_key)
         value = str(raw_value)
@@ -151,6 +152,12 @@ def plan_env_ref_bindings(secrets: dict[str, str]) -> EnvRefPlan:
         if template is not None and template.is_single:
             var = template.var_names[0]
             alias = env_alias(var)
+            if alias in used_aliases:
+                index = 2
+                while f"{alias}_{index}" in used_aliases:
+                    index += 1
+                alias = f"{alias}_{index}"
+            used_aliases.add(alias)
             plan.env_aliases[alias] = var
             spec: dict[str, str] = {
                 "source": "credential",
@@ -167,11 +174,47 @@ def plan_env_ref_bindings(secrets: dict[str, str]) -> EnvRefPlan:
     return plan
 
 
+def _env_ref_template(
+    spec: dict[str, Any],
+    env_aliases: dict[str, str] | None = None,
+) -> str | None:
+    """Render an env-backed credential binding as its ${VAR} template.
+
+    Returns e.g. ``Bearer ${ANYSEARCH_API_KEY}`` for a binding whose
+    ``credential`` alias is ``env_<var>`` with a ``format`` of
+    ``Bearer {value}``.  ``None`` when the binding is not env-backed.
+
+    The original variable name (preserving case) is taken from
+    ``env_aliases`` (alias -> var name, derived from the card's
+    ``env:`` credential refs); when absent the alias is uppercased as a
+    fallback.
+    """
+    credential = str(spec.get("credential") or "")
+    if not credential.startswith("env_"):
+        return None
+    var_name = ""
+    if env_aliases:
+        var_name = env_aliases.get(credential, "")
+    if not var_name:
+        var_name = credential[len("env_") :].upper()
+    fmt = str(spec.get("format") or "{value}")
+    return fmt.replace("{value}", "${" + var_name + "}")
+
+
+def _is_env_ref_spec(spec: Any) -> bool:
+    return (
+        isinstance(spec, dict)
+        and spec.get("source") == "credential"
+        and str(spec.get("credential") or "").startswith("env_")
+    )
+
+
 def binding_to_response(
     binding: Any,
     credential: CredentialRecord | None,
     *,
     credential_alias: str,
+    env_aliases: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Return masked Console response values from a Driver endpoint binding."""
     if not isinstance(binding, dict):
@@ -182,6 +225,10 @@ def binding_to_response(
         for key, spec in binding.items():
             if isinstance(spec, dict) and spec.get("source") == "literal":
                 result[str(key)] = str(spec.get("value") or "")
+            elif _is_env_ref_spec(spec):
+                template = _env_ref_template(spec, env_aliases)
+                if template:
+                    result[str(key)] = template
             elif (
                 isinstance(spec, dict)
                 and spec.get("source") == "credential"
@@ -209,6 +256,7 @@ def binding_plain_keys(
     binding: Any,
     *,
     credential_alias: str,
+    env_aliases: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Return unmasked public values and blank placeholders for secret keys."""
     if not isinstance(binding, dict):
@@ -218,6 +266,10 @@ def binding_plain_keys(
         for key, spec in binding.items():
             if isinstance(spec, dict) and spec.get("source") == "literal":
                 result[str(key)] = str(spec.get("value") or "")
+            elif _is_env_ref_spec(spec):
+                template = _env_ref_template(spec, env_aliases)
+                if template:
+                    result[str(key)] = template
             elif (
                 isinstance(spec, dict)
                 and spec.get("source") == "credential"

--- a/src/qwenpaw/drivers/adapters/mcp_binding.py
+++ b/src/qwenpaw/drivers/adapters/mcp_binding.py
@@ -201,12 +201,18 @@ def _env_ref_template(
     return fmt.replace("{value}", "${" + var_name + "}")
 
 
-def _is_env_ref_spec(spec: Any) -> bool:
-    return (
-        isinstance(spec, dict)
-        and spec.get("source") == "credential"
-        and str(spec.get("credential") or "").startswith("env_")
-    )
+def _is_env_ref_spec(
+    spec: Any,
+    env_aliases: dict[str, str] | None = None,
+) -> bool:
+    """Whether a binding is env-backed, decided by the env: credential
+    refs (via env_aliases) rather than the alias naming convention — a
+    static alias like ``env_custom`` must not be misclassified."""
+    if not (isinstance(spec, dict) and spec.get("source") == "credential"):
+        return False
+    if not env_aliases:
+        return False
+    return str(spec.get("credential") or "") in env_aliases
 
 
 def binding_to_response(
@@ -225,7 +231,7 @@ def binding_to_response(
         for key, spec in binding.items():
             if isinstance(spec, dict) and spec.get("source") == "literal":
                 result[str(key)] = str(spec.get("value") or "")
-            elif _is_env_ref_spec(spec):
+            elif _is_env_ref_spec(spec, env_aliases):
                 template = _env_ref_template(spec, env_aliases)
                 if template:
                     result[str(key)] = template
@@ -266,7 +272,7 @@ def binding_plain_keys(
         for key, spec in binding.items():
             if isinstance(spec, dict) and spec.get("source") == "literal":
                 result[str(key)] = str(spec.get("value") or "")
-            elif _is_env_ref_spec(spec):
+            elif _is_env_ref_spec(spec, env_aliases):
                 template = _env_ref_template(spec, env_aliases)
                 if template:
                     result[str(key)] = template

--- a/src/qwenpaw/drivers/adapters/mcp_card_builder.py
+++ b/src/qwenpaw/drivers/adapters/mcp_card_builder.py
@@ -12,10 +12,13 @@ from .mcp_binding import (
     binding_to_response,
     classify_mcp_binding,
     normalize_secret_key,
+    parse_env_template,
+    plan_env_ref_bindings,
     restore_masked_value,
     source_binding_from_split,
     split_mcp_binding,
 )
+from .env_ref import env_ref
 from ..constants import (
     CAPABILITY_KIND_TOOL,
     CREDENTIAL_ALIAS_OAUTH,
@@ -50,7 +53,12 @@ def build_mcp_credential_record(
     *,
     existing: CredentialRecord | None = None,
 ) -> CredentialRecord:
-    """Build the static MCP credential record from console request data."""
+    """Build the static MCP credential record from console request data.
+
+    Values that embed a single ``${VAR}`` reference are env-backed and
+    never stored as static secrets — they resolve from the process
+    environment at runtime (see ``plan_env_ref_bindings``).
+    """
     ref = mcp_credential_ref(client_key)
     incoming_env = dict(_read_field(client, "env", {}) or {})
     incoming_headers = dict(_read_field(client, "headers", {}) or {})
@@ -62,6 +70,9 @@ def build_mcp_credential_record(
             classify_mcp_binding(section="env", key=str(key), value=str(value))
             == "public"
         ):
+            continue
+        template = parse_env_template(str(value))
+        if template is not None and template.is_single:
             continue
         secret_key = str(key)
         secrets[secret_key] = restore_masked_value(
@@ -79,6 +90,9 @@ def build_mcp_credential_record(
             )
             == "public"
         ):
+            continue
+        template = parse_env_template(str(value))
+        if template is not None and template.is_single:
             continue
         secret_key = normalize_secret_key(str(header), used)
         used.add(secret_key)
@@ -115,40 +129,51 @@ def build_mcp_driver_card(
     if transport == "stdio":
         env = dict(data.get("env") or {})
         public_env, secret_env = split_mcp_binding("env", env)
+        env_plan = plan_env_ref_bindings(secret_env)
+        env_binding = source_binding_from_split(
+            public_env,
+            {str(key): str(key) for key in env_plan.plain_secrets},
+            STATIC_CREDENTIAL_ALIAS,
+        )
+        env_binding.update(env_plan.env_bindings)
         endpoint: dict[str, Any] = {
             "transport": "stdio",
             "command": str(data.get("command") or ""),
             "args": list(data.get("args") or []),
-            "env": source_binding_from_split(
-                public_env,
-                {str(key): str(key) for key in secret_env},
-                STATIC_CREDENTIAL_ALIAS,
-            ),
+            "env": env_binding,
         }
         cwd = str(data.get("cwd") or "")
         if cwd:
             endpoint["cwd"] = cwd
+        env_aliases = env_plan.env_aliases
     else:
         headers = dict(data.get("headers") or {})
         public_headers, secret_headers = split_mcp_binding("headers", headers)
+        header_plan = plan_env_ref_bindings(secret_headers)
         used: set[str] = set()
         secret_refs: dict[str, str] = {}
-        for header in secret_headers:
+        for header in header_plan.plain_secrets:
             secret_key = normalize_secret_key(str(header), used)
             used.add(secret_key)
             secret_refs[str(header)] = secret_key
+        header_binding = source_binding_from_split(
+            public_headers,
+            secret_refs,
+            STATIC_CREDENTIAL_ALIAS,
+        )
+        header_binding.update(header_plan.env_bindings)
         endpoint = {
             "transport": transport,
             "url": str(data.get("url") or ""),
-            "headers": source_binding_from_split(
-                public_headers,
-                secret_refs,
-                STATIC_CREDENTIAL_ALIAS,
-            ),
+            "headers": header_binding,
         }
         _preserve_oauth_authorization_binding(existing, endpoint)
+        env_aliases = header_plan.env_aliases
 
     credentials = _credential_refs_from_existing(existing)
+    for alias, ref in list(credentials.items()):
+        if ref.ref.startswith("env:"):
+            credentials.pop(alias, None)
     if secrets:
         credentials[STATIC_CREDENTIAL_ALIAS] = CredentialRef(
             kind=CREDENTIAL_KIND_STATIC,
@@ -156,6 +181,11 @@ def build_mcp_driver_card(
         )
     else:
         credentials.pop(STATIC_CREDENTIAL_ALIAS, None)
+    for alias, var in env_aliases.items():
+        credentials[alias] = CredentialRef(
+            kind=CREDENTIAL_KIND_STATIC,
+            ref=env_ref(var),
+        )
     # Generic DriverPolicy defaults to deny as the low-level safe fallback.
     # Console-created MCP clients default to ask so a newly added external
     # server requires human approval instead of failing silently before the
@@ -180,6 +210,21 @@ def build_mcp_driver_card(
     )
 
 
+def _env_aliases_from_credentials(
+    credentials: dict[str, CredentialRef],
+) -> dict[str, str]:
+    """Return alias -> var name for ``env:`` credential refs.
+
+    Preserves the original variable name (case-sensitive) recorded on the
+    card, instead of reverse-engineering it from the lowercased alias.
+    """
+    aliases: dict[str, str] = {}
+    for alias, ref in (credentials or {}).items():
+        if ref.ref.startswith("env:"):
+            aliases[str(alias)] = ref.ref[len("env:") :]
+    return aliases
+
+
 def build_mcp_client_info_payload(
     card: DriverCard,
     credential: CredentialRecord | None,
@@ -188,15 +233,18 @@ def build_mcp_client_info_payload(
     """Return the MCPClientInfo-compatible API response payload."""
     endpoint = card.endpoint
     transport = str(endpoint.get("transport") or "stdio")
+    env_aliases = _env_aliases_from_credentials(card.credentials)
     env = binding_to_response(
         endpoint.get("env") or {},
         credential,
         credential_alias=STATIC_CREDENTIAL_ALIAS,
+        env_aliases=env_aliases,
     )
     headers = binding_to_response(
         endpoint.get("headers") or {},
         credential,
         credential_alias=STATIC_CREDENTIAL_ALIAS,
+        env_aliases=env_aliases,
     )
     return {
         "key": card.name,
@@ -310,6 +358,7 @@ def _card_to_client_data(card: DriverCard | None) -> dict[str, Any]:
     if card is None:
         return {}
     endpoint = card.endpoint
+    env_aliases = _env_aliases_from_credentials(card.credentials)
     return {
         "name": card.config.get("display_name") or card.name,
         "description": card.config.get("description") or "",
@@ -319,12 +368,14 @@ def _card_to_client_data(card: DriverCard | None) -> dict[str, Any]:
         "headers": binding_plain_keys(
             endpoint.get("headers") or {},
             credential_alias=STATIC_CREDENTIAL_ALIAS,
+            env_aliases=env_aliases,
         ),
         "command": endpoint.get("command") or "",
         "args": list(endpoint.get("args") or []),
         "env": binding_plain_keys(
             endpoint.get("env") or {},
             credential_alias=STATIC_CREDENTIAL_ALIAS,
+            env_aliases=env_aliases,
         ),
         "cwd": endpoint.get("cwd") or "",
     }

--- a/src/qwenpaw/drivers/credentials/bindings.py
+++ b/src/qwenpaw/drivers/credentials/bindings.py
@@ -134,6 +134,7 @@ def lookup_credential_value(
     return None
 
 
+# pylint: disable-next=too-many-return-statements
 def _resolve_value_source(
     spec: Any,
     credentials: dict[str, ResolvedCredential],
@@ -154,11 +155,14 @@ def _resolve_value_source(
         if field
         else None
     )
-    if value is None:
+    if value is None or value == "":
         return None
 
     text = str(value)
     fmt = spec.get("format")
-    if isinstance(fmt, str) and fmt:
-        return fmt.replace("{value}", text)
-    return text
+    if not (isinstance(fmt, str) and fmt):
+        return text
+    resolved = fmt.replace("{value}", text)
+    if not resolved:
+        return None
+    return resolved

--- a/tests/integration/test_driver_mcp_http_flow.py
+++ b/tests/integration/test_driver_mcp_http_flow.py
@@ -71,3 +71,70 @@ async def test_driver_mcp_http_header_secret_flow(
         FakeHttpClient.instances[0].kwargs["headers"]
         == result.value["headers"]
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
+async def test_driver_mcp_anysearch_default_config_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test purpose:
+    - Verify the default MCP config ships an anysearch streamable_http
+      template that migrates to a buildable DriverCard.
+
+    Test flow:
+    1. Build MCPConfig() and grab the anysearch client entry.
+    2. Convert it to a DriverCard via the legacy migration helper.
+    3. Register the card and build the driver handler (HTTP faked).
+    4. Assert the exposed tool names match AnySearch's server.
+
+    API endpoints:
+    - none (driver layer, no app subprocess).
+    """
+    from qwenpaw.config.config import MCPConfig
+    from qwenpaw.drivers.adapters.mcp_legacy_config import (
+        legacy_mcp_client_to_driver,
+    )
+
+    patch_mcp_runtime_clients(monkeypatch)
+
+    cfg = MCPConfig()
+    assert "anysearch" in cfg.clients
+    client = cfg.clients["anysearch"]
+    assert client.enabled is False
+    assert client.transport == "streamable_http"
+    assert client.url == "https://api.anysearch.com/mcp"
+    assert client.headers == {
+        "Authorization": "Bearer ${ANYSEARCH_API_KEY}",
+    }
+
+    card, credential = legacy_mcp_client_to_driver("anysearch", client)
+    assert card.protocol == "mcp"
+    assert card.endpoint["transport"] == "streamable_http"
+    assert card.endpoint["url"] == "https://api.anysearch.com/mcp"
+    assert card.enabled is False
+    assert card.policy.rules[0].effect == "ask"
+
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    if credential is not None:
+        await store.put(credential)
+    card.enabled = True
+    dump_card(
+        card,
+        card_path(tmp_path / "drivers", "anysearch", protocol="mcp"),
+    )
+    manager = DriverManager(tmp_path / "drivers", store)
+    manager.register_handler_type("mcp", MCPDriverHandler)
+
+    await manager.build_drivers()
+    names = sorted(
+        item.name for item in await manager.list_capabilities(kind="tool")
+    )
+    assert names == [
+        "echo_http",
+        "inspect_headers",
+        "oauth_echo",
+    ]
+    assert "tavily_search" not in cfg.clients

--- a/tests/unit/agents/tools/test_websearch_providers.py
+++ b/tests/unit/agents/tools/test_websearch_providers.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Tests for the pluggable web search provider abstraction."""
+
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.agents.tools.websearch import (
+    AnySearchProvider,
+    SearchProvider,
+    TavilyProvider,
+    format_search_results,
+    get_search_provider,
+)
+
+
+def test_get_search_provider_defaults_to_tavily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("QWENPAW_WEBSEARCH_PROVIDER", raising=False)
+    assert isinstance(get_search_provider(), TavilyProvider)
+
+
+def test_get_search_provider_selects_anysearch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_WEBSEARCH_PROVIDER", "anysearch")
+    assert isinstance(get_search_provider(), AnySearchProvider)
+
+
+def test_get_search_provider_selects_tavily_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_WEBSEARCH_PROVIDER", "tavily")
+    assert isinstance(get_search_provider(), TavilyProvider)
+
+
+def test_get_search_provider_rejects_unknown_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_WEBSEARCH_PROVIDER", "bogus")
+    with pytest.raises(ValueError):
+        get_search_provider()
+
+
+def test_providers_are_search_provider_subclasses() -> None:
+    assert issubclass(AnySearchProvider, SearchProvider)
+    assert issubclass(TavilyProvider, SearchProvider)
+    assert AnySearchProvider.name == "anysearch"
+    assert TavilyProvider.name == "tavily"
+
+
+@pytest.mark.asyncio
+async def test_anysearch_provider_parses_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post(url, headers, payload):
+        assert url == "https://api.anysearch.com/v1/search"
+        assert "Authorization" not in headers
+        assert payload == {"query": "qwen", "max_results": 3}
+        return {
+            "code": 0,
+            "data": {
+                "results": [
+                    {
+                        "title": "T",
+                        "url": "https://example.com",
+                        "snippet": "S",
+                        "content": "C",
+                    },
+                ],
+            },
+        }
+
+    monkeypatch.setattr(
+        "qwenpaw.agents.tools.websearch._post",
+        fake_post,
+    )
+    provider = AnySearchProvider()
+    results = await provider.search("qwen", max_results=3)
+    assert results == [
+        {
+            "title": "T",
+            "url": "https://example.com",
+            "snippet": "S",
+            "content": "C",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_anysearch_provider_sends_key_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post(url, headers, payload):
+        del url, payload
+        assert headers["Authorization"] == "Bearer sk-test"
+        return {"code": 0, "data": {"results": []}}
+
+    monkeypatch.setattr(
+        "qwenpaw.agents.tools.websearch._post",
+        fake_post,
+    )
+    monkeypatch.setenv("ANYSEARCH_API_KEY", "sk-test")
+    provider = AnySearchProvider()
+    assert await provider.search("qwen") == []
+
+
+@pytest.mark.asyncio
+async def test_tavily_provider_uses_keyless_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post(url, headers, payload):
+        del payload
+        assert url == "https://api.tavily.com/search"
+        assert headers["X-Tavily-Access-Mode"] == "keyless"
+        return {"results": [{"title": "T", "url": "u", "content": "c"}]}
+
+    monkeypatch.setattr(
+        "qwenpaw.agents.tools.websearch._post",
+        fake_post,
+    )
+    provider = TavilyProvider()
+    results = await provider.search("qwen")
+    assert results == [{"title": "T", "url": "u", "content": "c"}]
+
+
+def test_format_search_results() -> None:
+    text = format_search_results(
+        [
+            {"title": "A", "url": "https://a.com", "content": "body"},
+            {"title": "B", "url": "https://b.com"},
+        ],
+    )
+    assert "[1] A" in text
+    assert "URL: https://a.com" in text
+    assert "[2] B" in text
+    assert format_search_results([]) == "No results found."

--- a/tests/unit/config/test_mcp_config_defaults.py
+++ b/tests/unit/config/test_mcp_config_defaults.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for default MCP client configuration (anysearch)."""
+
+from __future__ import annotations
+
+from qwenpaw.config.config import MCPConfig
+
+
+def test_default_mcp_config_contains_anysearch() -> None:
+    """Test purpose:
+    - Verify the default MCP config ships an anysearch client template.
+
+    Test flow:
+    1. Build MCPConfig() with default factory.
+    2. Assert the anysearch client entry exists with the agreed shape.
+
+    API endpoints:
+    - none (pure config model).
+    """
+    cfg = MCPConfig()
+    assert "anysearch" in cfg.clients
+    client = cfg.clients["anysearch"]
+
+    assert client.enabled is False
+    assert client.transport == "streamable_http"
+    assert client.url == "https://api.anysearch.com/mcp"
+    assert client.headers == {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"}
+    assert client.name == "anysearch_mcp"
+
+
+def test_default_mcp_config_has_no_tavily() -> None:
+    """Test purpose:
+    - Verify the tavily template is gone (replaced by anysearch).
+
+    Test flow:
+    1. Build MCPConfig() with default factory.
+    2. Assert no tavily_search entry remains.
+
+    API endpoints:
+    - none (pure config model).
+    """
+    cfg = MCPConfig()
+    assert "tavily_search" not in cfg.clients
+
+
+def test_default_mcp_config_migration_version_is_zero() -> None:
+    """Test purpose:
+    - Verify the migration watermark stays at 0 for a fresh config so the
+      v0->v1 migration picks up the default client on first start.
+
+    Test flow:
+    1. Build MCPConfig() with default factory.
+    2. Assert migration_version is 0.
+
+    API endpoints:
+    - none (pure config model).
+    """
+    cfg = MCPConfig()
+    assert cfg.migration_version == 0

--- a/tests/unit/drivers/adapters/test_credentials_bindings.py
+++ b/tests/unit/drivers/adapters/test_credentials_bindings.py
@@ -94,6 +94,7 @@ def test_binding_to_response_shows_env_ref_template() -> None:
         _ENV_REF_BINDING,
         None,
         credential_alias="static",
+        env_aliases={"env_anysearch_api_key": "ANYSEARCH_API_KEY"},
     ) == {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"}
 
 
@@ -104,7 +105,30 @@ def test_binding_plain_keys_preserves_env_ref_template() -> None:
     assert binding_plain_keys(
         _ENV_REF_BINDING,
         credential_alias="static",
+        env_aliases={"env_anysearch_api_key": "ANYSEARCH_API_KEY"},
     ) == {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"}
+
+
+def test_static_alias_starting_with_env_is_not_misclassified() -> None:
+    """A static credential alias like ``env_custom`` must not be treated
+    as env-backed (regression from rayrayraykk: identification must come
+    from the env: credential refs, not the alias naming convention)."""
+    static_binding = {
+        "X-K": {
+            "source": "credential",
+            "credential": "env_custom",
+            "field": "value",
+        },
+    }
+    assert (
+        binding_to_response(
+            static_binding,
+            None,
+            credential_alias="static",
+            env_aliases={"env_anysearch_api_key": "ANYSEARCH_API_KEY"},
+        )
+        == {}
+    )
 
 
 def test_resolve_binding_keeps_falsey_nonempty_values() -> None:

--- a/tests/unit/drivers/adapters/test_credentials_bindings.py
+++ b/tests/unit/drivers/adapters/test_credentials_bindings.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Tests for Driver credential binding resolution (bindings.py)."""
+
+from __future__ import annotations
+
+from qwenpaw.drivers.adapters.mcp_binding import (
+    binding_plain_keys,
+    binding_to_response,
+)
+from qwenpaw.drivers.credentials.bindings import resolve_binding
+from qwenpaw.drivers.credentials.types import ResolvedCredential
+
+
+def _env_credential(value: str) -> ResolvedCredential:
+    return ResolvedCredential(kind="env", secrets={"value": value})
+
+
+def test_resolve_binding_skips_empty_env_value() -> None:
+    """A ${VAR} credential whose environment variable is unset must not
+    produce a header (the empty value would otherwise yield an illegal
+    header like 'Authorization: Bearer ' and break the connection).
+    """
+    binding = {
+        "Authorization": {
+            "source": "credential",
+            "credential": "env_anysearch_api_key",
+            "field": "value",
+            "format": "Bearer {value}",
+        },
+    }
+    resolved = resolve_binding(
+        binding,
+        {"env_anysearch_api_key": _env_credential("")},
+    )
+    assert resolved == {}
+
+
+def test_resolve_binding_injects_populated_env_value() -> None:
+    """A populated environment variable is formatted and injected."""
+    binding = {
+        "Authorization": {
+            "source": "credential",
+            "credential": "env_anysearch_api_key",
+            "field": "value",
+            "format": "Bearer {value}",
+        },
+    }
+    resolved = resolve_binding(
+        binding,
+        {"env_anysearch_api_key": _env_credential("secret-token")},
+    )
+    assert resolved == {"Authorization": "Bearer secret-token"}
+
+
+def test_resolve_binding_skips_empty_format_result() -> None:
+    """A format template that resolves to an empty string is dropped."""
+    binding = {
+        "X-Token": {
+            "source": "credential",
+            "credential": "env_empty",
+            "field": "value",
+            "format": "{value}",
+        },
+    }
+    resolved = resolve_binding(
+        binding,
+        {"env_empty": _env_credential("")},
+    )
+    assert resolved == {}
+
+
+def test_resolve_binding_keeps_public_literal() -> None:
+    """Public literal headers pass through unchanged."""
+    binding = {"X-Client-Name": {"source": "literal", "value": "qwenpaw"}}
+    resolved = resolve_binding(binding, {})
+    assert resolved == {"X-Client-Name": "qwenpaw"}
+
+
+_ENV_REF_BINDING = {
+    "Authorization": {
+        "source": "credential",
+        "credential": "env_anysearch_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    },
+}
+
+
+def test_binding_to_response_shows_env_ref_template() -> None:
+    """B2: env-backed headers must be visible in the Console response
+    (previously silently dropped because the alias is not 'static').
+    """
+    assert binding_to_response(
+        _ENV_REF_BINDING,
+        None,
+        credential_alias="static",
+    ) == {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"}
+
+
+def test_binding_plain_keys_preserves_env_ref_template() -> None:
+    """B3: UI edit round-trip must preserve env-backed headers
+    (previously dropped, so saving the client silently deleted them).
+    """
+    assert binding_plain_keys(
+        _ENV_REF_BINDING,
+        credential_alias="static",
+    ) == {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"}
+
+
+def test_resolve_binding_keeps_falsey_nonempty_values() -> None:
+    """Zero and False are legitimate credential values and must survive
+    the empty-value guard (regression: `if not value` dropped them)."""
+    binding = {
+        "X-Num": {
+            "source": "credential",
+            "credential": "env_num",
+            "field": "value",
+        },
+        "X-Bool": {
+            "source": "credential",
+            "credential": "env_bool",
+            "field": "value",
+        },
+    }
+    resolved = resolve_binding(
+        binding,
+        {
+            "env_num": ResolvedCredential(kind="env", secrets={"value": 0}),
+            "env_bool": ResolvedCredential(
+                kind="env",
+                secrets={"value": False},
+            ),
+        },
+    )
+    assert resolved == {"X-Num": "0", "X-Bool": "False"}
+
+
+def test_resolve_binding_skips_none_and_empty() -> None:
+    """None and empty-string credential values are omitted entirely."""
+    binding = {
+        "X-A": {
+            "source": "credential",
+            "credential": "env_a",
+            "field": "value",
+        },
+        "X-B": {
+            "source": "credential",
+            "credential": "env_b",
+            "field": "value",
+        },
+    }
+    resolved = resolve_binding(
+        binding,
+        {
+            "env_a": ResolvedCredential(kind="env", secrets={"value": None}),
+            "env_b": ResolvedCredential(kind="env", secrets={"value": ""}),
+        },
+    )
+    assert resolved == {}

--- a/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 """Migration tests: legacy ${VAR} header/env values -> env: credential refs."""
+
 from types import SimpleNamespace
 
 from qwenpaw.drivers.adapters.mcp_binding import (
     EnvRefPlan,
     plan_env_ref_bindings,
 )
+from qwenpaw.drivers.adapters.mcp_card_builder import (
+    build_mcp_client_info_payload,
+    build_mcp_credential_record,
+    build_mcp_driver_card,
+    mcp_credential_ref,
+)
 from qwenpaw.drivers.adapters.mcp_legacy_config import (
     legacy_mcp_client_to_driver,
 )
 from qwenpaw.drivers.contracts import CredentialRef
-
+from qwenpaw.drivers.credentials.bindings import resolve_binding
+from qwenpaw.drivers.credentials.types import ResolvedCredential
 
 # --- plan_env_ref_bindings unit behavior ---
 
@@ -119,3 +127,298 @@ def test_migration_stdio_env_ref() -> None:
         "static",
         "env:TOKEN",
     )
+
+
+# --- Console save round-trip regression (review #6817) ---
+
+
+def _console_save_roundtrip(
+    client_key: str,
+    client: dict,
+) -> tuple[dict, dict]:
+    """Simulate: migrate -> API payload -> unchanged Console save -> resolve.
+
+    Returns ``(saved_headers, resolved_headers)`` for assertions.
+    """
+    card, credential = legacy_mcp_client_to_driver(
+        client_key,
+        SimpleNamespace(
+            transport=client.get("transport", "streamable_http"),
+            url=client.get("url", ""),
+            command=client.get("command", ""),
+            args=client.get("args", []),
+            headers=client.get("headers", {}),
+            env=client.get("env", {}),
+        ),
+    )
+    payload = build_mcp_client_info_payload(card, credential)
+
+    static_record = build_mcp_credential_record(client_key, payload)
+    saved = build_mcp_driver_card(
+        client_key,
+        payload,
+        mcp_credential_ref(client_key),
+        credential_record=static_record,
+        existing=card,
+    )
+
+    resolved = resolve_binding(
+        saved.endpoint["headers"],
+        {
+            "static": ResolvedCredential(
+                kind="static",
+                secrets=dict(static_record.secrets),
+            ),
+            **{
+                alias: ResolvedCredential(
+                    kind="env",
+                    secrets={"value": "live-token"},
+                )
+                for alias, ref in saved.credentials.items()
+                if ref.ref.startswith("env:")
+            },
+        },
+    )
+    return saved.endpoint["headers"], resolved
+
+
+def test_console_save_preserves_header_env_ref_binding() -> None:
+    """An unchanged Console save must keep the env binding, not degrade the
+    ${VAR} template into a static literal secret."""
+    saved_headers, resolved = _console_save_roundtrip(
+        "anysearch",
+        {
+            "transport": "streamable_http",
+            "url": "https://api.anysearch.com/mcp",
+            "headers": {"Authorization": "Bearer ${ANYSEARCH_API_KEY}"},
+        },
+    )
+    assert saved_headers["Authorization"] == {
+        "source": "credential",
+        "credential": "env_anysearch_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    }
+    assert resolved == {"Authorization": "Bearer live-token"}
+
+
+def test_console_save_preserves_stdio_env_ref_binding() -> None:
+    """The same round-trip must hold for stdio env-backed values."""
+    card, credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="stdio",
+            command="run-server",
+            args=[],
+            env={"API_TOKEN": "${TOKEN}"},
+        ),
+    )
+    payload = build_mcp_client_info_payload(card, credential)
+    static_record = build_mcp_credential_record("svc", payload)
+    saved = build_mcp_driver_card(
+        "svc",
+        payload,
+        mcp_credential_ref("svc"),
+        credential_record=static_record,
+        existing=card,
+    )
+    assert saved.endpoint["env"]["API_TOKEN"] == {
+        "source": "credential",
+        "credential": "env_token",
+        "field": "value",
+    }
+    resolved = resolve_binding(
+        saved.endpoint["env"],
+        {
+            "env_token": ResolvedCredential(
+                kind="env",
+                secrets={"value": "live-token"},
+            ),
+        },
+    )
+    assert resolved == {"API_TOKEN": "live-token"}
+
+
+def test_console_save_keeps_static_secret_untouched() -> None:
+    """A real static secret still lands in the static credential record.
+
+    Mirrors the Console flow: the GET payload shows a masked value, and
+    the user's unchanged save submits it; the save path restores the
+    original when an existing secret matches, or stores the submitted
+    literal for a fresh value.
+    """
+    card, credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://x/api/",
+            headers={"X-Api-Key": "literal-secret"},
+        ),
+    )
+    payload = build_mcp_client_info_payload(card, credential)
+    # Unchanged save submits the same payload; the masked static value is
+    # restored against the existing credential on update.
+    static_record = build_mcp_credential_record(
+        "svc",
+        payload,
+        existing=credential,
+    )
+    saved = build_mcp_driver_card(
+        "svc",
+        payload,
+        mcp_credential_ref("svc"),
+        credential_record=static_record,
+        existing=card,
+    )
+    assert saved.endpoint["headers"]["X-Api-Key"] == {
+        "source": "credential",
+        "credential": "static",
+        "field": "x_api_key",
+    }
+    resolved = resolve_binding(
+        saved.endpoint["headers"],
+        {
+            "static": ResolvedCredential(
+                kind="static",
+                secrets=dict(static_record.secrets),
+            ),
+        },
+    )
+    assert resolved == {"X-Api-Key": "literal-secret"}
+
+
+def test_console_save_preserves_env_var_case() -> None:
+    """Response serialization must preserve the original env var case from
+    the card's env: ref instead of uppercasing the lowercased alias."""
+    card, credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://x/api/",
+            headers={"Authorization": "Bearer ${ApiKey}"},
+        ),
+    )
+    payload = build_mcp_client_info_payload(card, credential)
+    assert payload["headers"] == {"Authorization": "Bearer ${ApiKey}"}
+
+
+def test_console_save_drops_stale_env_ref_when_switched_to_static() -> None:
+    """Switching a header from ${VAR} template to a static literal must
+    remove the stale env: credential ref so runtime resolution no longer
+    sees it."""
+    card, _credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://x/api/",
+            headers={"Authorization": "Bearer ${API_KEY}"},
+        ),
+    )
+    payload = SimpleNamespace(
+        transport="streamable_http",
+        url="https://x/api/",
+        headers={"Authorization": "Bearer static-key"},
+    )
+    static_record = build_mcp_credential_record("svc", payload)
+    saved = build_mcp_driver_card(
+        "svc",
+        payload,
+        mcp_credential_ref("svc"),
+        credential_record=static_record,
+        existing=card,
+    )
+    assert "env_api_key" not in saved.credentials
+    assert saved.credentials["static"].ref == mcp_credential_ref("svc")
+    resolved = resolve_binding(
+        saved.endpoint["headers"],
+        {
+            "static": ResolvedCredential(
+                kind="static",
+                secrets=dict(static_record.secrets),
+            ),
+        },
+    )
+    assert resolved == {"Authorization": "Bearer static-key"}
+
+
+def test_console_save_treats_multi_env_ref_as_static() -> None:
+    """A header embedding multiple ${VAR} refs (e.g. ${USER}:${PASS}) is not
+    a supported single-env binding; it must be stored as a static literal
+    instead of being silently dropped."""
+    payload = SimpleNamespace(
+        transport="streamable_http",
+        url="https://x/api/",
+        headers={"Authorization": "${USER}:${PASS}"},
+    )
+    static_record = build_mcp_credential_record("svc", payload)
+    assert static_record.secrets.get("authorization") == "${USER}:${PASS}"
+
+    saved = build_mcp_driver_card(
+        "svc",
+        payload,
+        mcp_credential_ref("svc"),
+        credential_record=static_record,
+    )
+    assert saved.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "static",
+        "field": "authorization",
+    }
+    resolved = resolve_binding(
+        saved.endpoint["headers"],
+        {
+            "static": ResolvedCredential(
+                kind="static",
+                secrets=dict(static_record.secrets),
+            ),
+        },
+    )
+    assert resolved == {"Authorization": "${USER}:${PASS}"}
+
+
+def test_env_aliases_do_not_collide_on_case() -> None:
+    """Two env vars differing only in case (${ApiKey} vs ${APIKEY}) must
+    get distinct, collision-free credential aliases and resolve from their
+    own environment variables on case-sensitive systems."""
+    plan = plan_env_ref_bindings(
+        {
+            "X-First": "${ApiKey}",
+            "X-Second": "${APIKEY}",
+        },
+    )
+    assert len(plan.env_aliases) == 2
+    assert plan.env_aliases["env_apikey"] == "ApiKey"
+    assert plan.env_aliases["env_apikey_2"] == "APIKEY"
+
+    card, _credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://x/api/",
+            headers={
+                "X-First": "${ApiKey}",
+                "X-Second": "${APIKEY}",
+            },
+        ),
+    )
+    refs = {v.ref for v in card.credentials.values()}
+    assert "env:ApiKey" in refs
+    assert "env:APIKEY" in refs
+
+    resolved = resolve_binding(
+        card.endpoint["headers"],
+        {
+            "env_apikey": ResolvedCredential(
+                kind="env",
+                secrets={"value": "first-token"},
+            ),
+            "env_apikey_2": ResolvedCredential(
+                kind="env",
+                secrets={"value": "second-token"},
+            ),
+        },
+    )
+    assert resolved == {
+        "X-First": "first-token",
+        "X-Second": "second-token",
+    }


### PR DESCRIPTION
## Description

Integrate **AnySearch** (https://anysearch.com) into QwenPaw as the built-in web search capability, replacing Tavily:

1. **Fix MCP env-ref header binding defects** (`fix(mcp): handle empty env-ref header bindings safely`)
   - Fix: when `Authorization: Bearer ${VAR}` is configured but the environment variable is empty, the empty value is formatted into an illegal HTTP header (`Bearer ` trailing space) which h11 rejects, breaking the MCP connection at startup
   - Fix: Console no longer shows `${VAR}`-style env-backed headers (displayed blank)
   - Fix: editing and saving a client no longer silently deletes these env-backed headers
2. **Replace the built-in MCP client** (`feat(mcp): replace tavily with AnySearch as the built-in MCP client`)
   - Remove the `tavily_search` MCP template and ship AnySearch MCP instead (`https://api.anysearch.com/mcp`, streamable HTTP)
   - Disabled by default (`enabled=False`), follows the default ask policy — no blanket allow
3. **Abstract web_search behind a pluggable SearchProvider** (`feat(tools): abstract web_search behind a pluggable SearchProvider`)
   - Built-in `web_search` now uses AnySearch REST API by default (`https://api.anysearch.com/v1/search`, anonymous)
   - Setting `ANYSEARCH_API_KEY` automatically sends `Authorization: Bearer`
   - TavilyProvider kept as fallback (switch via `QWENPAW_WEBSEARCH_PROVIDER=tavily`)

**Related Issue:** None (partner integration)

**Security Considerations:** MCP client is disabled by default (`enabled=False`), follows the default ask policy, no blanket allow; header secrets are referenced via `${VAR}` env vars, never persisted in plaintext.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes（pre-commit not installed locally; CI will run it. black/flake8/pylint checked locally on changed files and pass）
- [x] I ran tests locally (`pytest` or as relevant) and they pass（19 related tests pass）
- [ ] Documentation updated (if needed)（README changes prepared separately, will be submitted in a follow-up PR）
- [x] Ready for review

## Testing

```bash
pytest tests/unit/config/test_mcp_config_defaults.py \
       tests/unit/drivers/adapters/test_credentials_bindings.py \
       tests/unit/agents/tools/test_websearch_providers.py \
       tests/integration/test_driver_mcp_http_flow.py \
       tests/integration/test_driver_mcp_env_ref_flow.py --no-cov
```

## Evidence

```bash
# 19 related unit/integration tests pass
$ pytest tests/unit/config/test_mcp_config_defaults.py tests/unit/drivers/adapters/test_credentials_bindings.py tests/unit/agents/tools/test_websearch_providers.py tests/integration/test_driver_mcp_http_flow.py tests/integration/test_driver_mcp_env_ref_flow.py --no-cov
19 passed in 0.51s
```

```text
# End-to-end against the real AnySearch endpoint (anonymous web_search call)
web_search 匿名调用(默认 AnySearchProvider): success
返回样例: [1] GitHub - agentscope-ai/QwenPaw: Your Personal AI Assistant; easy ... URL
```

```text
# MCP migration verified against the real legacy migration path
默认 clients: ['anysearch']   # tavily removed
anysearch: enabled=False, transport=streamable_http, url=https://api.anysearch.com/mcp
迁移后: enabled=False, policy_rules[0].effect=ask   # default ask policy
```

```text
# Code style on changed files (black --check)
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```

## Additional Notes

- The PR surfaced a latent generic defect in QwenPaw (commit 1): any HTTP MCP client using a `${VAR}` header with an unset environment variable would fail to connect. It was never triggered before because no built-in client combined "optional auth" with "env-ref header" (Tavily uses stdio and never goes through the header binding path). AnySearch's "anonymous by default, optional key" configuration is the first to expose it.
- README changes (AnySearch integration docs, badge, news entry) are prepared but intentionally excluded from this PR; they will be submitted separately.