### PR TITLE
fix(console): remove stale Coding OS references

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -153,7 +153,6 @@
     "changeWallpaper": "Change wallpaper",
     "clearAll": "Clear all",
     "closeApp": "Close",
-    "codingModeLaunchFailed": "Failed to switch mode",
     "currentSpace": "Current space",
     "currentSpaceLabel": "Current space: {{name}}",
     "currentAppLabel": "Current app: {{name}}",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -103,7 +103,6 @@
     "changeWallpaper": "Ganti wallpaper",
     "clearAll": "Bersihkan semua",
     "closeApp": "Tutup",
-    "codingModeLaunchFailed": "Gagal mengganti mode",
     "currentSpace": "Ruang saat ini",
     "currentSpaceLabel": "Ruang saat ini: {{name}}",
     "currentAppLabel": "Aplikasi saat ini: {{name}}",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -101,7 +101,6 @@
     "changeWallpaper": "壁紙を変更",
     "clearAll": "すべてクリア",
     "closeApp": "閉じる",
-    "codingModeLaunchFailed": "モードの切り替えに失敗しました",
     "currentSpace": "現在のスペース",
     "currentSpaceLabel": "現在のスペース：{{name}}",
     "currentAppLabel": "現在のアプリ：{{name}}",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -103,7 +103,6 @@
     "changeWallpaper": "Alterar papel de parede",
     "clearAll": "Limpar tudo",
     "closeApp": "Fechar",
-    "codingModeLaunchFailed": "Não foi possível alternar o modo",
     "currentSpace": "Espaço atual",
     "currentSpaceLabel": "Espaço atual: {{name}}",
     "currentAppLabel": "Aplicativo atual: {{name}}",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -101,7 +101,6 @@
     "changeWallpaper": "Сменить обои",
     "clearAll": "Очистить все",
     "closeApp": "Закрыть",
-    "codingModeLaunchFailed": "Не удалось переключить режим",
     "currentSpace": "Текущее пространство",
     "currentSpaceLabel": "Текущее пространство: {{name}}",
     "currentAppLabel": "Текущее приложение: {{name}}",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -105,7 +105,6 @@
     "changeWallpaper": "Đổi hình nền",
     "clearAll": "Xóa tất cả",
     "closeApp": "Đóng",
-    "codingModeLaunchFailed": "Không thể chuyển chế độ",
     "currentSpace": "Không gian hiện tại",
     "currentSpaceLabel": "Không gian hiện tại: {{name}}",
     "currentAppLabel": "Ứng dụng hiện tại: {{name}}",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -153,7 +153,6 @@
     "changeWallpaper": "更换壁纸",
     "clearAll": "全部清除",
     "closeApp": "关闭",
-    "codingModeLaunchFailed": "模式切换失败",
     "currentSpace": "当前空间",
     "currentSpaceLabel": "当前空间：{{name}}",
     "currentAppLabel": "当前应用：{{name}}",

--- a/console/src/os/WindowRouter.tsx
+++ b/console/src/os/WindowRouter.tsx
@@ -24,7 +24,7 @@ import {
 } from "react-router-dom";
 import { useRoutes } from "../plugins/registry/hooks";
 import { useOsRoute } from "./osRouteStore";
-import { isModeWindowTransition, pathToRouteId } from "./osRouteMap";
+import { pathToRouteId } from "./osRouteMap";
 
 interface WindowRouterProps {
   /** This window's route id (e.g. "core.chat"). */
@@ -68,13 +68,7 @@ function WindowRouterBridge({
       lastOwnPath.current = location.pathname + location.search;
       return;
     }
-    const replaceSource = isModeWindowTransition(routeId, targetId);
-    navigateTo(
-      targetId,
-      location.pathname + location.search,
-      replaceSource ? routeId : undefined,
-    );
-    if (replaceSource) return;
+    navigateTo(targetId, location.pathname + location.search);
     // Restore this window to its last own-app location (preserve state).
     navigate(lastOwnPath.current, { replace: true });
   }, [location, routeId, routes, navigate, navigateTo]);

--- a/console/src/os/osApps.ts
+++ b/console/src/os/osApps.ts
@@ -15,7 +15,6 @@ import {
   HeartPulse,
   Wifi,
   Inbox,
-  Code,
   Store,
   Settings,
   Puzzle,
@@ -56,8 +55,7 @@ export interface OsAppDef {
 }
 
 /**
- * The PoC features these 6 (+ Chat & Coding) apps to demonstrate the desktop
- * shell. Each entry references a route already registered in builtinRoutes.
+ * Each entry references a route already registered in builtinRoutes.
  */
 export const OS_APPS: OsAppDef[] = [
   {
@@ -79,15 +77,6 @@ export const OS_APPS: OsAppDef[] = [
     defaultH: 720,
     minW: 760,
     minH: 480,
-  },
-  {
-    routeId: "core.coding",
-    labelKey: "nav.coding",
-    fallback: "Coding IDE",
-    Icon: Code,
-    accent: "#64748b",
-    defaultW: 1020,
-    defaultH: 700,
   },
   {
     routeId: "core.skills",

--- a/console/src/os/osRouteMap.test.ts
+++ b/console/src/os/osRouteMap.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  baseFromRoutePath,
-  isModeWindowTransition,
-  pathToRouteId,
-} from "./osRouteMap";
+import { baseFromRoutePath, pathToRouteId } from "./osRouteMap";
 
 const routes = [
   { id: "core.chat", path: "/chat/*", source: "core" },
@@ -30,12 +26,6 @@ describe("osRouteMap", () => {
 
   it("routes dynamic children to their owning app", () => {
     expect(pathToRouteId("/chat/session-1", routes)).toBe("core.chat");
-  });
-
-  it("treats Chat and Coding navigation as a window replacement", () => {
-    expect(isModeWindowTransition("core.chat", "core.coding")).toBe(true);
-    expect(isModeWindowTransition("core.coding", "core.chat")).toBe(true);
-    expect(isModeWindowTransition("core.chat", "core.inbox")).toBe(false);
   });
 
   it("prefers a concrete PawApp over the aggregate apps route", () => {

--- a/console/src/os/osRouteMap.ts
+++ b/console/src/os/osRouteMap.ts
@@ -11,8 +11,6 @@
 /** Route id of the aggregate System Settings window. */
 export const SETTINGS_APP_ID = "os.settings";
 
-const MODE_ROUTE_IDS = new Set(["core.chat", "core.coding"]);
-
 /** Minimal route shape needed here (matches ResolvedRoute from the registry). */
 export interface RouteLike {
   id: string;
@@ -52,18 +50,6 @@ export function baseFromRoutePath(path: string | undefined): string {
 export function topSegment(pathname: string): string {
   const noQuery = pathname.split("?")[0];
   return noQuery.replace(/^\/+/, "").split("/")[0] || "";
-}
-
-/** Chat and Coding are two modes of the same workspace, not parallel apps. */
-export function isModeWindowTransition(
-  sourceRouteId: string,
-  targetRouteId: string,
-): boolean {
-  return (
-    sourceRouteId !== targetRouteId &&
-    MODE_ROUTE_IDS.has(sourceRouteId) &&
-    MODE_ROUTE_IDS.has(targetRouteId)
-  );
 }
 
 function normalizePath(path: string): string {

--- a/console/src/os/osRouteStore.test.ts
+++ b/console/src/os/osRouteStore.test.ts
@@ -29,21 +29,6 @@ describe("osRouteStore", () => {
     resetStores();
   });
 
-  it("replaces the source window during a mode transition", () => {
-    useOsWindows.getState().open("core.chat");
-
-    useOsRoute
-      .getState()
-      .navigateTo("core.coding", "/coding/session-1", "core.chat");
-
-    expect(useOsWindows.getState().windows["core.chat"]).toBeUndefined();
-    expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    expect(useOsWindows.getState().activeId).toBe("core.coding");
-    expect(useOsRoute.getState().targets["core.coding"]?.path).toBe(
-      "/coding/session-1",
-    );
-  });
-
   it("keeps the source window for normal cross-app navigation", () => {
     useOsWindows.getState().open("core.chat");
 

--- a/console/src/os/useOsAppLauncher.test.tsx
+++ b/console/src/os/useOsAppLauncher.test.tsx
@@ -1,50 +1,20 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
 import { renderWithProviders } from "@/test/common_setup";
-import { codingModeApi } from "../api/modules/codingMode";
-import { useAgentStore } from "../stores/agentStore";
-import { useCodingModeStore } from "../stores/codingModeStore";
 import { useOsWindows } from "./osWindowStore";
 import { useOsAppLauncher } from "./useOsAppLauncher";
-
-vi.mock("../api/modules/codingMode", () => ({
-  codingModeApi: {
-    toggle: vi.fn(),
-  },
-}));
-
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
-  }),
-}));
 
 function Harness() {
   const launchApp = useOsAppLauncher();
   return (
-    <>
-      <button type="button" onClick={() => void launchApp("core.coding")}>
-        Open Coding
-      </button>
-      <button type="button" onClick={() => void launchApp("core.chat")}>
-        Open Chat
-      </button>
-    </>
+    <button type="button" onClick={() => void launchApp("plugin.kanban")}>
+      Open Kanban
+    </button>
   );
 }
 
 describe("useOsAppLauncher", () => {
   beforeEach(() => {
-    vi.mocked(codingModeApi.toggle).mockReset();
-    vi.mocked(codingModeApi.toggle).mockResolvedValue({
-      enabled: true,
-      agent_id: "default",
-    });
-    useAgentStore.setState({ selectedAgent: "default" });
-    useCodingModeStore.setState({
-      codingModeByAgent: { default: false },
-      codingModeRevisionByAgent: {},
-    });
     useOsWindows.setState({
       windows: {},
       order: [],
@@ -65,76 +35,11 @@ describe("useOsAppLauncher", () => {
     });
   });
 
-  it("enables Coding Mode before opening its desktop window", async () => {
-    useOsWindows.getState().open("core.chat");
+  it("opens a PawApp window", () => {
     renderWithProviders(<Harness />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
 
-    await waitFor(() => {
-      expect(codingModeApi.toggle).toHaveBeenCalledWith(true);
-      expect(useOsWindows.getState().windows["core.chat"]).toBeUndefined();
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(useCodingModeStore.getState().codingModeByAgent.default).toBe(true);
-  });
-
-  it("does not open Coding when backend activation fails", async () => {
-    vi.mocked(codingModeApi.toggle).mockRejectedValueOnce(
-      new Error("Activation failed"),
-    );
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(codingModeApi.toggle).toHaveBeenCalledWith(true);
-    });
-    expect(useOsWindows.getState().windows["core.coding"]).toBeUndefined();
-  });
-
-  it("reopens the current mode after its window is closed", async () => {
-    useCodingModeStore.setState({
-      codingModeByAgent: { default: true },
-    });
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-
-    useOsWindows.getState().close("core.coding");
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(codingModeApi.toggle).not.toHaveBeenCalled();
-  });
-
-  it("can switch modes and reopen after both windows were closed", async () => {
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Chat" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeUndefined();
-      expect(useOsWindows.getState().windows["core.chat"]).toBeDefined();
-    });
-
-    useOsWindows.getState().close("core.chat");
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(1, true);
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(2, false);
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(3, true);
+    expect(useOsWindows.getState().windows["plugin.kanban"]).toBeDefined();
   });
 });

--- a/console/src/os/useOsAppLauncher.ts
+++ b/console/src/os/useOsAppLauncher.ts
@@ -1,75 +1,10 @@
 import { useCallback } from "react";
-import { App } from "antd";
-import { useTranslation } from "react-i18next";
-import { codingModeApi } from "../api/modules/codingMode";
-import { useAgentStore } from "../stores/agentStore";
-import { useCodingModeStore } from "../stores/codingModeStore";
-import { useOsRoute } from "./osRouteStore";
 import { useOsWindows } from "./osWindowStore";
 
-const MODE_TARGETS = {
-  "core.chat": {
-    enabled: false,
-    path: "/chat",
-    oppositeRouteId: "core.coding",
-  },
-  "core.coding": {
-    enabled: true,
-    path: "/coding",
-    oppositeRouteId: "core.chat",
-  },
-} as const;
-
-let modeLaunchPromise: Promise<boolean> | null = null;
-
-/** Open a desktop app, applying Chat/Coding backend mode before navigation. */
+/** Open an app through the shared desktop launcher entry point. */
 export function useOsAppLauncher(): (routeId: string) => Promise<boolean> {
-  const { message } = App.useApp();
-  const { t } = useTranslation();
-
-  return useCallback(
-    async (routeId: string) => {
-      const target = MODE_TARGETS[routeId as keyof typeof MODE_TARGETS];
-      if (!target) {
-        useOsWindows.getState().open(routeId);
-        return true;
-      }
-
-      if (modeLaunchPromise) return modeLaunchPromise;
-
-      const launchPromise = (async () => {
-        const agentId = useAgentStore.getState().selectedAgent;
-        const codingState = useCodingModeStore.getState();
-        const currentMode = codingState.codingModeByAgent[agentId];
-
-        try {
-          if (currentMode !== target.enabled) {
-            await codingModeApi.toggle(target.enabled);
-            codingState.setCodingMode(agentId, target.enabled);
-          }
-          useOsRoute
-            .getState()
-            .navigateTo(routeId, target.path, target.oppositeRouteId);
-          return true;
-        } catch (error) {
-          message.error(
-            error instanceof Error
-              ? error.message
-              : t("os.codingModeLaunchFailed", "Failed to switch mode"),
-          );
-          return false;
-        }
-      })();
-      modeLaunchPromise = launchPromise;
-
-      try {
-        return await launchPromise;
-      } finally {
-        if (modeLaunchPromise === launchPromise) {
-          modeLaunchPromise = null;
-        }
-      }
-    },
-    [message, t],
-  );
+  return useCallback(async (routeId: string) => {
+    useOsWindows.getState().open(routeId);
+    return true;
+  }, []);
 }


### PR DESCRIPTION
## Description

Remove stale Desktop OS references to the retired standalone Coding route and window model. Unified Workspace removed the `/coding` frontend route, but the OS catalog, launcher, and cross-window routing still modeled `core.coding` as a separate app.

This change removes the obsolete Coding app entry and mode-transition special cases while preserving the shared `useOsAppLauncher` entry point for built-in apps and PawApps such as Kanban. The launcher test now verifies the PawApp path explicitly.

**Related Issue:** Relates to Aone work item 85237610

**Security Considerations:** No security impact. This change only removes stale frontend routing and launcher behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Run `npm run test:run -- src/os` from `console/`.
- Run `npx tsc -b --noEmit` from `console/`.
- Run ESLint and Prettier checks for all changed TypeScript, TSX, and locale files.
- Confirm `core.coding`, `MODE_ROUTE_IDS`, `isModeWindowTransition`, `/coding`, and `codingModeLaunchFailed` no longer appear under `console/src/os` or `console/src/locales`.

## Evidence

```text
Test Files  25 passed (25)
Tests       109 passed (109)
Duration    9.47s
```

```text
npx tsc -b --noEmit
# exited 0

npx eslint <changed OS files>
# exited 0

npx prettier --check <changed files>
All matched files use Prettier code style!
```

The PawApp launcher test opens `plugin.kanban` and confirms its window is registered, preserving the common launcher path after removal of Coding-specific behavior.

## Additional Notes

The Coding backend capability remains unchanged. This PR only removes the obsolete standalone Coding route and window assumptions introduced before Unified Workspace landed.

The channel contract checklist is not applicable because no channel implementation changed.