### PR TITLE
fix(mcp): apply configured timeout to client sessions

### DIFF
--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -119,6 +119,7 @@ class _MCPClientMixin:
     _reload_event: asyncio.Event
     _ready_event: asyncio.Event
     _lifecycle_task: asyncio.Task | None
+    read_timeout_seconds: float | timedelta | None
 
     # ------------------------------------------------------------------
     # Transport hook (implemented by each concrete subclass)
@@ -158,7 +159,17 @@ class _MCPClientMixin:
                         stack,
                     )
 
-                    self.session = ClientSession(read_stream, write_stream)
+                    read_timeout = self.read_timeout_seconds
+                    if read_timeout is not None and not isinstance(
+                        read_timeout,
+                        timedelta,
+                    ):
+                        read_timeout = timedelta(seconds=read_timeout)
+                    self.session = ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=read_timeout,
+                    )
                     await stack.enter_async_context(self.session)
                     await self.session.initialize()
 

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -25,12 +25,18 @@ deterministic unit coverage behind the ``fail_under`` gate.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
+
+import anyio
 import httpx
 import pytest
+from mcp import ClientSession
+from mcp.shared.exceptions import McpError
 
 import qwenpaw.drivers.handlers.mcp_stateful_client as mod
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
     HttpStatefulClient,
+    StdIOStatefulClient,
     _is_401_error,
     _is_transport_error,
 )
@@ -46,6 +52,47 @@ def _client() -> HttpStatefulClient:
     return HttpStatefulClient("test-client", "streamable_http", "http://x")
 
 
+async def _assert_lifecycle_wires_session_timeout(
+    client: HttpStatefulClient | StdIOStatefulClient,
+    expected_timeout: timedelta,
+    monkeypatch,
+) -> None:
+    """Exercise the real lifecycle while replacing only its I/O boundaries."""
+    timeout_not_passed = object()
+    observed_timeouts: list[object] = []
+
+    class SessionSpy:
+        def __init__(
+            self,
+            read_stream,
+            write_stream,
+            read_timeout_seconds=timeout_not_passed,
+        ) -> None:
+            del read_stream, write_stream
+            observed_timeouts.append(read_timeout_seconds)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            del exc_type, exc_value, traceback
+
+        async def initialize(self) -> None:
+            return None
+
+    async def setup_transport(_stack):
+        return object(), object()
+
+    monkeypatch.setattr(mod, "ClientSession", SessionSpy)
+    monkeypatch.setattr(client, "_setup_transport", setup_transport)
+
+    await client.connect(timeout=1)
+    try:
+        assert observed_timeouts == [expected_timeout]
+    finally:
+        await client.close(ignore_errors=False)
+
+
 # ---------------------------------------------------------------------------
 # Error classification helpers
 # ---------------------------------------------------------------------------
@@ -53,8 +100,6 @@ def _client() -> HttpStatefulClient:
 
 def test_is_transport_error_distinguishes_transport_from_mcp_errors():
     # anyio.ClosedResourceError is in _TRANSPORT_ERRORS when anyio imports.
-    import anyio
-
     assert _is_transport_error(anyio.ClosedResourceError())
     assert _is_transport_error(ConnectionResetError("reset"))
     assert _is_transport_error(EOFError())
@@ -120,8 +165,6 @@ def test_handle_transport_error_noops_for_non_transport_errors():
 
 
 def test_handle_transport_error_marks_disconnected_and_schedules_reload():
-    import anyio
-
     c = _client()
     c.is_connected = True
     c._ready_event.set()
@@ -132,8 +175,6 @@ def test_handle_transport_error_marks_disconnected_and_schedules_reload():
 
 
 def test_handle_transport_error_skips_reload_when_already_stopping():
-    import anyio
-
     c = _client()
     c.is_connected = True
     c._stop_event.set()
@@ -220,6 +261,93 @@ async def test_wait_for_lifecycle_exit_timeout_spawns_reaper(monkeypatch):
         if reaper is not None:
             await asyncio.wait_for(reaper, timeout=2)
     assert task not in mod._LIFECYCLE_REAPERS
+
+
+# ---------------------------------------------------------------------------
+# Session request timeout wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_http_lifecycle_wires_read_timeout_to_client_session(
+    monkeypatch,
+):
+    client = HttpStatefulClient(
+        "http-client",
+        "streamable_http",
+        "http://x",
+        sse_read_timeout=0.25,
+    )
+
+    await _assert_lifecycle_wires_session_timeout(
+        client,
+        timedelta(seconds=0.25),
+        monkeypatch,
+    )
+
+
+async def test_stdio_lifecycle_wires_read_timeout_to_client_session(
+    monkeypatch,
+):
+    client = StdIOStatefulClient(
+        "stdio-client",
+        "unused-command",
+        read_timeout_seconds=0.75,
+    )
+
+    await _assert_lifecycle_wires_session_timeout(
+        client,
+        timedelta(seconds=0.75),
+        monkeypatch,
+    )
+
+
+async def test_http_lifecycle_preserves_timedelta_read_timeout(monkeypatch):
+    configured_timeout = timedelta(seconds=1.25)
+    client = HttpStatefulClient(
+        "http-client",
+        "streamable_http",
+        "http://x",
+    )
+    client.read_timeout_seconds = configured_timeout
+
+    await _assert_lifecycle_wires_session_timeout(
+        client,
+        configured_timeout,
+        monkeypatch,
+    )
+
+
+async def test_real_client_session_times_out_unanswered_request():
+    """The MCP SDK converts its session timeout into a terminal error."""
+    server_send, client_read = anyio.create_memory_object_stream(1)
+    client_write, server_read = anyio.create_memory_object_stream(1)
+    request_received = asyncio.Event()
+
+    async def consume_request_without_responding() -> None:
+        await server_read.receive()
+        request_received.set()
+
+    consumer = asyncio.create_task(consume_request_without_responding())
+    try:
+        async with ClientSession(
+            client_read,
+            client_write,
+            read_timeout_seconds=timedelta(seconds=0.05),
+        ) as session:
+            with pytest.raises(McpError):
+                await asyncio.wait_for(session.list_tools(), timeout=3)
+            await asyncio.wait_for(request_received.wait(), timeout=1)
+    finally:
+        if not consumer.done():
+            consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        for stream in (
+            server_send,
+            client_read,
+            client_write,
+            server_read,
+        ):
+            await stream.aclose()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #6822.

The stateful MCP clients stored a five-minute request timeout, but the
shared lifecycle created each SDK `ClientSession` without passing it. The
SDK therefore used its `None` default, which allows an in-flight request on
an old session to wait indefinitely even after the transport lifecycle has
reconnected.

This change converts stored second values to `timedelta` and passes the
result to every `ClientSession` created by the shared lifecycle. It applies
the existing client timeout to session requests without changing the
transport, reconnect, cache, or cleanup state machines.

**Related Issue:** Fixes #6822

**Security Considerations:** No authentication, credential, configuration
default, or trust-boundary changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this change does not touch a channel or the Console.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `python -m pytest --noconftest -q tests/unit/drivers/handlers/test_mcp_stateful_client.py` — 29 passed
- `python -m pytest --noconftest -q tests/unit/drivers` — 166 passed
- `python -m pytest --noconftest -q tests/integration/test_driver_mcp_http_flow.py tests/integration/test_driver_mcp_stdio_flow.py` — 2 passed
- `black --check --line-length 79 src/qwenpaw/drivers/handlers/mcp_stateful_client.py tests/unit/drivers/handlers/test_mcp_stateful_client.py` — unchanged
- `ruff check --target-version py311 src/qwenpaw/drivers/handlers/mcp_stateful_client.py tests/unit/drivers/handlers/test_mcp_stateful_client.py` — passed
- `mypy` with the repository hook arguments on both changed Python files — passed

The isolated verification environment did not include every development
extra needed to run the repository-wide `pre-commit run --all-files` and
full `pytest` gates. The focused handler, driver, and MCP integration checks
above passed; the full gates remain for CI.

## Evidence

Before the source fix, the new HTTP and stdio lifecycle regressions proved
that `ClientSession` did not receive the stored timeout:

```text
FF                                                                       [100%]
FAILED test_http_lifecycle_wires_read_timeout_to_client_session
FAILED test_stdio_lifecycle_wires_read_timeout_to_client_session
2 failed
```

After the fix, both lifecycle wiring tests and the real MCP in-memory
no-response contract pass. The broader affected test surface is also green:

```text
.............................                                            [100%]
29 passed in 0.43s

........................................................................ [ 43%]
........................................................................ [ 86%]
......................                                                   [100%]
166 passed in 0.55s

..                                                                       [100%]
2 passed in 0.56s
```

The real SDK contract consumes a `list_tools` request without responding and
verifies that the configured session deadline produces a terminal
`McpError`, rather than relying on the test's three-second outer watchdog.

## Additional Notes

- The existing default remains 300 seconds. This guarantees an eventual
  terminal error; it does not retry or migrate an old request to the newly
  connected session.
- The timeout applies to all SDK session requests, including initialization,
  tool listing, and tool calls.
- No dependency, public configuration, or public API changes are included.
- Validation is mechanism-level (QwenPaw lifecycle wiring plus real SDK
  timeout behavior); a live transient HTTP disconnect was not replayed
  end-to-end.
