### PR TITLE
fix(cli): handle missing agent configuration in task command

### DIFF
--- a/src/qwenpaw/cli/task_cmd.py
+++ b/src/qwenpaw/cli/task_cmd.py
@@ -258,6 +258,7 @@ def task_cmd(
     """Run a single task instruction headlessly (no web server)."""
     from ..config.config import load_agent_config
     from ..config.config import ModelSlotConfig
+    from ..exceptions import ConfigurationException
     from ..utils.logging import setup_logger
 
     setup_logger("info")
@@ -269,7 +270,7 @@ def task_cmd(
 
     try:
         agent_config = load_agent_config(agent_id)
-    except ValueError as exc:
+    except (ConfigurationException, ValueError) as exc:
         click.echo(f"Error loading agent config: {exc}", err=True)
         sys.exit(1)
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2749,7 +2749,7 @@ def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
         AgentProfileConfig: Complete agent configuration
 
     Raises:
-        ValueError: If agent ID not found in root config
+        ConfigurationException: If agent ID not found in root config
     """
     from .utils import (
         load_config,

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -64,6 +64,42 @@ def test_task_rejects_empty_instruction(monkeypatch) -> None:
     )
 
 
+def test_task_reports_missing_agent_without_traceback(monkeypatch) -> None:
+    from qwenpaw.exceptions import ConfigurationException
+
+    missing_agent = "missing-agent"
+
+    def _raise_missing_agent(agent_id: str) -> None:
+        raise ConfigurationException(
+            config_key="agent",
+            message=f"Agent '{agent_id}' not found in config",
+        )
+
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        _raise_missing_agent,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "task",
+            "-i",
+            "hello",
+            "--agent-id",
+            missing_agent,
+        ],
+    )
+    output = result.output
+    if result.stderr_bytes:
+        output = f"{output}\n{result.stderr_bytes.decode()}"
+
+    assert result.exit_code == 1
+    assert "Error loading agent config" in output
+    assert f"Agent '{missing_agent}' not found in config" in output
+    assert "Traceback" not in output
+
+
 # ── --model flag ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Description

Catch `ConfigurationException` when loading an agent for `qwenpaw task`, preventing uncaught tracebacks and returning a clear error with a non-zero exit code. Also update the outdated docstring and add regression coverage.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
