### PR TITLE
feat(agents): add hidden flag to hide agents from UI selectors

### DIFF
--- a/console/src/api/modules/agents.ts
+++ b/console/src/api/modules/agents.ts
@@ -88,4 +88,13 @@ export const agentsApi = {
         body: JSON.stringify({ pinned }),
       },
     ),
+
+  setAgentHidden: (agentId: string, hidden: boolean) =>
+    request<{ success: boolean; agent_id: string; hidden: boolean }>(
+      `/agents/${agentId}/hide`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ hidden }),
+      },
+    ),
 };

--- a/console/src/api/types/agents.ts
+++ b/console/src/api/types/agents.ts
@@ -17,6 +17,7 @@ export interface AgentSummary {
   workspace_dir: string;
   enabled: boolean;
   pinned?: boolean;
+  hidden?: boolean;
   startup_status?: AgentStartupStatus;
   backend: AgentBackend;
   backend_capabilities?: Partial<HarnessCapabilities>;

--- a/console/src/components/AgentSelector/index.tsx
+++ b/console/src/components/AgentSelector/index.tsx
@@ -70,27 +70,31 @@ export default function AgentSelector({
     void loadAgents();
   }, [loadAgents]);
 
-  const enabledAgents = useMemo(
-    () => agents.filter((agent) => agent.enabled),
+  const visibleAgents = useMemo(
+    () => agents.filter((agent) => !agent.hidden),
     [agents],
   );
+  const enabledAgents = useMemo(
+    () => visibleAgents.filter((agent) => agent.enabled),
+    [visibleAgents],
+  );
   const pinnedAgents = useMemo(
-    () => agents.filter((agent) => agent.id === "default" || agent.pinned),
-    [agents],
+    () => visibleAgents.filter((agent) => agent.id === "default" || agent.pinned),
+    [visibleAgents],
   );
   const regularEnabledAgents = useMemo(
     () =>
-      agents.filter(
+      visibleAgents.filter(
         (agent) => agent.enabled && agent.id !== "default" && !agent.pinned,
       ),
-    [agents],
+    [visibleAgents],
   );
   const regularDisabledAgents = useMemo(
     () =>
-      agents.filter(
+      visibleAgents.filter(
         (agent) => !agent.enabled && agent.id !== "default" && !agent.pinned,
       ),
-    [agents],
+    [visibleAgents],
   );
 
   const handleChange = (value: string) => {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -755,6 +755,11 @@
     "pinSuccess": "Agent pinned",
     "unpinSuccess": "Agent unpinned",
     "pinFailed": "Failed to update pinned state",
+    "hideAgent": "Hide agent",
+    "unhideAgent": "Unhide agent",
+    "hideSuccess": "Agent hidden",
+    "unhideSuccess": "Agent unhidden",
+    "hideFailed": "Failed to update hidden state",
     "status": {
       "disabled": "Disabled",
       "pending": "Waiting to start",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -537,6 +537,11 @@
     "pinSuccess": "智能体已固定",
     "unpinSuccess": "智能体已取消固定",
     "pinFailed": "更新固定状态失败",
+    "hideAgent": "隐藏智能体",
+    "unhideAgent": "取消隐藏智能体",
+    "hideSuccess": "智能体已隐藏",
+    "unhideSuccess": "智能体已取消隐藏",
+    "hideFailed": "更新隐藏状态失败",
     "status": {
       "disabled": "已禁用",
       "pending": "等待启动",

--- a/console/src/pages/Settings/Agents/components/AgentTable.test.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentTable.test.tsx
@@ -35,6 +35,7 @@ describe("AgentTable", () => {
         onDelete={vi.fn()}
         onToggle={vi.fn()}
         onPin={vi.fn()}
+        onHide={vi.fn()}
         onReorder={vi.fn()}
       />,
     );
@@ -58,6 +59,7 @@ describe("AgentTable", () => {
         onDelete={vi.fn()}
         onToggle={vi.fn()}
         onPin={vi.fn()}
+        onHide={vi.fn()}
         onReorder={vi.fn()}
       />,
     );
@@ -78,6 +80,7 @@ describe("AgentTable", () => {
         onDelete={vi.fn()}
         onToggle={vi.fn()}
         onPin={vi.fn()}
+        onHide={vi.fn()}
         onReorder={vi.fn()}
       />,
     );
@@ -101,6 +104,7 @@ describe("AgentTable", () => {
         onDelete={vi.fn()}
         onToggle={vi.fn()}
         onPin={vi.fn()}
+        onHide={vi.fn()}
         onReorder={vi.fn()}
       />,
     );

--- a/console/src/pages/Settings/Agents/components/AgentTable.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentTable.tsx
@@ -50,6 +50,7 @@ interface AgentTableProps {
   onDelete: (agentId: string) => void;
   onToggle: (agentId: string, currentEnabled: boolean) => void;
   onPin: (agentId: string, currentPinned: boolean) => void;
+  onHide: (agentId: string, currentHidden: boolean) => void;
   onReorder: (activeId: string, overId: string) => void;
 }
 
@@ -62,6 +63,7 @@ export function AgentTable({
   onDelete,
   onToggle,
   onPin,
+  onHide,
   onReorder,
 }: AgentTableProps) {
   const { t } = useTranslation();
@@ -244,7 +246,7 @@ export function AgentTable({
     {
       title: t("common.actions"),
       key: "actions",
-      width: 240,
+      width: 275,
       fixed: "right",
       render: (_value: unknown, record: AgentSummary) => {
         const startupInProgress =
@@ -257,6 +259,9 @@ export function AgentTable({
             : record.pinned
             ? t("agent.unpinAgent")
             : t("agent.pinAgent");
+        const hideActionLabel = record.hidden
+          ? t("agent.unhideAgent")
+          : t("agent.hideAgent");
 
         return (
           <Space>
@@ -273,6 +278,17 @@ export function AgentTable({
                   )
                 }
                 onClick={() => onPin(record.id, Boolean(record.pinned))}
+                disabled={record.id === "default"}
+                style={record.id === "default" ? disabledStyle : iconStyle}
+              />
+            </Tooltip>
+            <Tooltip title={hideActionLabel}>
+              <Button
+                type="text"
+                size="middle"
+                aria-label={hideActionLabel}
+                icon={record.hidden ? <Eye size={14} /> : <EyeOff size={14} />}
+                onClick={() => onHide(record.id, Boolean(record.hidden))}
                 disabled={record.id === "default"}
                 style={record.id === "default" ? disabledStyle : iconStyle}
               />

--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -21,6 +21,7 @@ export default function AgentsPage() {
     deleteAgent,
     toggleAgent,
     pinAgent,
+    hideAgent,
     loadAgents,
     setAgents,
   } = useAgents();
@@ -126,6 +127,14 @@ export default function AgentsPage() {
   const handlePin = async (agentId: string, currentPinned: boolean) => {
     try {
       await pinAgent(agentId, !currentPinned);
+    } catch {
+      // Error already handled in hook
+    }
+  };
+
+  const handleHide = async (agentId: string, currentHidden: boolean) => {
+    try {
+      await hideAgent(agentId, !currentHidden);
     } catch {
       // Error already handled in hook
     }
@@ -248,6 +257,7 @@ export default function AgentsPage() {
           onDelete={handleDelete}
           onToggle={handleToggle}
           onPin={handlePin}
+          onHide={handleHide}
           onReorder={handleReorder}
         />
       </Card>

--- a/console/src/pages/Settings/Agents/useAgents.ts
+++ b/console/src/pages/Settings/Agents/useAgents.ts
@@ -14,6 +14,7 @@ interface UseAgentsReturn {
   deleteAgent: (agentId: string) => Promise<void>;
   toggleAgent: (agentId: string, enabled: boolean) => Promise<void>;
   pinAgent: (agentId: string, pinned: boolean) => Promise<void>;
+  hideAgent: (agentId: string, hidden: boolean) => Promise<void>;
   setAgents: (agents: AgentSummary[]) => void;
 }
 
@@ -131,6 +132,20 @@ export function useAgents(): UseAgentsReturn {
     }
   };
 
+  const hideAgent = async (agentId: string, hidden: boolean) => {
+    try {
+      await agentsApi.setAgentHidden(agentId, hidden);
+      message.success(
+        hidden ? t("agent.hideSuccess") : t("agent.unhideSuccess"),
+      );
+      await fetchAgents(false, false);
+    } catch (err: unknown) {
+      await fetchAgents(false, false);
+      message.error(err instanceof Error ? err.message : t("agent.hideFailed"));
+      throw err;
+    }
+  };
+
   useEffect(() => {
     void loadAgents();
   }, [loadAgents]);
@@ -143,6 +158,7 @@ export function useAgents(): UseAgentsReturn {
     deleteAgent,
     toggleAgent,
     pinAgent,
+    hideAgent,
     setAgents: setAgentsState,
   };
 }

--- a/console/src/pages/Settings/Agents/useAgents.ts
+++ b/console/src/pages/Settings/Agents/useAgents.ts
@@ -133,6 +133,11 @@ export function useAgents(): UseAgentsReturn {
   };
 
   const hideAgent = async (agentId: string, hidden: boolean) => {
+    setAgentsState(
+      agents.map((agent) =>
+        agent.id === agentId ? { ...agent, hidden } : agent,
+      ),
+    );
     try {
       await agentsApi.setAgentHidden(agentId, hidden);
       message.success(

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -51,6 +51,7 @@ class AgentSummary(BaseModel):
     workspace_dir: str
     enabled: bool
     pinned: bool
+    hidden: bool = False
     startup_status: AgentStartupStatus
     backend: str = "qwenpaw"
     backend_capabilities: dict[str, Any] = Field(default_factory=dict)
@@ -287,6 +288,7 @@ async def list_agents(request: Request = None) -> AgentListResponse:
             "pinned",
             False,
         )
+        hidden = getattr(agent_ref, "hidden", False)
         startup_status = (
             manager.get_agent_startup_status(agent_id, enabled=enabled)
             if manager is not None
@@ -326,6 +328,7 @@ async def list_agents(request: Request = None) -> AgentListResponse:
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=enabled,
                     pinned=pinned,
+                    hidden=hidden,
                     startup_status=startup_status,
                     backend=agent_config.backend,
                     backend_capabilities=backend_capabilities,
@@ -347,6 +350,7 @@ async def list_agents(request: Request = None) -> AgentListResponse:
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=enabled,
                     pinned=pinned,
+                    hidden=hidden,
                     startup_status=startup_status,
                 ),
             )
@@ -427,6 +431,46 @@ async def set_agent_pinned(
         "success": True,
         "agent_id": agentId,
         "pinned": True if agentId == "default" else pinned,
+    }
+
+
+@router.patch(
+    "/{agentId}/hide",
+    summary="Hide or unhide an agent",
+    description=(
+        "Persist an agent's hidden state. Hidden agents remain enabled "
+        "and addressable via submit_to_agent but do not appear in agent "
+        "selectors."
+    ),
+)
+async def set_agent_hidden(
+    agentId: str = PathParam(...),
+    hidden: bool = Body(..., embed=True),
+) -> dict:
+    """Persist an agent's hidden state without changing enabled state."""
+    config = load_config()
+
+    if agentId not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agentId}' not found",
+        )
+
+    if agentId == "default" and hidden:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot hide the default agent",
+        )
+
+    agent_ref = config.agents.profiles[agentId]
+    agent_ref.hidden = hidden
+    config.agents.agent_order = _display_agent_order(config)
+    save_config(config)
+
+    return {
+        "success": True,
+        "agent_id": agentId,
+        "hidden": hidden,
     }
 
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1646,6 +1646,15 @@ class AgentProfileRef(BaseModel):
         default=False,
         description="Whether agent is pinned in agent selectors",
     )
+    hidden: bool = Field(
+        default=False,
+        description=(
+            "Whether agent is hidden from agent selectors and sidebars. "
+            "Hidden agents remain enabled and can be addressed via "
+            "submit_to_agent, but do not appear in the UI agent picker. "
+            "Useful for background/internal agents created by plugins."
+        ),
+    )
 
 
 class PlanConfig(BaseModel):


### PR DESCRIPTION
## What

Add a `hidden` boolean field to `AgentProfileRef` that controls whether an agent appears in the UI agent selector/sidebar. Hidden agents remain **enabled** and fully addressable via `submit_to_agent`, but are invisible in the AgentSelector and agent picker.

## Why

Plugins often create internal/background agents that users never interact with directly — they're only dispatched by other agents via `submit_to_agent`. For example, a bug-fix plugin might create an `analyst`, `worker`, and `reviewer` agent that are called by a `fixer` or `orchestrator`. Currently all 5 agents clutter the user-facing agent list, creating confusion.

The existing `enabled` field can't be used (disabled agents can't run), and `pinned` is the opposite of what's needed (it makes agents *more* visible). A dedicated `hidden` flag fills this gap.

## How

Mirrors the existing `pinned` pattern exactly:

**Backend:**
- `AgentProfileRef` (`config.py`): new `hidden: bool = Field(default=False)`
- `AgentSummary` (`agents.py`): include `hidden` in `list_agents` response
- New `PATCH /agents/{agentId}/hide` endpoint — same structure as `set_agent_pinned`
- Default agent cannot be hidden (400 error, same as "cannot unpin default")

**Frontend:**
- `AgentSelector`: single `visibleAgents` memo filters `!agent.hidden`, all 4 partitioning memos derive from it
- `AgentTable`: new hide/unhide button (EyeOff/Eye from lucide-react, already imported)
- `useAgents` hook: `hideAgent` handler with optimistic update + error rollback
- en/zh locale: 5 new keys (`hideAgent`, `unhideAgent`, `hideSuccess`, `unhideSuccess`, `hideFailed`)

**Design decisions:**
- `list_agents` API does **not** filter hidden agents — they're still returned so the Settings/Agents management page can show and unhide them. Filtering is purely frontend (AgentSelector).
- `hidden` is independent of `enabled` — a hidden+enabled agent runs normally for heartbeat/background tasks.
- Stored on `AgentProfileRef` (root config.json), not `AgentProfileConfig` (per-agent agent.json) — matches `enabled`/`pinned` and is what `list_agents` reads.

## Testing

- Backend: verified `list_agents` returns `hidden` field for all agents; `PATCH /agents/{id}/hide` persists state correctly
- Frontend: verified hidden agents don't appear in AgentSelector sidebar; hide/unhide button toggles state in Settings/Agents table
- Plugin integration: `android-bugfix` plugin sets `hidden=True` for 3 internal agents at creation time — only user-facing `fixer` and `orchestrator` appear in UI