### PR TITLE
fix(agents): default background task timeout and stop spawn overriding it

### DIFF
--- a/src/qwenpaw/agents/fork_project.py
+++ b/src/qwenpaw/agents/fork_project.py
@@ -1413,16 +1413,30 @@ def finalize_fork_worktree_or_fail(
     same per-branch lock as finalize, so a peer cannot be marked failed
     until its in-flight finalize finishes.
 
+    Exceptions after the row is ``finalizing`` (for example
+    ``subprocess.TimeoutExpired`` from a hung ``git commit``) also mark
+    ``failed``. Otherwise a detached timeout worker can leave the registry
+    stuck and block later merge/cleanup.
+
     *expected_scope* is required for scoped registry rows; it is never
     inferred from the live row (that would let a stale caller mark/fail a
     newer scope that reused the branch).
     """
-    ok = finalize_fork_worktree(
-        worktree_path,
-        branch,
-        message=message,
-        expected_scope=expected_scope,
-    )
+    try:
+        ok = finalize_fork_worktree(
+            worktree_path,
+            branch,
+            message=message,
+            expected_scope=expected_scope,
+        )
+    except Exception:
+        mark_fork_failed(
+            worktree_path,
+            branch,
+            reason="finalize_fork_worktree raised an exception",
+            expected_scope=expected_scope,
+        )
+        raise
     if ok:
         return True
     mark_fork_failed(

--- a/src/qwenpaw/agents/skills/chat_with_agent-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/chat_with_agent-en/SKILL.md
@@ -58,8 +58,12 @@ Follow this flow strictly when using this skill:
   - `timeout`: (optional) estimated time needed for the foreground wait, to avoid premature timeouts
 
 4) If the task is better suited for background execution, use the background tool path:
-  - `submit_to_agent(...)`: submit a background task — only requires `to_agent`, `text`, and optionally `session_id`
+  - `submit_to_agent(...)`: submit a background task — requires `to_agent`, `text`, and optionally `session_id` / `task_timeout`
+    - Default execution budget is **3600 seconds (1 hour)** when `task_timeout` is omitted
+    - For work that may exceed 1 hour, pass an explicit positive `task_timeout` in seconds
+    - Numeric strings such as `"7200"` are accepted
   - `check_agent_task(...)`: check task status by `task_id`; returns the final result when complete
+    - On timeout the task finishes as failed with an error like `Task timed out after Ns` (and `code=timeout` in the API payload)
 
 ## Minimal Call Examples
 
@@ -90,6 +94,7 @@ chat_with_agent(
 submit_to_agent(
   to_agent="<target_agent_id>",
   text="[Agent <your_agent_id> requesting] Please complete this longer task in the background.",
+  task_timeout=7200,
 )
 
 check_agent_task(

--- a/src/qwenpaw/agents/skills/chat_with_agent-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/chat_with_agent-zh/SKILL.md
@@ -58,8 +58,12 @@ metadata:
   - `timeout`: （可选）预估任务需要的前台等待时间，避免过早超时
 
 4) 如果任务适合后台执行，请使用新的后台工具路径
-  - `submit_to_agent(...)`：提交后台任务，参数只需要 `to_agent`、`text` 和可选 `session_id`
+  - `submit_to_agent(...)`：提交后台任务，需要 `to_agent`、`text`，以及可选的 `session_id` / `task_timeout`
+    - 省略 `task_timeout` 时，默认执行预算为 **3600 秒（1 小时）**
+    - 预计超过 1 小时的任务，请显式传入正数秒
+    - 也接受数字字符串，例如 `"7200"`
   - `check_agent_task(...)`：通过 `task_id` 查询任务状态，完成时返回最终结果
+    - 超时后任务会以失败结束，错误类似 `Task timed out after Ns`（API 载荷中带 `code=timeout`）
 
 ## 最小调用示例
 
@@ -90,6 +94,7 @@ chat_with_agent(
 submit_to_agent(
   to_agent="<target_agent_id>",
   text="[Agent <your_agent_id> requesting] 请在后台完成这个较长任务。",
+  task_timeout=7200,
 )
 
 check_agent_task(

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -963,39 +963,31 @@ def _parse_positive_timeout_seconds(
     Rejects ``None``, bools, non-numeric values, and non-positive timeouts.
     Does not apply a default — callers decide what ``None`` means.
     """
+    err = (
+        f"'{field_name}' must be a positive number (seconds), "
+        f"got {value!r}"
+    )
     # bool is an int subclass — do not treat True/False as 1/0 seconds.
     if isinstance(value, bool):
-        raise ValueError(
-            f"'{field_name}' must be a positive number (seconds)",
-        )
+        raise ValueError(err)
     if isinstance(value, (int, float)):
         as_float = float(value)
     elif isinstance(value, str):
         text = value.strip()
         if not text:
-            raise ValueError(
-                f"'{field_name}' must be a positive number (seconds)",
-            )
+            raise ValueError(err)
         try:
             as_float = float(text)
         except ValueError as exc:
-            raise ValueError(
-                f"'{field_name}' must be a positive number (seconds)",
-            ) from exc
+            raise ValueError(err) from exc
     else:
-        raise ValueError(
-            f"'{field_name}' must be a positive number (seconds)",
-        )
+        raise ValueError(err)
     if not math.isfinite(as_float):
-        raise ValueError(
-            f"'{field_name}' must be a positive number (seconds)",
-        )
+        raise ValueError(err)
     # Truncation can turn (0, 1) into 0 — reject after int(), not before.
     as_int = int(as_float)
     if as_int <= 0:
-        raise ValueError(
-            f"'{field_name}' must be a positive number (seconds)",
-        )
+        raise ValueError(err)
     return as_int
 
 

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -21,6 +21,9 @@ from ...constant import (
 )
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.http import trust_env_for_url
+from ...utils.timeout import (
+    parse_positive_timeout_seconds as _parse_positive_timeout_seconds,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -955,21 +958,6 @@ def _coerce_bool(
         f"'{field_name}' must be a boolean "
         f"(or 0/1 / true/false / yes/no / on/off)",
     )
-
-
-def _parse_positive_timeout_seconds(
-    value: Any,
-    *,
-    field_name: str = "timeout",
-) -> int:
-    """Parse a required timeout value to positive ``int`` seconds.
-
-    Delegates to :func:`qwenpaw.utils.timeout.parse_positive_timeout_seconds`
-    so tool and console HTTP paths share one contract.
-    """
-    from ...utils.timeout import parse_positive_timeout_seconds
-
-    return parse_positive_timeout_seconds(value, field_name=field_name)
 
 
 def _foreground_wait_seconds(parsed_timeout: Optional[int]) -> int:

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -4,7 +4,6 @@
 import asyncio
 import json
 import logging
-import math
 import re
 import time
 from typing import Any, Callable, Dict, Optional
@@ -656,7 +655,9 @@ async def submit_to_agent(
             Task execution timeout in seconds. Numeric strings (e.g.
             ``"1800"``) are accepted for LLM mis-serialization. When
             omitted, the backend ``POST /console/chat/task`` applies
-            ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS``.
+            ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS`` (3600). Must be a
+            positive value when provided; pass a larger explicit value for
+            long-running tasks.
 
     Returns:
         `ToolChunk`:
@@ -959,36 +960,12 @@ def _parse_positive_timeout_seconds(
 ) -> int:
     """Parse a required timeout value to positive ``int`` seconds.
 
-    Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
-    Rejects ``None``, bools, non-numeric values, and non-positive timeouts.
-    Does not apply a default — callers decide what ``None`` means.
+    Delegates to :func:`qwenpaw.utils.timeout.parse_positive_timeout_seconds`
+    so tool and console HTTP paths share one contract.
     """
-    err = (
-        f"'{field_name}' must be a positive number (seconds), "
-        f"got {value!r}"
-    )
-    # bool is an int subclass — do not treat True/False as 1/0 seconds.
-    if isinstance(value, bool):
-        raise ValueError(err)
-    if isinstance(value, (int, float)):
-        as_float = float(value)
-    elif isinstance(value, str):
-        text = value.strip()
-        if not text:
-            raise ValueError(err)
-        try:
-            as_float = float(text)
-        except ValueError as exc:
-            raise ValueError(err) from exc
-    else:
-        raise ValueError(err)
-    if not math.isfinite(as_float):
-        raise ValueError(err)
-    # Truncation can turn (0, 1) into 0 — reject after int(), not before.
-    as_int = int(as_float)
-    if as_int <= 0:
-        raise ValueError(err)
-    return as_int
+    from ...utils.timeout import parse_positive_timeout_seconds
+
+    return parse_positive_timeout_seconds(value, field_name=field_name)
 
 
 def _coerce_timeout(

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -414,10 +414,15 @@ def format_background_submission_text(
     if not task_id:
         return "ERROR: No task_id returned from server"
 
-    return "\n".join(
+    lines = [
+        f"[TASK_ID: {task_id}]",
+        f"[SESSION: {session_id}]",
+    ]
+    timeout = task_result.get("timeout")
+    if timeout is not None:
+        lines.append(f"[TIMEOUT: {timeout}s]")
+    lines.extend(
         [
-            f"[TASK_ID: {task_id}]",
-            f"[SESSION: {session_id}]",
             "",
             "Task submitted successfully.",
             "The subagent is working autonomously"
@@ -426,6 +431,7 @@ def format_background_submission_text(
             f"  check_agent_task(task_id='{task_id}')",
         ],
     )
+    return "\n".join(lines)
 
 
 def format_background_status_text(
@@ -629,7 +635,7 @@ async def submit_to_agent(
     to_agent: str,
     text: str,
     session_id: Optional[str] = None,
-    task_timeout: Optional[float] = None,
+    task_timeout: float | int | str | None = None,
 ) -> ToolChunk:
     """Submit a background message to another configured agent.
 
@@ -646,9 +652,11 @@ async def submit_to_agent(
         session_id (`str`, optional):
             Existing session ID to continue a previous conversation in the
             background. If not provided, a new session ID is generated.
-        task_timeout (`float`, optional):
-            Task execution timeout in seconds. Overrides the server-side
-            default stream_task_timeout for this specific task.
+        task_timeout (`float | int | str`, optional):
+            Task execution timeout in seconds. Numeric strings (e.g.
+            ``"1800"``) are accepted for LLM mis-serialization. When
+            omitted, the backend ``POST /console/chat/task`` applies
+            ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS``.
 
     Returns:
         `ToolChunk`:
@@ -666,6 +674,16 @@ async def submit_to_agent(
         return _tool_text_response(
             "ERROR: 'text' is required for submission",
         )
+
+    parsed_timeout: Optional[int] = None
+    if task_timeout is not None:
+        try:
+            parsed_timeout = _parse_positive_timeout_seconds(
+                task_timeout,
+                field_name="task_timeout",
+            )
+        except ValueError as exc:
+            return _tool_text_response(f"ERROR: {exc}")
 
     target_exists = await asyncio.to_thread(
         agent_exists,
@@ -701,7 +719,7 @@ async def submit_to_agent(
         request_payload,
         normalized_to_agent,
         int(DEFAULT_AGENT_API_TIMEOUT),
-        task_timeout,
+        parsed_timeout,
     )
     return _tool_text_response(
         format_background_submission_text(result, final_session_id),
@@ -934,19 +952,17 @@ def _coerce_bool(
     )
 
 
-def _coerce_timeout(
+def _parse_positive_timeout_seconds(
     value: Any,
-    default: int = 600,
     *,
     field_name: str = "timeout",
 ) -> int:
-    """Parse a timeout tool field to ``int`` seconds.
+    """Parse a required timeout value to positive ``int`` seconds.
 
     Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
-    Rejects bools, non-numeric values, and non-positive timeouts.
+    Rejects ``None``, bools, non-numeric values, and non-positive timeouts.
+    Does not apply a default — callers decide what ``None`` means.
     """
-    if value is None:
-        return default
     # bool is an int subclass — do not treat True/False as 1/0 seconds.
     if isinstance(value, bool):
         raise ValueError(
@@ -981,6 +997,22 @@ def _coerce_timeout(
             f"'{field_name}' must be a positive number (seconds)",
         )
     return as_int
+
+
+def _coerce_timeout(
+    value: Any,
+    default: int = 600,
+    *,
+    field_name: str = "timeout",
+) -> int:
+    """Resolve a spawn-style timeout field to ``int`` seconds.
+
+    ``None`` becomes ``default`` (foreground wait budget). Non-``None``
+    values are parsed by :func:`_parse_positive_timeout_seconds`.
+    """
+    if value is None:
+        return default
+    return _parse_positive_timeout_seconds(value, field_name=field_name)
 
 
 def _normalize_batch(

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -15,6 +15,10 @@ from agentscope.tool import ToolChunk
 from agentscope.message import ToolResultState
 
 from ...config.utils import read_last_api
+from ...constant import (
+    DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS,
+    DEFAULT_STREAM_TASK_TIMEOUT_SECONDS,
+)
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.http import trust_env_for_url
 
@@ -968,20 +972,31 @@ def _parse_positive_timeout_seconds(
     return parse_positive_timeout_seconds(value, field_name=field_name)
 
 
-def _coerce_timeout(
-    value: Any,
-    default: int = 600,
-    *,
-    field_name: str = "timeout",
-) -> int:
-    """Resolve a spawn-style timeout field to ``int`` seconds.
+def _foreground_wait_seconds(parsed_timeout: Optional[int]) -> int:
+    """HTTP wait for spawn foreground; omit uses the spawn-only default."""
+    if parsed_timeout is None:
+        return int(DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS)
+    return parsed_timeout
 
-    ``None`` becomes ``default`` (foreground wait budget). Non-``None``
-    values are parsed by :func:`_parse_positive_timeout_seconds`.
+
+def _watchdog_timeout_from_submit_result(task_result: Any) -> int:
+    """Prefer the ``/chat/task`` echo; never invent a third default.
+
+    Must use :data:`DEFAULT_STREAM_TASK_TIMEOUT_SECONDS` — the same
+    symbol as ``resolve_stream_task_timeout``. Do not hardcode 3600.
     """
-    if value is None:
-        return default
-    return _parse_positive_timeout_seconds(value, field_name=field_name)
+    raw = None
+    if isinstance(task_result, dict):
+        raw = task_result.get("timeout")
+    if raw is not None:
+        try:
+            return _parse_positive_timeout_seconds(
+                raw,
+                field_name="timeout",
+            )
+        except ValueError:
+            pass
+    return int(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS)
 
 
 def _normalize_batch(
@@ -1033,7 +1048,7 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
     task: str,
     fork: bool | str | int = False,
     background: bool | str | int = False,
-    timeout: int | float | str = 600,
+    timeout: int | float | str | None = None,
     allowed_tools: Optional[list[str] | str] = None,
     skills: Optional[list[str] | str] = None,
     batch: Optional[list[Dict[str, Any]] | str] = None,
@@ -1075,10 +1090,16 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             a single subagent — it blocks until completion, eliminating
             the need to poll entirely.  String booleans are accepted
             like ``fork``; ambiguous values return ERROR.
-        timeout: Foreground wait timeout in seconds (default 600).
-            Ignored when ``background=True``.  Numeric strings (e.g.
-            ``"600"``) are accepted for LLM mis-serialization; invalid
-            values return ERROR.  Ignored entirely in batch mode.
+        timeout: Time budget in seconds.  Numeric strings (e.g.
+            ``"1800"``) are accepted for LLM mis-serialization; invalid
+            values return ERROR.  Foreground: parent HTTP wait on
+            ``/console/chat``; omit uses
+            ``DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS`` (600).
+            Background: task execution budget on ``/console/chat/task``;
+            omit leaves the field unset so the server applies
+            ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS`` (3600).  An explicit
+            positive value applies in both modes.  Ignored entirely in
+            batch mode (use per-item ``timeout``).
         allowed_tools: Tool-name whitelist.  Only the listed tools are
             available to the subagent.  ``None`` (default) inherits the
             parent's full tool set.  An empty list denies all tools.
@@ -1141,7 +1162,12 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             default=False,
             field_name="background",
         )
-        timeout = _coerce_timeout(timeout, default=600, field_name="timeout")
+        parsed_timeout: Optional[int] = None
+        if timeout is not None:
+            parsed_timeout = _parse_positive_timeout_seconds(
+                timeout,
+                field_name="timeout",
+            )
     except ValueError as exc:
         return _tool_text_response(f"ERROR: {exc}")
 
@@ -1161,7 +1187,7 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             current_agent_id=current_agent_id,
             subagent_session_id=subagent_session_id,
             background=background,
-            timeout=timeout,
+            timeout=parsed_timeout,
             allowed_tools=allowed_tools,
             skills=skills,
         )
@@ -1189,7 +1215,7 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             request_payload,
             current_agent_id,
             int(DEFAULT_AGENT_API_TIMEOUT),
-            float(timeout),
+            parsed_timeout,
         )
         return _tool_text_response(
             format_background_submission_text(
@@ -1203,7 +1229,7 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
         None,
         request_payload,
         current_agent_id,
-        timeout,
+        _foreground_wait_seconds(parsed_timeout),
     )
     if not response_data:
         return _tool_text_response(
@@ -1271,10 +1297,13 @@ async def _spawn_batch(
                         default=False,
                         field_name=f"batch[{i}].fork",
                     ),
-                    "timeout": _coerce_timeout(
-                        spec.get("timeout"),
-                        default=600,
-                        field_name=f"batch[{i}].timeout",
+                    "timeout": (
+                        None
+                        if spec.get("timeout") is None
+                        else _parse_positive_timeout_seconds(
+                            spec.get("timeout"),
+                            field_name=f"batch[{i}].timeout",
+                        )
                     ),
                 },
             )
@@ -1295,7 +1324,7 @@ async def _spawn_batch(
         session_id = _generate_subagent_session_id()
         task_text = spec["task"]
         spec_fork = bool(spec["fork"])
-        spec_timeout = int(spec["timeout"])
+        spec_timeout = spec["timeout"]
         spec_allowed = spec.get("allowed_tools")
         spec_skills = spec.get("skills")
 
@@ -1335,7 +1364,7 @@ async def _spawn_batch(
                 payload,
                 current_agent_id,
                 int(DEFAULT_AGENT_API_TIMEOUT),
-                float(spec_timeout),
+                spec_timeout,
             )
             return format_background_submission_text(result, session_id)
 
@@ -1390,7 +1419,7 @@ async def _spawn_forked_subagent(
     current_agent_id: str,
     subagent_session_id: str,
     background: bool,
-    timeout: int,
+    timeout: Optional[int],
     allowed_tools: Optional[list[str]] = None,
     skills: Optional[list[str]] = None,
 ) -> ToolChunk:
@@ -1495,8 +1524,8 @@ async def _spawn_forked_subagent(
             request_payload,
             current_agent_id,
             int(DEFAULT_AGENT_API_TIMEOUT),
-            # Align console cancel with spawn timeout / fork watchdog.
-            float(timeout),
+            # Explicit budget as-is; omit None so /chat/task applies default.
+            timeout,
         )
         task_id = result.get("task_id") if isinstance(result, dict) else None
         if worktree_path and task_id:
@@ -1515,7 +1544,7 @@ async def _spawn_forked_subagent(
                     str(task_id),
                     worktree_path,
                     worktree_branch,
-                    timeout=timeout,
+                    timeout=_watchdog_timeout_from_submit_result(result),
                     expected_scope=fork_scope_id or None,
                 ),
             )
@@ -1536,7 +1565,7 @@ async def _spawn_forked_subagent(
         None,
         request_payload,
         current_agent_id,
-        timeout,
+        _foreground_wait_seconds(timeout),
     )
 
     # Only commit on a successful worker response (avoid half-baked commits).
@@ -1594,16 +1623,20 @@ async def _watch_background_fork_finalize(
     worktree_path: str,
     worktree_branch: str,
     *,
-    timeout: int = 600,
+    timeout: int,
     expected_scope: str | None = None,
 ) -> None:
-    """Poll until the background task finishes or *timeout* elapses."""
+    """Poll until the background task finishes or *timeout* elapses.
+
+    ``timeout`` is the effective execution budget from the submit
+    response (or ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS`` if the echo is
+    missing). Console completion hook remains primary.
+    """
     from ..fork_project import (
         finalize_fork_worktree_or_fail,
         mark_fork_failed,
     )
 
-    # Align with worker timeout (default 600s); console hook remains primary.
     deadline = time.time() + max(30, int(timeout) + 30)
     delay = 2.0
     while time.time() < deadline:

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -731,10 +731,15 @@ async def _mark_background_fork_failed(
     summary="Submit a background chat task",
 )
 async def post_console_chat_task(  # pylint: disable=too-many-statements
-    request_data: Union[AgentRequest, dict],
+    request_data: dict,
     request: Request,
 ) -> dict:
     """Run an agent chat as a background task.
+
+    Accepts a raw JSON object (not the shared ``AgentRequest`` model) so
+    task-only fields such as ``timeout`` are not validated on the common
+    chat envelope. ``timeout`` is resolved in-handler: omitted/null uses
+    the server default; invalid values raise HTTP 400.
 
     Returns a ``task_id`` immediately. Poll status via
     ``GET /console/chat/task/{task_id}``.
@@ -747,13 +752,10 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
             detail="Channel Console not found",
         )
 
-    if isinstance(request_data, dict):
-        raw_timeout = request_data.get("timeout")
-    else:
-        raw_timeout = getattr(request_data, "timeout", None)
+    # Single validation path for task timeout — always HTTP 400 on error.
     try:
         effective_timeout = _resolve_effective_stream_task_timeout(
-            raw_timeout,
+            request_data.get("timeout"),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -780,22 +782,13 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
     fork_project_dir = ""
     fork_worktree_branch = ""
     fork_scope_id = ""
-    if isinstance(request_data, dict):
-        rc = request_data.get("request_context")
-        if isinstance(rc, dict):
-            fork_project_dir = str(rc.get("fork_project_dir") or "")
-            fork_worktree_branch = str(
-                rc.get("fork_worktree_branch") or "",
-            )
-            fork_scope_id = str(rc.get("fork_scope_id") or "")
-    else:
-        rc = getattr(request_data, "request_context", None)
-        if isinstance(rc, dict):
-            fork_project_dir = str(rc.get("fork_project_dir") or "")
-            fork_worktree_branch = str(
-                rc.get("fork_worktree_branch") or "",
-            )
-            fork_scope_id = str(rc.get("fork_scope_id") or "")
+    rc = request_data.get("request_context")
+    if isinstance(rc, dict):
+        fork_project_dir = str(rc.get("fork_project_dir") or "")
+        fork_worktree_branch = str(
+            rc.get("fork_worktree_branch") or "",
+        )
+        fork_scope_id = str(rc.get("fork_scope_id") or "")
 
     from ...config.config import load_agent_config
     from ...services.project_directory import (

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -670,11 +670,13 @@ async def _finalize_background_fork(
     *,
     scope_id: str,
 ) -> bool:
-    """Finish an in-flight fork commit before publishing task state.
+    """Finish an in-flight fork commit before publishing a *success* result.
 
-    Cancelling an ``asyncio.to_thread`` await cannot stop its worker thread.
-    Once finalization starts, keep waiting for its authoritative result so the
-    task API, fork registry, and branch HEAD cannot report conflicting states.
+    Cancelling ``asyncio.to_thread`` cannot stop the Git worker. If the
+    parent task is cancelled (timeout or manual cancel), re-raise immediately
+    so the task API can publish a terminal failure. The Git worker keeps
+    running as detached bookkeeping and must not rewrite that failure into
+    ``completed``.
     """
     from qwenpaw.agents.fork_project import finalize_fork_worktree_or_fail
 
@@ -687,12 +689,23 @@ async def _finalize_background_fork(
             expected_scope=scope_id or None,
         ),
     )
-    while True:
+
+    def _log_detached(task: asyncio.Task) -> None:
         try:
-            return await asyncio.shield(finalizer)
-        except asyncio.CancelledError:
-            if finalizer.done():
-                return finalizer.result()
+            task.result()
+        except Exception:
+            logger.warning(
+                "Detached fork finalize failed for %s",
+                sanitize_log_value(branch),
+                exc_info=True,
+            )
+
+    try:
+        return await asyncio.shield(finalizer)
+    except asyncio.CancelledError:
+        if not finalizer.done():
+            finalizer.add_done_callback(_log_detached)
+        raise
 
 
 async def _mark_background_fork_failed(
@@ -757,7 +770,7 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
         effective_timeout = _resolve_effective_stream_task_timeout(
             request_data.get("timeout"),
         )
-    except ValueError as exc:
+    except (ValueError, OverflowError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     task_id = f"task-{uuid.uuid4().hex[:12]}"
@@ -824,6 +837,7 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
 
     async def _run() -> None:
         last_response: Optional[Dict[str, Any]] = None
+        finalize_started = False
         try:
             async for sse_line in console_channel.stream_one(
                 native_payload,
@@ -835,6 +849,7 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
             # Fork subagents: commit dirty worktree so branch tips are
             # mergeable before exposing a completed task result.
             if fork_project_dir and fork_worktree_branch:
+                finalize_started = True
                 try:
                     finalized = await _finalize_background_fork(
                         fork_project_dir,
@@ -877,13 +892,16 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 "status": "failed",
                 "error": cancel_error,
             }
-            await _mark_background_fork_failed(
-                fork_project_dir,
-                fork_worktree_branch,
-                scope_id=fork_scope_id,
-                reason=str(cancel_error["message"]),
-                context="cancel",
-            )
+            # In-flight Git finalize is detached bookkeeping; do not race
+            # it with mark_fork_failed or let it flip this result later.
+            if not finalize_started:
+                await _mark_background_fork_failed(
+                    fork_project_dir,
+                    fork_worktree_branch,
+                    scope_id=fork_scope_id,
+                    reason=str(cancel_error["message"]),
+                    context="cancel",
+                )
             return
         except Exception as exc:
             bg.status = "finished"

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import math
 import re
 import time
 import uuid
@@ -24,11 +23,11 @@ from fastapi import (
 from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
-from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
 from qwenpaw.schemas import (
     AgentRequest,
     _coerce_content_item,
 )
+from qwenpaw.utils.timeout import resolve_stream_task_timeout
 from ...utils.logging import LOG_FILE_PATH, sanitize_log_value
 from ..agent_context import get_agent_for_request
 from ..approvals.display import approval_display_fields
@@ -72,38 +71,10 @@ def _resolve_effective_stream_task_timeout(
 ) -> int:
     """Resolve background chat-task timeout in seconds.
 
-    ``None`` (omitted / null) uses ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS``.
-    Positive numbers and numeric strings are accepted. Non-numeric values
-    and non-positive numbers raise ``ValueError`` (callers map to HTTP 400).
-    Unbounded execution is not supported.
+    Thin wrapper over :func:`qwenpaw.utils.timeout.resolve_stream_task_timeout`
+    so console routes share one parse/default contract with tools.
     """
-    if raw_timeout is None:
-        return int(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS)
-    # bool is an int subclass — reject True/False as 1/0 seconds.
-    if isinstance(raw_timeout, bool):
-        raise ValueError(
-            f"'timeout' must be a positive number (seconds), "
-            f"got {raw_timeout!r}",
-        )
-    try:
-        as_float = float(raw_timeout)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"'timeout' must be a positive number (seconds), "
-            f"got {raw_timeout!r}",
-        ) from exc
-    if not math.isfinite(as_float):
-        raise ValueError(
-            f"'timeout' must be a positive number (seconds), "
-            f"got {raw_timeout!r}",
-        )
-    as_int = int(as_float)
-    if as_int <= 0:
-        raise ValueError(
-            f"'timeout' must be a positive number (seconds), "
-            f"got {raw_timeout!r}",
-        )
-    return as_int
+    return resolve_stream_task_timeout(raw_timeout, field_name="timeout")
 
 
 def _background_task_cancel_error(

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import re
 import time
 import uuid
@@ -64,6 +65,59 @@ class MarkInboxReadRequest(BaseModel):
 
 
 MAX_DEBUG_LOG_LINES = 1000
+
+
+def _resolve_effective_stream_task_timeout(
+    raw_timeout: Any,
+) -> int:
+    """Resolve background chat-task timeout in seconds.
+
+    ``None`` (omitted / null) uses ``DEFAULT_STREAM_TASK_TIMEOUT_SECONDS``.
+    Positive numbers and numeric strings are accepted. Non-numeric values
+    and non-positive numbers raise ``ValueError`` (callers map to HTTP 400).
+    Unbounded execution is not supported.
+    """
+    if raw_timeout is None:
+        return int(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS)
+    # bool is an int subclass — reject True/False as 1/0 seconds.
+    if isinstance(raw_timeout, bool):
+        raise ValueError(
+            f"'timeout' must be a positive number (seconds), "
+            f"got {raw_timeout!r}",
+        )
+    try:
+        as_float = float(raw_timeout)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"'timeout' must be a positive number (seconds), "
+            f"got {raw_timeout!r}",
+        ) from exc
+    if not math.isfinite(as_float):
+        raise ValueError(
+            f"'timeout' must be a positive number (seconds), "
+            f"got {raw_timeout!r}",
+        )
+    as_int = int(as_float)
+    if as_int <= 0:
+        raise ValueError(
+            f"'timeout' must be a positive number (seconds), "
+            f"got {raw_timeout!r}",
+        )
+    return as_int
+
+
+def _background_task_cancel_error(
+    *,
+    timed_out: bool,
+    timeout_seconds: int,
+) -> Dict[str, Any]:
+    """Build the error payload for a cancelled background chat task."""
+    if timed_out:
+        return {
+            "message": f"Task timed out after {timeout_seconds}s",
+            "code": "timeout",
+        }
+    return {"message": "Task cancelled"}
 
 
 def _safe_filename(name: str) -> str:
@@ -722,6 +776,17 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
             detail="Channel Console not found",
         )
 
+    if isinstance(request_data, dict):
+        raw_timeout = request_data.get("timeout")
+    else:
+        raw_timeout = getattr(request_data, "timeout", None)
+    try:
+        effective_timeout = _resolve_effective_stream_task_timeout(
+            raw_timeout,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     task_id = f"task-{uuid.uuid4().hex[:12]}"
     native_payload = _extract_session_and_payload(request_data)
     session_id = console_channel.resolve_session_id(
@@ -741,12 +806,10 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
         native_payload,
     )
 
-    task_timeout: Optional[float] = None
     fork_project_dir = ""
     fork_worktree_branch = ""
     fork_scope_id = ""
     if isinstance(request_data, dict):
-        task_timeout = request_data.get("timeout")
         rc = request_data.get("request_context")
         if isinstance(rc, dict):
             fork_project_dir = str(rc.get("fork_project_dir") or "")
@@ -754,8 +817,7 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                 rc.get("fork_worktree_branch") or "",
             )
             fork_scope_id = str(rc.get("fork_scope_id") or "")
-    elif hasattr(request_data, "timeout"):
-        task_timeout = getattr(request_data, "timeout", None)
+    else:
         rc = getattr(request_data, "request_context", None)
         if isinstance(rc, dict):
             fork_project_dir = str(rc.get("fork_project_dir") or "")
@@ -794,6 +856,7 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
         status="running",
         started_at=time.time(),
     )
+    timed_out = False
 
     async def _run() -> None:
         last_response: Optional[Dict[str, Any]] = None
@@ -840,17 +903,21 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
                     }
                     return
         except asyncio.CancelledError:
+            cancel_error = _background_task_cancel_error(
+                timed_out=timed_out,
+                timeout_seconds=effective_timeout,
+            )
             bg.status = "finished"
             bg.finished_at = time.time()
             bg.result = {
                 "status": "failed",
-                "error": {"message": "Task cancelled"},
+                "error": cancel_error,
             }
             await _mark_background_fork_failed(
                 fork_project_dir,
                 fork_worktree_branch,
                 scope_id=fork_scope_id,
-                reason="Task cancelled",
+                reason=str(cancel_error["message"]),
                 context="cancel",
             )
             return
@@ -888,23 +955,23 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
     atask = asyncio.create_task(_run())
     bg.asyncio_task = atask
 
-    try:
-        requested_timeout = (
-            float(task_timeout) if task_timeout is not None else None
-        )
-    except (TypeError, ValueError):
-        requested_timeout = None
-    if requested_timeout is not None and requested_timeout > 0:
-        effective_timeout = requested_timeout
-    else:
-        effective_timeout = float(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS)
-
     async def _timeout_guard() -> None:
-        await asyncio.sleep(effective_timeout)
+        nonlocal timed_out
+        try:
+            await asyncio.sleep(effective_timeout)
+        except asyncio.CancelledError:
+            return
         if not atask.done():
+            timed_out = True
             atask.cancel()
 
-    asyncio.create_task(_timeout_guard())
+    guard_task = asyncio.create_task(_timeout_guard())
+
+    def _stop_timeout_guard(_task: asyncio.Task) -> None:
+        if not guard_task.done():
+            guard_task.cancel()
+
+    atask.add_done_callback(_stop_timeout_guard)
 
     async with _bg_lock:
         _bg_tasks[task_id] = bg

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -23,6 +23,7 @@ from fastapi import (
 from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
+from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
 from qwenpaw.schemas import (
     AgentRequest,
     _coerce_content_item,
@@ -887,19 +888,28 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
     atask = asyncio.create_task(_run())
     bg.asyncio_task = atask
 
-    if task_timeout is not None and task_timeout > 0:
+    try:
+        requested_timeout = (
+            float(task_timeout) if task_timeout is not None else None
+        )
+    except (TypeError, ValueError):
+        requested_timeout = None
+    if requested_timeout is not None and requested_timeout > 0:
+        effective_timeout = requested_timeout
+    else:
+        effective_timeout = float(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS)
 
-        async def _timeout_guard() -> None:
-            await asyncio.sleep(task_timeout)
-            if not atask.done():
-                atask.cancel()
+    async def _timeout_guard() -> None:
+        await asyncio.sleep(effective_timeout)
+        if not atask.done():
+            atask.cancel()
 
-        asyncio.create_task(_timeout_guard())
+    asyncio.create_task(_timeout_guard())
 
     async with _bg_lock:
         _bg_tasks[task_id] = bg
 
-    return {"task_id": task_id}
+    return {"task_id": task_id, "timeout": effective_timeout}
 
 
 @router.get(

--- a/src/qwenpaw/cli/agents_cmd.py
+++ b/src/qwenpaw/cli/agents_cmd.py
@@ -22,7 +22,10 @@ from ..config.config import (
     generate_short_agent_id,
     save_agent_config,
 )
-from ..constant import WORKING_DIR
+from ..constant import (
+    DEFAULT_STREAM_TASK_TIMEOUT_SECONDS,
+    WORKING_DIR,
+)
 from ..config.config import ModelSlotConfig
 from ..providers.provider_manager import ProviderManager
 from .http import print_json, resolve_base_url
@@ -788,7 +791,8 @@ def delete_cmd(
     default=None,
     help=(
         "Task execution timeout in seconds for background tasks. "
-        "Overrides server-side default stream_task_timeout."
+        "Overrides the server-side default "
+        f"({DEFAULT_STREAM_TASK_TIMEOUT_SECONDS}s)."
     ),
 )
 @click.option(

--- a/src/qwenpaw/cli/agents_cmd.py
+++ b/src/qwenpaw/cli/agents_cmd.py
@@ -792,7 +792,8 @@ def delete_cmd(
     help=(
         "Task execution timeout in seconds for background tasks. "
         "Overrides the server-side default "
-        f"({DEFAULT_STREAM_TASK_TIMEOUT_SECONDS}s)."
+        f"({DEFAULT_STREAM_TASK_TIMEOUT_SECONDS}s). "
+        "Must be a positive number when set."
     ),
 )
 @click.option(

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -230,6 +230,10 @@ HEARTBEAT_DEFAULT_EVERY = "6h"
 HEARTBEAT_DEFAULT_TARGET = "main"
 HEARTBEAT_DEFAULT_TIMEOUT_SECONDS = 300
 HEARTBEAT_MAX_TIMEOUT_SECONDS = 3600
+
+# Default execution budget for POST /console/chat/task when the request
+# omits ``timeout``. Aligned with Xiaoyi channel task_timeout_ms (1 hour).
+DEFAULT_STREAM_TASK_TIMEOUT_SECONDS = 3600
 HEARTBEAT_TARGET_LAST = "last"
 HEARTBEAT_TARGET_INBOX = "inbox"
 

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -234,6 +234,8 @@ HEARTBEAT_MAX_TIMEOUT_SECONDS = 3600
 # Default execution budget for POST /console/chat/task when the request
 # omits ``timeout``. Aligned with Xiaoyi channel task_timeout_ms (1 hour).
 DEFAULT_STREAM_TASK_TIMEOUT_SECONDS = 3600
+# Parent HTTP wait for spawn_subagent foreground (/console/chat).
+DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS = 600
 HEARTBEAT_TARGET_LAST = "last"
 HEARTBEAT_TARGET_INBOX = "inbox"
 

--- a/src/qwenpaw/schemas.py
+++ b/src/qwenpaw/schemas.py
@@ -260,6 +260,29 @@ class AgentRequest(BaseModel):
     user_id: Optional[str] = None
     stream: bool = True
     metadata: Optional[Dict[str, Any]] = None
+    # Used by POST /console/chat/task (and forwarded by submit_to_agent).
+    # Omitted/null → server default; must be a positive number of seconds
+    # when provided.
+    timeout: Optional[Union[int, float, str]] = Field(
+        default=None,
+        description=(
+            "Background task execution timeout in seconds for "
+            "POST /console/chat/task. Omit or null for the server default "
+            "(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS). Must be a positive "
+            "number (int/float/numeric string) when provided."
+        ),
+    )
+
+    @field_validator("timeout", mode="before")
+    @classmethod
+    def _reject_bool_timeout(cls, value: Any) -> Any:
+        # bool is an int subclass; without this, True would coerce to 1s.
+        if isinstance(value, bool):
+            raise ValueError(
+                f"'timeout' must be a positive number (seconds), "
+                f"got {value!r}",
+            )
+        return value
 
 
 class AgentResponse(BaseModel):

--- a/src/qwenpaw/schemas.py
+++ b/src/qwenpaw/schemas.py
@@ -260,29 +260,6 @@ class AgentRequest(BaseModel):
     user_id: Optional[str] = None
     stream: bool = True
     metadata: Optional[Dict[str, Any]] = None
-    # Used by POST /console/chat/task (and forwarded by submit_to_agent).
-    # Omitted/null → server default; must be a positive number of seconds
-    # when provided.
-    timeout: Optional[Union[int, float, str]] = Field(
-        default=None,
-        description=(
-            "Background task execution timeout in seconds for "
-            "POST /console/chat/task. Omit or null for the server default "
-            "(DEFAULT_STREAM_TASK_TIMEOUT_SECONDS). Must be a positive "
-            "number (int/float/numeric string) when provided."
-        ),
-    )
-
-    @field_validator("timeout", mode="before")
-    @classmethod
-    def _reject_bool_timeout(cls, value: Any) -> Any:
-        # bool is an int subclass; without this, True would coerce to 1s.
-        if isinstance(value, bool):
-            raise ValueError(
-                f"'timeout' must be a positive number (seconds), "
-                f"got {value!r}",
-            )
-        return value
 
 
 class AgentResponse(BaseModel):

--- a/src/qwenpaw/utils/timeout.py
+++ b/src/qwenpaw/utils/timeout.py
@@ -3,9 +3,27 @@
 from __future__ import annotations
 
 import math
+import sys
 from typing import Any
 
 from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+
+# asyncio.sleep converts its delay to float. Integers above this (e.g.
+# 10**1000) raise OverflowError in the timeout guard and leave the task
+# unbounded. Keep ints exact below this ceiling so 2**53+1 still echoes.
+MAX_STREAM_TASK_TIMEOUT_SECONDS = int(sys.float_info.max)
+
+
+def _ensure_sleepable_timeout(seconds: int, err: str) -> None:
+    """Reject values that asyncio.sleep cannot use as a finite delay."""
+    if seconds > MAX_STREAM_TASK_TIMEOUT_SECONDS:
+        raise ValueError(err)
+    try:
+        as_float = float(seconds)
+    except OverflowError as exc:
+        raise ValueError(err) from exc
+    if not math.isfinite(as_float):
+        raise ValueError(err)
 
 
 def parse_positive_timeout_seconds(
@@ -16,8 +34,10 @@ def parse_positive_timeout_seconds(
     """Parse a required timeout value to positive ``int`` seconds.
 
     Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
-    Rejects ``None``, bools, non-numeric values, and non-positive timeouts.
-    Does not apply a default — callers decide what ``None`` means.
+    Rejects ``None``, bools, non-numeric values, non-positive timeouts, and
+    values that overflow ``asyncio.sleep`` (non-finite / too large to convert
+    to float). Does not apply a default — callers decide what ``None`` means.
+    Integers that pass are returned exactly, not coerced through float.
     """
     err = (
         f"'{field_name}' must be a positive number (seconds), "
@@ -26,15 +46,20 @@ def parse_positive_timeout_seconds(
     # bool is an int subclass — do not treat True/False as 1/0 seconds.
     if isinstance(value, bool):
         raise ValueError(err)
-    if isinstance(value, (int, float)):
-        as_float = float(value)
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(err)
+        _ensure_sleepable_timeout(value, err)
+        return value
+    if isinstance(value, float):
+        as_float = value
     elif isinstance(value, str):
         text = value.strip()
         if not text:
             raise ValueError(err)
         try:
             as_float = float(text)
-        except ValueError as exc:
+        except (ValueError, OverflowError) as exc:
             raise ValueError(err) from exc
     else:
         raise ValueError(err)
@@ -44,6 +69,7 @@ def parse_positive_timeout_seconds(
     as_int = int(as_float)
     if as_int <= 0:
         raise ValueError(err)
+    _ensure_sleepable_timeout(as_int, err)
     return as_int
 
 

--- a/src/qwenpaw/utils/timeout.py
+++ b/src/qwenpaw/utils/timeout.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Shared positive-timeout parsing for tool args and console chat tasks."""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+
+
+def parse_positive_timeout_seconds(
+    value: Any,
+    *,
+    field_name: str = "timeout",
+) -> int:
+    """Parse a required timeout value to positive ``int`` seconds.
+
+    Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
+    Rejects ``None``, bools, non-numeric values, and non-positive timeouts.
+    Does not apply a default — callers decide what ``None`` means.
+    """
+    err = (
+        f"'{field_name}' must be a positive number (seconds), "
+        f"got {value!r}"
+    )
+    # bool is an int subclass — do not treat True/False as 1/0 seconds.
+    if isinstance(value, bool):
+        raise ValueError(err)
+    if isinstance(value, (int, float)):
+        as_float = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError(err)
+        try:
+            as_float = float(text)
+        except ValueError as exc:
+            raise ValueError(err) from exc
+    else:
+        raise ValueError(err)
+    if not math.isfinite(as_float):
+        raise ValueError(err)
+    # Truncation can turn (0, 1) into 0 — reject after int(), not before.
+    as_int = int(as_float)
+    if as_int <= 0:
+        raise ValueError(err)
+    return as_int
+
+
+def resolve_stream_task_timeout(
+    raw_timeout: Any,
+    *,
+    field_name: str = "timeout",
+    default_seconds: int = DEFAULT_STREAM_TASK_TIMEOUT_SECONDS,
+) -> int:
+    """Resolve background chat-task timeout in seconds.
+
+    ``None`` (omitted / null) uses ``default_seconds``. Otherwise parses via
+    :func:`parse_positive_timeout_seconds`. Omitting timeout is never
+    unbounded; callers that need a longer budget must pass an explicit
+    positive value.
+    """
+    if raw_timeout is None:
+        return int(default_seconds)
+    return parse_positive_timeout_seconds(
+        raw_timeout,
+        field_name=field_name,
+    )

--- a/tests/unit/agents/test_fork_project.py
+++ b/tests/unit/agents/test_fork_project.py
@@ -849,6 +849,47 @@ def test_finalize_requires_matching_scope(tmp_path: Path) -> None:
     assert after2["forks"][branch]["scope_id"] == scope2
 
 
+def test_finalize_or_fail_marks_failed_when_commit_raises(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A raising finalize must not leave the registry stuck in finalizing."""
+    from qwenpaw.agents import fork_project as fp
+
+    project = tmp_path / "repo"
+    _init_repo(project)
+    scope = begin_fork_scope(project)
+    wt = project / ".qwenpaw" / "worktrees" / "w1"
+    branch = "fork/w1"
+    _git(project, "worktree", "add", str(wt), "-b", branch)
+    assert register_fork(
+        str(wt),
+        branch,
+        workspace_dir=project,
+        scope_id=scope,
+    )
+    (wt / "feat.txt").write_text("feat\n", encoding="utf-8")
+
+    def _raise(*_args, **_kwargs) -> bool:
+        raise OSError("simulated git failure")
+
+    monkeypatch.setattr(fp, "commit_dirty_worktree", _raise)
+    try:
+        finalize_fork_worktree_or_fail(
+            str(wt),
+            branch,
+            message="x",
+            expected_scope=scope,
+        )
+    except OSError:
+        pass
+    else:
+        raise AssertionError("expected OSError from finalize")
+
+    after = json.loads((project / REGISTRY_REL).read_text(encoding="utf-8"))
+    assert after["forks"][branch]["status"] == "failed"
+
+
 def test_mark_fork_failed_dirty_recovery_ignores_new_scope(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -614,7 +614,10 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
         try:
             agent_management._coerce_timeout(bad, field_name="timeout")
         except ValueError as exc:
-            assert "timeout" in str(exc)
+            message = str(exc)
+            assert "timeout" in message
+            assert "got" in message
+            assert repr(bad) in message
         else:
             raise AssertionError(f"expected ValueError for {bad!r}")
 
@@ -626,7 +629,9 @@ def test_parse_positive_timeout_seconds_rejects_none():
             field_name="task_timeout",
         )
     except ValueError as exc:
-        assert "task_timeout" in str(exc)
+        message = str(exc)
+        assert "task_timeout" in message
+        assert "got None" in message
     else:
         raise AssertionError("expected ValueError for None")
 
@@ -739,6 +744,7 @@ async def test_submit_to_agent_invalid_timeout_returns_error(monkeypatch):
     text = response.content[0].text
     assert text.startswith("ERROR:")
     assert "task_timeout" in text
+    assert "got 'abc'" in text
 
 
 async def test_submit_to_agent_omitted_timeout_passes_none(monkeypatch):

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -593,6 +593,7 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
     assert agent_management._coerce_timeout("600") == 600
     assert agent_management._coerce_timeout(30.9) == 30
     assert agent_management._coerce_timeout(1) == 1
+    assert agent_management._coerce_timeout(None) == 600
     # Truncation of (0, 1) must not silently become timeout=0.
     for bad in (
         0,
@@ -616,6 +617,168 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
             assert "timeout" in str(exc)
         else:
             raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+def test_parse_positive_timeout_seconds_rejects_none():
+    try:
+        agent_management._parse_positive_timeout_seconds(
+            None,
+            field_name="task_timeout",
+        )
+    except ValueError as exc:
+        assert "task_timeout" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for None")
+
+
+def test_submit_to_agent_schema_accepts_task_timeout_string():
+    """Tool JSON schema must allow string so AgentScope validation passes."""
+    import jsonschema
+
+    tool = FunctionTool(agent_management.submit_to_agent)
+    schema = tool.input_schema
+    jsonschema.validate(
+        {
+            "to_agent": "worker",
+            "text": "do work",
+            "task_timeout": "30",
+        },
+        schema,
+    )
+    jsonschema.validate(
+        {
+            "to_agent": "worker",
+            "text": "do work",
+            "task_timeout": 30,
+        },
+        schema,
+    )
+    jsonschema.validate(
+        {"to_agent": "worker", "text": "do work"},
+        schema,
+    )
+
+
+def test_format_background_submission_text_includes_timeout():
+    text = agent_management.format_background_submission_text(
+        {"task_id": "task-abc", "timeout": 3600},
+        "sid-1",
+    )
+    assert "[TASK_ID: task-abc]" in text
+    assert "[SESSION: sid-1]" in text
+    assert "[TIMEOUT: 3600s]" in text
+
+
+async def test_submit_to_agent_string_timeout_reaches_submit(monkeypatch):
+    captured: dict = {}
+
+    def fake_submit(
+        _base,
+        _payload,
+        agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured["agent_id"] = agent_id
+        captured["task_timeout"] = task_timeout
+        return {"task_id": "task-xyz", "timeout": task_timeout}
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda _to_agent, _base_url=None: True,
+    )
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.submit_to_agent(
+        to_agent="worker",
+        text="do work",
+        task_timeout="30",
+    )
+    assert captured["task_timeout"] == 30
+    assert "[TASK_ID: task-xyz]" in response.content[0].text
+    assert "[TIMEOUT: 30s]" in response.content[0].text
+
+
+async def test_submit_to_agent_invalid_timeout_returns_error(monkeypatch):
+    called = {"submit": False}
+
+    def fake_submit(*_args, **_kwargs):
+        called["submit"] = True
+        return {"task_id": "task-should-not"}
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda *_a, **_k: True,
+    )
+
+    response = await agent_management.submit_to_agent(
+        to_agent="worker",
+        text="do work",
+        task_timeout="abc",
+    )
+    assert called["submit"] is False
+    text = response.content[0].text
+    assert text.startswith("ERROR:")
+    assert "task_timeout" in text
+
+
+async def test_submit_to_agent_omitted_timeout_passes_none(monkeypatch):
+    captured: dict = {}
+
+    def fake_submit(
+        _base,
+        _payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured["task_timeout"] = task_timeout
+        return {"task_id": "task-def", "timeout": 3600}
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda *_a, **_k: True,
+    )
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.submit_to_agent(
+        to_agent="worker",
+        text="do work",
+    )
+    assert captured["task_timeout"] is None
+    assert "[TIMEOUT: 3600s]" in response.content[0].text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -608,6 +608,7 @@ def test_parse_positive_timeout_seconds_accepts_numeric_and_rejects_invalid():
         True,
         False,
         "",
+        10**1000,
     ):
         try:
             agent_management._parse_positive_timeout_seconds(
@@ -779,6 +780,36 @@ async def test_submit_to_agent_invalid_timeout_returns_error(monkeypatch):
     assert text.startswith("ERROR:")
     assert "task_timeout" in text
     assert "got 'abc'" in text
+
+
+async def test_submit_to_agent_huge_int_timeout_returns_error(monkeypatch):
+    """Values that overflow asyncio.sleep must be tool ERROR, not a submit."""
+    called = {"submit": False}
+
+    def fake_submit(*_args, **_kwargs):
+        called["submit"] = True
+        return {"task_id": "task-should-not"}
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda *_a, **_k: True,
+    )
+
+    response = await agent_management.submit_to_agent(
+        to_agent="worker",
+        text="do work",
+        task_timeout=10**1000,
+    )
+    assert called["submit"] is False
+    text = response.content[0].text
+    assert text.startswith("ERROR:")
+    assert "task_timeout" in text
 
 
 async def test_submit_to_agent_omitted_timeout_passes_none(monkeypatch):

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import httpx
@@ -327,8 +328,6 @@ async def test_chat_with_agent_uses_async_collect_for_final_mode(monkeypatch):
 
 async def test_chat_with_agent_arms_kill_deadline_from_timeout(monkeypatch):
     """Caller timeout must register kill_deadline (may exceed hook offload)."""
-    import asyncio
-
     from qwenpaw.tool_calls import reset_call_context, set_call_context
     from qwenpaw.tool_calls._context import ToolCallContext
 
@@ -589,11 +588,10 @@ def test_coerce_bool_rejects_ambiguous_values():
             raise AssertionError(f"expected ValueError for {bad!r}")
 
 
-def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
-    assert agent_management._coerce_timeout("600") == 600
-    assert agent_management._coerce_timeout(30.9) == 30
-    assert agent_management._coerce_timeout(1) == 1
-    assert agent_management._coerce_timeout(None) == 600
+def test_parse_positive_timeout_seconds_accepts_numeric_and_rejects_invalid():
+    assert agent_management._parse_positive_timeout_seconds("600") == 600
+    assert agent_management._parse_positive_timeout_seconds(30.9) == 30
+    assert agent_management._parse_positive_timeout_seconds(1) == 1
     # Truncation of (0, 1) must not silently become timeout=0.
     for bad in (
         0,
@@ -612,7 +610,10 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
         "",
     ):
         try:
-            agent_management._coerce_timeout(bad, field_name="timeout")
+            agent_management._parse_positive_timeout_seconds(
+                bad,
+                field_name="timeout",
+            )
         except ValueError as exc:
             message = str(exc)
             assert "timeout" in message
@@ -620,6 +621,39 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
             assert repr(bad) in message
         else:
             raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+def test_foreground_wait_omitted_uses_spawn_constant():
+    from qwenpaw.constant import DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+
+    assert (
+        agent_management._foreground_wait_seconds(None)
+        == DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+    )
+    assert agent_management._foreground_wait_seconds(1800) == 1800
+
+
+def test_watchdog_timeout_prefers_submit_echo():
+    from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+
+    assert (
+        agent_management._watchdog_timeout_from_submit_result(
+            {"task_id": "t", "timeout": 1800},
+        )
+        == 1800
+    )
+    assert (
+        agent_management._watchdog_timeout_from_submit_result(
+            {"task_id": "t"},
+        )
+        == DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+    )
+    assert (
+        agent_management._watchdog_timeout_from_submit_result(
+            {"timeout": "abc"},
+        )
+        == DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+    )
 
 
 def test_parse_positive_timeout_seconds_rejects_none():
@@ -1387,3 +1421,269 @@ async def test_spawn_subagent_batch_item_timeout_errors_before_dispatch(
     assert "timeout" in text3.lower()
     assert not submitted
     assert not forked
+
+
+def _patch_spawn_runtime(monkeypatch):
+    from qwenpaw.app import agent_context
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+
+async def test_spawn_background_omitted_timeout_passes_none(monkeypatch):
+    captured: dict = {}
+
+    def fake_submit(
+        _base,
+        _payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured["task_timeout"] = task_timeout
+        return {"task_id": "task-bg", "timeout": 3600}
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    response = await agent_management.spawn_subagent(
+        task="long work",
+        background=True,
+    )
+    assert captured["task_timeout"] is None
+    text = response.content[0].text
+    assert "ERROR" not in text
+    assert "[TIMEOUT: 3600s]" in text
+
+
+async def test_spawn_background_explicit_timeout_reaches_submit(monkeypatch):
+    captured: dict = {}
+
+    def fake_submit(
+        _base,
+        _payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured["task_timeout"] = task_timeout
+        return {"task_id": "task-bg", "timeout": task_timeout}
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    response = await agent_management.spawn_subagent(
+        task="long work",
+        background=True,
+        timeout="1800",
+    )
+    assert captured["task_timeout"] == 1800
+    assert "[TIMEOUT: 1800s]" in response.content[0].text
+
+
+async def test_spawn_foreground_omitted_timeout_waits_600(monkeypatch):
+    from qwenpaw.constant import DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+
+    captured: dict = {}
+
+    def fake_collect(_base, _payload, _agent_id, timeout):
+        captured["timeout"] = timeout
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    response = await agent_management.spawn_subagent(task="do work")
+    assert captured["timeout"] == DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+    assert "ERROR" not in response.content[0].text
+
+
+async def test_spawn_batch_omitted_timeout_passes_none(monkeypatch):
+    captured: list = []
+
+    def fake_submit(
+        _base,
+        _payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured.append(task_timeout)
+        return {"task_id": f"t-{len(captured)}", "timeout": 3600}
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[
+            {"task": "a"},
+            {"task": "b", "timeout": 7200},
+        ],
+    )
+    assert "ERROR" not in response.content[0].text
+    assert captured == [None, 7200]
+
+
+async def test_spawn_fork_foreground_omitted_timeout_waits_600(monkeypatch):
+    from qwenpaw.constant import DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+
+    captured: dict = {}
+
+    async def fake_fork_api(**_kwargs):
+        return {
+            "fork_session_id": "fork-s",
+            "worktree_path": "",
+            "worktree_branch": "",
+        }
+
+    def fake_collect(_base, _payload, _agent_id, timeout):
+        captured["timeout"] = timeout
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(agent_management, "_call_fork_api", fake_fork_api)
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    response = await agent_management.spawn_subagent(
+        task="do work",
+        fork=True,
+    )
+    assert captured["timeout"] == DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
+    assert "ERROR" not in response.content[0].text
+
+
+async def test_spawn_fork_background_uses_submit_echo_for_watchdog(
+    monkeypatch,
+):
+    from qwenpaw.agents import fork_project
+
+    captured: dict = {}
+    watch: dict = {}
+
+    async def fake_fork_api(**_kwargs):
+        return {
+            "fork_session_id": "fork-s",
+            "worktree_path": "/tmp/wt",
+            "worktree_branch": "fork/x",
+        }
+
+    def fake_submit(
+        _base,
+        _payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,
+    ):
+        captured["task_timeout"] = task_timeout
+        return {"task_id": "task-fork", "timeout": 3600}
+
+    async def fake_watch(*_args, **kwargs):
+        watch["timeout"] = kwargs.get("timeout")
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(agent_management, "_call_fork_api", fake_fork_api)
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "_watch_background_fork_finalize",
+        fake_watch,
+    )
+    monkeypatch.setattr(fork_project, "register_fork", lambda *a, **k: True)
+    monkeypatch.setattr(
+        fork_project,
+        "get_active_fork_scope",
+        lambda *_a, **_k: "scope",
+    )
+    monkeypatch.setattr(fork_project, "bind_fork_task", lambda *a, **k: None)
+
+    response = await agent_management.spawn_subagent(
+        task="do work",
+        fork=True,
+        background=True,
+    )
+    await asyncio.sleep(0)
+    assert captured["task_timeout"] is None
+    assert watch["timeout"] == 3600
+    assert "[TIMEOUT: 3600s]" in response.content[0].text
+
+
+async def test_spawn_batch_fork_omitted_timeout_is_none(monkeypatch):
+    forked: list[dict] = []
+
+    async def fake_forked(**kwargs):
+        forked.append(kwargs)
+        return agent_management._tool_text_response("forked")
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "_spawn_forked_subagent",
+        fake_forked,
+    )
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[{"task": "a", "fork": True}],
+    )
+    assert "ERROR" not in response.content[0].text
+    assert forked[0]["timeout"] is None
+    assert forked[0]["background"] is True
+
+
+def test_spawn_subagent_schema_accepts_timeout_string_and_omission():
+    import jsonschema
+
+    tool = FunctionTool(agent_management.spawn_subagent)
+    schema = tool.input_schema
+    timeout_schema = schema["properties"]["timeout"]
+    assert timeout_schema.get("default") is None
+    jsonschema.validate({"task": "do work", "timeout": "1800"}, schema)
+    jsonschema.validate({"task": "do work", "timeout": 1800}, schema)
+    jsonschema.validate({"task": "do work"}, schema)

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -191,14 +191,6 @@ async def _wait_for_task_to_finish(task_id: str) -> dict[str, Any]:
     raise TimeoutError(f"background task did not finish: {task_id}")
 
 
-async def _wait_for_task_cancellation(task: asyncio.Task[Any]) -> None:
-    for _ in range(200):
-        if task.cancelling() > 0:
-            return
-        await asyncio.sleep(0.05)
-    raise TimeoutError("background task was not cancelled")
-
-
 @pytest.mark.asyncio
 async def test_forked_task_reports_failed_when_worktree_cannot_be_finalized(
     tmp_path: Path,
@@ -273,11 +265,15 @@ async def test_forked_task_reports_failed_when_worktree_finalization_raises(
 
 
 @pytest.mark.asyncio
-async def test_forked_task_timeout_during_finalization_waits_for_commit(
+async def test_forked_task_timeout_during_finalization_stays_failed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Once a Git commit starts, timeout waits for its authoritative result."""
+    """Timeout during Git finalize must publish failed/timeout immediately.
+
+    The in-flight commit may still finish as bookkeeping, but it must not
+    rewrite the task API result back to completed.
+    """
     fork = _create_fork(tmp_path, "finalize-timeout")
     _install_hook(
         fork,
@@ -294,24 +290,20 @@ async def test_forked_task_timeout_during_finalization_waits_for_commit(
     )
     try:
         await _wait_for_file(fork.worktree / ".hook-started")
-        await _wait_for_task_cancellation(background_task)
-        before_release = await console.get_console_chat_task(task_id)
+        timed_out = await _wait_for_task_to_finish(task_id)
+        error = (timed_out.get("result") or {}).get("error") or {}
+        assert timed_out["status"] == "finished"
+        assert timed_out["result"]["status"] == "failed"
+        assert error.get("code") == "timeout"
 
         (fork.worktree / ".hook-release").touch()
         await asyncio.wait_for(background_task, timeout=10)
-        completed = await console.get_console_chat_task(task_id)
-        registry = json.loads(
-            (fork.project / REGISTRY_REL).read_text(encoding="utf-8"),
-        )
-        fork_head = _git(fork.worktree, "rev-parse", "HEAD").stdout.strip()
-
-        assert (
-            before_release["status"],
-            completed["status"],
-            completed["result"]["status"],
-            registry["forks"][fork.branch]["status"],
-            fork_head != fork.base_head,
-        ) == ("running", "finished", "completed", "finalized", True)
+        # Detached Git may still commit; the task result must stay timeout.
+        after_release = await console.get_console_chat_task(task_id)
+        after_error = (after_release.get("result") or {}).get("error") or {}
+        assert after_release["status"] == "finished"
+        assert after_release["result"]["status"] == "failed"
+        assert after_error.get("code") == "timeout"
     finally:
         (fork.worktree / ".hook-release").touch(exist_ok=True)
         await asyncio.gather(background_task, return_exceptions=True)

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import stat
 import subprocess
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -191,6 +192,28 @@ async def _wait_for_task_to_finish(task_id: str) -> dict[str, Any]:
     raise TimeoutError(f"background task did not finish: {task_id}")
 
 
+async def _wait_for_fork_status(
+    project: Path,
+    branch: str,
+    status: str,
+) -> dict[str, Any]:
+    registry_path = project / REGISTRY_REL
+    for _ in range(200):
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        if registry["forks"][branch]["status"] == status:
+            return registry
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f"fork {branch} did not reach status {status}")
+
+
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    for _ in range(200):
+        if event.is_set():
+            return
+        await asyncio.sleep(0.05)
+    raise TimeoutError("threading event was not set")
+
+
 @pytest.mark.asyncio
 async def test_forked_task_reports_failed_when_worktree_cannot_be_finalized(
     tmp_path: Path,
@@ -306,6 +329,63 @@ async def test_forked_task_timeout_during_finalization_stays_failed(
         assert after_error.get("code") == "timeout"
     finally:
         (fork.worktree / ".hook-release").touch(exist_ok=True)
+        await asyncio.gather(background_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_timeout_then_detached_finalize_exception_marks_registry_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later finalize exception must not leave the registry finalizing."""
+    fork = _create_fork(tmp_path, "finalize-timeout-exc")
+    started = threading.Event()
+    release = threading.Event()
+
+    def _blocked_then_raise(*_args: Any, **_kwargs: Any) -> bool:
+        started.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("test did not release finalize")
+        raise OSError("simulated git failure")
+
+    monkeypatch.setattr(
+        fork_project,
+        "commit_dirty_worktree",
+        _blocked_then_raise,
+    )
+    task_id, background_task = await _submit_forked_task(
+        monkeypatch,
+        worktree=fork.worktree,
+        branch=fork.branch,
+        scope=fork.scope,
+        timeout=3.0,
+    )
+    try:
+        await _wait_for_thread_event(started)
+        timed_out = await _wait_for_task_to_finish(task_id)
+        error = (timed_out.get("result") or {}).get("error") or {}
+        assert timed_out["status"] == "finished"
+        assert timed_out["result"]["status"] == "failed"
+        assert error.get("code") == "timeout"
+        mid = json.loads(
+            (fork.project / REGISTRY_REL).read_text(encoding="utf-8"),
+        )
+        assert mid["forks"][fork.branch]["status"] == "finalizing"
+
+        release.set()
+        after_reg = await _wait_for_fork_status(
+            fork.project,
+            fork.branch,
+            "failed",
+        )
+        after = await console.get_console_chat_task(task_id)
+        after_error = (after.get("result") or {}).get("error") or {}
+        assert after["status"] == "finished"
+        assert after["result"]["status"] == "failed"
+        assert after_error.get("code") == "timeout"
+        assert after_reg["forks"][fork.branch]["status"] == "failed"
+    finally:
+        release.set()
         await asyncio.gather(background_task, return_exceptions=True)
 
 

--- a/tests/unit/app/routers/test_console_chat_task_timeout.py
+++ b/tests/unit/app/routers/test_console_chat_task_timeout.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for console background chat-task timeout handling."""
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.routers import console as console_mod
+from qwenpaw.app.routers.console import (
+    _background_task_cancel_error,
+    _resolve_effective_stream_task_timeout,
+)
+from qwenpaw.app.task_tracker import TaskTracker
+from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+
+
+def test_resolve_timeout_omitted_uses_default() -> None:
+    assert (
+        _resolve_effective_stream_task_timeout(None)
+        == DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+    )
+
+
+def test_resolve_timeout_accepts_positive_number_and_string() -> None:
+    assert _resolve_effective_stream_task_timeout(30) == 30
+    assert _resolve_effective_stream_task_timeout(30.9) == 30
+    assert _resolve_effective_stream_task_timeout("1800") == 1800
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["abc", "", "null", True, False, 0, -1, 0.5, "0", "-3", float("nan")],
+)
+def test_resolve_timeout_rejects_invalid(bad) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        _resolve_effective_stream_task_timeout(bad)
+    message = str(exc_info.value)
+    assert "timeout" in message
+    assert "got" in message
+
+
+def test_background_cancel_error_distinguishes_timeout() -> None:
+    timed_out = _background_task_cancel_error(
+        timed_out=True,
+        timeout_seconds=30,
+    )
+    assert timed_out["code"] == "timeout"
+    assert timed_out["message"] == "Task timed out after 30s"
+
+    cancelled = _background_task_cancel_error(
+        timed_out=False,
+        timeout_seconds=30,
+    )
+    assert cancelled == {"message": "Task cancelled"}
+
+
+async def test_timeout_guard_marks_timeout_before_cancel() -> None:
+    """Mirrors console `_timeout_guard` + `_run` cancel handling."""
+    timed_out = False
+    captured: dict = {}
+
+    async def _run() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            captured["error"] = _background_task_cancel_error(
+                timed_out=timed_out,
+                timeout_seconds=1,
+            )
+
+    atask = asyncio.create_task(_run())
+
+    async def _timeout_guard() -> None:
+        nonlocal timed_out
+        await asyncio.sleep(0.01)
+        if not atask.done():
+            timed_out = True
+            atask.cancel()
+
+    await asyncio.gather(atask, _timeout_guard(), return_exceptions=True)
+    assert captured["error"]["code"] == "timeout"
+    assert captured["error"]["message"] == "Task timed out after 1s"
+
+
+@pytest.fixture
+def console_workspace(workspace_mock, monkeypatch):
+    """Workspace with console channel + chat manager for /chat/task."""
+    console_channel = MagicMock(name="ConsoleChannel")
+    console_channel.resolve_session_id = MagicMock(
+        return_value="console:default",
+    )
+
+    async def _stream_one(_payload):
+        # Complete immediately so TestClient does not leave hung tasks.
+        # Empty async generator: zero iterations.
+        for _ in ():
+            yield ""
+
+    console_channel.stream_one = _stream_one
+    workspace_mock.channel_manager.get_channel = AsyncMock(
+        return_value=console_channel,
+    )
+    workspace_mock.console_channel = console_channel
+
+    chat = MagicMock(name="ChatSpec")
+    chat.id = "chat-1"
+    chat.name = "New Chat"
+    chat.meta = {}
+    workspace_mock.chat_manager = MagicMock(name="ChatManager")
+    workspace_mock.chat_manager.get_or_create_chat = AsyncMock(
+        return_value=chat,
+    )
+    workspace_mock.task_tracker = TaskTracker()
+    workspace_mock.agent_id = "default"
+    workspace_mock.workspace_dir = "/tmp/qwenpaw-test-workspace"
+
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda _agent_id: MagicMock(project_dir=None),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.services.project_directory.resolve_effective_project_dir",
+        lambda *args, **kwargs: ("/tmp/project", "test"),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.services.project_directory.session_project_dir",
+        lambda _meta: None,
+    )
+    monkeypatch.setattr(
+        console_mod,
+        "_apply_session_project_dir",
+        AsyncMock(side_effect=lambda _ws, chat_obj, _payload: chat_obj),
+    )
+    return workspace_mock
+
+
+@pytest.fixture
+def app(manager_mock, console_workspace) -> FastAPI:
+    application = FastAPI()
+    application.state.multi_agent_manager = manager_mock
+    application.include_router(console_mod.router, prefix="/api")
+    return application
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _chat_task_body(**extra):
+    body = {
+        "channel": "console",
+        "user_id": "default",
+        "session_id": "console:default",
+        "input": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        ],
+    }
+    body.update(extra)
+    return body
+
+
+def test_chat_task_omitted_timeout_returns_default(
+    client,
+    console_workspace,
+):
+    response = client.post("/api/console/chat/task", json=_chat_task_body())
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["timeout"] == DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+    assert body["task_id"].startswith("task-")
+
+
+def test_chat_task_explicit_timeout_echoed(
+    client,
+    console_workspace,
+):
+    response = client.post(
+        "/api/console/chat/task",
+        json=_chat_task_body(timeout=30),
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["timeout"] == 30
+
+
+@pytest.mark.parametrize("bad_timeout", ["abc", 0, -1, True])
+def test_chat_task_invalid_timeout_returns_400(
+    client,
+    console_workspace,
+    bad_timeout,
+):
+    response = client.post(
+        "/api/console/chat/task",
+        json=_chat_task_body(timeout=bad_timeout),
+    )
+    assert response.status_code == 400, response.text
+    assert "timeout" in response.json()["detail"]

--- a/tests/unit/app/routers/test_console_chat_task_timeout.py
+++ b/tests/unit/app/routers/test_console_chat_task_timeout.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
 from qwenpaw.app.routers import console as console_mod
 from qwenpaw.app.routers.console import (
@@ -17,6 +19,7 @@ from qwenpaw.app.routers.console import (
 )
 from qwenpaw.app.task_tracker import TaskTracker
 from qwenpaw.constant import DEFAULT_STREAM_TASK_TIMEOUT_SECONDS
+from qwenpaw.utils.timeout import parse_positive_timeout_seconds
 
 
 def test_resolve_timeout_omitted_uses_default() -> None:
@@ -30,11 +33,24 @@ def test_resolve_timeout_accepts_positive_number_and_string() -> None:
     assert _resolve_effective_stream_task_timeout(30) == 30
     assert _resolve_effective_stream_task_timeout(30.9) == 30
     assert _resolve_effective_stream_task_timeout("1800") == 1800
+    assert _resolve_effective_stream_task_timeout(10**15) == 10**15
 
 
 @pytest.mark.parametrize(
     "bad",
-    ["abc", "", "null", True, False, 0, -1, 0.5, "0", "-3", float("nan")],
+    [
+        "abc",
+        "",
+        "null",
+        True,
+        False,
+        0,
+        -1,
+        0.5,
+        "0",
+        "-3",
+        float("nan"),
+    ],
 )
 def test_resolve_timeout_rejects_invalid(bad) -> None:
     with pytest.raises(ValueError) as exc_info:
@@ -42,6 +58,13 @@ def test_resolve_timeout_rejects_invalid(bad) -> None:
     message = str(exc_info.value)
     assert "timeout" in message
     assert "got" in message
+
+
+def test_shared_parse_used_by_tool_and_console() -> None:
+    """Tool and console wrappers must share the same parse rules."""
+    assert parse_positive_timeout_seconds("30") == 30
+    assert _resolve_effective_stream_task_timeout("30") == 30
+    assert parse_positive_timeout_seconds(10**15) == 10**15
 
 
 def test_background_cancel_error_distinguishes_timeout() -> None:
@@ -59,32 +82,11 @@ def test_background_cancel_error_distinguishes_timeout() -> None:
     assert cancelled == {"message": "Task cancelled"}
 
 
-async def test_timeout_guard_marks_timeout_before_cancel() -> None:
-    """Mirrors console `_timeout_guard` + `_run` cancel handling."""
-    timed_out = False
-    captured: dict = {}
-
-    async def _run() -> None:
-        try:
-            await asyncio.sleep(3600)
-        except asyncio.CancelledError:
-            captured["error"] = _background_task_cancel_error(
-                timed_out=timed_out,
-                timeout_seconds=1,
-            )
-
-    atask = asyncio.create_task(_run())
-
-    async def _timeout_guard() -> None:
-        nonlocal timed_out
-        await asyncio.sleep(0.01)
-        if not atask.done():
-            timed_out = True
-            atask.cancel()
-
-    await asyncio.gather(atask, _timeout_guard(), return_exceptions=True)
-    assert captured["error"]["code"] == "timeout"
-    assert captured["error"]["message"] == "Task timed out after 1s"
+@pytest.fixture(autouse=True)
+def _clear_bg_tasks():
+    console_mod._bg_tasks.clear()
+    yield
+    console_mod._bg_tasks.clear()
 
 
 @pytest.fixture
@@ -97,7 +99,6 @@ def console_workspace(workspace_mock, monkeypatch):
 
     async def _stream_one(_payload):
         # Complete immediately so TestClient does not leave hung tasks.
-        # Empty async generator: zero iterations.
         for _ in ():
             yield ""
 
@@ -192,7 +193,10 @@ def test_chat_task_explicit_timeout_echoed(
     assert response.json()["timeout"] == 30
 
 
-@pytest.mark.parametrize("bad_timeout", ["abc", 0, -1, True])
+@pytest.mark.parametrize(
+    "bad_timeout",
+    ["abc", 0, -1, True],
+)
 def test_chat_task_invalid_timeout_returns_400(
     client,
     console_workspace,
@@ -204,3 +208,115 @@ def test_chat_task_invalid_timeout_returns_400(
     )
     assert response.status_code == 400, response.text
     assert "timeout" in response.json()["detail"]
+
+
+async def test_chat_task_timeout_on_production_path(
+    app,
+    console_workspace,
+    monkeypatch,
+):
+    """Exercise real post_console_chat_task guard + CancelledError wiring."""
+    hang = asyncio.Event()
+
+    async def _hanging_stream(_payload):
+        await hang.wait()
+        for _ in ():
+            yield ""
+
+    console_workspace.console_channel.stream_one = _hanging_stream
+
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(delay, result=None):
+        # Collapse the production timeout sleep; keep other sleeps real.
+        if delay == 1:
+            await real_sleep(0.01)
+            return result
+        return await real_sleep(delay, result=result)
+
+    monkeypatch.setattr(console_mod.asyncio, "sleep", _fast_sleep)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as ac:
+        response = await ac.post(
+            "/api/console/chat/task",
+            json=_chat_task_body(timeout=1),
+        )
+        assert response.status_code == 200, response.text
+        task_id = response.json()["task_id"]
+        assert response.json()["timeout"] == 1
+
+        deadline = time.time() + 3.0
+        last = None
+        while time.time() < deadline:
+            status = await ac.get(f"/api/console/chat/task/{task_id}")
+            assert status.status_code == 200, status.text
+            last = status.json()
+            if last.get("status") == "finished":
+                break
+            await asyncio.sleep(0.02)
+
+    assert last is not None
+    assert last["status"] == "finished", last
+    result = last.get("result") or {}
+    assert result.get("status") == "failed", result
+    error = result.get("error") or {}
+    assert error.get("code") == "timeout"
+    assert error.get("message") == "Task timed out after 1s"
+
+
+async def test_chat_task_manual_cancel_is_not_timeout(
+    app,
+    console_workspace,
+):
+    """Non-timeout cancel must stay Task cancelled without code=timeout."""
+    entered = asyncio.Event()
+    hang = asyncio.Event()
+
+    async def _hanging_stream(_payload):
+        entered.set()
+        await hang.wait()
+        for _ in ():
+            yield ""
+
+    console_workspace.console_channel.stream_one = _hanging_stream
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as ac:
+        response = await ac.post(
+            "/api/console/chat/task",
+            json=_chat_task_body(timeout=3600),
+        )
+        assert response.status_code == 200, response.text
+        task_id = response.json()["task_id"]
+
+        await asyncio.wait_for(entered.wait(), timeout=2.0)
+        bg = console_mod._bg_tasks[task_id]
+        assert bg.asyncio_task is not None
+
+        # Cancel the production `_run` task (not the timeout guard).
+        bg.asyncio_task.cancel()
+        try:
+            await bg.asyncio_task
+        except asyncio.CancelledError:
+            pass
+
+        assert bg.status == "finished", (bg.status, bg.result)
+        error = (bg.result or {}).get("error") or {}
+        assert error.get("message") == "Task cancelled"
+        assert "code" not in error
+
+        status = await ac.get(f"/api/console/chat/task/{task_id}")
+        assert status.status_code == 200, status.text
+        last = status.json()
+
+    assert last["status"] == "finished", last
+    error = (last.get("result") or {}).get("error") or {}
+    assert error.get("message") == "Task cancelled"
+    assert "code" not in error

--- a/tests/unit/app/routers/test_console_chat_task_timeout.py
+++ b/tests/unit/app/routers/test_console_chat_task_timeout.py
@@ -195,19 +195,38 @@ def test_chat_task_explicit_timeout_echoed(
 
 @pytest.mark.parametrize(
     "bad_timeout",
-    ["abc", 0, -1, True],
+    [
+        "abc",
+        0,
+        -1,
+        True,
+        False,
+        {},
+        [],
+        {"seconds": 30},
+    ],
 )
 def test_chat_task_invalid_timeout_returns_400(
     client,
     console_workspace,
     bad_timeout,
 ):
+    """All illegal timeout values must be HTTP 400 (not FastAPI 422)."""
     response = client.post(
         "/api/console/chat/task",
         json=_chat_task_body(timeout=bad_timeout),
     )
     assert response.status_code == 400, response.text
     assert "timeout" in response.json()["detail"]
+
+
+def test_agent_request_does_not_declare_task_timeout() -> None:
+    """Shared AgentRequest must not own the background-task timeout field."""
+    from qwenpaw.schemas import AgentRequest
+
+    assert "timeout" not in AgentRequest.model_fields
+    dumped = AgentRequest().model_dump()
+    assert "timeout" not in dumped
 
 
 async def test_chat_task_timeout_on_production_path(

--- a/tests/unit/app/routers/test_console_chat_task_timeout.py
+++ b/tests/unit/app/routers/test_console_chat_task_timeout.py
@@ -34,6 +34,8 @@ def test_resolve_timeout_accepts_positive_number_and_string() -> None:
     assert _resolve_effective_stream_task_timeout(30.9) == 30
     assert _resolve_effective_stream_task_timeout("1800") == 1800
     assert _resolve_effective_stream_task_timeout(10**15) == 10**15
+    assert _resolve_effective_stream_task_timeout(2**53 + 1) == 2**53 + 1
+    assert _resolve_effective_stream_task_timeout("1e20") == int(1e20)
 
 
 @pytest.mark.parametrize(
@@ -50,6 +52,9 @@ def test_resolve_timeout_accepts_positive_number_and_string() -> None:
         "0",
         "-3",
         float("nan"),
+        float("inf"),
+        "1e400",
+        10**1000,
     ],
 )
 def test_resolve_timeout_rejects_invalid(bad) -> None:
@@ -65,6 +70,7 @@ def test_shared_parse_used_by_tool_and_console() -> None:
     assert parse_positive_timeout_seconds("30") == 30
     assert _resolve_effective_stream_task_timeout("30") == 30
     assert parse_positive_timeout_seconds(10**15) == 10**15
+    assert parse_positive_timeout_seconds(2**53 + 1) == 2**53 + 1
 
 
 def test_background_cancel_error_distinguishes_timeout() -> None:
@@ -193,6 +199,20 @@ def test_chat_task_explicit_timeout_echoed(
     assert response.json()["timeout"] == 30
 
 
+def test_chat_task_large_int_timeout_echoed_exactly(
+    client,
+    console_workspace,
+):
+    """Ints must not be coerced through float (2**53+1 stays exact)."""
+    huge = 2**53 + 1
+    response = client.post(
+        "/api/console/chat/task",
+        json=_chat_task_body(timeout=huge),
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["timeout"] == huge
+
+
 @pytest.mark.parametrize(
     "bad_timeout",
     [
@@ -204,6 +224,8 @@ def test_chat_task_explicit_timeout_echoed(
         {},
         [],
         {"seconds": 30},
+        "1e400",
+        10**1000,
     ],
 )
 def test_chat_task_invalid_timeout_returns_400(


### PR DESCRIPTION
## Description

Unify the **background** `/console/chat/task` timeout contract used by
`submit_to_agent`, CLI `--task-timeout`, and `spawn_subagent` (background /
batch / fork-background). This PR does **not** merge those tools into one API.

**`submit_to_agent` / `POST /console/chat/task`**

- LLM-serialized numeric strings (e.g. `"30"`) were rejected by AgentScope
  jsonschema (`anyOf: number|null`), so `task_timeout` never reached the server.
- Omitting `timeout` left background tasks with **no cancel guard** (zombie
  `running`).
- Docs claimed a server default (`stream_task_timeout`) that did not exist.

**`spawn_subagent` background**

- Docstring said `timeout` is ignored when `background=True`, but the code
  passed the signature default **600** as `task_timeout`, overriding the
  server default. Tasks longer than 10 minutes were silently cancelled.
- First-party Mission prompts already pass `timeout=<seconds>` with
  `background=True`; ignoring timeout would break that.

**Changes**

- Widen `submit_to_agent.task_timeout` to `float | int | str | None`; parse
  via shared `utils.timeout`; field-named `ERROR` on invalid values.
- Add `DEFAULT_STREAM_TASK_TIMEOUT_SECONDS = 3600` and always arm the console
  background-task guard; echo effective `timeout` in the submit response and
  `[TIMEOUT: …s]` in tool text. Distinguish timeout (`code=timeout`) from
  manual cancel (`Task cancelled`).
- Keep task `timeout` **off** the shared `AgentRequest`; `/chat/task` accepts
  a raw `dict` and maps all illegal timeouts to **HTTP 400** (not 422).
- `spawn_subagent.timeout` default is now `None` (so omit ≠ 600):
  - **Foreground** (`/console/chat` HTTP wait): omit →
    `DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS` (**600**).
  - **Background / batch / fork-background**: omit → do not write
    `payload["timeout"]` → server **3600**. Explicit positive values apply
    in both modes.
- Delete `_coerce_timeout`. Fork finalize watchdog is required (no default)
  and prefers the submit-response echo.
- Update `chat_with_agent` skills and CLI `--task-timeout` help.

**Security Considerations:** N/A — timeout parsing rejects non-positive /
non-numeric values; no auth or secret handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

## Testing

1. `submit_to_agent`: schema accepts `task_timeout="30"`; invalid → `ERROR`
   containing `task_timeout`; omit stays `None` for the server default.
2. `POST /api/console/chat/task`: omit → `"timeout": 3600` and guard armed;
   `"timeout": 30` → `30`; `true` / `{}` / `"abc"` / `0` → **400**.
3. Timeout vs cancel: guard expiry → `Task timed out after Ns` +
   `code=timeout`; manual cancel → `Task cancelled` without that code.
4. `spawn_subagent(background=True)` omit → `task_timeout is None` (server
   3600); `timeout="1800"` → 1800; foreground omit → HTTP wait **600**.
5. Batch: omit per item → `None`; explicit item timeout honored; illegal
   item → ERROR and zero dispatches. Fork watchdog uses the submit echo.

## Additional Notes

This PR unifies the **`/chat/task` timeout contract**, not the two tools.

| Caller | Omit | Explicit positive |
| --- | --- | --- |
| `submit_to_agent` / CLI / raw HTTP | server **3600s** | that value |
| `spawn_subagent` background / batch / fork-bg | same (do not send 600) | that value |
| `spawn_subagent` foreground | HTTP wait **600s** | that value |

### Breaking change: `POST /console/chat/task`

| Request timeout | Before | After |
| --- | --- | --- |
| omitted / null | No timeout guard (unbounded) | **3600s** |
| > 0 | Guard armed | Unchanged |
| <= 0 | No guard (unbounded) | **HTTP 400** |
| invalid | Undefined / no usable guard | **HTTP 400** |

Unbounded execution is not supported. Longer runs need an explicit positive
`timeout` / `task_timeout`. `<= 0` is not an “unlimited” sentinel.

### Breaking change: `spawn_subagent` background

| Call | Before | After |
| --- | --- | --- |
| `background=True` omit `timeout` | Execution budget **600s** (silent cancel) | Server default **3600s** |
| `background=True, timeout=N` | N (despite docs saying “ignored”) | N (docs match code) |
| foreground omit `timeout` | HTTP wait 600s | Unchanged (600s) |

**Migration**

- “Omit timeout ⇒ run forever” on `/chat/task` → now capped at 3600s unless
  a larger positive value is set.
- `timeout: 0` / negative as unlimited → send a positive budget, or omit
  and accept 3600s.
- Background spawn that relied on the accidental 600s cap → omit now means
  1 hour; pass an explicit `timeout` to keep a shorter/longer budget.
- Need > 1 hour: pass a larger positive `task_timeout` / `timeout`.