### PR TITLE
fix: normalize legacy local-path media sources when loading sessions

### DIFF
--- a/src/qwenpaw/_compat/message.py
+++ b/src/qwenpaw/_compat/message.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import json
 import mimetypes
+from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import unquote
 
 from agentscope.message import (
     Base64Source,
@@ -31,6 +33,36 @@ _MODALITY_DEFAULT_MIME = {
     "audio": "audio/*",
     "video": "video/*",
 }
+
+
+def _ensure_url_scheme(url: str) -> str:
+    """Prepend ``file://`` when *url* is an absolute local path.
+
+    Handles Unix paths (``/``, ``~``), Windows drive paths
+    (e.g. ``C:\\`` or ``C:/``) and Windows UNC paths
+    (e.g. ``\\\\server\\share\\x.png`` → ``file://server/share/x.png``).
+
+    Always ``unquote()`` first so percent-encoded non-ASCII characters
+    (e.g. ``%E6%B5%8B%E8%AF%95`` → ``测试``) resolve to the real
+    filename on disk.  Then uses ``file://`` + raw path (not
+    ``Path.as_uri()``) to avoid re-encoding.
+    """
+    if url.startswith(("/", "~")):
+        resolved = str(Path(unquote(url)).expanduser().resolve())
+    elif len(url) >= 3 and url[1] == ":" and url[2] in ("/", "\\"):
+        resolved = str(Path(unquote(url)).resolve())
+    elif url.startswith("\\\\"):
+        resolved = unquote(url)
+    else:
+        return url
+
+    resolved = resolved.replace("\\", "/")
+    if resolved.startswith("//"):
+        # UNC path: \\server\share\... -> file://server/share/...
+        return "file://" + resolved.lstrip("/")
+    if not resolved.startswith("/"):
+        resolved = "/" + resolved
+    return "file://" + resolved
 
 
 def _coerce_source(
@@ -53,7 +85,12 @@ def _coerce_source(
 
     src_type = source.get("type")
     if src_type == "url":
-        url = source["url"]
+        # Legacy sessions (pre-2.0) sometimes stored local filesystem
+        # paths in ``url`` (e.g. WeCom images under the working dir).
+        # ``URLSource`` requires an absolute RFC 3986 URI, so normalize
+        # local paths to ``file://`` URIs here; the provider layer
+        # resolves those back to on-disk files when building requests.
+        url = _ensure_url_scheme(str(source["url"]))
         media_type = source.get("media_type")
         if not media_type:
             guessed, _ = mimetypes.guess_type(str(url))

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import logging
 import mimetypes
 from typing import Any, List
-from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 from ..constant import (
     EXTERNAL_USER_QUERY_MESSAGE_TAG,
     QWENPAW_MESSAGE_TAG_KEY,
 )
+from .._compat.message import _ensure_url_scheme
 
 logger = logging.getLogger(__name__)
 
@@ -49,30 +49,6 @@ def _get_last_user_text(msgs: List[Any]) -> str | None:
     if hasattr(last, "get_text_content"):
         return last.get_text_content()
     return None
-
-
-def _ensure_url_scheme(url: str) -> str:
-    """Prepend ``file://`` when *url* is an absolute local path.
-
-    Handles both Unix paths (``/``, ``~``) and Windows paths
-    (e.g. ``C:\\`` or ``C:/``).
-
-    Always ``unquote()`` first so percent-encoded non-ASCII characters
-    (e.g. ``%E6%B5%8B%E8%AF%95`` → ``测试``) resolve to the real
-    filename on disk.  Then uses ``file://`` + raw path (not
-    ``Path.as_uri()``) to avoid re-encoding.
-    """
-    if url.startswith(("/", "~")):
-        resolved = str(Path(unquote(url)).expanduser().resolve())
-    elif len(url) >= 3 and url[1] == ":" and url[2] in ("/", "\\"):
-        resolved = str(Path(unquote(url)).resolve())
-    else:
-        return url
-
-    resolved = resolved.replace("\\", "/")
-    if not resolved.startswith("/"):
-        resolved = "/" + resolved
-    return "file://" + resolved
 
 
 # pylint: disable=too-many-branches

--- a/tests/unit/_compat/test_message.py
+++ b/tests/unit/_compat/test_message.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for legacy session message compatibility shims."""
+
+from __future__ import annotations
+
+from agentscope.message import DataBlock, URLSource
+
+from qwenpaw._compat.message import _ensure_url_scheme, msg_from_dict
+
+
+def test_ensure_url_scheme_unc_path():
+    assert _ensure_url_scheme(r"\\server\share\image.png") == (
+        "file://server/share/image.png"
+    )
+
+
+def test_ensure_url_scheme_unquotes_percent_encoded_path():
+    assert _ensure_url_scheme(
+        "/app/working/media/wecom_%E4%BC%81%E4%B8%9A%E5%BE%AE%E4%BF%A1.png",
+    ).endswith("wecom_企业微信.png")
+
+
+def test_msg_from_dict_legacy_image_with_local_path_source(tmp_path):
+    """Legacy image blocks with local paths must not break session load."""
+    image = tmp_path / "wecom_企业微信截图.png"
+    image.write_bytes(b"fake-png")
+
+    msg = msg_from_dict(
+        {
+            "id": "m1",
+            "name": "user",
+            "role": "user",
+            "timestamp": "2026-05-29 01:32:00.000",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": str(image)},
+                },
+            ],
+        },
+    )
+    block = msg.content[0]
+    assert isinstance(block, DataBlock)
+    assert isinstance(block.source, URLSource)
+    assert str(block.source.url).startswith("file://")


### PR DESCRIPTION
## Description

Legacy (pre-2.0) sessions can contain media blocks whose `source.url` is a **local filesystem path** (e.g. WeCom images saved under the working dir). When such a session is loaded, `_coerce_source` builds `URLSource` directly from the raw path and pydantic rejects it (`Input should be a valid URL, relative URL without a base`), so every message in that session fails with a generic `Internal error`.

The agentscope 2.0 migration added `_ensure_url_scheme` (local path → `file://`) but only wired it into the new-input direction (`_request_input_to_msgs`), not the legacy session-load direction. This PR moves the helper to `_compat/message.py` so both directions share one implementation, applies it in `_coerce_source`, and extends it to Windows UNC paths.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core
- [x] Tests

## Checklist

- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests (`pytest` or as applicable)
- [ ] Update documentation if needed

## Testing

- Legacy image block with a platform-native absolute local path (`tmp_path`) loads successfully and produces a `file://` `URLSource`
- Windows UNC path normalization (`\\server\share\image.png` → `file://server/share/image.png`)
- Percent-encoded non-ASCII local paths are unquoted before normalization

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/_compat/message.py src/qwenpaw/runtime/message_convert.py tests/unit/_compat/test_message.py
# check python ast ....... Passed
# check docstring is first  Passed
# mypy .................... Passed
# black ................... Passed
# flake8 .................. Passed
# pylint .................. Passed

pytest tests/unit/_compat/test_message.py tests/unit/runtime/test_message_convert.py -q
# 6 passed in 0.17s
```

Fixes #6872
