### PR TITLE
fix(timestamp): interpret naive Msg timestamps as process-local timezone

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -36,6 +36,28 @@ from ...constant import (
 logger = logging.getLogger(__name__)
 
 
+def _process_local_tz():
+    """Return the process-local timezone used by ``datetime.now()``."""
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def _normalize_msg_timestamp(ts_value: str, user_tz: ZoneInfo) -> str:
+    """Normalize a Msg timestamp string into the user's timezone.
+
+    AgentScope writes ``Msg.created_at`` with ``datetime.now().isoformat()``,
+    so a naive value is a process-local wall clock — not UTC and not
+    ``user_timezone``. Aware values keep their encoded offset.
+    Unparseable inputs are returned unchanged.
+    """
+    try:
+        dt_obj = datetime.fromisoformat(ts_value)
+        if dt_obj.tzinfo is None:
+            dt_obj = dt_obj.replace(tzinfo=_process_local_tz())
+        return dt_obj.astimezone(user_tz).isoformat()
+    except (ValueError, TypeError):
+        return ts_value
+
+
 def _is_scroll_memory_placeholder(msg: Msg) -> bool:
     """Return whether *msg* is model-only Scroll context, not transcript.
 
@@ -530,13 +552,7 @@ def agentscope_msg_to_message(
 
         ts_value = msg.timestamp
         if ts_value:
-            try:
-                dt_obj = datetime.fromisoformat(ts_value)
-                if dt_obj.tzinfo is None:
-                    dt_obj = dt_obj.replace(tzinfo=timezone.utc)
-                ts_value = dt_obj.astimezone(user_tz).isoformat()
-            except (ValueError, TypeError):
-                pass
+            ts_value = _normalize_msg_timestamp(ts_value, user_tz)
 
         metadata = {
             "original_id": msg.id,

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
 from agentscope.message import Msg
 
 from qwenpaw.app.chats.utils import (
     _abspath_from_url,
     _is_local_file_url,
+    _normalize_msg_timestamp,
     _resolve_content_url,
     agentscope_msg_to_message,
     clean_display_text,
@@ -329,6 +335,78 @@ def test_history_batch_hides_scroll_internals_but_keeps_transcript():
     assert "system-info" not in rendered_text
     assert "private continuation state" not in rendered_text
     assert "private retrieval headline" not in rendered_text
+
+
+# ---------------------------------------------------------------------------
+# message timestamp normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_msg_timestamp_naive_process_utc_to_shanghai():
+    """Docker/UTC process: naive wall clock is UTC (#6301)."""
+    shanghai = ZoneInfo("Asia/Shanghai")
+    with patch(
+        "qwenpaw.app.chats.utils._process_local_tz",
+        return_value=ZoneInfo("UTC"),
+    ):
+        assert (
+            _normalize_msg_timestamp("2026-08-10 12:52:57.000000", shanghai)
+            == "2026-08-10T20:52:57+08:00"
+        )
+
+
+def test_normalize_msg_timestamp_naive_process_shanghai_no_drift():
+    """Desktop Asia/Shanghai: naive wall clock stays on the same face."""
+    shanghai = ZoneInfo("Asia/Shanghai")
+    with patch(
+        "qwenpaw.app.chats.utils._process_local_tz",
+        return_value=shanghai,
+    ):
+        assert (
+            _normalize_msg_timestamp("2026-08-10 12:52:57.000000", shanghai)
+            == "2026-08-10T12:52:57+08:00"
+        )
+
+
+def test_normalize_msg_timestamp_aware_keeps_instant():
+    shanghai = ZoneInfo("Asia/Shanghai")
+    assert (
+        _normalize_msg_timestamp("2026-08-10T04:52:57+00:00", shanghai)
+        == "2026-08-10T12:52:57+08:00"
+    )
+
+
+def test_normalize_msg_timestamp_invalid_passthrough():
+    shanghai = ZoneInfo("Asia/Shanghai")
+    assert _normalize_msg_timestamp("not-a-date", shanghai) == "not-a-date"
+
+
+def test_agentscope_msg_to_message_timestamp_uses_process_local_tz():
+    """End-to-end through agentscope_msg_to_message (Shanghai process)."""
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[{"type": "text", "text": "hi"}],
+        created_at="2026-08-10T12:52:57.000000",
+    )
+    shanghai = ZoneInfo("Asia/Shanghai")
+    with (
+        patch(
+            "qwenpaw.app.chats.utils.load_config",
+            return_value=SimpleNamespace(user_timezone="Asia/Shanghai"),
+        ),
+        patch(
+            "qwenpaw.app.chats.utils._process_local_tz",
+            return_value=shanghai,
+        ),
+    ):
+        [message] = agentscope_msg_to_message(msg)
+
+    assert message.metadata["timestamp"] == "2026-08-10T12:52:57+08:00"
+    # Wall-clock must not drift into the future relative to the source.
+    converted = datetime.fromisoformat(message.metadata["timestamp"])
+    assert converted.hour == 12
+    assert converted.tzinfo is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix a +8h message timestamp drift regression introduced by #6685.

AgentScope writes `Msg.created_at` with `datetime.now().isoformat()`, so naive timestamps are process-local wall clocks — not UTC. #6685 treated every naive value as UTC and then converted to `user_timezone`, which is correct for UTC containers but wrong for Asia/Shanghai (and other non-UTC) deployments: e.g. `12:52:57` was shown as `20:52:57+08:00`.

This PR interprets naive timestamps using the process-local timezone, then converts to the configured user timezone. Aware timestamps still convert from their encoded offset. That restores correct desktop/local display while preserving the Docker UTC → user-TZ behavior from #6301.

**Related Issue:** Relates to #6301 (refines the naive-timestamp assumption from #6685)

**Security Considerations:** N/A — display-time conversion only; no auth, channel, or secret handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Unit matrix:
   ```bash
   python -m pytest tests/unit/app/chats/test_utils.py -k timestamp -q
   python -m pytest tests/unit/app/chats/test_utils.py -q
   ```
2. Manual / UI (Asia/Shanghai): send a chat message and confirm the bubble timestamp matches local wall clock (no ~+8h future drift); reload the session and confirm history timestamps stay correct.
3. Regression check for #6301: naive timestamp under process TZ=UTC + `user_timezone=Asia/Shanghai` should still shift by +8h (e.g. `12:52:57` → `20:52:57+08:00`).

## Evidence

```bash
$ .venv/bin/pre-commit run --files src/qwenpaw/app/chats/utils.py tests/unit/app/chats/test_utils.py
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

$ .venv/bin/python -m pytest tests/unit/app/chats/test_utils.py -k timestamp -q
.....                                                                    [100%]
5 passed, 33 deselected in 0.24s

$ .venv/bin/python -m pytest tests/unit/app/chats/test_utils.py -q
......................................                                   [100%]
38 passed in 0.37s
```

Live `Msg` → `agentscope_msg_to_message` under `TZ=Asia/Shanghai` / `user_timezone=Asia/Shanghai`:
- `Msg.created_at`: `2026-08-10T10:19:51...`
- converted: `2026-08-10T10:19:51...+08:00`
- `wall-clock drift_hours = 0.0` (was `8.0` under #6685)

Also verified:
- historical naive `12:52:57` → `12:52:57+08:00` (Shanghai process)
- UTC-container naive `12:52:57` → `20:52:57+08:00` (#6301 preserved)
- aware `2026-08-08T04:52:57+00:00` → `12:52:57+08:00` (no double shift)

## Additional Notes

- Change is confined to `agentscope_msg_to_message` conversion (`_normalize_msg_timestamp`); session on-disk format and AgentScope `Msg.created_at` writer are unchanged.
- Console UI was not modified; it displays the timestamp produced by this backend conversion path.