### PR TITLE
docs(blog): add QwenPaw checkpoint blog

### DIFF
--- a/website/public/blog/qwenpaw-checkpoint.en.md
+++ b/website/public/blog/qwenpaw-checkpoint.en.md
@@ -1,0 +1,164 @@
+---
+title: "Agent Conversations Checkpoints: Introducing QwenPaw Checkpoint"
+date: 2026-08-07
+author: QwenPaw Team
+tags: [Checkpoint, Conversation Recovery, State Management]
+cover: https://img.alicdn.com/imgextra/i3/O1CN01LXaNPg4UfYB3rvs1_!!6000000007061-2-tps-1906-943.png
+excerpt: "QwenPaw Checkpoint saves Agent conversation state and can optionally restore long-term memory and workspace files, so a conversation that drifts off course can return to the right timeline."
+---
+
+# Give Agent Conversations a Save Point: Introducing QwenPaw Checkpoint 🎮
+
+Agent conversations sometimes drift because of a single misunderstanding. Correcting the Agent does not remove the bad context, so later turns may continue in the wrong direction. Starting a new conversation works, but then you have to explain the background and requirements all over again. QwenPaw Checkpoint is built for this situation: it saves conversation state and lets you return to an earlier point when needed.
+
+> In short: **when a conversation goes off course, do not start over—return to the point before it drifted.**
+
+## 1. How It Works
+
+A checkpoint works much like a save point in a game. Create one after confirming requirements, completing a feature, or before attempting a risky operation, then restore it later if necessary. Every restore includes the current conversation. Long-term memory and workspace files are optional:
+
+| Restore scope        | Default  | Content                                    |
+| -------------------- | -------- | ------------------------------------------ |
+| Current conversation | Included | Session files and Agent conversation state |
+| Long-term memory     | Excluded | `MEMORY.md` and `memory/`                  |
+| Workspace files      | Excluded | Files explicitly selected after preview    |
+
+QwenPaw uses three checkpoint types:
+
+- **Named snapshot:** Created manually for an important state and excluded from automatic GC.
+- **Automatic checkpoint:** Created by the system when enabled and cleaned according to count and age policies.
+- **Pre-restore safety point:** Created automatically before an applied restore, providing a way back if you change your mind.
+
+Continuing a conversation after restoring an older node creates a new timeline branch. Later history is not simply erased. **HEAD** marks the checkpoint currently selected by the conversation.
+
+Checkpoint data stays in the current Agent workspace and is separate from the project's own `.git/`. It does not create project commits, switch project branches, or rewrite Git history. Checkpoints are intended for everyday conversation rollback, not full-machine backups or cross-device migration.
+
+![Checkpoint timeline](https://img.alicdn.com/imgextra/i3/O1CN01LXaNPg4UfYB3rvs1_!!6000000007061-2-tps-1906-943.png)
+
+## 2. Command Overview
+
+You can manage checkpoints from the Console or use magic commands directly in Chat.
+
+![Viewing Checkpoint commands in Chat](https://img.alicdn.com/imgextra/i2/O1CN01ygWpyuERcQG2b85m_!!6000000000472-1-tps-1280-638.gif)
+
+| Command                                       | Description                                           |
+| --------------------------------------------- | ----------------------------------------------------- |
+| `/checkpoint`                                 | Show command help                                     |
+| `/checkpoint auto [on\|off]`                  | View, enable, or disable automatic checkpoints        |
+| `/checkpoint snapshot [name]`                 | Create a named snapshot                               |
+| `/checkpoint timeline [--limit=N] [--all]`    | View checkpoint history                               |
+| `/checkpoint restore <target> [options]`      | Preview or apply a restore                            |
+| `/checkpoint gc [--all-sessions] [--compact]` | Preview or clean up old checkpoints                   |
+| `/checkpoint reset --confirm`                 | Clear checkpoint history and restore default settings |
+
+A restore target can be a timeline number such as `#3`, a snapshot name, or a SHA prefix with at least seven characters. These are the options most people need day to day:
+
+| Option               | Purpose                                                |
+| -------------------- | ------------------------------------------------------ |
+| `--dry-run`          | Preview changes without restoring or cleaning anything |
+| `--confirm`          | Confirm and apply the operation                        |
+| `--include-memory`   | Include long-term memory in a restore                  |
+| `--include-files`    | Include workspace files in a restore                   |
+| `--files <paths...>` | Select workspace files to restore or delete            |
+| `--all-sessions`     | Run GC across all conversations in the workspace       |
+| `--compact`          | Delete every non-HEAD automatic checkpoint             |
+
+A common command flow looks like this:
+
+```text
+/checkpoint snapshot demo-start
+/checkpoint auto on
+/checkpoint timeline
+/checkpoint restore demo-start --dry-run
+/checkpoint restore demo-start --confirm
+```
+
+Run `--dry-run` first, inspect the target and changes, then use `--confirm`. The two options cannot be used together.
+
+To restore workspace files, first inspect the candidate differences:
+
+```text
+/checkpoint restore demo-start --include-files --dry-run
+```
+
+Then explicitly select the paths to apply:
+
+```text
+/checkpoint restore demo-start --include-files --files checkpoint-demo/state.txt checkpoint-demo/temp.txt --confirm
+```
+
+If a selected file does not exist in the target checkpoint, the restore deletes the current file. The preview marks these operations clearly, so check the list before applying it.
+
+## 3. Feature Walkthrough
+
+The following small file-editing example shows how Checkpoint restores both a conversation and its workspace files.
+
+### Create a Baseline
+
+First, ask the Agent to create `checkpoint-demo/state.txt`:
+
+```text
+Checkpoint Demo
+version=1
+status=baseline
+```
+
+The conversation and file are now in the expected state. Open **Workspace → Checkpoints**, select **Create Snapshot**, and name it `demo-start`. To record later states automatically, enable **Automatic Checkpoints** in the upper-right corner.
+
+![Creating the demo-start snapshot](https://img.alicdn.com/imgextra/i4/O1CN01SFtF4KZZWqF2b85m_!!6000000008121-1-tps-1280-638.gif)
+
+### Change the Files
+
+Next, ask the Agent to replace `state.txt` with:
+
+```text
+Checkpoint Demo
+version=2
+status=modified
+```
+
+Also create `checkpoint-demo/temp.txt`:
+
+```text
+temporary=true
+```
+
+Return to the Checkpoints page. A new automatic checkpoint now appears in the timeline, and HEAD has moved forward.
+
+![Named and automatic checkpoints in the timeline](https://img.alicdn.com/imgextra/i3/O1CN01dETNOWraAFB5CGBb_!!6000000007332-2-tps-2560-1279.png)
+
+### Preview and Restore
+
+Select `demo-start`, choose **Restore**, enable **Workspace Files**, and preview the changes.
+
+The preview contains two candidates:
+
+- `checkpoint-demo/state.txt`: restore
+- `checkpoint-demo/temp.txt`: delete
+
+`temp.txt` was created after the target snapshot, so restoring the workspace to `demo-start` removes it. Review the file list, select the candidates, and apply the restore.
+
+![Previewing and restoring workspace files](https://img.alicdn.com/imgextra/i1/O1CN01e0eWox9nnTI2b85m_!!6000000004176-1-tps-1280-638.gif)
+
+Reading `state.txt` again now returns:
+
+```text
+Checkpoint Demo
+version=1
+status=baseline
+```
+
+The later `temp.txt` is gone. More importantly, the conversation itself has returned to the snapshot state, so the context that drifted off course no longer affects later turns.
+
+The timeline preserves the previous history and creates a pre-restore safety point. When automatic checkpoints begin to accumulate, preview and run GC from the Console or Chat:
+
+```text
+/checkpoint gc --dry-run
+/checkpoint gc --confirm
+```
+
+For a more aggressive cleanup, add `--compact`. Named snapshots and conversation HEADs remain available.
+
+![Clearing the checkpoints](https://img.alicdn.com/imgextra/i1/O1CN01y0la0Zgm81F2b85m_!!6000000007125-1-tps-1280-638.gif)
+
+Checkpoint is not meant to encourage constant undo. It provides a reliable return point when the Agent misunderstands a request or the conversation moves in the wrong direction. Choose the saved state, preview the changes, and restore—the conversation and important context remain, and the work can continue from the right place. 🙂

--- a/website/public/blog/qwenpaw-checkpoint.zh.md
+++ b/website/public/blog/qwenpaw-checkpoint.zh.md
@@ -1,0 +1,164 @@
+---
+title: "Agent 会话“存档点”：QwenPaw Checkpoint 功能展示"
+date: 2026-08-07
+author: QwenPaw Team
+tags: [Checkpoint, 会话恢复, 状态管理]
+cover: https://img.alicdn.com/imgextra/i3/O1CN01LXaNPg4UfYB3rvs1_!!6000000007061-2-tps-1906-943.png
+excerpt: "QwenPaw Checkpoint 可以保存 Agent 的会话状态，并按需恢复长期记忆和工作区文件，让走偏的对话回到正确的时间线。"
+---
+
+# 给 Agent 会话加个“存档点”：QwenPaw Checkpoint 来了 🎮
+
+和 Agent 对话时，偶尔会遇到这种情况：某一步理解错了，后面的内容也跟着越走越偏。继续纠正，错误上下文还留在会话里；重新开始，又得把背景和需求全部讲一遍。QwenPaw Checkpoint 就是为这种情况准备的。它可以保存会话状态，并在需要时回到之前的节点继续。
+
+> 简单说：**对话走偏了，不用从头再来，回到还没走偏的时候就好。**
+
+## 1. 功能说明
+
+Checkpoint 类似游戏里的存档点。你可以在需求确认、功能完成或高风险操作开始前创建快照，之后再从这个节点恢复。每次恢复都会包含当前会话，另外还可以按需选择长期记忆和工作区文件：
+
+| 恢复范围   | 默认状态 | 内容                      |
+| ---------- | -------- | ------------------------- |
+| 当前会话   | 包含     | 会话文件和 Agent 对话状态 |
+| 长期记忆   | 不包含   | `MEMORY.md` 和 `memory/`  |
+| 工作区文件 | 不包含   | 预览后明确选中的文件      |
+
+Checkpoint 主要包含三种节点：
+
+- **命名快照**：手动创建，适合保存重要状态，不参与自动 GC；
+- **自动检查点**：开启后由系统自动记录，按照数量和时间规则清理；
+- **恢复前安全点**：真正恢复前自动创建，避免恢复后想反悔却没有退路。
+
+恢复旧节点后继续对话，会形成新的时间线分支，后面的历史不会直接消失。页面中的 **HEAD** 表示当前会话所在的检查点。
+
+Checkpoint 的数据保存在当前 Agent 工作区，并与项目自身的 `.git/` 分离。它不会创建项目提交、切换项目分支或改写 Git 历史。它更适合日常会话回滚，不是整机备份或跨设备迁移工具。
+
+![Checkpoint 状态检查点页面](https://img.alicdn.com/imgextra/i3/O1CN01LXaNPg4UfYB3rvs1_!!6000000007061-2-tps-1906-943.png)
+
+## 2. 命令总览
+
+Checkpoint 可以在 Console 页面中操作，也可以直接在聊天中使用魔法命令。
+
+![在聊天中查看 Checkpoint 命令](https://img.alicdn.com/imgextra/i2/O1CN01ygWpyuERcQG2b85m_!!6000000000472-1-tps-1280-638.gif)
+
+| 命令                                          | 说明                         |
+| --------------------------------------------- | ---------------------------- |
+| `/checkpoint`                                 | 查看命令帮助                 |
+| `/checkpoint auto [on\|off]`                  | 查看、开启或关闭自动检查点   |
+| `/checkpoint snapshot [名称]`                 | 创建命名快照                 |
+| `/checkpoint timeline [--limit=N] [--all]`    | 查看检查点历史               |
+| `/checkpoint restore <目标> [选项]`           | 预览或执行恢复               |
+| `/checkpoint gc [--all-sessions] [--compact]` | 预览或清理旧检查点           |
+| `/checkpoint reset --confirm`                 | 清空检查点历史并恢复默认配置 |
+
+恢复目标可以写成时间线编号（如 `#3`）、命名快照或至少 7 位的 SHA 前缀。日常使用时，记住下面几个参数基本就够了：
+
+| 参数                | 作用                         |
+| ------------------- | ---------------------------- |
+| `--dry-run`         | 只预览变化，不实际恢复或清理 |
+| `--confirm`         | 确认执行操作                 |
+| `--include-memory`  | 恢复时包含长期记忆           |
+| `--include-files`   | 恢复时包含工作区文件         |
+| `--files <路径...>` | 指定要恢复或删除的工作区文件 |
+| `--all-sessions`    | GC 时处理工作区内的全部会话  |
+| `--compact`         | 删除所有非 HEAD 自动检查点   |
+
+一个常见的命令流程如下：
+
+```text
+/checkpoint snapshot demo-start
+/checkpoint auto on
+/checkpoint timeline
+/checkpoint restore demo-start --dry-run
+/checkpoint restore demo-start --confirm
+```
+
+建议先执行 `--dry-run`，确认目标和变化后再使用 `--confirm`。两者不能同时使用。
+
+如果需要恢复工作区文件，可以先查看候选差异：
+
+```text
+/checkpoint restore demo-start --include-files --dry-run
+```
+
+确认后再指定路径：
+
+```text
+/checkpoint restore demo-start --include-files --files checkpoint-demo/state.txt checkpoint-demo/temp.txt --confirm
+```
+
+如果某个已选文件在目标检查点中不存在，恢复时会删除当前文件。预览会明确标记这类操作，执行前记得看一眼。
+
+## 3. 功能展示
+
+下面用一个简单的文件修改场景，看看 Checkpoint 怎么把走偏的会话和文件一起恢复。
+
+### 创建基线状态
+
+先让 Agent 创建 `checkpoint-demo/state.txt`：
+
+```text
+Checkpoint Demo
+version=1
+status=baseline
+```
+
+此时会话和文件都处于正确状态。进入「工作区 → 状态检查点」，点击「创建快照」，将它命名为 `demo-start`。如果希望后续状态自动被记录，也可以打开右上角的「自动检查点」。
+
+![创建 demo-start 快照](https://img.alicdn.com/imgextra/i4/O1CN01SFtF4KZZWqF2b85m_!!6000000008121-1-tps-1280-638.gif)
+
+### 修改文件，让状态发生变化
+
+接着让 Agent 把 `state.txt` 改成：
+
+```text
+Checkpoint Demo
+version=2
+status=modified
+```
+
+同时新建 `checkpoint-demo/temp.txt`：
+
+```text
+temporary=true
+```
+
+回到检查点页面，可以看到时间线上已经出现新的自动检查点，当前 HEAD 也向前移动。
+
+![命名快照和自动检查点](https://img.alicdn.com/imgextra/i3/O1CN01dETNOWraAFB5CGBb_!!6000000007332-2-tps-2560-1279.png)
+
+### 预览并恢复
+
+选中 `demo-start`，点击「恢复」，勾选「工作区文件」，然后先预览变化。
+
+在这个例子中，预览结果会包含：
+
+- `checkpoint-demo/state.txt`：恢复；
+- `checkpoint-demo/temp.txt`：删除。
+
+`temp.txt` 是在目标快照之后才创建的，所以恢复到 `demo-start` 时会被删除。确认文件列表后，执行恢复即可。
+
+![预览并恢复工作区文件](https://img.alicdn.com/imgextra/i1/O1CN01e0eWox9nnTI2b85m_!!6000000004176-1-tps-1280-638.gif)
+
+恢复完成后再次读取 `state.txt`，内容已经回到：
+
+```text
+Checkpoint Demo
+version=1
+status=baseline
+```
+
+快照之后创建的 `temp.txt` 也已经消失。更重要的是，会话本身同样回到了快照时的状态，之前走偏的上下文不会再继续影响对话。
+
+恢复后，时间线会保留原来的历史，并生成恢复前安全点。自动检查点积累较多时，可以通过 Console 或下面的命令先预览 GC：
+
+```text
+/checkpoint gc --dry-run
+/checkpoint gc --confirm
+```
+
+如果需要更彻底地压缩历史，可以使用 `--compact`。命名快照和会话 HEAD 仍会保留。
+
+![清理检查点](https://img.alicdn.com/imgextra/i1/O1CN01y0la0Zgm81F2b85m_!!6000000007125-1-tps-1280-638.gif)
+
+Checkpoint 的目标并不是让我们频繁撤销，而是在 Agent 理解偏离预期时，提供一个可靠的返回点。找到之前保存的状态，预览变化，然后恢复——会话还在，重要上下文还在，工作也能从正确的位置继续。🙂

--- a/website/src/pages/Blog/blogData.ts
+++ b/website/src/pages/Blog/blogData.ts
@@ -74,6 +74,11 @@ export const BLOG_POSTS: BlogPostMeta[] = [
     cover:
       "https://img.alicdn.com/imgextra/i1/6000000004826/O1CN014843Da1lWMZIlKBgv_!!6000000004826-0-tbvideo.jpg",
   },
+  {
+    slug: "qwenpaw-checkpoint",
+    cover:
+      "https://img.alicdn.com/imgextra/i3/O1CN01LXaNPg4UfYB3rvs1_!!6000000007061-2-tps-1906-943.png",
+  },
 ];
 
 /** Previous post in list order (top → bottom on /blog, date-desc). */


### PR DESCRIPTION
## Description

Add Chinese and English blog posts introducing QwenPaw Checkpoint, including its recovery workflow, commands, GC behavior, and demonstration images.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
