### PR TITLE
fix(scroll): fix of recall correctness issues from aone

### DIFF
--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -68,6 +68,21 @@ _SAVED_TOOL_FILE_RE = re.compile(
 )
 
 _FTS_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+# ``unicode61`` does not perform word segmentation for CJK scripts. A
+# punctuation-delimited run such as ``紫水晶河马在周二跳舞`` is indexed as one
+# token, so a natural keyword query like ``紫水晶河马`` cannot MATCH it. Route
+# queries containing these scripts through the bounded literal-substring path
+# instead. This keeps Porter stemming/BM25 for languages it tokenizes well.
+_CJK_QUERY_RE = re.compile(
+    "["
+    "\u3040-\u30ff"  # Hiragana and Katakana
+    "\u3400-\u4dbf"  # CJK Extension A
+    "\u4e00-\u9fff"  # CJK Unified Ideographs
+    "\uac00-\ud7af"  # Hangul syllables
+    "\uf900-\ufaff"  # CJK Compatibility Ideographs
+    "\U00020000-\U0002fa1f"  # Supplementary CJK ideographs
+    "]",
+)
 # FTS5's boolean operators are UPPERCASE-only; we pass these through bare so a
 # query like ``tank OR aquarium`` casts a wide net, while every other token is
 # quoted as a literal phrase. A lowercase ``or`` stays a search term.
@@ -752,7 +767,8 @@ class MemorySpace:
         when that fallback search is partial. The query is plain text:
         punctuation is treated as word separators (so ``C++`` searches the
         term ``C``), not FTS5 operators. Falls back to a LIKE scan if this
-        SQLite lacks FTS5 or the query has no word tokens.
+        SQLite lacks FTS5, the query has no word tokens, or the query contains
+        CJK text that SQLite's ``unicode61`` tokenizer cannot segment.
 
         The agent's current ACTIVE TURN (the latest user request of this
         session and everything after it) never appears in the hits — it is
@@ -793,10 +809,16 @@ class MemorySpace:
 
         # FTS5 MATCH takes a query grammar, not plain text. Sanitize first; an
         # all-punctuation query (no word tokens) has nothing to MATCH, so use
-        # the LIKE scan instead — as we also do when FTS5 is unavailable.
+        # the LIKE scan instead — as we also do when FTS5 is unavailable. The
+        # unicode61 tokenizer treats a continuous CJK sentence as one token;
+        # use literal substring search for CJK queries so keyword recall works.
         match = fts_match_query(query)
         fts_available = self._fts_available()
-        use_like = not fts_available or not match
+        use_like = (
+            not fts_available
+            or not match
+            or _CJK_QUERY_RE.search(query) is not None
+        )
         if not include_turn:
             return self._search_matching_rows_only(
                 query,

--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -71,8 +71,10 @@ _FTS_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 # ``unicode61`` does not perform word segmentation for CJK scripts. A
 # punctuation-delimited run such as ``紫水晶河马在周二跳舞`` is indexed as one
 # token, so a natural keyword query like ``紫水晶河马`` cannot MATCH it. Route
-# queries containing these scripts through the bounded literal-substring path
-# instead. This keeps Porter stemming/BM25 for languages it tokenizes well.
+# queries containing these scripts through bounded LIKE search instead. That
+# path matches each whitespace-delimited term as a literal substring, with
+# implicit AND and bare-uppercase OR groups. This keeps Porter stemming/BM25
+# for languages ``unicode61`` tokenizes well.
 _CJK_QUERY_RE = re.compile(
     "["
     "\u3040-\u30ff"  # Hiragana and Katakana

--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -188,11 +188,49 @@ def fts_match_query(raw: str) -> str:
     operator sequence just raises in ``MATCH`` and the caller degrades to LIKE.
     Returns ``""`` when there are no word tokens (caller falls back to LIKE).
     """
-    toks = _FTS_TOKEN_RE.findall(raw)
-    return " ".join(
-        t if t in _FTS_OPERATORS else '"' + t.replace('"', '""') + '"'
-        for t in toks
-    )
+
+    def render(group: str) -> str:
+        toks = _FTS_TOKEN_RE.findall(group)
+        return " ".join(
+            t if t in _FTS_OPERATORS else '"' + t.replace('"', '""') + '"'
+            for t in toks
+        )
+
+    groups = _or_query_groups(raw)
+    rendered = [render(group) for group in groups]
+    # Preserve the old malformed-query behavior when one OR arm contains no
+    # searchable word token: MATCH raises and the caller safely falls back to
+    # the literal LIKE path instead of silently dropping that arm.
+    if any(not group for group in rendered):
+        return render(raw)
+    return " OR ".join(rendered)
+
+
+def _or_query_groups(raw: str) -> list[str]:
+    """Split a valid bare-uppercase ``OR`` query into alternative groups.
+
+    Whitespace-separated terms inside each group retain implicit-AND
+    semantics. Malformed leading, trailing, or repeated ``OR`` is kept as one
+    literal group so the fallback remains restrictive instead of broadening a
+    bad query by discarding an empty alternative.
+    """
+    tokens = raw.split()
+    if not tokens:
+        return [raw]
+    groups: list[str] = []
+    current: list[str] = []
+    for token in tokens:
+        if token == "OR":
+            if not current:
+                return [raw]
+            groups.append(" ".join(current))
+            current = []
+        else:
+            current.append(token)
+    if not current:
+        return [raw]
+    groups.append(" ".join(current))
+    return groups
 
 
 def _like_search_terms(raw: str) -> list[str]:
@@ -201,6 +239,11 @@ def _like_search_terms(raw: str) -> list[str]:
     # Keep direct/internal all-whitespace calls restrictive instead of
     # accidentally producing a predicate-free query that returns every row.
     return terms or [raw]
+
+
+def _like_search_groups(raw: str) -> list[list[str]]:
+    """Literal LIKE terms grouped as implicit AND arms joined by OR."""
+    return [_like_search_terms(group) for group in _or_query_groups(raw)]
 
 
 def _like_pattern(term: str) -> str:
@@ -1371,9 +1414,10 @@ class MemorySpace:
         # If this is the *FTS-unavailable* fallback (not just an
         # all-punctuation query on an FTS-capable build), tell the model its
         # search degraded:
-        # LIKE is a literal substring scan with no ranking and no boolean/OR
-        # grammar. The notice shares the row schema so a ``r["content"]`` loop
-        # over results never breaks.
+        # LIKE is a literal substring scan with no ranking. It preserves the
+        # public uppercase-OR contract, but not the rest of FTS5's grammar.
+        # The notice shares the row schema so a ``r["content"]`` loop over
+        # results never breaks.
         if not self._fts_available():
             rows.insert(0, self._like_notice())
         return rows
@@ -1388,14 +1432,23 @@ class MemorySpace:
         offset: int = 0,
         created_bounds: tuple[str | None, str | None] = (None, None),
     ) -> list[dict]:
-        """Return one stable page matching every literal query term."""
-        terms = _like_search_terms(query)
+        """Return one stable page matching AND terms in any OR group."""
+        groups = _like_search_groups(query)
+        query_clauses: list[str] = []
+        query_params: list[str] = []
+        for terms in groups:
+            query_clauses.append(
+                "("
+                + " AND ".join("content LIKE ? ESCAPE '\\'" for _ in terms)
+                + ")",
+            )
+            query_params.extend(map(_like_pattern, terms))
         # Exclude the recall tool's own turns (NULL-safe: keep un-named rows).
         where = [
-            *("content LIKE ? ESCAPE '\\'" for _ in terms),
+            "(" + " OR ".join(query_clauses) + ")",
             f"(name IS NULL OR name NOT IN ({_RECALL_EXCL_PLACEHOLDERS}))",
         ]
-        params: list = [*map(_like_pattern, terms), *_RECALL_TOOL_NAMES]
+        params: list = [*query_params, *_RECALL_TOOL_NAMES]
         excl = self._active_turn_exclusion()
         if excl:
             where.append(excl[0])
@@ -1870,9 +1923,10 @@ class MemorySpace:
             "content": (
                 "NOTE: full-text search is unavailable (no FTS5 in this "
                 "SQLite build), so this is a literal substring (LIKE) scan — "
-                "no relevance ranking, and boolean/OR syntax is NOT supported "
-                "(operators are matched as ordinary terms). Whitespace-"
-                "separated terms are AND-combined."
+                "no relevance ranking. Bare uppercase OR alternatives are "
+                "supported; whitespace-separated terms within each "
+                "alternative are AND-combined. Other boolean operators are "
+                "matched as ordinary terms."
             ),
         }
 

--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -69,8 +69,8 @@ _SAVED_TOOL_FILE_RE = re.compile(
 
 _FTS_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 # ``unicode61`` does not perform word segmentation for CJK scripts. A
-# punctuation-delimited run such as ``紫水晶河马在周二跳舞`` is indexed as one
-# token, so a natural keyword query like ``紫水晶河马`` cannot MATCH it. Route
+# continuous run such as ``项目的截止日期是周二`` is indexed as one token, so a
+# natural keyword query like ``截止日期`` cannot MATCH it. Route
 # queries containing these scripts through bounded LIKE search instead. That
 # path matches each whitespace-delimited term as a literal substring, with
 # implicit AND and bare-uppercase OR groups. This keeps Porter stemming/BM25

--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -195,6 +195,22 @@ def fts_match_query(raw: str) -> str:
     )
 
 
+def _like_search_terms(raw: str) -> list[str]:
+    """Whitespace-delimited literal terms for the LIKE search path."""
+    terms = raw.split()
+    # Keep direct/internal all-whitespace calls restrictive instead of
+    # accidentally producing a predicate-free query that returns every row.
+    return terms or [raw]
+
+
+def _like_pattern(term: str) -> str:
+    """Wrap one literal term as a SQLite LIKE contains-pattern."""
+    escaped = (
+        term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
+    return f"%{escaped}%"
+
+
 def sanitize_suffix(session_id: str | None) -> str:
     """Turn a session id into a SQL-identifier-safe table suffix."""
     if not session_id:
@@ -1356,8 +1372,8 @@ class MemorySpace:
         # all-punctuation query on an FTS-capable build), tell the model its
         # search degraded:
         # LIKE is a literal substring scan with no ranking and no boolean/OR
-        # grammar, so it must query one term at a time. The notice shares the
-        # row schema so a ``r["content"]`` loop over results never breaks.
+        # grammar. The notice shares the row schema so a ``r["content"]`` loop
+        # over results never breaks.
         if not self._fts_available():
             rows.insert(0, self._like_notice())
         return rows
@@ -1372,13 +1388,14 @@ class MemorySpace:
         offset: int = 0,
         created_bounds: tuple[str | None, str | None] = (None, None),
     ) -> list[dict]:
-        """Return one stable page from the literal LIKE fallback."""
+        """Return one stable page matching every literal query term."""
+        terms = _like_search_terms(query)
         # Exclude the recall tool's own turns (NULL-safe: keep un-named rows).
         where = [
-            "content LIKE ?",
+            *("content LIKE ? ESCAPE '\\'" for _ in terms),
             f"(name IS NULL OR name NOT IN ({_RECALL_EXCL_PLACEHOLDERS}))",
         ]
-        params: list = [f"%{query}%", *_RECALL_TOOL_NAMES]
+        params: list = [*map(_like_pattern, terms), *_RECALL_TOOL_NAMES]
         excl = self._active_turn_exclusion()
         if excl:
             where.append(excl[0])
@@ -1854,8 +1871,8 @@ class MemorySpace:
                 "NOTE: full-text search is unavailable (no FTS5 in this "
                 "SQLite build), so this is a literal substring (LIKE) scan — "
                 "no relevance ranking, and boolean/OR syntax is NOT supported "
-                "(it would be matched literally). Search a single term at a "
-                "time and scan the rows yourself."
+                "(operators are matched as ordinary terms). Whitespace-"
+                "separated terms are AND-combined."
             ),
         }
 

--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -1574,8 +1574,8 @@ class MemorySpace:
         """Search full saved tool-result files referenced by history rows."""
         if limit <= 0:
             return []
-        needles = self._query_needles(query)
-        if not needles:
+        needle_groups = self._query_needle_groups(query)
+        if not needle_groups:
             return []
         rows: list[dict] = []
         seen: set[tuple[int, str, int]] = set()
@@ -1603,7 +1603,7 @@ class MemorySpace:
                         break
                     matches = self._file_line_matches(
                         path,
-                        needles,
+                        needle_groups,
                         budget=budget,
                     )
                     for match in matches:
@@ -1655,7 +1655,7 @@ class MemorySpace:
         query: str,
     ) -> list[dict]:
         """Annotate recall_tool rows with saved-file metadata when present."""
-        needles = self._query_needles(query)
+        needle_groups = self._query_needle_groups(query)
         out: list[dict] = []
         budget = self._new_saved_tool_scan_budget()
         for row in rows:
@@ -1699,10 +1699,10 @@ class MemorySpace:
                         f"file_path={str(path)!r} start_line={start_line}."
                     ),
                 }
-                if needles and not budget.is_exhausted():
+                if needle_groups and not budget.is_exhausted():
                     matches = self._file_line_matches(
                         path,
-                        needles,
+                        needle_groups,
                         limit=3,
                         budget=budget,
                     )
@@ -1813,25 +1813,38 @@ class MemorySpace:
         return path
 
     @staticmethod
-    def _query_needles(query: str) -> list[str]:
-        """Plain AND-style terms suitable for a saved-file line scan."""
-        return [
-            tok.casefold()
-            for tok in _FTS_TOKEN_RE.findall(query)
-            if tok not in _FTS_OPERATORS
-        ]
+    def _query_needle_groups(query: str) -> list[list[str]]:
+        """Saved-file terms grouped as AND arms joined by uppercase OR."""
+        groups: list[list[str]] = []
+        for raw_group in _or_query_groups(query):
+            needles = [
+                tok.casefold()
+                for tok in _FTS_TOKEN_RE.findall(raw_group)
+                if tok not in _FTS_OPERATORS
+            ]
+            # An empty arm must never become ``all([]) == True`` and match
+            # every artifact line. Keep punctuation-only/malformed searches
+            # restrictive, matching the old empty-needle behavior.
+            if not needles:
+                return []
+            groups.append(needles)
+        return groups
 
     @staticmethod
     def _file_line_matches(  # pylint: disable=too-many-branches
         path: Path,
-        needles: list[str],
+        needle_groups: list[list[str]],
         *,
         limit: int = 5,
         context: int = 1,
         budget: _ScanBudget | None = None,
     ) -> list[dict]:
         """Stream line matches with bounded memory and byte consumption."""
-        if not needles or limit <= 0:
+        if (
+            not needle_groups
+            or any(not group for group in needle_groups)
+            or limit <= 0
+        ):
             return []
         if budget is None:
             budget = _ScanBudget(
@@ -1866,7 +1879,10 @@ class MemorySpace:
                     break
 
                 folded = line.casefold()
-                if all(needle in folded for needle in needles):
+                if any(
+                    all(needle in folded for needle in group)
+                    for group in needle_groups
+                ):
                     item = {
                         "line": line_no,
                         "lines": [*previous, (line_no, line)],

--- a/src/qwenpaw/agents/context/scroll/recall_tool.py
+++ b/src/qwenpaw/agents/context/scroll/recall_tool.py
@@ -103,7 +103,18 @@ def _normalize_expand_args(
         # type regardless of the model-facing compatibility schema.
         return None, None
     try:
-        return _normalize_seq_arg(lo, "lo"), _normalize_seq_arg(hi, "hi")
+        normalized_lo = _normalize_seq_arg(lo, "lo")
+        normalized_hi = _normalize_seq_arg(hi, "hi")
+        if (
+            normalized_lo is not None
+            and normalized_hi is not None
+            and normalized_lo > normalized_hi
+        ):
+            raise ValueError(
+                f"lo ({normalized_lo}) must be less than or equal to "
+                f"hi ({normalized_hi}); swap lo and hi and retry",
+            )
+        return normalized_lo, normalized_hi
     except ValueError as exc:
         text = _bound_observation(
             f'RECALL FAILED — invalid op="expand" seq span '

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -1760,6 +1760,39 @@ def test_saved_tool_search_checks_each_multiblock_artifact(tmp_path: Path):
     assert "deepneedle" in rows[0]["content"]
 
 
+def test_saved_tool_search_preserves_uppercase_or(tmp_path: Path):
+    artifact = tmp_path / "saved-tool-output.txt"
+    artifact.write_text("项目状态\n", encoding="utf-8")
+    history = HistoryStore(tmp_path / "history.db")
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="saved-result",
+        entry=LogEntry(
+            kind="tool_result",
+            role="assistant",
+            content=_saved_tool_notice(artifact),
+            tool_call_id="saved-call",
+        ),
+    )
+    history.close()
+    space = MemorySpace(
+        history_db_path=tmp_path / "history.db",
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    try:
+        rows = space.search("项目 OR 截止日期", k=10)
+    finally:
+        space.close()
+
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "tool_result"
+    assert f"file_path={artifact}" in rows[0]["content"]
+    assert "项目状态" in rows[0]["content"]
+
+
 def test_recall_tool_annotates_each_multiblock_artifact(tmp_path: Path):
     first_file = tmp_path / "first-block.txt"
     first_file.write_text("first block\n", encoding="utf-8")
@@ -1908,7 +1941,7 @@ def test_saved_tool_file_search_streams_without_read_text(
 
     monkeypatch.setattr(Path, "read_text", fail_read_text)
 
-    matches = MemorySpace._file_line_matches(artifact, ["needle"])
+    matches = MemorySpace._file_line_matches(artifact, [["needle"]])
 
     assert matches == [
         {
@@ -1916,6 +1949,25 @@ def test_saved_tool_file_search_streams_without_read_text(
             "excerpt": "1: before\n2: needle match\n3: after",
         },
     ]
+
+
+def test_saved_tool_file_search_keeps_and_terms_on_same_line(
+    tmp_path: Path,
+):
+    artifact = tmp_path / "and-terms.txt"
+    artifact.write_text(
+        "foo\nbar\nfoo bar\n",
+        encoding="utf-8",
+    )
+    needle_groups = MemorySpace._query_needle_groups("foo bar")
+
+    matches = MemorySpace._file_line_matches(
+        artifact,
+        needle_groups,
+        context=0,
+    )
+
+    assert matches == [{"line": 3, "excerpt": "3: foo bar"}]
 
 
 def test_attach_saved_tool_preserves_preview_when_scan_budget_exhausts(

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -354,6 +354,76 @@ def test_search_returns_and_deduplicates_complete_turn(tmp_path: Path):
     assert user_hits[0]["turn"] == hits[0]["turn"]
 
 
+def test_search_cjk_substring_returns_complete_turn(tmp_path: Path):
+    history = HistoryStore(tmp_path / "history.db")
+    user_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="u1",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="紫水晶河马在周二跳舞",
+        ),
+    )
+    assistant_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="a1",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="我记住了这个暗号",
+        ),
+    )
+    tool_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="t1",
+        entry=LogEntry(
+            kind="tool_result",
+            role="assistant",
+            name="lookup",
+            content="工具结果",
+            tool_call_id="call-1",
+        ),
+    )
+    history.close()
+    space = MemorySpace(
+        history_db_path=tmp_path / "history.db",
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    try:
+        hits = space.search("紫水晶河马", session_id="archive", k=10)
+        legacy_hits = space.search(
+            "紫水晶河马",
+            session_id="archive",
+            k=10,
+            include_turn=False,
+        )
+    finally:
+        space.close()
+
+    assert len(hits) == 1
+    assert hits[0]["match_seq"] == user_seq
+    assert hits[0]["turn_start_seq"] == user_seq
+    assert hits[0]["turn_end_seq"] == tool_seq
+    assert hits[0]["turn_complete"] is True
+    assert [row["seq"] for row in hits[0]["turn"]] == [
+        user_seq,
+        assistant_seq,
+        tool_seq,
+    ]
+    assert [row["content"] for row in hits[0]["turn"]] == [
+        "紫水晶河马在周二跳舞",
+        "我记住了这个暗号",
+        "工具结果",
+    ]
+    assert [row["seq"] for row in legacy_hits] == [user_seq]
+
+
 def test_search_loads_duplicate_hit_turn_once(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -424,6 +424,105 @@ def test_search_cjk_substring_returns_complete_turn(tmp_path: Path):
     assert [row["seq"] for row in legacy_hits] == [user_seq]
 
 
+def test_search_cjk_multiple_terms_are_and_combined(tmp_path: Path):
+    history = HistoryStore(tmp_path / "history.db")
+    user_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="u1",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="项目的截止日期是周二",
+        ),
+    )
+    assistant_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="a1",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="好的，我记住了",
+        ),
+    )
+    history.close()
+    space = MemorySpace(
+        history_db_path=tmp_path / "history.db",
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    try:
+        hits = space.search(
+            "项目 截止日期",
+            session_id="archive",
+            k=10,
+        )
+    finally:
+        space.close()
+
+    assert len(hits) == 1
+    assert hits[0]["match_seq"] == user_seq
+    assert hits[0]["turn_complete"] is True
+    assert [row["seq"] for row in hits[0]["turn"]] == [
+        user_seq,
+        assistant_seq,
+    ]
+
+
+def test_search_like_metacharacters_are_literal(tmp_path: Path):
+    history = HistoryStore(tmp_path / "history.db")
+    for index, content in enumerate(
+        (
+            "项目_编号",
+            "项目X编号",
+            "项目%进度",
+            "项目任意长度进度",
+            "项目\\路径",
+        ),
+    ):
+        history.append(
+            session_id="archive",
+            agent_id="ag1",
+            dedup_key=f"row-{index}",
+            entry=LogEntry(
+                kind="model_turn",
+                role="assistant",
+                content=content,
+            ),
+        )
+    history.close()
+    space = MemorySpace(
+        history_db_path=tmp_path / "history.db",
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    try:
+        underscore = space.search(
+            "项目_编号",
+            session_id="archive",
+            include_turn=False,
+        )
+        percent = space.search(
+            "项目%进度",
+            session_id="archive",
+            include_turn=False,
+        )
+        backslash = space.search(
+            "项目\\路径",
+            session_id="archive",
+            include_turn=False,
+        )
+    finally:
+        space.close()
+
+    assert [row["content"] for row in underscore] == ["项目_编号"]
+    assert [row["content"] for row in percent] == ["项目%进度"]
+    assert [row["content"] for row in backslash] == ["项目\\路径"]
+
+
 def test_search_loads_duplicate_hit_turn_once(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -471,6 +471,60 @@ def test_search_cjk_multiple_terms_are_and_combined(tmp_path: Path):
     ]
 
 
+def test_search_cjk_uppercase_or_matches_either_term(tmp_path: Path):
+    history = HistoryStore(tmp_path / "history.db")
+    project_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="project",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="项目状态",
+        ),
+    )
+    deadline_seq = history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="deadline",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="截止日期",
+        ),
+    )
+    history.close()
+    space = MemorySpace(
+        history_db_path=tmp_path / "history.db",
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    try:
+        hits = space.search(
+            "项目 OR 截止日期",
+            session_id="archive",
+            k=10,
+        )
+        matching_rows = space.search(
+            "项目 OR 截止日期",
+            session_id="archive",
+            k=10,
+            include_turn=False,
+        )
+    finally:
+        space.close()
+
+    assert {hit["match_seq"] for hit in hits} == {
+        project_seq,
+        deadline_seq,
+    }
+    assert {row["content"] for row in matching_rows} == {
+        "项目状态",
+        "截止日期",
+    }
+
+
 def test_search_like_metacharacters_are_literal(tmp_path: Path):
     history = HistoryStore(tmp_path / "history.db")
     for index, content in enumerate(
@@ -1328,6 +1382,16 @@ def test_like_fallback_respects_scope(ms: MemorySpace):
     # explicit targeting works on the LIKE path too
     pinned = _hits(ms.search("tanks", agent_id="ag2"))
     assert pinned == {"tanks of another agent"}
+
+
+def test_like_fallback_preserves_uppercase_or(ms: MemorySpace):
+    """The public OR contract also holds when FTS5 is unavailable."""
+    ms._fts_ok = False
+
+    assert _hits(ms.search("rolled OR regrouped")) == {
+        "tanks rolled in",
+        "tanks regrouped later",
+    }
 
 
 def test_like_fallback_emits_degradation_notice(ms: MemorySpace):

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -531,6 +531,49 @@ async def test_search_saved_tool_output_keeps_match_excerpt(tmp_path: Path):
     assert str(artifact) in text
 
 
+async def test_search_saved_tool_output_preserves_uppercase_or(
+    tmp_path: Path,
+):
+    artifact = tmp_path / "saved-tool-output-or.txt"
+    artifact.write_text("项目状态\n", encoding="utf-8")
+    history = HistoryStore(tmp_path / "history.db")
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="t1",
+        entry=LogEntry(
+            kind="tool_result",
+            role="assistant",
+            name="shell",
+            tool_call_id="call-saved-or",
+            content=(
+                "[tool output truncated]\n"
+                "If more content is needed, call `read_file` with "
+                f"file_path={artifact} start_line=1 to read more."
+            ),
+        ),
+    )
+    history.close()
+    recall = make_recall_history(
+        history_db_path=str(tmp_path / "history.db"),
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    chunk = await recall(
+        op="search",
+        query="项目 OR 截止日期",
+        k=10,
+    )
+
+    assert chunk.state == ToolResultState.SUCCESS
+    text = _text(chunk)
+    assert "0 rows" not in text
+    assert "[matched content excerpt]" in text
+    assert "项目状态" in text
+    assert str(artifact) in text
+
+
 async def test_recall_tool_by_call_id(tool):
     chunk = await tool(op="recall_tool", tool_call_id="call_abc")
     assert chunk.state == ToolResultState.SUCCESS

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -266,6 +266,53 @@ async def test_search_cjk_substring_returns_same_complete_turn(
     assert "工具结果" in text
 
 
+async def test_search_cjk_multiple_terms_returns_complete_turn(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "cjk-multiple-terms.db"
+    history = HistoryStore(db_path)
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="u1",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="项目的截止日期是周二",
+        ),
+    )
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="a1",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="好的，我记住了",
+        ),
+    )
+    history.close()
+    recall = make_recall_history(
+        history_db_path=str(db_path),
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    chunk = await recall(
+        op="search",
+        query="项目 截止日期",
+        session_id="archive",
+        k=10,
+    )
+
+    assert chunk.state == ToolResultState.SUCCESS
+    text = _text(chunk)
+    assert "matched_seq=1" in text
+    assert "turn_seq=1–2" in text
+    assert "项目的截止日期是周二" in text
+    assert "好的，我记住了" in text
+
+
 async def test_search_filters_and_displays_created_at(tool):
     chunk = await tool(
         op="search",

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -144,6 +144,34 @@ async def test_expand_rejects_non_positive_or_non_decimal_seqs(
     assert argument in _text(chunk)
 
 
+@pytest.mark.parametrize(
+    ("lo", "hi"),
+    [
+        (3, 1),
+        ("3", "1"),
+        (3, "1"),
+        ("3", 1),
+    ],
+)
+async def test_expand_rejects_descending_seq_span(tool, lo, hi):
+    chunk = await tool(op="expand", lo=lo, hi=hi)
+
+    assert chunk.state == ToolResultState.ERROR
+    text = _text(chunk)
+    assert text.startswith('RECALL FAILED — invalid op="expand" seq span')
+    assert "lo (3) must be less than or equal to hi (1)" in text
+    assert "swap lo and hi and retry" in text
+
+
+async def test_expand_accepts_single_seq_span(tool):
+    chunk = await tool(op="expand", lo=1, hi=1)
+
+    assert chunk.state == ToolResultState.SUCCESS
+    text = _text(chunk)
+    assert "expand [1, 1]" in text
+    assert "hello there" in text
+
+
 def test_expand_schema_accepts_integer_or_string_seqs(tool):
     properties = FunctionTool(tool).input_schema["properties"]
 

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -313,6 +313,52 @@ async def test_search_cjk_multiple_terms_returns_complete_turn(
     assert "好的，我记住了" in text
 
 
+async def test_search_cjk_uppercase_or_does_not_report_false_empty(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "cjk-or.db"
+    history = HistoryStore(db_path)
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="project",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="项目状态",
+        ),
+    )
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="deadline",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="截止日期",
+        ),
+    )
+    history.close()
+    recall = make_recall_history(
+        history_db_path=str(db_path),
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    chunk = await recall(
+        op="search",
+        query="项目 OR 截止日期",
+        session_id="archive",
+        k=10,
+    )
+
+    assert chunk.state == ToolResultState.SUCCESS
+    text = _text(chunk)
+    assert "项目状态" in text
+    assert "截止日期" in text
+    assert "0 rows" not in text
+
+
 async def test_search_filters_and_displays_created_at(tool):
     chunk = await tool(
         op="search",

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -178,6 +178,66 @@ async def test_search_user_hit_returns_same_complete_turn(tool):
     assert "RESULT-FULL" in text
 
 
+async def test_search_cjk_substring_returns_same_complete_turn(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "cjk-history.db"
+    history = HistoryStore(db_path)
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="u1",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="紫水晶河马在周二跳舞",
+        ),
+    )
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="a1",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="我记住了这个暗号",
+        ),
+    )
+    history.append(
+        session_id="archive",
+        agent_id="ag1",
+        dedup_key="t1",
+        entry=LogEntry(
+            kind="tool_result",
+            role="assistant",
+            name="lookup",
+            content="工具结果",
+            tool_call_id="call-cjk",
+        ),
+    )
+    history.close()
+    recall = make_recall_history(
+        history_db_path=str(db_path),
+        session_id="current",
+        agent_id="ag1",
+    )
+
+    chunk = await recall(
+        op="search",
+        query="紫水晶河马",
+        session_id="archive",
+        k=10,
+    )
+
+    assert chunk.state == ToolResultState.SUCCESS
+    text = _text(chunk)
+    assert "matched_seq=1" in text
+    assert "turn_seq=1–3" in text
+    assert "紫水晶河马在周二跳舞" in text
+    assert "我记住了这个暗号" in text
+    assert "工具结果" in text
+
+
 async def test_search_filters_and_displays_created_at(tool):
     chunk = await tool(
         op="search",


### PR DESCRIPTION
## Description

Fix two Scroll recall correctness issues:

1. CJK substring searches could return no results when FTS5 was available.
   SQLite's `porter unicode61` tokenizer indexes a continuous CJK sentence as
   a single token, so a query such as `紫水晶河马` could not match
   `紫水晶河马在周二跳舞`.

   Queries containing CJK characters now use the existing bounded,
   parameterized LIKE substring-search path. English and other tokenizable
   queries continue to use FTS5, BM25 ranking, and Porter stemming.

2. `recall_history(op="expand")` accepted reversed sequence ranges such as
   `lo=999999, hi=999990`. The empty SQL result was incorrectly reported as a
   successful, genuine absence of history.

   Expand arguments are now normalized and checked for `lo <= hi`. Reversed
   ranges return an actionable error such as:

   ```text
   RECALL FAILED — invalid op="expand" seq span
   (ValueError: lo (...) must be less than or equal to hi (...);
   swap lo and hi and retry).