### PR TITLE
fix(console): stream SSE in real-time via pure ASGI middleware

### DIFF
--- a/src/qwenpaw/app/auth.py
+++ b/src/qwenpaw/app/auth.py
@@ -29,7 +29,6 @@ import time
 from typing import Optional
 
 from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from ..constant import SECRET_DIR, EnvVarLoader
 from ..security.secret_store import (
@@ -687,31 +686,51 @@ def _resolve_client_ip(request: Request) -> str:
 resolve_client_ip = _resolve_client_ip
 
 
-class AuthMiddleware(BaseHTTPMiddleware):
-    """Middleware that checks Bearer token on protected routes."""
+class AuthMiddleware:
+    """Middleware that checks Bearer token on protected routes.
 
-    async def dispatch(self, request: Request, call_next):
+    Implemented as a pure-ASGI middleware (not ``BaseHTTPMiddleware``)
+    so that streaming responses (SSE) are forwarded chunk-by-chunk
+    without buffering.  ``BaseHTTPMiddleware`` bridges the response
+    through an internal anyio memory stream which delays flushes and
+    breaks real-time SSE delivery.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            return await self.app(scope, receive, send)
+
+        request = Request(scope, receive)
+
         if self._should_skip_auth(request):
-            return await call_next(request)
+            return await self.app(scope, receive, send)
 
         token = self._extract_token(request)
         if not token:
-            return Response(
+            response = Response(
                 content='{"detail":"Not authenticated"}',
                 status_code=401,
                 media_type="application/json",
             )
+            return await response(scope, receive, send)
 
         user = verify_token(token)
         if user is None:
-            return Response(
+            response = Response(
                 content='{"detail":"Invalid or expired token"}',
                 status_code=401,
                 media_type="application/json",
             )
+            return await response(scope, receive, send)
 
+        # ``request.state`` is backed by ``scope["state"]``, so this
+        # value is visible to downstream code that builds its own
+        # ``Request`` from the same scope.
         request.state.user = user
-        return await call_next(request)
+        return await self.app(scope, receive, send)
 
     @staticmethod
     def _should_skip_auth(  # pylint: disable=too-many-return-statements

--- a/src/qwenpaw/app/routers/agent_scoped.py
+++ b/src/qwenpaw/app/routers/agent_scoped.py
@@ -6,26 +6,30 @@ allowing downstream APIs to access the correct agent context.
 """
 
 from fastapi import APIRouter, Request
-from starlette.middleware.base import (
-    BaseHTTPMiddleware,
-    RequestResponseEndpoint,
-)
-from starlette.responses import Response
 
 
-class AgentContextMiddleware(BaseHTTPMiddleware):
-    """Middleware to inject agentId into request.state."""
+class AgentContextMiddleware:
+    """Middleware to inject agentId into request.state.
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
-    ) -> Response:
-        """Extract agentId and root_session_id from path/headers."""
+    Implemented as a pure-ASGI middleware (not ``BaseHTTPMiddleware``)
+    so that streaming responses (SSE) are forwarded chunk-by-chunk
+    without buffering.  ``BaseHTTPMiddleware`` bridges the response
+    through an internal anyio memory stream which delays flushes and
+    breaks real-time SSE delivery.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            return await self.app(scope, receive, send)
+
         import logging
         from ..agent_context import set_current_agent_id
 
         logger = logging.getLogger(__name__)
+        request = Request(scope, receive)
         agent_id = None
 
         # Priority 1: Extract agentId from path: /api/agents/{agentId}/...
@@ -33,6 +37,9 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
         if len(path_parts) >= 4 and path_parts[1] == "api":
             if path_parts[2] == "agents":
                 agent_id = path_parts[3]
+                # ``request.state`` is backed by ``scope["state"]``, so
+                # this value is visible to downstream code that builds
+                # its own ``Request`` from the same scope.
                 request.state.agent_id = agent_id
                 logger.debug(
                     f"AgentContextMiddleware: agent_id={agent_id} "
@@ -50,18 +57,18 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
         # Extract X-Root-Session-Id header for cross-session approval routing
         root_session_id = request.headers.get("X-Root-Session-Id")
         if root_session_id:
-            # Inject into request.request_context for runner access
-            if not hasattr(request, "request_context"):
-                request.request_context = {}
-            request.request_context["root_session_id"] = root_session_id
+            # Store on request.state (not a custom Request attribute)
+            # so it survives into downstream code under pure ASGI.
+            if not hasattr(request.state, "request_context"):
+                request.state.request_context = {}
+            request.state.request_context["root_session_id"] = root_session_id
             logger.debug(
                 "AgentContextMiddleware: root_session_id=%s from "
                 "X-Root-Session-Id header",
                 root_session_id[:12],
             )
 
-        response = await call_next(request)
-        return response
+        return await self.app(scope, receive, send)
 
 
 def create_agent_scoped_router() -> APIRouter:


### PR DESCRIPTION
## What

Console UI does not display model output, tool calls, or thinking process incrementally — everything appears at once only after the full response completes.

## Why

`BaseHTTPMiddleware` (Starlette) buffers the entire SSE response through an internal anyio memory stream before forwarding. This means `send()` calls from the streaming generator are not flushed to the client until the upstream generator finishes, defeating the purpose of server-sent events.

Root cause confirmed: `AuthMiddleware` and `AgentContextMiddleware` both inherit from `BaseHTTPMiddleware`. The anyio memory object stream between the middleware and the app creates a buffering layer that collects all chunks and only releases them when the generator is exhausted.

Reproduced on v2.1.0b3 (exe installer), all models, all conversations — not model/provider specific. Reported in #6820.

## How

Convert `AuthMiddleware` and `AgentContextMiddleware` from `BaseHTTPMiddleware` subclass to **pure ASGI middleware** (`__call__` protocol). In pure ASGI, `send()` calls pass straight through to the client without intermediate buffering.

Key change: `request.request_context` (custom attribute on Starlette `Request`) does not survive pure ASGI because `Request` is reconstructed per-call. Moved to `request.state.request_context` which persists across the ASGI call chain.

Files changed:
- `src/qwenpaw/app/auth.py` — convert both middlewares to pure ASGI `__call__`
- `src/qwenpaw/app/routers/agent_scoped.py` — read context from `request.state` instead of custom attribute

## Testing

- Verified on v2.1.0b3 exe install: text, thinking process, and tool calls now stream incrementally in real-time
- All models tested — streaming works uniformly
- Auth and agent context still function correctly (no auth bypass, context properly propagated)

Fixes #6820