### PR TITLE
feat(os shell): remove OS deep-link routing and coding mode launcher

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -153,7 +153,6 @@
     "changeWallpaper": "Change wallpaper",
     "clearAll": "Clear all",
     "closeApp": "Close",
-    "codingModeLaunchFailed": "Failed to switch mode",
     "currentSpace": "Current space",
     "currentSpaceLabel": "Current space: {{name}}",
     "currentAppLabel": "Current app: {{name}}",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -103,7 +103,6 @@
     "changeWallpaper": "Ganti wallpaper",
     "clearAll": "Bersihkan semua",
     "closeApp": "Tutup",
-    "codingModeLaunchFailed": "Gagal mengganti mode",
     "currentSpace": "Ruang saat ini",
     "currentSpaceLabel": "Ruang saat ini: {{name}}",
     "currentAppLabel": "Aplikasi saat ini: {{name}}",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -101,7 +101,6 @@
     "changeWallpaper": "壁紙を変更",
     "clearAll": "すべてクリア",
     "closeApp": "閉じる",
-    "codingModeLaunchFailed": "モードの切り替えに失敗しました",
     "currentSpace": "現在のスペース",
     "currentSpaceLabel": "現在のスペース：{{name}}",
     "currentAppLabel": "現在のアプリ：{{name}}",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -103,7 +103,6 @@
     "changeWallpaper": "Alterar papel de parede",
     "clearAll": "Limpar tudo",
     "closeApp": "Fechar",
-    "codingModeLaunchFailed": "Não foi possível alternar o modo",
     "currentSpace": "Espaço atual",
     "currentSpaceLabel": "Espaço atual: {{name}}",
     "currentAppLabel": "Aplicativo atual: {{name}}",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -101,7 +101,6 @@
     "changeWallpaper": "Сменить обои",
     "clearAll": "Очистить все",
     "closeApp": "Закрыть",
-    "codingModeLaunchFailed": "Не удалось переключить режим",
     "currentSpace": "Текущее пространство",
     "currentSpaceLabel": "Текущее пространство: {{name}}",
     "currentAppLabel": "Текущее приложение: {{name}}",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -105,7 +105,6 @@
     "changeWallpaper": "Đổi hình nền",
     "clearAll": "Xóa tất cả",
     "closeApp": "Đóng",
-    "codingModeLaunchFailed": "Không thể chuyển chế độ",
     "currentSpace": "Không gian hiện tại",
     "currentSpaceLabel": "Không gian hiện tại: {{name}}",
     "currentAppLabel": "Ứng dụng hiện tại: {{name}}",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -153,7 +153,6 @@
     "changeWallpaper": "更换壁纸",
     "clearAll": "全部清除",
     "closeApp": "关闭",
-    "codingModeLaunchFailed": "模式切换失败",
     "currentSpace": "当前空间",
     "currentSpaceLabel": "当前空间：{{name}}",
     "currentAppLabel": "当前应用：{{name}}",

--- a/console/src/os/DesktopOS.tsx
+++ b/console/src/os/DesktopOS.tsx
@@ -9,14 +9,7 @@
  * Reachable at /os (registered in App.tsx) — isolated from MainLayout so the
  * classic sidebar layout is untouched.
  */
-import {
-  Suspense,
-  useMemo,
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-} from "react";
+import { Suspense, useMemo, useEffect, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { App, Dropdown, Spin, type MenuProps } from "antd";
 import { Grid2X2, Image as ImageIcon, RefreshCw, Trash2 } from "lucide-react";
@@ -36,8 +29,7 @@ import { useOsNotifyPoller } from "./useOsNotifyPoller";
 import { purgeAppState, purgePluginAppState } from "./osCleanup";
 import WindowFrame from "./WindowFrame";
 import WindowRouter from "./WindowRouter";
-import { baseFromRoutePath, pathToRouteId } from "./osRouteMap";
-import { useOsRoute } from "./osRouteStore";
+import { baseFromRoutePath } from "./osRouteMap";
 import MenuBar from "./MenuBar";
 import Dock from "./Dock";
 import SpacesPanel from "./SpacesPanel";
@@ -62,11 +54,7 @@ import {
   getPawAppIdFromPath,
   setActivePawAppId,
 } from "../plugins/pawapp-sdk/context";
-import {
-  getOsAppHref,
-  getOsRootHref,
-  stripRouterBasename,
-} from "../utils/navigationMode";
+import { getOsRootHref } from "../utils/navigationMode";
 import "./osWindowBody.css";
 
 /** Session flag so the boot splash plays once per browser session. */
@@ -204,21 +192,8 @@ export default function DesktopOS() {
     return map;
   }, [routes]);
 
-  const restoredDeepLink = useRef(false);
-  useEffect(() => {
-    if (restoredDeepLink.current) return;
-    restoredDeepLink.current = true;
-    const appPath = stripRouterBasename(window.location.pathname).replace(
-      /^\/os(?=\/|$)/,
-      "",
-    );
-    if (!appPath || appPath === "/") return;
-    const routeId = pathToRouteId(appPath, routes);
-    if (routeId) useOsRoute.getState().openApp(routeId, appPath);
-  }, [routes]);
-
-  // Keep the browser path OS-owned and expose the focused PawApp id to the
-  // legacy SDK without letting app windows navigate the top-level document.
+  // The desktop has one browser entry point: /os. Window navigation stays in
+  // each app's MemoryRouter and never becomes a browser deep link.
   useEffect(() => {
     const activeRoute = activeId ? routeById.get(activeId) : undefined;
     const pawAppId =
@@ -226,12 +201,7 @@ export default function DesktopOS() {
         ? getPawAppIdFromPath(activeRoute.path)
         : "";
     setActivePawAppId(pawAppId || null);
-    const browserPath = pawAppId
-      ? getOsAppHref(
-          window.location.pathname,
-          baseFromRoutePath(activeRoute?.path),
-        )
-      : getOsRootHref(window.location.pathname);
+    const browserPath = getOsRootHref(window.location.pathname);
     if (
       `${window.location.pathname}${window.location.search}` !== browserPath
     ) {

--- a/console/src/os/DesktopOS.tsx
+++ b/console/src/os/DesktopOS.tsx
@@ -205,7 +205,11 @@ export default function DesktopOS() {
     if (
       `${window.location.pathname}${window.location.search}` !== browserPath
     ) {
-      window.history.replaceState({ osApp: activeId }, "", browserPath);
+      window.history.replaceState(
+        { ...window.history.state, osApp: activeId },
+        "",
+        browserPath,
+      );
     }
   }, [activeId, routeById]);
 

--- a/console/src/os/WindowRouter.tsx
+++ b/console/src/os/WindowRouter.tsx
@@ -24,7 +24,7 @@ import {
 } from "react-router-dom";
 import { useRoutes } from "../plugins/registry/hooks";
 import { useOsRoute } from "./osRouteStore";
-import { isModeWindowTransition, pathToRouteId } from "./osRouteMap";
+import { pathToRouteId } from "./osRouteMap";
 
 interface WindowRouterProps {
   /** This window's route id (e.g. "core.chat"). */
@@ -68,13 +68,7 @@ function WindowRouterBridge({
       lastOwnPath.current = location.pathname + location.search;
       return;
     }
-    const replaceSource = isModeWindowTransition(routeId, targetId);
-    navigateTo(
-      targetId,
-      location.pathname + location.search,
-      replaceSource ? routeId : undefined,
-    );
-    if (replaceSource) return;
+    navigateTo(targetId, location.pathname + location.search);
     // Restore this window to its last own-app location (preserve state).
     navigate(lastOwnPath.current, { replace: true });
   }, [location, routeId, routes, navigate, navigateTo]);

--- a/console/src/os/osApps.ts
+++ b/console/src/os/osApps.ts
@@ -15,7 +15,6 @@ import {
   HeartPulse,
   Wifi,
   Inbox,
-  Code,
   Store,
   Settings,
   Puzzle,
@@ -56,8 +55,7 @@ export interface OsAppDef {
 }
 
 /**
- * The PoC features these 6 (+ Chat & Coding) apps to demonstrate the desktop
- * shell. Each entry references a route already registered in builtinRoutes.
+ * Each entry references a route already registered in builtinRoutes.
  */
 export const OS_APPS: OsAppDef[] = [
   {
@@ -79,15 +77,6 @@ export const OS_APPS: OsAppDef[] = [
     defaultH: 720,
     minW: 760,
     minH: 480,
-  },
-  {
-    routeId: "core.coding",
-    labelKey: "nav.coding",
-    fallback: "Coding IDE",
-    Icon: Code,
-    accent: "#64748b",
-    defaultW: 1020,
-    defaultH: 700,
   },
   {
     routeId: "core.skills",

--- a/console/src/os/osRouteMap.test.ts
+++ b/console/src/os/osRouteMap.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  baseFromRoutePath,
-  isModeWindowTransition,
-  pathToRouteId,
-} from "./osRouteMap";
+import { baseFromRoutePath, pathToRouteId } from "./osRouteMap";
 
 const routes = [
   { id: "core.chat", path: "/chat/*", source: "core" },
@@ -30,12 +26,6 @@ describe("osRouteMap", () => {
 
   it("routes dynamic children to their owning app", () => {
     expect(pathToRouteId("/chat/session-1", routes)).toBe("core.chat");
-  });
-
-  it("treats Chat and Coding navigation as a window replacement", () => {
-    expect(isModeWindowTransition("core.chat", "core.coding")).toBe(true);
-    expect(isModeWindowTransition("core.coding", "core.chat")).toBe(true);
-    expect(isModeWindowTransition("core.chat", "core.inbox")).toBe(false);
   });
 
   it("prefers a concrete PawApp over the aggregate apps route", () => {

--- a/console/src/os/osRouteMap.ts
+++ b/console/src/os/osRouteMap.ts
@@ -11,8 +11,6 @@
 /** Route id of the aggregate System Settings window. */
 export const SETTINGS_APP_ID = "os.settings";
 
-const MODE_ROUTE_IDS = new Set(["core.chat", "core.coding"]);
-
 /** Minimal route shape needed here (matches ResolvedRoute from the registry). */
 export interface RouteLike {
   id: string;
@@ -52,18 +50,6 @@ export function baseFromRoutePath(path: string | undefined): string {
 export function topSegment(pathname: string): string {
   const noQuery = pathname.split("?")[0];
   return noQuery.replace(/^\/+/, "").split("/")[0] || "";
-}
-
-/** Chat and Coding are two modes of the same workspace, not parallel apps. */
-export function isModeWindowTransition(
-  sourceRouteId: string,
-  targetRouteId: string,
-): boolean {
-  return (
-    sourceRouteId !== targetRouteId &&
-    MODE_ROUTE_IDS.has(sourceRouteId) &&
-    MODE_ROUTE_IDS.has(targetRouteId)
-  );
 }
 
 function normalizePath(path: string): string {

--- a/console/src/os/osRouteStore.test.ts
+++ b/console/src/os/osRouteStore.test.ts
@@ -29,21 +29,6 @@ describe("osRouteStore", () => {
     resetStores();
   });
 
-  it("replaces the source window during a mode transition", () => {
-    useOsWindows.getState().open("core.chat");
-
-    useOsRoute
-      .getState()
-      .navigateTo("core.coding", "/coding/session-1", "core.chat");
-
-    expect(useOsWindows.getState().windows["core.chat"]).toBeUndefined();
-    expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    expect(useOsWindows.getState().activeId).toBe("core.coding");
-    expect(useOsRoute.getState().targets["core.coding"]?.path).toBe(
-      "/coding/session-1",
-    );
-  });
-
   it("keeps the source window for normal cross-app navigation", () => {
     useOsWindows.getState().open("core.chat");
 

--- a/console/src/os/osRouteStore.ts
+++ b/console/src/os/osRouteStore.ts
@@ -31,7 +31,7 @@ interface OsRouteStore {
    * Settings window (selecting the pane); everything else opens the app whose
    * route id is given. Returns true when handled.
    */
-  navigateTo: (routeId: string, path: string, replaceRouteId?: string) => void;
+  navigateTo: (routeId: string, path: string) => void;
   /** Transactional cleanup: drop deep-links for confirmed-removed apps. */
   purge: (ids: ReadonlySet<string>) => void;
 }
@@ -54,7 +54,7 @@ export const useOsRoute = create<OsRouteStore>((set) => ({
     useOsWindows.getState().open(routeId);
   },
 
-  navigateTo: (routeId, path, replaceRouteId) => {
+  navigateTo: (routeId, path) => {
     if (SETTINGS_ROUTE_IDS.has(routeId)) {
       // Settings routes live inside the aggregate System Settings window; the
       // "path" for that window is the target pane's route id.
@@ -68,9 +68,6 @@ export const useOsRoute = create<OsRouteStore>((set) => ({
         },
       }));
       useOsWindows.getState().open(SETTINGS_APP_ID);
-      if (replaceRouteId && replaceRouteId !== SETTINGS_APP_ID) {
-        useOsWindows.getState().close(replaceRouteId);
-      }
       return;
     }
     set((s) => ({
@@ -83,9 +80,6 @@ export const useOsRoute = create<OsRouteStore>((set) => ({
       },
     }));
     useOsWindows.getState().open(routeId);
-    if (replaceRouteId && replaceRouteId !== routeId) {
-      useOsWindows.getState().close(replaceRouteId);
-    }
   },
 
   purge: (ids) =>

--- a/console/src/os/useOsAppLauncher.test.tsx
+++ b/console/src/os/useOsAppLauncher.test.tsx
@@ -1,50 +1,20 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
 import { renderWithProviders } from "@/test/common_setup";
-import { codingModeApi } from "../api/modules/codingMode";
-import { useAgentStore } from "../stores/agentStore";
-import { useCodingModeStore } from "../stores/codingModeStore";
 import { useOsWindows } from "./osWindowStore";
 import { useOsAppLauncher } from "./useOsAppLauncher";
-
-vi.mock("../api/modules/codingMode", () => ({
-  codingModeApi: {
-    toggle: vi.fn(),
-  },
-}));
-
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
-  }),
-}));
 
 function Harness() {
   const launchApp = useOsAppLauncher();
   return (
-    <>
-      <button type="button" onClick={() => void launchApp("core.coding")}>
-        Open Coding
-      </button>
-      <button type="button" onClick={() => void launchApp("core.chat")}>
-        Open Chat
-      </button>
-    </>
+    <button type="button" onClick={() => void launchApp("plugin.kanban")}>
+      Open Kanban
+    </button>
   );
 }
 
 describe("useOsAppLauncher", () => {
   beforeEach(() => {
-    vi.mocked(codingModeApi.toggle).mockReset();
-    vi.mocked(codingModeApi.toggle).mockResolvedValue({
-      enabled: true,
-      agent_id: "default",
-    });
-    useAgentStore.setState({ selectedAgent: "default" });
-    useCodingModeStore.setState({
-      codingModeByAgent: { default: false },
-      codingModeRevisionByAgent: {},
-    });
     useOsWindows.setState({
       windows: {},
       order: [],
@@ -65,76 +35,11 @@ describe("useOsAppLauncher", () => {
     });
   });
 
-  it("enables Coding Mode before opening its desktop window", async () => {
-    useOsWindows.getState().open("core.chat");
+  it("opens a PawApp window", () => {
     renderWithProviders(<Harness />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
 
-    await waitFor(() => {
-      expect(codingModeApi.toggle).toHaveBeenCalledWith(true);
-      expect(useOsWindows.getState().windows["core.chat"]).toBeUndefined();
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(useCodingModeStore.getState().codingModeByAgent.default).toBe(true);
-  });
-
-  it("does not open Coding when backend activation fails", async () => {
-    vi.mocked(codingModeApi.toggle).mockRejectedValueOnce(
-      new Error("Activation failed"),
-    );
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(codingModeApi.toggle).toHaveBeenCalledWith(true);
-    });
-    expect(useOsWindows.getState().windows["core.coding"]).toBeUndefined();
-  });
-
-  it("reopens the current mode after its window is closed", async () => {
-    useCodingModeStore.setState({
-      codingModeByAgent: { default: true },
-    });
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-
-    useOsWindows.getState().close("core.coding");
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(codingModeApi.toggle).not.toHaveBeenCalled();
-  });
-
-  it("can switch modes and reopen after both windows were closed", async () => {
-    renderWithProviders(<Harness />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Chat" }));
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeUndefined();
-      expect(useOsWindows.getState().windows["core.chat"]).toBeDefined();
-    });
-
-    useOsWindows.getState().close("core.chat");
-    fireEvent.click(screen.getByRole("button", { name: "Open Coding" }));
-
-    await waitFor(() => {
-      expect(useOsWindows.getState().windows["core.coding"]).toBeDefined();
-    });
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(1, true);
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(2, false);
-    expect(codingModeApi.toggle).toHaveBeenNthCalledWith(3, true);
+    expect(useOsWindows.getState().windows["plugin.kanban"]).toBeDefined();
   });
 });

--- a/console/src/os/useOsAppLauncher.ts
+++ b/console/src/os/useOsAppLauncher.ts
@@ -1,75 +1,10 @@
 import { useCallback } from "react";
-import { App } from "antd";
-import { useTranslation } from "react-i18next";
-import { codingModeApi } from "../api/modules/codingMode";
-import { useAgentStore } from "../stores/agentStore";
-import { useCodingModeStore } from "../stores/codingModeStore";
-import { useOsRoute } from "./osRouteStore";
 import { useOsWindows } from "./osWindowStore";
 
-const MODE_TARGETS = {
-  "core.chat": {
-    enabled: false,
-    path: "/chat",
-    oppositeRouteId: "core.coding",
-  },
-  "core.coding": {
-    enabled: true,
-    path: "/coding",
-    oppositeRouteId: "core.chat",
-  },
-} as const;
-
-let modeLaunchPromise: Promise<boolean> | null = null;
-
-/** Open a desktop app, applying Chat/Coding backend mode before navigation. */
+/** Open an app through the shared desktop launcher entry point. */
 export function useOsAppLauncher(): (routeId: string) => Promise<boolean> {
-  const { message } = App.useApp();
-  const { t } = useTranslation();
-
-  return useCallback(
-    async (routeId: string) => {
-      const target = MODE_TARGETS[routeId as keyof typeof MODE_TARGETS];
-      if (!target) {
-        useOsWindows.getState().open(routeId);
-        return true;
-      }
-
-      if (modeLaunchPromise) return modeLaunchPromise;
-
-      const launchPromise = (async () => {
-        const agentId = useAgentStore.getState().selectedAgent;
-        const codingState = useCodingModeStore.getState();
-        const currentMode = codingState.codingModeByAgent[agentId];
-
-        try {
-          if (currentMode !== target.enabled) {
-            await codingModeApi.toggle(target.enabled);
-            codingState.setCodingMode(agentId, target.enabled);
-          }
-          useOsRoute
-            .getState()
-            .navigateTo(routeId, target.path, target.oppositeRouteId);
-          return true;
-        } catch (error) {
-          message.error(
-            error instanceof Error
-              ? error.message
-              : t("os.codingModeLaunchFailed", "Failed to switch mode"),
-          );
-          return false;
-        }
-      })();
-      modeLaunchPromise = launchPromise;
-
-      try {
-        return await launchPromise;
-      } finally {
-        if (modeLaunchPromise === launchPromise) {
-          modeLaunchPromise = null;
-        }
-      }
-    },
-    [message, t],
-  );
+  return useCallback(async (routeId: string) => {
+    useOsWindows.getState().open(routeId);
+    return true;
+  }, []);
 }

--- a/console/src/pages/AppCenter/index.test.tsx
+++ b/console/src/pages/AppCenter/index.test.tsx
@@ -289,4 +289,17 @@ describe("AppCenterPage", () => {
       await screen.findByText("appCenter.appNotLoaded"),
     ).toBeInTheDocument();
   });
+
+  it("keeps the single OS entry path when opening an embedded app", async () => {
+    window.history.replaceState({}, "", "/os/apps/legacy");
+    renderPage();
+    await screen.findByText("alpha-app");
+
+    fireEvent.click(screen.getByText("alpha-app"));
+
+    expect(window.location.pathname).toBe("/os");
+    expect(
+      await screen.findByText("appCenter.appNotLoaded"),
+    ).toBeInTheDocument();
+  });
 });

--- a/console/src/pages/AppCenter/index.test.tsx
+++ b/console/src/pages/AppCenter/index.test.tsx
@@ -290,14 +290,28 @@ describe("AppCenterPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the single OS entry path when opening an embedded app", async () => {
-    window.history.replaceState({}, "", "/os/apps/legacy");
+  it("restores an OS PawApp when navigating back and forward", async () => {
+    window.history.replaceState({ osApp: "core.app-center" }, "", "/os");
     renderPage();
     await screen.findByText("alpha-app");
 
     fireEvent.click(screen.getByText("alpha-app"));
 
     expect(window.location.pathname).toBe("/os");
+    expect(window.history.state).toEqual({
+      osApp: "core.app-center",
+      osPawAppId: "alpha-app",
+    });
+    expect(
+      await screen.findByText("appCenter.appNotLoaded"),
+    ).toBeInTheDocument();
+
+    window.history.back();
+    await waitFor(() => {
+      expect(screen.getByText("alpha-app")).toBeInTheDocument();
+    });
+
+    window.history.forward();
     expect(
       await screen.findByText("appCenter.appNotLoaded"),
     ).toBeInTheDocument();

--- a/console/src/pages/AppCenter/index.tsx
+++ b/console/src/pages/AppCenter/index.tsx
@@ -40,8 +40,10 @@ import { AppCard, pickAppDescription, type AppCardData } from "./AppCard";
 import { ChunkErrorBoundary } from "@/components/ChunkErrorBoundary";
 import {
   addRouterBasename,
+  getOsPawAppIdFromHistoryState,
   getOsRootHref,
   isOsPath,
+  withOsPawAppHistoryState,
 } from "../../utils/navigationMode";
 import styles from "./index.module.less";
 
@@ -176,18 +178,41 @@ export default function AppCenterPage() {
 
   const handleAppClick = (app: AppCardData) => {
     const target = appTarget(app);
-    const browserPath = isOsPath(window.location.pathname)
-      ? getOsRootHref(window.location.pathname)
-      : addRouterBasename(window.location.pathname, target);
-    window.history.pushState({ pawappInline: true }, "", browserPath);
+    if (isOsPath(window.location.pathname)) {
+      window.history.pushState(
+        withOsPawAppHistoryState(window.history.state, app.id),
+        "",
+        getOsRootHref(window.location.pathname),
+      );
+    } else {
+      window.history.pushState(
+        { pawappInline: true },
+        "",
+        addRouterBasename(window.location.pathname, target),
+      );
+    }
     setActiveApp(app);
   };
 
   const handleBack = () => {
-    const browserPath = isOsPath(window.location.pathname)
-      ? getOsRootHref(window.location.pathname)
-      : addRouterBasename(window.location.pathname, "/apps");
-    window.history.pushState({}, "", browserPath);
+    if (isOsPath(window.location.pathname)) {
+      if (getOsPawAppIdFromHistoryState(window.history.state)) {
+        window.history.back();
+        return;
+      }
+      window.history.replaceState(
+        withOsPawAppHistoryState(window.history.state, null),
+        "",
+        getOsRootHref(window.location.pathname),
+      );
+      setActiveApp(null);
+      return;
+    }
+    window.history.pushState(
+      {},
+      "",
+      addRouterBasename(window.location.pathname, "/apps"),
+    );
     setActiveApp(null);
   };
 
@@ -222,17 +247,15 @@ export default function AppCenterPage() {
 
   // Keep the inline view in sync with browser back/forward.
   useEffect(() => {
-    const onPop = () => {
-      const pathAppId =
-        window.location.pathname.match(/\/apps\/([^/?#]+)/)?.[1];
-      if (!pathAppId) {
+    const onPop = (event: PopStateEvent) => {
+      const appId = isOsPath(window.location.pathname)
+        ? getOsPawAppIdFromHistoryState(event.state)
+        : window.location.pathname.match(/\/apps\/([^/?#]+)/)?.[1];
+      if (!appId) {
         setActiveApp(null);
         return;
       }
-      const found = apps.find((app) => app.id === pathAppId);
-      if (found) {
-        setActiveApp(found);
-      }
+      setActiveApp(apps.find((app) => app.id === appId) ?? null);
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);

--- a/console/src/pages/AppCenter/index.tsx
+++ b/console/src/pages/AppCenter/index.tsx
@@ -3,8 +3,8 @@
  *
  * Lists all plugins with `meta.pawapp` from the backend. Clicking an
  * app renders its registered route component INLINE within this page
- * (no full-page navigation). The URL bar mirrors the app path while keeping
- * OS-owned pages under `/os`, so refresh never falls back to the classic UI.
+ * (no full-page navigation). The classic console mirrors the app path in the
+ * URL; the Desktop OS keeps its single `/os` browser entry point.
  */
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -40,7 +40,6 @@ import { AppCard, pickAppDescription, type AppCardData } from "./AppCard";
 import { ChunkErrorBoundary } from "@/components/ChunkErrorBoundary";
 import {
   addRouterBasename,
-  getOsAppHref,
   getOsRootHref,
   isOsPath,
 } from "../../utils/navigationMode";
@@ -178,7 +177,7 @@ export default function AppCenterPage() {
   const handleAppClick = (app: AppCardData) => {
     const target = appTarget(app);
     const browserPath = isOsPath(window.location.pathname)
-      ? getOsAppHref(window.location.pathname, target)
+      ? getOsRootHref(window.location.pathname)
       : addRouterBasename(window.location.pathname, target);
     window.history.pushState({ pawappInline: true }, "", browserPath);
     setActiveApp(app);

--- a/console/src/plugins/pawapp-sdk/context.test.ts
+++ b/console/src/plugins/pawapp-sdk/context.test.ts
@@ -8,10 +8,14 @@ import {
 afterEach(() => setActivePawAppId(null));
 
 describe("PawApp context", () => {
-  it("extracts app ids from classic and OS-owned paths", () => {
+  it("extracts app ids from classic console paths", () => {
     expect(getPawAppIdFromPath("/apps/office")).toBe("office");
-    expect(getPawAppIdFromPath("/os/apps/office/settings")).toBe("office");
-    expect(getPawAppIdFromPath("/console/os/apps/office")).toBe("office");
+    expect(getPawAppIdFromPath("/console/apps/office/settings")).toBe("office");
+  });
+
+  it("does not infer app context from unsupported OS subpaths", () => {
+    expect(getPawAppIdFromPath("/os/apps/office/settings")).toBe("");
+    expect(getPawAppIdFromPath("/console/os/apps/office")).toBe("");
   });
 
   it("prefers the explicit active app context", () => {
@@ -20,8 +24,8 @@ describe("PawApp context", () => {
     expect(getActivePawAppId()).toBe("office");
   });
 
-  it("falls back to the current browser path", () => {
-    window.history.replaceState({}, "", "/os/apps/reviewer");
+  it("falls back to the current classic browser path", () => {
+    window.history.replaceState({}, "", "/apps/reviewer");
     expect(getActivePawAppId()).toBe("reviewer");
   });
 });

--- a/console/src/plugins/pawapp-sdk/context.ts
+++ b/console/src/plugins/pawapp-sdk/context.ts
@@ -1,7 +1,7 @@
 let activePawAppId = "";
 
 export function getPawAppIdFromPath(pathname: string): string {
-  const match = pathname.match(/\/apps\/([^/?#]+)/);
+  const match = pathname.match(/^\/(?:console\/)?apps\/([^/?#]+)/);
   return match?.[1] ?? "";
 }
 

--- a/console/src/utils/navigationMode.test.ts
+++ b/console/src/utils/navigationMode.test.ts
@@ -5,7 +5,6 @@ import {
   getConsoleRootHref,
   getLoginHref,
   getLoginPath,
-  getOsAppHref,
   getOsRootHref,
   getPostLoginHref,
   getRouterBasename,
@@ -49,16 +48,17 @@ describe("navigationMode", () => {
     expect(isLoginPath("/console/login")).toBe(true);
   });
 
-  it("only requests a hard post-login redirect for OS destinations", () => {
+  it("canonicalizes OS destinations after login", () => {
     expect(getPostLoginHref("/console/login", "/os/apps/office")).toBe(
-      "/console/os/apps/office",
+      "/console/os",
     );
+    expect(getPostLoginHref("/login", "/os/chat")).toBe("/os");
     expect(getPostLoginHref("/login", "/chat")).toBeNull();
   });
 
-  it("builds OS-owned browser paths", () => {
+  it("builds the single OS browser entry path", () => {
     expect(getOsRootHref("/console/os/apps/office")).toBe("/console/os");
-    expect(getOsAppHref("/os", "/apps/office")).toBe("/os/apps/office");
+    expect(getOsRootHref("/os/chat")).toBe("/os");
     expect(addRouterBasename("/console/login", "/os")).toBe("/console/os");
   });
 

--- a/console/src/utils/navigationMode.test.ts
+++ b/console/src/utils/navigationMode.test.ts
@@ -5,12 +5,14 @@ import {
   getConsoleRootHref,
   getLoginHref,
   getLoginPath,
+  getOsPawAppIdFromHistoryState,
   getOsRootHref,
   getPostLoginHref,
   getRouterBasename,
   isLoginPath,
   isOsPath,
   stripRouterBasename,
+  withOsPawAppHistoryState,
 } from "./navigationMode";
 
 describe("navigationMode", () => {
@@ -60,6 +62,16 @@ describe("navigationMode", () => {
     expect(getOsRootHref("/console/os/apps/office")).toBe("/console/os");
     expect(getOsRootHref("/os/chat")).toBe("/os");
     expect(addRouterBasename("/console/login", "/os")).toBe("/console/os");
+  });
+
+  it("stores OS PawApp history without discarding other shell state", () => {
+    const appState = withOsPawAppHistoryState({ osApp: "core.apps" }, "office");
+    expect(appState).toEqual({ osApp: "core.apps", osPawAppId: "office" });
+    expect(getOsPawAppIdFromHistoryState(appState)).toBe("office");
+
+    const rootState = withOsPawAppHistoryState(appState, null);
+    expect(rootState).toEqual({ osApp: "core.apps" });
+    expect(getOsPawAppIdFromHistoryState(rootState)).toBeUndefined();
   });
 
   it("builds basename-safe classic console paths", () => {

--- a/console/src/utils/navigationMode.ts
+++ b/console/src/utils/navigationMode.ts
@@ -22,6 +22,7 @@ export function stripRouterBasename(pathname: string): string {
 
 export function isOsPath(path: string): boolean {
   const pathname = stripRouterBasename(pathnameOnly(path));
+  // Descendants still enter the shell so it can canonicalize them to /os.
   return pathname === "/os" || pathname.startsWith("/os/");
 }
 
@@ -57,7 +58,7 @@ export function getPostLoginHref(
   redirect: string,
 ): string | null {
   if (!isOsPath(redirect)) return null;
-  return addRouterBasename(currentPathname, redirect);
+  return getOsRootHref(currentPathname);
 }
 
 export function getOsRootHref(currentPathname: string): string {
@@ -67,9 +68,4 @@ export function getOsRootHref(currentPathname: string): string {
 /** Build the classic console entry URL while preserving an optional basename. */
 export function getConsoleRootHref(currentPathname: string): string {
   return addRouterBasename(currentPathname, "/chat");
-}
-
-export function getOsAppHref(currentPathname: string, appPath: string): string {
-  const normalized = appPath.startsWith("/") ? appPath : `/${appPath}`;
-  return addRouterBasename(currentPathname, `/os${normalized}`);
 }

--- a/console/src/utils/navigationMode.ts
+++ b/console/src/utils/navigationMode.ts
@@ -5,6 +5,12 @@ interface LocationLike {
 }
 
 const CONSOLE_BASENAME = "/console";
+const OS_PAW_APP_STATE_KEY = "osPawAppId";
+
+function historyStateRecord(state: unknown): Record<string, unknown> {
+  if (!state || typeof state !== "object" || Array.isArray(state)) return {};
+  return state as Record<string, unknown>;
+}
 
 function pathnameOnly(path: string): string {
   return path.split(/[?#]/, 1)[0] || "/";
@@ -63,6 +69,26 @@ export function getPostLoginHref(
 
 export function getOsRootHref(currentPathname: string): string {
   return addRouterBasename(currentPathname, "/os");
+}
+
+export function getOsPawAppIdFromHistoryState(
+  state: unknown,
+): string | undefined {
+  const appId = historyStateRecord(state)[OS_PAW_APP_STATE_KEY];
+  return typeof appId === "string" && appId ? appId : undefined;
+}
+
+export function withOsPawAppHistoryState(
+  state: unknown,
+  appId: string | null,
+): Record<string, unknown> {
+  const nextState = { ...historyStateRecord(state) };
+  if (appId) {
+    nextState[OS_PAW_APP_STATE_KEY] = appId;
+  } else {
+    delete nextState[OS_PAW_APP_STATE_KEY];
+  }
+  return nextState;
 }
 
 /** Build the classic console entry URL while preserving an optional basename. */


### PR DESCRIPTION
## Fixes

Desktop OS effectively supports only `/os` as the unified entry point; it does not support directly opening applications via paths such as `/os/chat`, `/os/coding`, or `/os/apps/<id>`.

Previously, the frontend would parse paths following `/os/` and automatically open the corresponding window. Meanwhile, the App Center, post-login redirects, and the PawApp SDK continued to generate or recognize such deep links, resulting in a discrepancy between product behavior and actual routing conventions.

## Key Changes

Removed the logic that automatically opened application windows based on `/os/*` paths upon Desktop OS startup.

Standardized all Desktop OS browser URLs to simply `/os`.

The App Center no longer generates `/os/apps/<id>` paths when opening PawApps within the OS.

Consolidated all post-login redirects (previously targeting `/os/*`) to point to `/os`.

The PawApp SDK no longer infers the current application from `/os/apps/*` paths.

Retained `WindowRouter`, `pathToRouteId`, and the capability for cross-application navigation within windows.

Maintained the cleanup (from PR #6863) regarding the deprecated Coding OS window, launcher entry point, and modal window switching logic.

## Outcome

Accessing `/os/chat`, `/os/coding`, or `/os/apps/<id>` now simply loads Desktop OS and resets the URL to `/os`, without creating new application windows or focusing existing ones based on the URL. The ability to launch applications from within the desktop environment—via menus, the launcher, or window navigation—remains unaffected.

## Verification

Targeted tests: 31/31 passed

Full frontend test suite: 1679/1679 passed

ESLint, Prettier, and TypeScript checks passed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
