### PR TITLE
fix(config): resolve channel declaration drift breaking OneBot config API

### DIFF
--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -32,22 +32,9 @@ from ...config import (
 )
 from ...config.config import (
     AgentsLLMRoutingConfig,
-    ConsoleConfig,
-    DingTalkConfig,
-    DiscordConfig,
-    FeishuConfig,
     HeartbeatConfig,
-    IMessageChannelConfig,
-    MatrixConfig,
-    MattermostConfig,
-    MQTTConfig,
-    QQConfig,
-    SIPChannelConfig,
     SkillScannerConfig,
     SkillScannerWhitelistEntry,
-    TelegramConfig,
-    VoiceChannelConfig,
-    WecomConfig,
 )
 from ...config.timezone import normalize_tz
 from ..channels.qrcode_auth_handler import (
@@ -65,21 +52,20 @@ from .schemas_config import (
 router = APIRouter(prefix="/config", tags=["config"])
 
 
-_CHANNEL_CONFIG_CLASS_MAP = {
-    "telegram": TelegramConfig,
-    "dingtalk": DingTalkConfig,
-    "discord": DiscordConfig,
-    "feishu": FeishuConfig,
-    "qq": QQConfig,
-    "imessage": IMessageChannelConfig,
-    "console": ConsoleConfig,
-    "voice": VoiceChannelConfig,
-    "sip": SIPChannelConfig,
-    "mattermost": MattermostConfig,
-    "mqtt": MQTTConfig,
-    "matrix": MatrixConfig,
-    "wecom": WecomConfig,
-}
+def _channel_config_class(name: str) -> Optional[type[BaseModel]]:
+    """Config model for a built-in channel, None for plugin channels.
+
+    Built-in channel shapes are declared once as ``ChannelConfig``
+    fields, so deriving them here cannot drift when a channel is added
+    later. This is the same source of truth doctor already walks.
+    """
+    field = ChannelConfig.model_fields.get(name)
+    annotation = field.annotation if field is not None else None
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    return None
+
+
 _ALLOWED_ACP_TOOL_PARSE_MODES = {
     "call_title",
     "update_detail",
@@ -417,7 +403,7 @@ async def put_channel(
     if agent.config.channels is None:
         agent.config.channels = ChannelConfig()
 
-    config_class = _CHANNEL_CONFIG_CLASS_MAP.get(channel_name)
+    config_class = _channel_config_class(channel_name)
     if config_class is not None:
         channel_config = config_class(**single_channel_config)
     else:

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2564,7 +2564,9 @@ ChannelConfigUnion = Union[
     SlackConfig,
     WecomConfig,
     XiaoYiConfig,
+    YuanbaoConfig,
     WeChatConfig,
+    OneBotConfig,
 ]
 
 

--- a/tests/unit/app/routers/test_config_router.py
+++ b/tests/unit/app/routers/test_config_router.py
@@ -8,6 +8,8 @@ errors.  Covers:
 - ``GET /config/channels/types`` — pure list
 - ``GET /config/channels`` — happy path through ``get_agent_for_request``
 - ``PUT /config/channels`` — round-trip + agent reload trigger
+- ``GET/PUT /config/channels/{name}`` — per-channel shape is preserved
+  and built-in payloads are validated before they reach the disk
 - ``GET /config/security/tool-guard`` — happy path
 - ``PUT /config/security/tool-guard`` — happy path + engine reload
 - 422 on a malformed PUT body
@@ -26,10 +28,12 @@ from fastapi.testclient import TestClient
 
 from qwenpaw.app.crons import heartbeat
 from qwenpaw.app.routers.config import router as config_router
+from qwenpaw.config import get_available_channels
 from qwenpaw.config.config import (
     ChannelConfig,
     ConsoleConfig,
     HeartbeatConfig,
+    OneBotConfig,
     ToolGuardConfig,
 )
 from qwenpaw.constant import (
@@ -165,6 +169,121 @@ def test_put_channels_422_on_invalid_payload(client, patch_get_agent):
     )
 
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /config/channels/{name} — per-channel shape must not be coerced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("channel_name", sorted(ChannelConfig.model_fields))
+def test_get_single_channel_returns_its_own_shape(
+    client,
+    patch_get_agent,
+    channel_name,
+):
+    """Each built-in channel answers with exactly its own fields.
+
+    Regression guard: a config model missing from ``ChannelConfigUnion``
+    could not be matched by FastAPI, which then coerced the response
+    into another member and served a foreign channel's fields.
+    """
+    if channel_name not in get_available_channels():
+        pytest.skip(f"channel {channel_name} unavailable in this env")
+
+    response = client.get(f"/api/config/channels/{channel_name}")
+
+    assert response.status_code == 200, response.text
+    own_fields = set(
+        ChannelConfig.model_fields[channel_name].annotation.model_fields,
+    )
+    assert set(response.json()) == own_fields
+
+
+def test_get_onebot_channel_keeps_reverse_ws_fields(
+    client,
+    fake_agent_workspace,
+    patch_get_agent,
+):
+    """OneBot reverse WebSocket fields survive serialization."""
+    fake_agent_workspace.config.channels = ChannelConfig(
+        onebot=OneBotConfig(
+            enabled=True,
+            ws_host="10.88.0.10",
+            ws_port=6199,
+            access_token="secret-token",
+        ),
+    )
+
+    response = client.get("/api/config/channels/onebot")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ws_host"] == "10.88.0.10"
+    assert body["ws_port"] == 6199
+    assert body["access_token"] == "secret-token"
+    # Fields belonging to an unrelated channel must not leak in.
+    assert "app_id" not in body
+    assert "domain" not in body
+
+
+def test_put_onebot_channel_stores_a_validated_model(
+    client,
+    fake_agent_workspace,
+    patch_get_agent,
+):
+    """A built-in channel payload is parsed into its config model."""
+    payload = OneBotConfig(
+        enabled=True,
+        ws_host="10.88.0.10",
+        access_token="secret-token",
+    ).model_dump()
+
+    with (
+        patch("qwenpaw.config.config.save_agent_config") as save_mock,
+        patch(
+            "qwenpaw.app.routers.config.schedule_agent_reload",
+        ) as reload_mock,
+    ):
+        response = client.put("/api/config/channels/onebot", json=payload)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ws_host"] == "10.88.0.10"
+    # A raw dict here would bypass validation and reach agent.json.
+    stored = fake_agent_workspace.config.channels.onebot
+    assert isinstance(stored, OneBotConfig)
+    assert stored.access_token == "secret-token"
+
+    save_mock.assert_called_once()
+    reload_mock.assert_called_once()
+
+
+def test_put_onebot_channel_rejects_invalid_value(
+    app,
+    fake_agent_workspace,
+    patch_get_agent,
+):
+    """An invalid value is refused instead of reaching the disk.
+
+    The rejection currently surfaces as a 500 because the model error
+    propagates; 422 is accepted too so that turning it into a proper
+    validation response stays a green change.  A 404 would mean the
+    route never ran, which must not pass for this guard.
+    """
+    lenient_client = TestClient(app, raise_server_exceptions=False)
+
+    with patch("qwenpaw.config.config.save_agent_config") as save_mock:
+        response = lenient_client.put(
+            "/api/config/channels/onebot",
+            json={"enabled": True, "ws_port": "not-a-port"},
+        )
+
+    assert response.status_code in (422, 500)
+    save_mock.assert_not_called()
+    assert isinstance(
+        fake_agent_workspace.config.channels.onebot,
+        OneBotConfig,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_channel_shape_consistency.py
+++ b/tests/unit/config/test_channel_shape_consistency.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Consistency guards for built-in channel shape declarations.
+
+A built-in channel is declared in more than one place, and those places
+must stay in sync.  ``ChannelConfig`` is the source of truth for the
+config shape (this is what doctor already walks), while the registry
+and the API layer keep their own lists.
+
+These tests fail loudly when a newly added channel is missing from one
+of those lists.  That drift is what made ``GET`` on a single channel
+answer with an unrelated channel's fields for ``onebot``, and what let
+``PUT`` write an unvalidated dict to disk.
+"""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from typing import get_args
+
+from qwenpaw.app.channels.registry import _BUILTIN_SPECS
+from qwenpaw.app.routers.config import _channel_config_class
+from qwenpaw.config.config import ChannelConfig, ChannelConfigUnion
+
+
+def _declared_config_classes() -> set[type]:
+    """Config models declared as ``ChannelConfig`` fields."""
+    return {field.annotation for field in ChannelConfig.model_fields.values()}
+
+
+def test_builtin_specs_match_channel_config_fields() -> None:
+    """Every built-in channel implementation has a config field."""
+    assert set(_BUILTIN_SPECS) == set(ChannelConfig.model_fields)
+
+
+def test_channel_config_union_covers_every_builtin_channel() -> None:
+    """``ChannelConfigUnion`` must list every built-in config model.
+
+    The single-channel endpoints use it as ``response_model``.  When a
+    model is missing, FastAPI cannot match the returned instance and
+    falls back to coercing it into another member, silently dropping
+    the channel's own fields.
+    """
+    assert set(get_args(ChannelConfigUnion)) == _declared_config_classes()
+
+
+def test_channel_config_class_resolves_every_builtin_channel() -> None:
+    """PUT validation must find a model for every built-in channel."""
+    for name, field in ChannelConfig.model_fields.items():
+        assert _channel_config_class(name) is field.annotation
+
+
+def test_channel_config_class_returns_none_for_plugin_channel() -> None:
+    """Plugin channels are not declared, so they stay untyped dicts."""
+    assert _channel_config_class("some_plugin_channel") is None


### PR DESCRIPTION
## Description

Two hand-written lists of built-in channels had fallen out of sync with
`ChannelConfig`, which is the actual source of truth for channel config
shapes. `onebot` was missing from both, so the single-channel config API
misbehaved:

- `GET /config/channels/onebot` answered with **Feishu** fields
  (`app_id`, `domain`, ...) and silently dropped OneBot's own
  `ws_host` / `ws_port` / `access_token`. `ChannelConfigUnion` is the
  `response_model`; with no matching member FastAPI could not identify
  the returned instance and coerced it into another union member.
- `PUT /config/channels/onebot` fell through to the untyped
  "plugin channel" branch, storing the raw request body without
  validation. A bad value such as `ws_port: "not-a-port"` reached
  `agent.json` and made the next config load raise `ValidationError`.

## Changes:

1. Replace `_CHANNEL_CONFIG_CLASS_MAP` with `_channel_config_class()`,
   which derives the model from `ChannelConfig.model_fields`. Adding a
   channel now requires no second list to update. This also restores
   PUT validation for `slack`, `xiaoyi`, `yuanbao` and `wechat`, which
   were missing for the same reason.
2. Add `OneBotConfig` and `YuanbaoConfig` to `ChannelConfigUnion`.
3. Add consistency guards so this drift fails a test instead of
   reaching users.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
