### PR TITLE
fix(providers): strip unsupported Gemini schema metadata

### DIFF
--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -92,6 +92,7 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
 
     Removes or rewrites constructs that Gemini does not support:
 
+    - ``$schema``: removed entirely.
     - ``additionalProperties``: removed entirely.
     - ``anyOf`` containing ``{"type": "null"}``: simplified to the single
       non-null type (i.e. ``Optional[X]`` becomes just ``X``).
@@ -109,6 +110,7 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
         return schema
 
     schema = dict(schema)
+    schema.pop("$schema", None)
 
     # Replace standalone "type": "null" with "type": "object".
     # Some MCP servers emit ``{"type": "null"}`` for parameters that

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from types import SimpleNamespace
 
 import pytest
 from google.genai import errors as genai_errors
+from google.genai import types as genai_types
 
 import qwenpaw.providers.gemini_provider as gemini_provider_module
 from qwenpaw.providers.gemini_provider import GeminiProvider
@@ -489,6 +491,55 @@ def test_sanitize_all_null_anyOf_becomes_object() -> None:
     }
     result = _sanitize_schema_for_gemini(schema)
     assert "anyOf" not in result
+
+
+def test_format_tools_strips_schema_metadata_before_sdk_validation() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search for a query.",
+                "parameters": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "$schema": (
+                                "http://json-schema.org/draft-07/schema#"
+                            ),
+                            "type": "string",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+    ]
+    original_tools = copy.deepcopy(tools)
+
+    model = _make_provider().get_chat_model_instance("gemini-2.5-flash")
+    formatted_tools, tool_config = model._format_tools(tools, None)
+
+    config = genai_types.GenerateContentConfig(tools=formatted_tools)
+    assert tool_config is None
+    assert config.tools is not None
+    assert formatted_tools == [
+        {
+            "function_declarations": [
+                {
+                    "name": "search",
+                    "description": "Search for a query.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            ],
+        },
+    ]
+    assert tools == original_tools
 
 
 # -- update_config ------------------------------------------------------------


### PR DESCRIPTION
## Description

Gemini tool requests can fail during local Google SDK validation when a JSON Schema carries the `$schema` metadata keyword. The SDK rejects that keyword as an extra field before any model request is sent, which can surface as a model `unknown` failure.

This change removes `$schema` at every level of the existing recursive Gemini schema sanitizer. The shared adapter covers MCP, built-in, and plugin tool schemas without adding a model-specific workaround. Other providers and tool execution behavior are unchanged.

**Related Issue:** Fixes #6812

**Security Considerations:** No new data flow or permission behavior. This only removes unsupported schema metadata before Gemini SDK validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration or API change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The regression passes an OpenAI-style function schema with root and nested `$schema` fields through the real QwenPaw Gemini compatibility model, then constructs `google.genai.types.GenerateContentConfig`. It also asserts full formatted output equality and input immutability.

Verification matrix:

- Gemini tool schemas: covered at the final Google SDK boundary
- MCP, built-in, and plugin tools: covered through the shared sanitizer
- Root and nested schema metadata: tested
- OpenAI/Anthropic and other providers: unchanged
- Network calls: not required

The broader unit run had two environment-sensitive baseline failures outside providers; both reproduce unchanged on exact `upstream/main` (`bacac741`): file mode `0664` versus a fixed `0644` expectation under the host umask, and a HOME safety assertion when HOME is isolated under `/tmp`.

## Evidence

```text
RED before the fix:
test_format_tools_strips_schema_metadata_before_sdk_validation FAILED
tools.0.Tool.function_declarations.0.parameters.$schema
  Extra inputs are not permitted
tools.0.Tool.function_declarations.0.parameters.properties.query.$schema
  Extra inputs are not permitted

Focused regression after the fix:
1 passed in 0.26s

Gemini provider file:
24 passed in 0.36s

All provider unit tests:
367 passed in 4.65s

Full unit suite:
6518 passed, 16 skipped, 2 baseline failures in 274.43s

Exact upstream/main comparison for the two unrelated failures:
2 failed in 0.79s

pre-commit run --all-files:
All hooks passed, including mypy, Black, Flake8, Pylint, Prettier, and actionlint.

git diff --check:
Passed.
```

## Additional Notes

AgentScope 2.0.4.post1 is unchanged. The existing compatibility shim can still be removed when the repository upgrades to an AgentScope release whose Gemini formatter provides equivalent sanitization.