### PR TITLE
fix(chats): preserve assistant completion time

### DIFF
--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -145,9 +145,12 @@ function generateId(): string {
   return `${Date.now()}-${randomBase36(9)}`;
 }
 
-/** Parse metadata.timestamp string (e.g. "2026-05-27 10:44:53.362") to unix seconds. */
-const parseTimestamp = (msg: Record<string, unknown>): number => {
-  const ts = (msg.metadata as Record<string, unknown>)?.timestamp;
+/** Parse a metadata timestamp string to unix seconds. */
+const parseTimestamp = (
+  msg: Record<string, unknown>,
+  field: "timestamp" | "finished_at" = "timestamp",
+): number => {
+  const ts = (msg.metadata as Record<string, unknown>)?.[field];
   if (!ts || typeof ts !== "string") return 0;
   const ms = new Date(ts.replace(" ", "T")).getTime();
   return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
@@ -282,7 +285,9 @@ const buildResponseCard = (
   );
 
   const firstTs = parseTimestamp(outputMessages[0]);
-  const lastTs = parseTimestamp(outputMessages[outputMessages.length - 1]);
+  const lastMessage = outputMessages[outputMessages.length - 1];
+  const lastTs = parseTimestamp(lastMessage);
+  const completedTs = parseTimestamp(lastMessage, "finished_at");
 
   const normalizedMessages = outputMessages.map((msg) => ({
     ...msg,
@@ -305,7 +310,7 @@ const buildResponseCard = (
           created_at: firstTs || fallbackNow,
           sequence_number: maxSeq + 1,
           error: null,
-          completed_at: lastTs || fallbackNow,
+          completed_at: completedTs || lastTs || fallbackNow,
           usage: turnUsage?.usage ?? null,
           context_usage: turnUsage?.context_usage ?? null,
         },

--- a/console/src/pages/Chat/tests/testLargeSession.test.ts
+++ b/console/src/pages/Chat/tests/testLargeSession.test.ts
@@ -549,6 +549,50 @@ describe("buildUserCard / buildResponseCard helpers", () => {
     expect(data.sequence_number).toBe(13);
   });
 
+  it("buildResponseCard uses the persisted reply completion time", () => {
+    const card = buildResponseCard([
+      toOutputMessage({
+        role: "assistant",
+        content: "working",
+        metadata: {
+          timestamp: "2026-08-08T10:00:00+00:00",
+          finished_at: "2026-08-08T10:02:00+00:00",
+        },
+      }),
+      toOutputMessage({
+        role: "assistant",
+        content: "done",
+        metadata: {
+          timestamp: "2026-08-08T10:00:00+00:00",
+          finished_at: "2026-08-08T10:02:00+00:00",
+        },
+      }),
+    ]);
+    const data = card.cards![0].data as Record<string, unknown>;
+
+    expect(data.created_at).toBe(
+      Date.parse("2026-08-08T10:00:00+00:00") / 1000,
+    );
+    expect(data.completed_at).toBe(
+      Date.parse("2026-08-08T10:02:00+00:00") / 1000,
+    );
+  });
+
+  it("buildResponseCard falls back to the last persisted creation time", () => {
+    const card = buildResponseCard([
+      toOutputMessage({
+        role: "assistant",
+        content: "legacy reply",
+        metadata: { timestamp: "2026-08-08T10:00:00+00:00" },
+      }),
+    ]);
+    const data = card.cards![0].data as Record<string, unknown>;
+
+    expect(data.completed_at).toBe(
+      Date.parse("2026-08-08T10:00:00+00:00") / 1000,
+    );
+  });
+
   it("parseTimestamp handles malformed timestamps without throwing", () => {
     expect(parseTimestamp({ metadata: {} } as any)).toBe(0);
     expect(

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -553,12 +553,16 @@ def agentscope_msg_to_message(
         ts_value = msg.timestamp
         if ts_value:
             ts_value = _normalize_msg_timestamp(ts_value, user_tz)
+        finished_at = getattr(msg, "finished_at", None)
+        if finished_at:
+            finished_at = _normalize_msg_timestamp(finished_at, user_tz)
 
         metadata = {
             "original_id": msg.id,
             "original_name": msg.name,
             "metadata": msg.metadata,
             "timestamp": ts_value,
+            "finished_at": finished_at,
         }
 
         if isinstance(msg.content, str):

--- a/src/qwenpaw/runtime/executor.py
+++ b/src/qwenpaw/runtime/executor.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any, AsyncGenerator
 
+from agentscope.event import ReplyEndEvent
+
 from .envelope import Envelope
 from .heartbeat import (
     _iter_with_heartbeat,
@@ -33,6 +35,22 @@ class AgentExecutor:
         self._agent = agent
         self._envelope = envelope
 
+    def _record_reply_completion(self, event: ReplyEndEvent) -> None:
+        """Apply a terminal reply event to its persisted context message."""
+        state = getattr(self._agent, "state", None)
+        context = getattr(state, "context", None)
+        if not context:
+            return
+        for message in reversed(context):
+            if getattr(message, "id", None) != event.reply_id:
+                continue
+            if (
+                getattr(message, "role", None) == "assistant"
+                and getattr(message, "finished_at", None) is None
+            ):
+                message.append_event(event)
+            return
+
     async def run(
         self,
         msgs: list[Any],
@@ -52,6 +70,9 @@ class AgentExecutor:
                 async for obj in self._envelope.heartbeat():
                     yield obj
                 continue
+
+            if isinstance(event, ReplyEndEvent):
+                self._record_reply_completion(event)
 
             async for obj in self._envelope.translate_event(event):
                 yield obj

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -155,6 +155,34 @@ def test_msg_to_message_hides_headline_in_history_path():
     assert "all set" in rendered
 
 
+def test_msg_to_message_preserves_reply_completion_time(monkeypatch):
+    monkeypatch.setattr(
+        "qwenpaw.app.chats.utils.load_config",
+        lambda: SimpleNamespace(user_timezone="UTC"),
+    )
+    msg = Msg(
+        id="reply-1",
+        name="assistant",
+        role="assistant",
+        created_at="2026-08-08T10:00:00+00:00",
+        finished_at="2026-08-08T10:02:00+00:00",
+        content=[
+            {"type": "thinking", "thinking": "working"},
+            {"type": "text", "text": "done"},
+        ],
+    )
+
+    messages = agentscope_msg_to_message(msg)
+
+    assert len(messages) == 2
+    assert {message.metadata["timestamp"] for message in messages} == {
+        "2026-08-08T10:00:00+00:00",
+    }
+    assert {message.metadata["finished_at"] for message in messages} == {
+        "2026-08-08T10:02:00+00:00",
+    }
+
+
 def test_msg_to_message_omits_tagged_scroll_memory_placeholder():
     placeholder = Msg(
         name="memory",

--- a/tests/unit/runtime/test_executor.py
+++ b/tests/unit/runtime/test_executor.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Agent execution event-to-state behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from agentscope.event import ReplyEndEvent
+from agentscope.message import Msg
+
+from qwenpaw.runtime.executor import AgentExecutor
+
+pytestmark = [pytest.mark.unit, pytest.mark.p1]
+
+
+class _RecordingEnvelope:
+    def __init__(self) -> None:
+        self.events = []
+
+    async def heartbeat(self):
+        for item in ():
+            yield item
+
+    async def translate_event(self, event):
+        self.events.append(event)
+        for item in ():
+            yield item
+
+
+class _ReplyingAgent:
+    def __init__(self, context: list[Msg], event: ReplyEndEvent) -> None:
+        self.state = SimpleNamespace(context=context)
+        self._event = event
+
+    async def reply_stream(self, inputs):
+        del inputs
+        yield self._event
+
+
+async def test_reply_end_event_stamps_only_matching_context_message():
+    historical = Msg(
+        id="reply-old",
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "old reply"}],
+    )
+    current = Msg(
+        id="reply-current",
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "current reply"}],
+    )
+    event = ReplyEndEvent(
+        session_id="session-1",
+        reply_id="reply-current",
+        created_at="2026-08-08T10:02:00+00:00",
+    )
+    envelope = _RecordingEnvelope()
+    executor = AgentExecutor(
+        _ReplyingAgent([historical, current], event),
+        envelope,
+    )
+
+    assert [item async for item in executor.run([])] == []
+
+    assert historical.finished_at is None
+    assert current.finished_at == "2026-08-08T10:02:00+00:00"
+    assert envelope.events == [event]


### PR DESCRIPTION
## Description

Preserve the actual assistant reply completion time when chat history is
reloaded. The live SSE path already carries the correct time, but persisted
AgentScope messages previously kept `finished_at` unset and history
reconstruction replaced `completed_at` with the message creation time.

This change:

- applies the terminal `ReplyEndEvent` to the matching assistant context
  message before post-response session persistence;
- propagates and timezone-normalizes `finished_at` through the chat history
  API for every output derived from the reply;
- makes Console response-card reconstruction prefer `finished_at`, with the
  existing creation timestamp as a stable fallback for legacy sessions.

The runtime layer is shared by all channels, so the persistence fix is not a
Console-only policy workaround. Live SSE behavior and cancellation semantics
are unchanged.

**Related Issue:** Fixes #6826

**Security Considerations:** No authentication, credentials, or new external
input handling is introduced. Persisted timestamps are parsed with the existing
invalid-value fallback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed: no configuration or public API change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Backend contract: exact `ReplyEndEvent.created_at` is written only to the
  matching assistant context message.
- History conversion: multi-block replies preserve one normalized
  `finished_at` on all derived outputs.
- Console reconstruction: persisted completion time wins; legacy null data
  falls back to the last creation time.
- Full Console tests were run with four workers. Three unrelated UI interaction
  tests hit their existing per-test timeouts under parallel load; all three
  files passed when rerun with one worker.

## Evidence

```bash
$ pytest -q -s tests/unit/runtime --no-cov
69 passed in 22.61s

$ pytest -x -vv -s tests/unit/app/chats --no-cov
102 passed in 1.70s

$ pytest -q tests/unit/runtime/test_executor.py tests/unit/app/chats/test_utils.py --no-cov
35 passed in 2.32s

$ npm run test:run -- src/pages/Chat/tests/testLargeSession.test.ts
Test Files  1 passed (1)
Tests       31 passed (31)

$ npm run test:run -- --maxWorkers=4
Test Files  3 failed | 220 passed (223)
Tests       3 failed | 1681 passed (1684)
# The three failures were unrelated interaction-test timeouts.

$ npm run test:run -- src/features/project-directory/SessionProjectDirectory.test.tsx src/pages/AppCenter/index.test.tsx src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx --maxWorkers=1
Test Files  3 passed (3)
Tests       20 passed (20)

$ npm run build
✓ built in 2m 31s
[verify-monaco-css] OK - Monaco stylesheet present in 35 CSS file(s).

$ pre-commit run --all-files
All hooks passed, including mypy, black, flake8, pylint, and actionlint.
```

## Additional Notes

Verification matrix:

| Surface | Result |
| --- | --- |
| AgentScope 2.0 terminal reply event | Covered |
| Shared runtime / all channels | Covered at common executor layer |
| HTTP history reconstruction | Covered |
| Live SSE response timestamps | Unchanged |
| Legacy `finished_at: null` sessions | Stable creation-time fallback |
| Cancellation path | Unchanged |

The channel contract checklist is not applicable because no channel adapter or
delivery contract changed. Existing sessions with a null completion timestamp
cannot recover an exact historical end time; this fix preserves exact times for
newly completed replies.
