### PR TITLE
fix(summary): honor disable_thinking and interruption (#6811)

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from agentscope.message import Msg, SystemMsg, TextBlock, UserMsg
+from agentscope.model import FinishedReason
 
 from ....constant import (
     QWENPAW_MESSAGE_TAG_KEY,
@@ -1004,16 +1005,29 @@ class ScrollContextManager:
             disable_thinking=True,
         )
         if not inspect.isasyncgen(response):
+            self._raise_if_summary_interrupted(response)
             return self._response_text(response)
         deltas: list[str] = []
         final = ""
         async for chunk in response:
+            self._raise_if_summary_interrupted(chunk)
             text = self._response_text(chunk)
             if getattr(chunk, "is_last", False):
                 final = text
             elif text:
                 deltas.append(text)
         return final or "".join(deltas).strip()
+
+    @staticmethod
+    def _raise_if_summary_interrupted(response: Any) -> None:
+        """Preserve cancellation converted into an AgentScope response."""
+        finished_reason = (
+            response.get("finished_reason")
+            if isinstance(response, dict)
+            else getattr(response, "finished_reason", None)
+        )
+        if finished_reason == FinishedReason.INTERRUPTED:
+            raise asyncio.CancelledError()
 
     @staticmethod
     def _summary_messages(prompt: str, language: str) -> list[Msg]:

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -15,6 +15,16 @@ from .openai_provider import OpenAIProvider
 logger = logging.getLogger(__name__)
 
 
+def _supports_none_reasoning_effort(model_name: str) -> bool:
+    """Whether an official GPT model accepts ``reasoning.effort=none``."""
+    canonical_name = model_name.rsplit("/", 1)[-1].lower()
+    prefix = "gpt-5."
+    if not canonical_name.startswith(prefix):
+        return False
+    minor_version = canonical_name[len(prefix) :].split("-", 1)[0]
+    return minor_version.isdigit() and int(minor_version) >= 2
+
+
 def _extract_response_text(response: Any) -> str:
     """Extract aggregated output text from a Responses API
     response object.
@@ -96,7 +106,10 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
         ):
             merged["max_output_tokens"] = inherited_max_tokens
         if disable_thinking:
-            merged.pop("reasoning", None)
+            if _supports_none_reasoning_effort(model_name):
+                merged["reasoning"] = {"effort": "none"}
+            else:
+                merged.pop("reasoning", None)
         return await super()._call_api(
             model_name,
             messages,

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -14,15 +14,20 @@ from .openai_provider import OpenAIProvider
 
 logger = logging.getLogger(__name__)
 
+_NONE_REASONING_EFFORT_MODELS = frozenset(
+    {
+        "gpt-5.5",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+    },
+)
+
 
 def _supports_none_reasoning_effort(model_name: str) -> bool:
-    """Whether an official GPT model accepts ``reasoning.effort=none``."""
+    """Whether a known model accepts ``reasoning.effort=none``."""
     canonical_name = model_name.rsplit("/", 1)[-1].lower()
-    prefix = "gpt-5."
-    if not canonical_name.startswith(prefix):
-        return False
-    minor_version = canonical_name[len(prefix) :].split("-", 1)[0]
-    return minor_version.isdigit() and int(minor_version) >= 2
+    return canonical_name in _NONE_REASONING_EFFORT_MODELS
 
 
 def _extract_response_text(response: Any) -> str:

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 _NONE_REASONING_EFFORT_MODELS = frozenset(
     {
         "gpt-5.5",
+        "gpt-5.5-2026-04-23",
+        "gpt-5.6",
         "gpt-5.6-luna",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -25,7 +27,7 @@ _NONE_REASONING_EFFORT_MODELS = frozenset(
 
 
 def _supports_none_reasoning_effort(model_name: str) -> bool:
-    """Whether a known model accepts ``reasoning.effort=none``."""
+    """Whether a documented model accepts ``reasoning.effort=none``."""
     canonical_name = model_name.rsplit("/", 1)[-1].lower()
     return canonical_name in _NONE_REASONING_EFFORT_MODELS
 
@@ -111,10 +113,9 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
         ):
             merged["max_output_tokens"] = inherited_max_tokens
         if disable_thinking:
+            merged.pop("reasoning", None)
             if _supports_none_reasoning_effort(model_name):
                 merged["reasoning"] = {"effort": "none"}
-            else:
-                merged.pop("reasoning", None)
         return await super()._call_api(
             model_name,
             messages,

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -81,8 +81,6 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
         tool_choice: Any | None = None,
         **generate_kwargs: Any,
     ) -> Any:
-        # Pop the neutral ``disable_thinking`` flag
-        generate_kwargs.pop("disable_thinking", None)
         max_tokens = generate_kwargs.pop("max_tokens", None)
         if (
             max_tokens is not None
@@ -90,6 +88,15 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
         ):
             generate_kwargs["max_output_tokens"] = max_tokens
         merged = {**self._extra_generate_kwargs, **generate_kwargs}
+        disable_thinking = merged.pop("disable_thinking", False)
+        inherited_max_tokens = merged.pop("max_tokens", None)
+        if (
+            inherited_max_tokens is not None
+            and "max_output_tokens" not in merged
+        ):
+            merged["max_output_tokens"] = inherited_max_tokens
+        if disable_thinking:
+            merged.pop("reasoning", None)
         return await super()._call_api(
             model_name,
             messages,

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -21,7 +21,7 @@ from agentscope.message import (
     ToolCallBlock,
     ToolResultBlock,
 )
-from agentscope.model import ChatResponse
+from agentscope.model import ChatModelBase, ChatResponse, FinishedReason
 
 from qwenpaw.agents.context.base import ContextManager
 from qwenpaw.agents.context.scroll import manager as scroll_manager_module
@@ -149,6 +149,49 @@ class HangingSummaryModel(FakeModel):
         del kwargs
         self.summary_calls += 1
         await asyncio.Event().wait()
+
+
+class CancelConvertingSummaryModel(ChatModelBase):
+    """AgentScope model that converts stream cancellation into a response."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            credential=SimpleNamespace(),
+            model="test-model",
+            parameters=self.Parameters(),
+            max_retries=0,
+        )
+
+    async def _call_api(
+        self,
+        model_name,
+        messages,
+        tools=None,
+        tool_choice=None,
+        **kwargs,
+    ):
+        del model_name, messages, tools, tool_choice, kwargs
+
+        async def hanging_stream():
+            await asyncio.Event().wait()
+            yield ChatResponse(
+                content=[TextBlock(type="text", text="unreachable")],
+                is_last=False,
+            )
+
+        return hanging_stream()
+
+
+class InterruptedSummaryModel(FakeModel):
+    """Chat model returning AgentScope's non-stream cancellation marker."""
+
+    async def __call__(self, **kwargs):
+        del kwargs
+        return ChatResponse(
+            content=[],
+            is_last=True,
+            finished_reason=FinishedReason.INTERRUPTED,
+        )
 
 
 class FailingSummaryModel(FakeModel):
@@ -1088,6 +1131,33 @@ async def test_summary_timeout_covers_prompt_fitting(
 
     assert agent.model.summary_calls == []
     assert mgr._summary_update_failed is True
+
+
+async def test_summary_timeout_survives_agentscope_stream_conversion():
+    mgr = object.__new__(ScrollContextManager)
+    agent = SimpleNamespace(model=CancelConvertingSummaryModel())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            mgr._generate_plain_summary(
+                agent,
+                "summarize",
+                max_tokens=256,
+            ),
+            timeout=0.05,
+        )
+
+
+async def test_non_stream_interrupted_summary_propagates_cancellation():
+    mgr = object.__new__(ScrollContextManager)
+    agent = SimpleNamespace(model=InterruptedSummaryModel(1000))
+
+    with pytest.raises(asyncio.CancelledError):
+        await mgr._generate_plain_summary(
+            agent,
+            "summarize",
+            max_tokens=256,
+        )
 
 
 def test_summary_input_includes_timezone_safe_message_times(

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -6,6 +6,7 @@ import time
 from types import SimpleNamespace
 
 import httpx
+import pytest
 from agentscope.model import OpenAIResponseModel
 from openai import BadRequestError
 
@@ -359,8 +360,21 @@ async def test_video_probe_reasoning_fallback(
 # ------ existing test -----------------------------------
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gpt-5.2-pro",
+        "gpt-5.3-codex",
+        "gpt-5.4-pro",
+        "gpt-5.5-pro",
+        "gpt-5.6",
+        "gpt-5.7",
+        "custom-reasoner",
+    ],
+)
 async def test_summary_call_removes_reasoning_when_none_is_unsupported(
     monkeypatch,
+    model_name: str,
 ) -> None:
     captured: dict = {}
 
@@ -385,10 +399,10 @@ async def test_summary_call_removes_reasoning_when_none_is_unsupported(
             "max_output_tokens": 100_000,
         },
     )
-    model = provider.get_chat_model_instance("gpt-5")
+    model = provider.get_chat_model_instance(model_name)
 
     result = await model._call_api(
-        "gpt-5",
+        model_name,
         [],
         max_tokens=256,
         disable_thinking=True,
@@ -400,8 +414,18 @@ async def test_summary_call_removes_reasoning_when_none_is_unsupported(
     assert "reasoning" not in captured
 
 
-async def test_summary_call_explicitly_disables_gpt_5_6_reasoning(
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
+    ],
+)
+async def test_summary_call_explicitly_disables_known_reasoning(
     monkeypatch,
+    model_name: str,
 ) -> None:
     captured: dict = {}
 
@@ -423,10 +447,10 @@ async def test_summary_call_explicitly_disables_gpt_5_6_reasoning(
         chat_model="OpenAIResponseModel",
         generate_kwargs={"reasoning": {"effort": "xhigh"}},
     )
-    model = provider.get_chat_model_instance("gpt-5.6")
+    model = provider.get_chat_model_instance(model_name)
 
     result = await model._call_api(
-        "gpt-5.6",
+        model_name,
         [],
         disable_thinking=True,
     )

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -367,7 +367,8 @@ async def test_video_probe_reasoning_fallback(
         "gpt-5.3-codex",
         "gpt-5.4-pro",
         "gpt-5.5-pro",
-        "gpt-5.6",
+        "gpt-5.5-pro-2026-04-23",
+        "gpt-5.6-codex-2026-07-16",
         "gpt-5.7",
         "custom-reasoner",
     ],
@@ -418,6 +419,8 @@ async def test_summary_call_removes_reasoning_when_none_is_unsupported(
     "model_name",
     [
         "gpt-5.5",
+        "gpt-5.5-2026-04-23",
+        "gpt-5.6",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "openai/gpt-5.6-luna",

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -359,7 +359,7 @@ async def test_video_probe_reasoning_fallback(
 # ------ existing test -----------------------------------
 
 
-async def test_summary_limit_is_adapted_for_responses_api(
+async def test_summary_call_disables_inherited_reasoning(
     monkeypatch,
 ) -> None:
     captured: dict = {}
@@ -374,7 +374,17 @@ async def test_summary_limit_is_adapted_for_responses_api(
         "_call_api",
         fake_call_api,
     )
-    provider = _make_provider()
+    provider = OpenAIResponseProvider(
+        id="openai-response",
+        name="OpenAI Responses",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        chat_model="OpenAIResponseModel",
+        generate_kwargs={
+            "reasoning": {"effort": "xhigh"},
+            "max_output_tokens": 100_000,
+        },
+    )
     model = provider.get_chat_model_instance("gpt-5")
 
     result = await model._call_api(
@@ -387,3 +397,35 @@ async def test_summary_limit_is_adapted_for_responses_api(
     assert result == "ok"
     assert captured["max_output_tokens"] == 256
     assert "max_tokens" not in captured
+    assert "reasoning" not in captured
+
+
+async def test_reasoning_is_preserved_when_thinking_is_enabled(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_call_api(self, *args, **kwargs):
+        del self, args
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(
+        OpenAIResponseModel,
+        "_call_api",
+        fake_call_api,
+    )
+    provider = OpenAIResponseProvider(
+        id="openai-response",
+        name="OpenAI Responses",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        chat_model="OpenAIResponseModel",
+        generate_kwargs={"reasoning": {"effort": "xhigh"}},
+    )
+    model = provider.get_chat_model_instance("gpt-5")
+
+    result = await model._call_api("gpt-5", [])
+
+    assert result == "ok"
+    assert captured["reasoning"] == {"effort": "xhigh"}

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -359,7 +359,7 @@ async def test_video_probe_reasoning_fallback(
 # ------ existing test -----------------------------------
 
 
-async def test_summary_call_disables_inherited_reasoning(
+async def test_summary_call_removes_reasoning_when_none_is_unsupported(
     monkeypatch,
 ) -> None:
     captured: dict = {}
@@ -398,6 +398,41 @@ async def test_summary_call_disables_inherited_reasoning(
     assert captured["max_output_tokens"] == 256
     assert "max_tokens" not in captured
     assert "reasoning" not in captured
+
+
+async def test_summary_call_explicitly_disables_gpt_5_6_reasoning(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_call_api(self, *args, **kwargs):
+        del self, args
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(
+        OpenAIResponseModel,
+        "_call_api",
+        fake_call_api,
+    )
+    provider = OpenAIResponseProvider(
+        id="openai-response",
+        name="OpenAI Responses",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        chat_model="OpenAIResponseModel",
+        generate_kwargs={"reasoning": {"effort": "xhigh"}},
+    )
+    model = provider.get_chat_model_instance("gpt-5.6")
+
+    result = await model._call_api(
+        "gpt-5.6",
+        [],
+        disable_thinking=True,
+    )
+
+    assert result == "ok"
+    assert captured["reasoning"] == {"effort": "none"}
 
 
 async def test_reasoning_is_preserved_when_thinking_is_enabled(


### PR DESCRIPTION
## Description

Continuation summaries sent through the OpenAI Responses provider could still inherit provider-level `reasoning` settings despite passing `disable_thinking=True`. Separately, AgentScope converts a cancelled model stream into a final `ChatResponse` with `FinishedReason.INTERRUPTED`; Scroll discarded that status, treated the empty text as malformed Markdown, and could start a repair attempt instead of preserving timeout semantics.

This change:

- merges provider and call-level generation kwargs before consuming `disable_thinking`, then explicitly sets `reasoning.effort=none` only for the documented GPT-5.5 alias/snapshot and GPT-5.6 alias/Sol/Terra/Luna models that support it; Pro, Codex, unknown, and custom model families instead have inherited reasoning removed;
- preserves `reasoning` for ordinary Responses calls where thinking remains enabled;
- detects both streaming and non-streaming interrupted summary responses before text parsing and re-raises cancellation;
- reads `finished_reason` from dict-like `ChatResponse` objects, where the mapping value contains the actual runtime status;
- adds deterministic regressions for both provider kwargs and AgentScope cancellation conversion.

**Related Issue:** Fixes #6811

**Security Considerations:** None. This only changes summary request adaptation and cancellation handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran all applicable changed-file pre-commit hooks locally and they pass
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; behavior is covered by regression tests)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Provider regressions configure inherited `reasoning={"effort": "xhigh"}` and verify `disable_thinking=True` emits explicit `none` for `gpt-5.5`, its documented `gpt-5.5-2026-04-23` snapshot, the official `gpt-5.6` alias, and the GPT-5.6 Sol/Terra/Luna family. They also verify inherited reasoning is removed for Pro, Codex, future, unknown, and custom models while preserving the per-call output limit.
- A companion provider test verifies reasoning remains enabled without the neutral flag.
- Scroll regression uses the real AgentScope `ChatModelBase` stream wrapper around a no-network hanging generator. The wrapper converts cancellation to an interrupted response; the test verifies QwenPaw restores `TimeoutError`.
- A non-stream regression verifies an interrupted `ChatResponse` propagates cancellation before Markdown parsing.

## Evidence

Before the fix on `bacac7410cf2ac122dd892152beff8b03f38729f`:

```text
FAILED test_disable_thinking_removes_inherited_responses_reasoning
AssertionError: assert 'reasoning' not in {
    'reasoning': {'effort': 'xhigh'},
    'max_output_tokens': 4000,
}

FAILED test_cancelled_summary_stream_remains_a_timeout
Failed: expected timeout from cancelled summary stream,
got completed result ''
```

After the fix:

```text
$ HOME=/tmp/qwenpaw-6811-home .venv/bin/pytest -q \
    tests/unit/providers tests/unit/agents/context
777 passed in 7.48s

$ HOME=/tmp/qwenpaw-6811-home SKIP=actionlint \
    .venv/bin/pre-commit run --files \
    src/qwenpaw/providers/openai_response_provider.py \
    src/qwenpaw/agents/context/scroll/manager.py \
    tests/unit/providers/test_openai_response_provider.py \
    tests/unit/agents/context/test_scroll_manager.py
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

`actionlint` was skipped because this PR changes no workflow files; all applicable hooks passed.

The post-review capability matrix verifies that `gpt-5.5`, its documented
`gpt-5.5-2026-04-23` snapshot, the official `gpt-5.6` alias, and the
`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` family receive
`reasoning={"effort":"none"}`. Pro/Codex variants, including dated forms,
plus future, unknown, and custom models do not.

## Additional Notes

The two fixes are kept together because they are the two independently reproduced causes in #6811's continuation-summary path. AI-assisted analysis was independently verified against the exact default-branch commit with deterministic no-network tests and review of every changed line.

