### PR TITLE
fix(creator): make file durability portable on Windows

### DIFF
--- a/plugins/apps/qwenpaw-creator/backend/services/media_files/keyframe_cache.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/media_files/keyframe_cache.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from domain.errors import StorageIntegrityError, ValidationError
 from services.project_files.assets import AssetFileStore
 from services.project_files.models import IndexedFile
+from services.runtime_files.durability import fsync_directory
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,11 +238,7 @@ def materialize_keyframe(
         finally:
             os.close(descriptor)
         os.replace(temporary, target)
-        directory_descriptor = os.open(cache_root, os.O_RDONLY)
-        try:
-            os.fsync(directory_descriptor)
-        finally:
-            os.close(directory_descriptor)
+        fsync_directory(cache_root)
         cached = _cached_entry(
             target,
             timestamp_seconds=timestamp,

--- a/plugins/apps/qwenpaw-creator/backend/services/project_files/remote_cache.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/project_files/remote_cache.py
@@ -20,6 +20,7 @@ from urllib.parse import urlsplit
 
 from domain.enums import TaskKind, TaskStatus
 from domain.errors import StorageIntegrityError
+from services.runtime_files.durability import fsync_directory
 from services.runtime_files.execution_models import TaskRecord
 
 from .assets import StagedAsset
@@ -121,11 +122,7 @@ def publish_remote_cache(
     except FileNotFoundError:
         os.chmod(staged.path, 0o600)
         os.replace(staged.path, target)
-        descriptor = os.open(cache_root, os.O_RDONLY)
-        try:
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
+        fsync_directory(cache_root)
     else:
         if stat.S_ISLNK(value.st_mode) or not stat.S_ISREG(value.st_mode):
             raise StorageIntegrityError(

--- a/plugins/apps/qwenpaw-creator/backend/services/project_files/store.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/project_files/store.py
@@ -19,6 +19,9 @@ from typing import Any, Final
 from uuid import uuid4
 
 from pydantic import ValidationError
+from services.runtime_files.durability import (
+    fsync_directory as _fsync_directory,
+)
 from services.runtime_files.locking import CrossProcessFileLock
 from services.storage_root import require_creator_data_root
 from utils.logger import setup_logger
@@ -707,17 +710,6 @@ def _snapshot(project: Project) -> ProjectSnapshot:
         etag=project_etag(project),
         generation=project.generation,
     )
-
-
-def _fsync_directory(directory: Path) -> None:
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
-    descriptor = os.open(directory, flags)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
 
 
 __all__ = [

--- a/plugins/apps/qwenpaw-creator/backend/services/runtime_files/atomic_store.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/runtime_files/atomic_store.py
@@ -16,6 +16,7 @@ from typing import Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel, ValidationError as PydanticValidationError
 
+from .durability import fsync_directory, set_descriptor_mode
 from .errors import (
     CorruptRecordError,
     RecordAlreadyExistsError,
@@ -40,20 +41,6 @@ def strict_json_loads(payload: str | bytes | bytearray) -> Any:
     """Decode standards-compliant JSON (Python accepts NaN by default)."""
 
     return json.loads(payload, parse_constant=_reject_nonfinite_json)
-
-
-def fsync_directory(path: str | os.PathLike[str]) -> None:
-    """Persist directory-entry changes on POSIX filesystems."""
-
-    directory = Path(path)
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
-    descriptor = os.open(directory, flags)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
 
 
 def _json_value(value: Any) -> Any:
@@ -134,7 +121,7 @@ def atomic_replace_bytes(
     if stage_hook is not None:
         stage_hook("temp_created", temporary)
     try:
-        os.fchmod(descriptor, mode)
+        set_descriptor_mode(descriptor, mode)
         with os.fdopen(descriptor, "wb") as handle:
             descriptor = -1
             handle.write(payload)
@@ -182,7 +169,7 @@ def atomic_create_bytes(
         stage_hook("temp_created", temporary)
     published = False
     try:
-        os.fchmod(descriptor, mode)
+        set_descriptor_mode(descriptor, mode)
         with os.fdopen(descriptor, "wb") as handle:
             descriptor = -1
             handle.write(payload)

--- a/plugins/apps/qwenpaw-creator/backend/services/runtime_files/durability.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/runtime_files/durability.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Cross-platform durability helpers for private Creator files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def set_descriptor_mode(descriptor: int, mode: int) -> None:
+    """Apply a POSIX descriptor mode when the platform provides it."""
+
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is not None:
+        fchmod(descriptor, mode)
+
+
+def fsync_directory(path: str | os.PathLike[str]) -> None:
+    """Persist directory-entry changes where directory handles are usable."""
+
+    if os.name == "nt":
+        return
+
+    directory = Path(path)
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(directory, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/plugins/apps/qwenpaw-creator/backend/services/runtime_files/jsonl_store.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/runtime_files/jsonl_store.py
@@ -24,6 +24,7 @@ from .atomic_store import (
     fsync_directory,
     strict_json_loads,
 )
+from .durability import set_descriptor_mode
 from .errors import (
     JsonlCorruptionError,
     RuntimeFileValidationError,
@@ -284,7 +285,7 @@ class DurableJsonlStore(Generic[T]):
                 flags |= os.O_CLOEXEC
             descriptor = os.open(self.path, flags, self.mode)
             try:
-                os.fchmod(descriptor, self.mode)
+                set_descriptor_mode(descriptor, self.mode)
                 view = memoryview(line)
                 while view:
                     written = os.write(descriptor, view)

--- a/plugins/apps/qwenpaw-creator/backend/services/runtime_files/locking.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/runtime_files/locking.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import time
 from types import TracebackType
 
+from .durability import set_descriptor_mode
 from .errors import LockTimeoutError, RuntimeFileValidationError
 
 logger = logging.getLogger("qwenpaw.creator.runtime_files.locking")
@@ -125,8 +126,7 @@ class CrossProcessFileLock:
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         descriptor = os.open(self.path, flags, self.mode)
-        if hasattr(os, "fchmod"):
-            os.fchmod(descriptor, self.mode)
+        set_descriptor_mode(descriptor, self.mode)
         started = time.monotonic()
         try:
             while True:

--- a/plugins/apps/qwenpaw-creator/backend/services/workspace/content_store.py
+++ b/plugins/apps/qwenpaw-creator/backend/services/workspace/content_store.py
@@ -22,6 +22,10 @@ import tempfile
 from typing import BinaryIO, Literal, Protocol
 
 from domain.errors import StorageIntegrityError, ValidationError
+from services.runtime_files.durability import (
+    fsync_directory,
+    set_descriptor_mode,
+)
 
 
 ContentNamespace = Literal["blob", "artifact"]
@@ -50,18 +54,10 @@ def _notify(hook: WriteStageHook | None, stage: str, path: Path) -> None:
 
 
 def _fsync_directory(path: Path) -> None:
-    """Persist a directory entry update where the platform supports it."""
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
     try:
-        descriptor = os.open(path, flags)
-    except OSError as exc:  # pragma: no cover - uncommon platform limitation
+        fsync_directory(path)
+    except OSError as exc:
         raise StorageIntegrityError(f"无法打开目录进行 fsync: {path}") from exc
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
 
 
 def atomic_replace_bytes(
@@ -88,7 +84,7 @@ def atomic_replace_bytes(
     temp_path = Path(raw_temp)
     _notify(stage_hook, "temp_created", temp_path)
     try:
-        os.fchmod(descriptor, mode)
+        set_descriptor_mode(descriptor, mode)
         with os.fdopen(descriptor, "wb") as handle:
             descriptor = -1
             handle.write(payload)
@@ -134,7 +130,7 @@ def atomic_copy_file(
     temp_path = Path(raw_temp)
     _notify(stage_hook, "temp_created", temp_path)
     try:
-        os.fchmod(descriptor, mode)
+        set_descriptor_mode(descriptor, mode)
         with source.open("rb") as input_handle, os.fdopen(
             descriptor,
             "wb",

--- a/plugins/apps/qwenpaw-creator/backend/tests/services/test_windows_file_durability.py
+++ b/plugins/apps/qwenpaw-creator/backend/tests/services/test_windows_file_durability.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from domain.errors import StorageIntegrityError
+from services.media_files import keyframe_cache
+from services.project_files import Project, ProjectStore
+from services.project_files import remote_cache, store as project_store
+from services.project_files.assets import StagedAsset
+from services.project_files.models import SourceAssetVersion
+from services.runtime_files import atomic_store, durability, jsonl_store
+from services.workspace import content_store
+
+
+pytestmark = pytest.mark.unit
+
+
+class _WindowsLikeOS:
+    """Expose regular file I/O but omit POSIX-only durability APIs."""
+
+    name = "nt"
+
+    def __getattr__(self, name: str):
+        if name == "fchmod":
+            raise AttributeError(name)
+        return getattr(os, name)
+
+    def open(
+        self,
+        path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd=None,
+    ) -> int:
+        if Path(path).is_dir():
+            raise PermissionError("Windows cannot open directories this way")
+        return os.open(path, flags, mode, dir_fd=dir_fd)
+
+
+def test_atomic_writes_work_without_posix_durability_apis(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(atomic_store, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+
+    replaced = tmp_path / "replaced.json"
+    atomic_store.atomic_replace_bytes(replaced, b'{"value":1}\n')
+    assert replaced.read_bytes() == b'{"value":1}\n'
+
+    created = tmp_path / "created.json"
+    assert atomic_store.atomic_create_bytes(created, b'{"value":2}\n')
+    assert created.read_bytes() == b'{"value":2}\n'
+
+
+def test_jsonl_append_works_without_fchmod(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(jsonl_store, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+    store = jsonl_store.DurableJsonlStore(tmp_path / "events.jsonl")
+
+    assert store.append({"event": "created"}).seq == 1
+    assert store.read_records() == [{"event": "created"}]
+
+
+def test_content_writes_work_without_posix_durability_apis(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(content_store, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+
+    replaced = tmp_path / "metadata.json"
+    content_store.atomic_replace_bytes(replaced, b'{"value":1}\n')
+    assert replaced.read_bytes() == b'{"value":1}\n'
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"content")
+    copied = tmp_path / "copied.bin"
+    content_store.atomic_copy_file(source, copied)
+    assert copied.read_bytes() == b"content"
+
+
+def test_content_write_keeps_directory_fsync_error_contract(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    def fail_directory_fsync(_path) -> None:
+        raise OSError("simulated directory failure")
+
+    monkeypatch.setattr(
+        content_store,
+        "fsync_directory",
+        fail_directory_fsync,
+    )
+
+    with pytest.raises(StorageIntegrityError, match="fsync"):
+        content_store.atomic_replace_bytes(
+            tmp_path / "metadata.json",
+            b'{"value":1}\n',
+        )
+
+
+def test_project_create_works_without_directory_handles(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(project_store, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+
+    store = ProjectStore(tmp_path.resolve())
+    created = store.create(Project.new(project_id="project-1", name="Demo"))
+
+    assert created.project.project_id == "project-1"
+    assert store.read("project-1") == created
+
+
+def test_keyframe_publish_works_without_directory_handles(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(keyframe_cache, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+    project_root = tmp_path / "project-1"
+    project_root.mkdir()
+    source = project_root / "source.mp4"
+    source.write_bytes(b"source-video")
+
+    def fake_run(command, **_kwargs):
+        Path(command[-1]).write_bytes(b"jpeg")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(keyframe_cache.subprocess, "run", fake_run)
+
+    cached = keyframe_cache.materialize_keyframe(
+        project_root,
+        source_path=source,
+        source_identity="sha256:source",
+        timestamp_seconds=1,
+        width=640,
+        ffmpeg_path="fake-ffmpeg",
+    )
+
+    assert cached.path.read_bytes() == b"jpeg"
+
+
+def test_remote_cache_publish_works_without_directory_handles(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    windows_os = _WindowsLikeOS()
+    monkeypatch.setattr(remote_cache, "os", windows_os)
+    monkeypatch.setattr(durability, "os", windows_os)
+    project_root = tmp_path / "project-1"
+    project_root.mkdir()
+    staged_path = tmp_path / "staged.mp4"
+    payload = b"remote-video"
+    staged_path.write_bytes(payload)
+    checksum = hashlib.sha256(payload).hexdigest()
+    staged = StagedAsset(
+        project_root=project_root,
+        path=staged_path,
+        sha256=checksum,
+        size_bytes=len(payload),
+    )
+    version = SourceAssetVersion(
+        version_id="version-1",
+        logical_asset_id="asset-1",
+        name="source.mp4",
+        file_id="file-1",
+        checksum=checksum,
+        media_kind="video",
+        media_type="video/mp4",
+        created_at=datetime.now(UTC),
+    )
+
+    published = remote_cache.publish_remote_cache(
+        project_root,
+        version,
+        staged,
+        media_type="video/mp4",
+    )
+
+    assert published.path.read_bytes() == payload


### PR DESCRIPTION
## Description

Fixes #6806.

Creator file persistence assumed POSIX descriptor APIs. On Windows, model configuration failed before publication because `os.fchmod` is unavailable, while generic directory `fsync` cannot open a directory handle.

This PR centralizes those platform differences in shared durability helpers, then applies them to atomic records, JSONL, locks, content storage, projects, keyframes, and remote cache publication. File `fsync` and atomic publication remain unchanged, and POSIX still performs descriptor chmod plus directory `fsync`.

**Security Considerations:** Security-sensitive `dir_fd` / `O_NOFOLLOW` paths in asset and media storage are unchanged and remain scoped to #6807. This PR does not relax path or symlink validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration changed)
- [x] Ready for review

## Testing

- Simulate Windows without `fchmod` and without directory handles across atomic create/replace, JSONL, content copy/replace, project creation, keyframe publication, and remote cache publication.
- Run existing atomic store, JSONL, lock, project store, keyframe, and model-config API tests to preserve POSIX behavior and the reported endpoint path.
- Run every repository pre-commit hook.

## Evidence

```bash
pytest tests/runtime_files/test_atomic_store.py \
  tests/runtime_files/test_jsonl_store.py \
  tests/runtime_files/test_locks.py \
  tests/project_files/test_store.py \
  tests/media_files/test_keyframe_cache.py \
  tests/api/test_file_model_api.py \
  tests/services/test_windows_file_durability.py -q
# 68 passed in 2.57s

pre-commit run --all-files
# all hooks passed (AST/config checks, mypy, Black, flake8, pylint, Prettier, Actions lint)
```

Full-suite note: enabling the managed jq binary makes `tests/api/test_example_routes.py::test_examples_list_reports_hosted_catalogue` time out during fixture setup in this environment. The same 15-second timeout reproduces on clean `upstream/main` (`bacac7410cf2`), so it is not introduced by this branch.

Verification matrix:

| Surface | Result |
| --- | --- |
| Windows-like generic durability | Covered |
| Model config save path | Covered |
| Linux/POSIX durability behavior | Existing tests pass |
| Security-sensitive asset/media directory handles | Unchanged; tracked by #6807 |

## Additional Notes

The commonality check intentionally includes every generic Creator durability writer. The remaining direct directory-handle implementations either already guard Windows or enforce security-sensitive path traversal contracts covered by #6807.