### PR TITLE
fix(approvals): pass channel routing fields in driver gate

### DIFF
--- a/src/qwenpaw/app/approvals/driver_gate.py
+++ b/src/qwenpaw/app/approvals/driver_gate.py
@@ -94,9 +94,10 @@ class QwenPawDriverApprovalGate:
                     "name": driver_label,
                     "input": context.extras,
                 },
+                "channel_meta": ctx.get("channel_meta"),
+                "_channel_instance": ctx.get("_channel_instance"),
                 **(
                     {
-                        "channel_meta": ctx.get("channel_meta"),
                         "_spawn_subagent": True,
                     }
                     if ctx.get("_spawn_subagent")

--- a/tests/unit/app/approvals/test_driver_gate.py
+++ b/tests/unit/app/approvals/test_driver_gate.py
@@ -224,3 +224,40 @@ async def test_request_approval_with_tool_target_uses_target_name_in_summary(
 
     asyncio.create_task(_approver())
     await gate.request_approval(ctx)
+
+
+async def test_request_approval_passes_channel_routing_fields_to_pending(
+    svc: ApprovalService,
+):
+    """The driver gate must pass channel_meta and _channel_instance to the
+    pending extra payload so that the ApprovalService can route notifications
+    to the correct channel (see #6819)."""
+    gate = QwenPawDriverApprovalGate()
+    ctx = _ctx(tool_call_id="tc-5")
+
+    # Inject channel routing data into the request context
+    ctx.request_context["channel_meta"] = {"conversation_id": "conv-1"}
+    ctx.request_context["_channel_instance"] = "mock_channel"
+
+    async def _approver() -> None:
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if svc._pending:
+                break
+
+        pending = next(iter(svc._pending.values()))
+
+        # Verify the channel routing fields were propagated unconditionally
+        assert pending.extra.get("channel_meta") == {
+            "conversation_id": "conv-1"
+        }
+        assert pending.extra.get("_channel_instance") == "mock_channel"
+        assert "_spawn_subagent" not in pending.extra
+
+        await svc.resolve_request(
+            pending.request_id,
+            ApprovalDecision.APPROVED,
+        )
+
+    asyncio.create_task(_approver())
+    await gate.request_approval(ctx)

--- a/tests/unit/app/approvals/test_driver_gate.py
+++ b/tests/unit/app/approvals/test_driver_gate.py
@@ -249,7 +249,7 @@ async def test_request_approval_passes_channel_routing_fields_to_pending(
 
         # Verify the channel routing fields were propagated unconditionally
         assert pending.extra.get("channel_meta") == {
-            "conversation_id": "conv-1"
+            "conversation_id": "conv-1",
         }
         assert pending.extra.get("_channel_instance") == "mock_channel"
         assert "_spawn_subagent" not in pending.extra


### PR DESCRIPTION
## What Problem This Solves
The `QwenPawDriverApprovalGate.request_approval` function currently drops the `channel_meta` and `_channel_instance` fields for normal driver invocations. Because of this, the approval pending is created and waits indefinitely without notifying the correct channel (like Slack or Discord). This PR ensures the channel routing fields are properly passed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist
- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
Tested locally and verified fixes with tests.

## Evidence
When triggering a tool that requires approval via the chat interface, the approval request correctly sends a notification message. Without this fix, the approval state would hang because the message was dropped without channel routing info.

✅ Local Verification Evidence:
```bash
pre-commit run --all-files
# passed

pytest
# passed
```
