### PR TITLE
feat(mcp): add configurable tool call timeout

### DIFF
--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
 
 
 class MCPClientOAuthStatus(BaseModel):
@@ -60,10 +62,13 @@ class MCPClientInfo(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    timeout: float = Field(
-        default=120.0,
+    tool_call_timeout: float = Field(
+        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
-        description="Maximum duration of one MCP tool call in seconds",
+        description=(
+            "Maximum duration of one MCP tool call in seconds. This does not "
+            "change HTTP transport timeouts."
+        ),
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -117,16 +122,28 @@ class MCPClientCreateRequest(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    timeout: float = Field(
-        default=120.0,
+    tool_call_timeout: float = Field(
+        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
-        description="Maximum duration of one MCP tool call in seconds",
+        description=(
+            "Maximum duration of one MCP tool call in seconds. This does not "
+            "change HTTP transport timeouts."
+        ),
     )
     tools: Optional[List[str]] = Field(
         default=None,
         description="Tool whitelist. Only listed tools will be loaded. "
         "None means load all tools.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_timeout(cls, data):
+        if isinstance(data, dict) and "timeout" in data:
+            payload = dict(data)
+            payload.setdefault("tool_call_timeout", payload["timeout"])
+            return payload
+        return data
 
 
 class MCPClientUpdateRequest(BaseModel):
@@ -166,16 +183,28 @@ class MCPClientUpdateRequest(BaseModel):
         None,
         description="Working directory for stdio MCP command",
     )
-    timeout: Optional[float] = Field(
+    tool_call_timeout: Optional[float] = Field(
         None,
         gt=0,
-        description="Maximum duration of one MCP tool call in seconds",
+        description=(
+            "Maximum duration of one MCP tool call in seconds. This does not "
+            "change HTTP transport timeouts."
+        ),
     )
     tools: Optional[List[str]] = Field(
         None,
         description="Tool whitelist (omit to leave unchanged). "
         "Set to null to remove the whitelist.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_timeout(cls, data):
+        if isinstance(data, dict) and "timeout" in data:
+            payload = dict(data)
+            payload.setdefault("tool_call_timeout", payload["timeout"])
+            return payload
+        return data
 
 
 class MCPAccessRule(BaseModel):

--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -60,6 +60,11 @@ class MCPClientInfo(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
+    timeout: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum duration of one MCP tool call in seconds",
+    )
     tools: Optional[List[str]] = Field(
         default=None,
         description="Tool whitelist. Only listed tools will be loaded. "
@@ -112,6 +117,11 @@ class MCPClientCreateRequest(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
+    timeout: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum duration of one MCP tool call in seconds",
+    )
     tools: Optional[List[str]] = Field(
         default=None,
         description="Tool whitelist. Only listed tools will be loaded. "
@@ -155,6 +165,11 @@ class MCPClientUpdateRequest(BaseModel):
     cwd: Optional[str] = Field(
         None,
         description="Working directory for stdio MCP command",
+    )
+    timeout: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Maximum duration of one MCP tool call in seconds",
     )
     tools: Optional[List[str]] = Field(
         None,

--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+from ...mcp_timeout import (
+    DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+)
 
 
 class MCPClientOAuthStatus(BaseModel):
@@ -65,9 +68,12 @@ class MCPClientInfo(BaseModel):
     tool_call_timeout: float = Field(
         default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
+        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+        allow_inf_nan=False,
         description=(
             "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP transport timeouts."
+            "change HTTP connect/write/pool transport timeouts or SSE read "
+            "timeouts."
         ),
     )
     tools: Optional[List[str]] = Field(
@@ -125,9 +131,12 @@ class MCPClientCreateRequest(BaseModel):
     tool_call_timeout: float = Field(
         default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
+        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+        allow_inf_nan=False,
         description=(
             "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP transport timeouts."
+            "change HTTP connect/write/pool transport timeouts or SSE read "
+            "timeouts."
         ),
     )
     tools: Optional[List[str]] = Field(
@@ -186,9 +195,12 @@ class MCPClientUpdateRequest(BaseModel):
     tool_call_timeout: Optional[float] = Field(
         None,
         gt=0,
+        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+        allow_inf_nan=False,
         description=(
             "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP transport timeouts."
+            "change HTTP connect/write/pool transport timeouts or SSE read "
+            "timeouts."
         ),
     )
     tools: Optional[List[str]] = Field(

--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from ...mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MCPToolCallTimeout,
     mcp_tool_call_timeout_field,
 )
 
@@ -65,7 +66,7 @@ class MCPClientInfo(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: float = mcp_tool_call_timeout_field(
+    tool_call_timeout: MCPToolCallTimeout = mcp_tool_call_timeout_field(
         DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(
@@ -120,7 +121,7 @@ class MCPClientCreateRequest(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: float = mcp_tool_call_timeout_field(
+    tool_call_timeout: MCPToolCallTimeout = mcp_tool_call_timeout_field(
         DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(
@@ -167,7 +168,9 @@ class MCPClientUpdateRequest(BaseModel):
         None,
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: Optional[float] = mcp_tool_call_timeout_field(None)
+    tool_call_timeout: Optional[
+        MCPToolCallTimeout
+    ] = mcp_tool_call_timeout_field(None)
     tools: Optional[List[str]] = Field(
         None,
         description="Tool whitelist (omit to leave unchanged). "

--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -10,8 +10,7 @@ from pydantic import BaseModel, Field
 
 from ...mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-    MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-    MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    mcp_tool_call_timeout_field,
 )
 
 
@@ -66,12 +65,8 @@ class MCPClientInfo(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: float = Field(
-        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        gt=0,
-        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        allow_inf_nan=False,
-        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    tool_call_timeout: float = mcp_tool_call_timeout_field(
+        DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -125,12 +120,8 @@ class MCPClientCreateRequest(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: float = Field(
-        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        gt=0,
-        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        allow_inf_nan=False,
-        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    tool_call_timeout: float = mcp_tool_call_timeout_field(
+        DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -176,13 +167,7 @@ class MCPClientUpdateRequest(BaseModel):
         None,
         description="Working directory for stdio MCP command",
     )
-    tool_call_timeout: Optional[float] = Field(
-        None,
-        gt=0,
-        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        allow_inf_nan=False,
-        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
-    )
+    tool_call_timeout: Optional[float] = mcp_tool_call_timeout_field(None)
     tools: Optional[List[str]] = Field(
         None,
         description="Tool whitelist (omit to leave unchanged). "

--- a/src/qwenpaw/app/mcp/schemas.py
+++ b/src/qwenpaw/app/mcp/schemas.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from ...mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
 )
 
 
@@ -70,11 +71,7 @@ class MCPClientInfo(BaseModel):
         gt=0,
         le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         allow_inf_nan=False,
-        description=(
-            "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP connect/write/pool transport timeouts or SSE read "
-            "timeouts."
-        ),
+        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -133,26 +130,13 @@ class MCPClientCreateRequest(BaseModel):
         gt=0,
         le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         allow_inf_nan=False,
-        description=(
-            "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP connect/write/pool transport timeouts or SSE read "
-            "timeouts."
-        ),
+        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
     )
     tools: Optional[List[str]] = Field(
         default=None,
         description="Tool whitelist. Only listed tools will be loaded. "
         "None means load all tools.",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_legacy_timeout(cls, data):
-        if isinstance(data, dict) and "timeout" in data:
-            payload = dict(data)
-            payload.setdefault("tool_call_timeout", payload["timeout"])
-            return payload
-        return data
 
 
 class MCPClientUpdateRequest(BaseModel):
@@ -197,26 +181,13 @@ class MCPClientUpdateRequest(BaseModel):
         gt=0,
         le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         allow_inf_nan=False,
-        description=(
-            "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP connect/write/pool transport timeouts or SSE read "
-            "timeouts."
-        ),
+        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
     )
     tools: Optional[List[str]] = Field(
         None,
         description="Tool whitelist (omit to leave unchanged). "
         "Set to null to remove the whitelist.",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_legacy_timeout(cls, data):
-        if isinstance(data, dict) and "timeout" in data:
-            payload = dict(data)
-            payload.setdefault("tool_call_timeout", payload["timeout"])
-            return payload
-        return data
 
 
 class MCPAccessRule(BaseModel):

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -35,6 +35,9 @@ from qwenpaw.exceptions import (
     AgentConfigConflictError,
     ConfigurationException,
 )
+from qwenpaw.mcp_timeout import (
+    DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+)
 
 from .timezone import detect_system_timezone
 from ..constant import (
@@ -2367,10 +2370,13 @@ class MCPClientConfig(BaseModel):
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
     cwd: str = ""
-    timeout: float = Field(
-        default=120.0,
+    tool_call_timeout: float = Field(
+        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
-        description="Maximum duration of one MCP tool call in seconds.",
+        description=(
+            "Maximum duration of one MCP tool call in seconds. This does not "
+            "change HTTP connect/write/pool transport timeouts."
+        ),
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -2396,6 +2402,9 @@ class MCPClientConfig(BaseModel):
 
         if "type" in payload and "transport" not in payload:
             payload["transport"] = payload["type"]
+
+        if "timeout" in payload and "tool_call_timeout" not in payload:
+            payload["tool_call_timeout"] = payload["timeout"]
 
         if (
             "transport" not in payload

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -37,6 +37,7 @@ from qwenpaw.exceptions import (
 )
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
 )
 
 from .timezone import detect_system_timezone
@@ -2373,9 +2374,12 @@ class MCPClientConfig(BaseModel):
     tool_call_timeout: float = Field(
         default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         gt=0,
+        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+        allow_inf_nan=False,
         description=(
             "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP connect/write/pool transport timeouts."
+            "change HTTP connect/write/pool transport timeouts or SSE read "
+            "timeouts."
         ),
     )
     tools: Optional[List[str]] = Field(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -37,6 +37,7 @@ from qwenpaw.exceptions import (
 )
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MCPToolCallTimeout,
     mcp_tool_call_timeout_field,
 )
 
@@ -2371,7 +2372,7 @@ class MCPClientConfig(BaseModel):
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
     cwd: str = ""
-    tool_call_timeout: float = mcp_tool_call_timeout_field(
+    tool_call_timeout: MCPToolCallTimeout = mcp_tool_call_timeout_field(
         DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -38,6 +38,7 @@ from qwenpaw.exceptions import (
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
 )
 
 from .timezone import detect_system_timezone
@@ -2376,11 +2377,7 @@ class MCPClientConfig(BaseModel):
         gt=0,
         le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         allow_inf_nan=False,
-        description=(
-            "Maximum duration of one MCP tool call in seconds. This does not "
-            "change HTTP connect/write/pool transport timeouts or SSE read "
-            "timeouts."
-        ),
+        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -2406,9 +2403,6 @@ class MCPClientConfig(BaseModel):
 
         if "type" in payload and "transport" not in payload:
             payload["transport"] = payload["type"]
-
-        if "timeout" in payload and "tool_call_timeout" not in payload:
-            payload["tool_call_timeout"] = payload["timeout"]
 
         if (
             "transport" not in payload

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -37,8 +37,7 @@ from qwenpaw.exceptions import (
 )
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-    MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-    MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    mcp_tool_call_timeout_field,
 )
 
 from .timezone import detect_system_timezone
@@ -2372,12 +2371,8 @@ class MCPClientConfig(BaseModel):
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
     cwd: str = ""
-    tool_call_timeout: float = Field(
-        default=DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        gt=0,
-        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
-        allow_inf_nan=False,
-        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    tool_call_timeout: float = mcp_tool_call_timeout_field(
+        DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     )
     tools: Optional[List[str]] = Field(
         default=None,
@@ -2426,6 +2421,15 @@ class MCPClientConfig(BaseModel):
                 normalized,
                 normalized,
             )
+
+        if payload.get("tool_call_timeout") is None:
+            if (
+                payload.get("transport", "stdio") == "stdio"
+                and "timeout" in payload
+            ):
+                payload["tool_call_timeout"] = payload["timeout"]
+            else:
+                payload.pop("tool_call_timeout", None)
 
         return payload
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2367,6 +2367,11 @@ class MCPClientConfig(BaseModel):
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
     cwd: str = ""
+    timeout: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum duration of one MCP tool call in seconds.",
+    )
     tools: Optional[List[str]] = Field(
         default=None,
         description="Tool whitelist. Only listed tools will be loaded. "

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2426,7 +2426,7 @@ class MCPClientConfig(BaseModel):
         if payload.get("tool_call_timeout") is None:
             if (
                 payload.get("transport", "stdio") == "stdio"
-                and "timeout" in payload
+                and payload.get("timeout") is not None
             ):
                 payload["tool_call_timeout"] = payload["timeout"]
             else:

--- a/src/qwenpaw/drivers/adapters/mcp_card_builder.py
+++ b/src/qwenpaw/drivers/adapters/mcp_card_builder.py
@@ -170,6 +170,7 @@ def build_mcp_driver_card(
         _preserve_oauth_authorization_binding(existing, endpoint)
         env_aliases = header_plan.env_aliases
 
+    endpoint["timeout"] = float(data.get("timeout") or 120.0)
     credentials = _credential_refs_from_existing(existing)
     for alias, ref in list(credentials.items()):
         if ref.ref.startswith("env:"):
@@ -258,6 +259,7 @@ def build_mcp_client_info_payload(
         "args": list(endpoint.get("args") or []),
         "env": env,
         "cwd": str(endpoint.get("cwd") or ""),
+        "timeout": float(endpoint.get("timeout") or 120.0),
         "tools": card.config.get("tools"),
         "oauth_status": _oauth_status(oauth_credential),
         "access_summary": {
@@ -378,6 +380,7 @@ def _card_to_client_data(card: DriverCard | None) -> dict[str, Any]:
             env_aliases=env_aliases,
         ),
         "cwd": endpoint.get("cwd") or "",
+        "timeout": float(endpoint.get("timeout") or 120.0),
     }
 
 

--- a/src/qwenpaw/drivers/adapters/mcp_card_builder.py
+++ b/src/qwenpaw/drivers/adapters/mcp_card_builder.py
@@ -33,6 +33,7 @@ from ..constants import (
 )
 from ..contracts import CredentialRef, DriverCard
 from ..credentials.types import CredentialRecord
+from ...mcp_timeout import get_mcp_tool_call_timeout
 from ..policy_types import DriverPolicy
 
 STATIC_CREDENTIAL_ALIAS = CREDENTIAL_ALIAS_STATIC
@@ -170,7 +171,7 @@ def build_mcp_driver_card(
         _preserve_oauth_authorization_binding(existing, endpoint)
         env_aliases = header_plan.env_aliases
 
-    endpoint["timeout"] = float(data.get("timeout") or 120.0)
+    endpoint["tool_call_timeout"] = get_mcp_tool_call_timeout(data)
     credentials = _credential_refs_from_existing(existing)
     for alias, ref in list(credentials.items()):
         if ref.ref.startswith("env:"):
@@ -259,7 +260,7 @@ def build_mcp_client_info_payload(
         "args": list(endpoint.get("args") or []),
         "env": env,
         "cwd": str(endpoint.get("cwd") or ""),
-        "timeout": float(endpoint.get("timeout") or 120.0),
+        "tool_call_timeout": get_mcp_tool_call_timeout(endpoint),
         "tools": card.config.get("tools"),
         "oauth_status": _oauth_status(oauth_credential),
         "access_summary": {
@@ -380,7 +381,7 @@ def _card_to_client_data(card: DriverCard | None) -> dict[str, Any]:
             env_aliases=env_aliases,
         ),
         "cwd": endpoint.get("cwd") or "",
-        "timeout": float(endpoint.get("timeout") or 120.0),
+        "tool_call_timeout": get_mcp_tool_call_timeout(endpoint),
     }
 
 

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -11,15 +11,7 @@ from typing import Any
 
 import yaml
 
-from .env_ref import env_ref
-from .mcp_console import (
-    mcp_credential_ref,
-    mcp_oauth_credential_ref,
-    normalize_secret_key,
-    plan_env_ref_bindings,
-    source_binding_from_split,
-    split_mcp_binding,
-)
+from ...mcp_timeout import get_mcp_tool_call_timeout
 from ..constants import (
     CAPABILITY_KIND_TOOL,
     CREDENTIAL_ALIAS_OAUTH,
@@ -38,9 +30,17 @@ from ..contracts import (
     PolicyTarget,
 )
 from ..credentials.types import CredentialRecord
-from ...mcp_timeout import get_mcp_tool_call_timeout
 from ..manager import DriverManager
 from ..storage import load_card
+from .env_ref import env_ref
+from .mcp_console import (
+    mcp_credential_ref,
+    mcp_oauth_credential_ref,
+    normalize_secret_key,
+    plan_env_ref_bindings,
+    source_binding_from_split,
+    split_mcp_binding,
+)
 
 # Schema version of the legacy-MCP -> DriverCard migration, persisted on
 # ``MCPConfig.migration_version`` (agent.json) as a one-shot watermark that
@@ -261,9 +261,12 @@ def legacy_mcp_client_to_driver(
             "headers": header_binding,
         }
 
-    endpoint["tool_call_timeout"] = get_mcp_tool_call_timeout(
-        config.model_dump(),
-    )
+    timeout_config: dict[str, Any] = {}
+    if hasattr(config, "tool_call_timeout"):
+        timeout_config["tool_call_timeout"] = config.tool_call_timeout
+    elif hasattr(config, "timeout"):
+        timeout_config["timeout"] = config.timeout
+    endpoint["tool_call_timeout"] = get_mcp_tool_call_timeout(timeout_config)
     credential = _build_legacy_credential(
         client_key,
         oauth,

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -262,6 +262,8 @@ def legacy_mcp_client_to_driver(
         }
 
     raw_tool_call_timeout = getattr(config, "tool_call_timeout", None)
+    if raw_tool_call_timeout is None and transport == "stdio":
+        raw_tool_call_timeout = getattr(config, "timeout", None)
     timeout_config = (
         {"tool_call_timeout": raw_tool_call_timeout}
         if raw_tool_call_timeout is not None

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -38,6 +38,7 @@ from ..contracts import (
     PolicyTarget,
 )
 from ..credentials.types import CredentialRecord
+from ...mcp_timeout import get_mcp_tool_call_timeout
 from ..manager import DriverManager
 from ..storage import load_card
 
@@ -260,7 +261,9 @@ def legacy_mcp_client_to_driver(
             "headers": header_binding,
         }
 
-    endpoint["timeout"] = float(getattr(config, "timeout", 120.0) or 120.0)
+    endpoint["tool_call_timeout"] = get_mcp_tool_call_timeout(
+        config.model_dump(),
+    )
     credential = _build_legacy_credential(
         client_key,
         oauth,

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -260,6 +260,7 @@ def legacy_mcp_client_to_driver(
             "headers": header_binding,
         }
 
+    endpoint["timeout"] = float(getattr(config, "timeout", 120.0) or 120.0)
     credential = _build_legacy_credential(
         client_key,
         oauth,

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -261,11 +261,12 @@ def legacy_mcp_client_to_driver(
             "headers": header_binding,
         }
 
-    timeout_config: dict[str, Any] = {}
-    if hasattr(config, "tool_call_timeout"):
-        timeout_config["tool_call_timeout"] = config.tool_call_timeout
-    elif hasattr(config, "timeout"):
-        timeout_config["timeout"] = config.timeout
+    raw_tool_call_timeout = getattr(config, "tool_call_timeout", None)
+    timeout_config = (
+        {"tool_call_timeout": raw_tool_call_timeout}
+        if raw_tool_call_timeout is not None
+        else {}
+    )
     endpoint["tool_call_timeout"] = get_mcp_tool_call_timeout(timeout_config)
     credential = _build_legacy_credential(
         client_key,

--- a/src/qwenpaw/drivers/handlers/mcp.py
+++ b/src/qwenpaw/drivers/handlers/mcp.py
@@ -270,7 +270,7 @@ def validate_mcp_endpoint(card: DriverCard) -> None:
         get_mcp_tool_call_timeout(endpoint)
     except ValueError as exc:
         raise DriverCardError(
-            f"DriverCard {card.name} endpoint.tool_call_timeout " f"{exc}",
+            f"DriverCard {card.name} endpoint.tool_call_timeout {exc}",
         ) from exc
 
     transport = str(endpoint.get("transport") or "stdio")

--- a/src/qwenpaw/drivers/handlers/mcp.py
+++ b/src/qwenpaw/drivers/handlers/mcp.py
@@ -65,6 +65,7 @@ class MCPDriverHandler(DriverHandler):
         """Create and connect StdIO / Auto / HttpStateful MCP clients."""
         endpoint = self._card.endpoint
         transport = str(endpoint.get("transport") or "stdio")
+        tool_call_timeout = float(endpoint.get("timeout") or 120.0)
         credentials = await self._resolve_credentials()
 
         if transport == "stdio":
@@ -77,6 +78,7 @@ class MCPDriverHandler(DriverHandler):
                     credentials,
                 ),
                 cwd=endpoint.get("cwd") or None,
+                tool_call_timeout=tool_call_timeout,
             )
         else:
             headers = resolve_binding(
@@ -95,6 +97,7 @@ class MCPDriverHandler(DriverHandler):
                 transport=transport,
                 url=str(endpoint.get("url") or ""),
                 headers=headers or None,
+                tool_call_timeout=tool_call_timeout,
             )
 
         try:

--- a/src/qwenpaw/drivers/handlers/mcp.py
+++ b/src/qwenpaw/drivers/handlers/mcp.py
@@ -31,6 +31,7 @@ from ..credentials.bindings import (
     implicit_auth_headers,
     resolve_binding,
 )
+from ...mcp_timeout import get_mcp_tool_call_timeout
 from .mcp_stateful_client import (
     HttpStatefulClient,
     StdIOStatefulClient,
@@ -65,7 +66,7 @@ class MCPDriverHandler(DriverHandler):
         """Create and connect StdIO / Auto / HttpStateful MCP clients."""
         endpoint = self._card.endpoint
         transport = str(endpoint.get("transport") or "stdio")
-        tool_call_timeout = float(endpoint.get("timeout") or 120.0)
+        tool_call_timeout = get_mcp_tool_call_timeout(endpoint)
         credentials = await self._resolve_credentials()
 
         if transport == "stdio":
@@ -265,6 +266,13 @@ class MCPDriverHandler(DriverHandler):
 def validate_mcp_endpoint(card: DriverCard) -> None:
     """Validate MCP endpoint shape beyond generic DriverCard checks."""
     endpoint = card.endpoint
+    try:
+        get_mcp_tool_call_timeout(endpoint)
+    except ValueError as exc:
+        raise DriverCardError(
+            f"DriverCard {card.name} endpoint.tool_call_timeout " f"{exc}",
+        ) from exc
+
     transport = str(endpoint.get("transport") or "stdio")
     if transport == "stdio":
         command = endpoint.get("command")

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -31,6 +31,8 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
 
+from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+
 logger = logging.getLogger(__name__)
 
 # anyio is a required transitive dependency of the mcp package, so it is
@@ -61,6 +63,7 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 _TRANSPORT_MCP_MESSAGES = frozenset(
     {"session terminated", "connection closed"},
 )
+_MCP_REQUEST_TIMEOUT_CODE = 408
 
 # How long ``list_tools`` waits for an in-flight reconnect before raising.
 # Picked to cover typical HTTP MCP reconnect latency (sub-second to ~1s
@@ -150,6 +153,13 @@ async def _gather_uncancelled(*tasks: Any) -> None:
     g = asyncio.gather(*tasks, return_exceptions=True)
     n = await _wait_task_uncancelled(g, "")
     _restore_cancel(asyncio.current_task(), n)
+
+
+def _is_mcp_request_timeout(exc: BaseException) -> bool:
+    if not isinstance(exc, McpError):
+        return False
+    error = getattr(exc, "error", None)
+    return getattr(error, "code", None) == _MCP_REQUEST_TIMEOUT_CODE
 
 
 class _MCPClientMixin:
@@ -577,7 +587,13 @@ Returns:
         if session is None:
             raise self._not_connected_error()
         try:
-            coro = session.call_tool(name, arguments or {})
+            coro = session.call_tool(
+                name,
+                arguments or {},
+                read_timeout_seconds=timedelta(
+                    seconds=self.tool_call_timeout,
+                ),
+            )
             return await self._await_rpc(coro, closed)
         except Exception as exc:
             # No same-session retry: the server may already have run it.
@@ -588,6 +604,11 @@ Returns:
             if isinstance(exc, _SessionGoneError):
                 raise RuntimeError(
                     f"MCP client '{self.name}' request was aborted.",
+                ) from exc
+            if _is_mcp_request_timeout(exc):
+                raise TimeoutError(
+                    f"MCP tool call '{name}' on client '{self.name}' timed "
+                    f"out after {self.tool_call_timeout:g}s",
                 ) from exc
             self._handle_transport_error(exc, session)
             raise
@@ -889,7 +910,7 @@ class StdIOStatefulClient(_MCPClientMixin):
             "replace",
         ] = "strict",
         read_timeout_seconds: float = 60 * 5,
-        tool_call_timeout: float = 120.0,
+        tool_call_timeout: float = DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     ) -> None:
         """Initialize the StdIO MCP client.
 
@@ -985,7 +1006,7 @@ class HttpStatefulClient(_MCPClientMixin):
         headers: dict[str, str] | None = None,
         timeout: float = 30,
         sse_read_timeout: float = 60 * 5,
-        tool_call_timeout: float = 120.0,
+        tool_call_timeout: float = DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         **client_kwargs: Any,
     ) -> None:
         """Initialize the HTTP MCP client.

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -158,10 +158,13 @@ async def _gather_uncancelled(*tasks: Any) -> None:
 def _is_mcp_request_timeout(exc: BaseException) -> bool:
     if isinstance(exc, httpx.TimeoutException):
         return True
-    if not isinstance(exc, McpError):
-        return False
-    error = getattr(exc, "error", None)
-    return getattr(error, "code", None) == _MCP_REQUEST_TIMEOUT_CODE
+    if isinstance(exc, McpError):
+        error = getattr(exc, "error", None)
+        return getattr(error, "code", None) == _MCP_REQUEST_TIMEOUT_CODE
+    sub_excs = getattr(exc, "exceptions", None)
+    return bool(sub_excs) and any(
+        _is_mcp_request_timeout(item) for item in sub_excs
+    )
 
 
 class _MCPClientMixin:

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -156,6 +156,8 @@ async def _gather_uncancelled(*tasks: Any) -> None:
 
 
 def _is_mcp_request_timeout(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.TimeoutException):
+        return True
     if not isinstance(exc, McpError):
         return False
     error = getattr(exc, "error", None)
@@ -576,11 +578,12 @@ class _MCPClientMixin:
             name: Tool name
             arguments: Tool arguments (optional)
 
-Returns:
+        Returns:
             Tool call result
 
         Raises:
             RuntimeError: If not connected or session was replaced
+            TimeoutError: If the tool call exceeds ``tool_call_timeout``
         """
         self._validate_connection()
         session, closed = self.session, self._session_closed
@@ -1045,8 +1048,16 @@ class HttpStatefulClient(_MCPClientMixin):
         self.url = url
         self.headers = headers
         self.timeout = timeout
-        self.sse_read_timeout = sse_read_timeout
-        self.read_timeout_seconds = sse_read_timeout
+        sse_read_timeout_seconds = (
+            sse_read_timeout.total_seconds()
+            if isinstance(sse_read_timeout, timedelta)
+            else float(sse_read_timeout)
+        )
+        self.sse_read_timeout = max(
+            sse_read_timeout_seconds,
+            float(tool_call_timeout),
+        )
+        self.read_timeout_seconds = self.sse_read_timeout
         self.tool_call_timeout = tool_call_timeout
         self.client_kwargs = client_kwargs
 

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -31,7 +31,10 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
 
-from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+from ...mcp_timeout import (
+    DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    is_mcp_request_timeout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +66,6 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 _TRANSPORT_MCP_MESSAGES = frozenset(
     {"session terminated", "connection closed"},
 )
-_MCP_REQUEST_TIMEOUT_CODE = 408
 
 # How long ``list_tools`` waits for an in-flight reconnect before raising.
 # Picked to cover typical HTTP MCP reconnect latency (sub-second to ~1s
@@ -153,18 +155,6 @@ async def _gather_uncancelled(*tasks: Any) -> None:
     g = asyncio.gather(*tasks, return_exceptions=True)
     n = await _wait_task_uncancelled(g, "")
     _restore_cancel(asyncio.current_task(), n)
-
-
-def _is_mcp_request_timeout(exc: BaseException) -> bool:
-    if isinstance(exc, httpx.TimeoutException):
-        return True
-    if isinstance(exc, McpError):
-        error = getattr(exc, "error", None)
-        return getattr(error, "code", None) == _MCP_REQUEST_TIMEOUT_CODE
-    sub_excs = getattr(exc, "exceptions", None)
-    return bool(sub_excs) and any(
-        _is_mcp_request_timeout(item) for item in sub_excs
-    )
 
 
 class _MCPClientMixin:
@@ -611,7 +601,7 @@ class _MCPClientMixin:
                 raise RuntimeError(
                     f"MCP client '{self.name}' request was aborted.",
                 ) from exc
-            if _is_mcp_request_timeout(exc):
+            if is_mcp_request_timeout(exc):
                 raise TimeoutError(
                     f"MCP tool call '{name}' on client '{self.name}' timed "
                     f"out after {self.tool_call_timeout:g}s",

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -178,6 +178,7 @@ class _MCPClientMixin:
     session: ClientSession | None
     is_connected: bool
     is_stateful: bool
+    tool_call_timeout: float
     _oauth_required: bool
     _cached_tools: Any
     _stop_event: asyncio.Event
@@ -565,7 +566,7 @@ class _MCPClientMixin:
             name: Tool name
             arguments: Tool arguments (optional)
 
-        Returns:
+Returns:
             Tool call result
 
         Raises:
@@ -888,6 +889,7 @@ class StdIOStatefulClient(_MCPClientMixin):
             "replace",
         ] = "strict",
         read_timeout_seconds: float = 60 * 5,
+        tool_call_timeout: float = 120.0,
     ) -> None:
         """Initialize the StdIO MCP client.
 
@@ -900,6 +902,7 @@ class StdIOStatefulClient(_MCPClientMixin):
             encoding: The text encoding used when sending/receiving messages
             encoding_error_handler: The text encoding error handler
             read_timeout_seconds: The read timeout seconds
+            tool_call_timeout: Maximum duration of one tool call in seconds
 
         Raises:
             TypeError: If name or command is not a string
@@ -922,6 +925,7 @@ class StdIOStatefulClient(_MCPClientMixin):
             encoding_error_handler=encoding_error_handler,
         )
         self.read_timeout_seconds = read_timeout_seconds
+        self.tool_call_timeout = tool_call_timeout
 
         # Lifecycle management
         self._lifecycle_task: asyncio.Task | None = None
@@ -981,6 +985,7 @@ class HttpStatefulClient(_MCPClientMixin):
         headers: dict[str, str] | None = None,
         timeout: float = 30,
         sse_read_timeout: float = 60 * 5,
+        tool_call_timeout: float = 120.0,
         **client_kwargs: Any,
     ) -> None:
         """Initialize the HTTP MCP client.
@@ -992,6 +997,7 @@ class HttpStatefulClient(_MCPClientMixin):
             headers: Additional headers to include in the HTTP request
             timeout: The timeout for the HTTP request in seconds
             sse_read_timeout: The timeout for reading SSE in seconds
+            tool_call_timeout: Maximum duration of one tool call in seconds
             **client_kwargs: Additional keyword arguments for the client
 
         Raises:
@@ -1020,6 +1026,7 @@ class HttpStatefulClient(_MCPClientMixin):
         self.timeout = timeout
         self.sse_read_timeout = sse_read_timeout
         self.read_timeout_seconds = sse_read_timeout
+        self.tool_call_timeout = tool_call_timeout
         self.client_kwargs = client_kwargs
 
         # Lifecycle management

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -1050,7 +1050,6 @@ class HttpStatefulClient(_MCPClientMixin):
             sse_read_timeout_seconds,
             float(tool_call_timeout),
         )
-        self.read_timeout_seconds = self.sse_read_timeout
         self.tool_call_timeout = tool_call_timeout
         self.client_kwargs = client_kwargs
 

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -242,7 +242,20 @@ class _MCPClientMixin:
                         stack,
                     )
 
-                    self.session = ClientSession(read_stream, write_stream)
+                    read_timeout = getattr(
+                        self,
+                        "read_timeout_seconds",
+                        None,
+                    )
+                    self.session = ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=(
+                            timedelta(seconds=read_timeout)
+                            if read_timeout is not None
+                            else None
+                        ),
+                    )
                     await stack.enter_async_context(self.session)
                     await self.session.initialize()
 

--- a/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
+++ b/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
@@ -22,6 +22,7 @@ import httpx
 from mcp import types as mcp_types
 
 from ...__version__ import __version__ as _QWENPAW_VERSION
+from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -460,6 +461,7 @@ class _HttpClientBase:
         headers: dict[str, str] | None = None,
         timeout: float = 30,
         sse_read_timeout: float = 60 * 5,
+        tool_call_timeout: float = DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
         **client_kwargs: Any,
     ) -> None:
         for label, value in (
@@ -481,7 +483,11 @@ class _HttpClientBase:
         self.url = url
         self.headers = headers
         self.timeout = timeout
-        self.sse_read_timeout = sse_read_timeout
+        self.tool_call_timeout = tool_call_timeout
+        self.sse_read_timeout = max(
+            _timeout_seconds(sse_read_timeout),
+            float(tool_call_timeout),
+        )
         self.client_kwargs = dict(client_kwargs)
         self.is_stateful = False
         self.is_connected = False
@@ -641,8 +647,6 @@ class HttpStatelessClient(_HttpClientBase):
     async def call_tool(self, name: str, arguments: dict | None = None):
         """Call a tool, mirroring ``x-mcp-header`` params into HTTP headers."""
         self._validate_connection()
-        if not self._tools_listed:
-            await self.list_tools()
 
         async def _call() -> Any:
             return await self._rpc(
@@ -656,13 +660,41 @@ class HttpStatelessClient(_HttpClientBase):
                 or None,
             )
 
+        async def _call_sequence() -> Any:
+            if not self._tools_listed:
+                await self.list_tools()
+            try:
+                return await _call()
+            except _JsonRpcError as exc:
+                if exc.code != _JSONRPC_HEADER_MISMATCH:
+                    raise
+                await self.list_tools()
+                return await _call()
+
+        task = asyncio.create_task(_call_sequence())
         try:
-            result = await _call()
-        except _JsonRpcError as exc:
-            if exc.code != _JSONRPC_HEADER_MISMATCH:
-                raise
-            await self.list_tools()
-            result = await _call()
+            done, _ = await asyncio.wait(
+                (task,),
+                timeout=self.tool_call_timeout,
+            )
+        except BaseException:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+        if not done:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise TimeoutError(
+                f"MCP tool call '{name}' on client '{self.name}' timed "
+                f"out after {self.tool_call_timeout:g}s",
+            )
+        try:
+            result = task.result()
+        except httpx.TimeoutException as exc:
+            raise TimeoutError(
+                f"MCP tool call '{name}' on client '{self.name}' timed "
+                f"out after {self.tool_call_timeout:g}s",
+            ) from exc
         normalized = _normalize_call_tool_result(result)
         if isinstance(normalized, dict):
             result_type = normalized.get("resultType")
@@ -893,6 +925,7 @@ class HttpAutoClient(_HttpClientBase):
             "headers": _headers_without_session_id(self.headers) or None,
             "timeout": self.timeout,
             "sse_read_timeout": self.sse_read_timeout,
+            "tool_call_timeout": self.tool_call_timeout,
             **kw,
         }
         deadline = time.monotonic() + float(timeout)

--- a/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
+++ b/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
@@ -22,7 +22,10 @@ import httpx
 from mcp import types as mcp_types
 
 from ...__version__ import __version__ as _QWENPAW_VERSION
-from ...mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+from ...mcp_timeout import (
+    DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    is_mcp_request_timeout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -690,7 +693,9 @@ class HttpStatelessClient(_HttpClientBase):
             )
         try:
             result = task.result()
-        except httpx.TimeoutException as exc:
+        except Exception as exc:
+            if not is_mcp_request_timeout(exc):
+                raise
             raise TimeoutError(
                 f"MCP tool call '{name}' on client '{self.name}' timed "
                 f"out after {self.tool_call_timeout:g}s",

--- a/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
+++ b/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
@@ -528,20 +528,44 @@ class HttpStatelessClient(_HttpClientBase):
         self._tool_param_headers: dict[str, list[_HeaderBinding]] = {}
         self._tools_listed = False
 
+    def _new_http_client(self) -> httpx.AsyncClient:
+        timeout = _timeout_seconds(self.timeout)
+        read_timeout = _timeout_seconds(self.sse_read_timeout)
+        return _AsyncClient(
+            headers=_headers_without_session_id(self.headers),
+            timeout=httpx.Timeout(
+                connect=timeout,
+                read=read_timeout,
+                write=timeout,
+                pool=timeout,
+            ),
+            follow_redirects=self._follow_redirects,
+            **self.client_kwargs,
+        )
+
+    async def _reset_http_client_after_deadline(self) -> None:
+        """Replace the connection pool cancelled by a local call deadline."""
+        old_http = self._http
+        if not isinstance(old_http, httpx.AsyncClient):
+            return
+        self.is_connected = False
+        self._http = None
+        try:
+            await old_http.aclose()
+        except Exception as exc:
+            logger.warning(
+                "Error closing timed-out MCP client %r: %s",
+                self.name,
+                exc,
+            )
+        self._http = self._new_http_client()
+        self.is_connected = True
+
     async def connect(self, timeout: float = 30.0) -> None:
         """Connect and negotiate the modern protocol version."""
         if self.is_connected or self._http is not None:
             raise _already_connected(self.name)
-        t = _timeout_seconds(self.timeout)
-        r = _timeout_seconds(self.sse_read_timeout)
-        # Drop leftover session ids without mutating caller-owned headers.
-        headers = _headers_without_session_id(self.headers)
-        self._http = _AsyncClient(
-            headers=headers,
-            timeout=httpx.Timeout(connect=t, read=r, write=t, pool=t),
-            follow_redirects=self._follow_redirects,
-            **self.client_kwargs,
-        )
+        self._http = self._new_http_client()
         try:
             await asyncio.wait_for(self._negotiate(), timeout=timeout)
         except BaseException:
@@ -687,6 +711,7 @@ class HttpStatelessClient(_HttpClientBase):
         if not done:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+            await self._reset_http_client_after_deadline()
             raise TimeoutError(
                 f"MCP tool call '{name}' on client '{self.name}' timed "
                 f"out after {self.tool_call_timeout:g}s",
@@ -694,7 +719,10 @@ class HttpStatelessClient(_HttpClientBase):
         try:
             result = task.result()
         except Exception as exc:
-            if not is_mcp_request_timeout(exc):
+            if not is_mcp_request_timeout(
+                exc,
+                json_rpc_error_type=_JsonRpcError,
+            ):
                 raise
             raise TimeoutError(
                 f"MCP tool call '{name}' on client '{self.name}' timed "

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
+MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 24 * 60 * 60
 MCP_TOOL_CALL_TIMEOUT_FIELD = "tool_call_timeout"
 LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD = "timeout"
 
@@ -41,6 +43,11 @@ def parse_mcp_tool_call_timeout(value: Any = _MISSING) -> float:
         timeout = float(raw_value)
     except (TypeError, ValueError) as exc:
         raise ValueError("must be a positive number") from exc
-    if timeout <= 0:
+    if not math.isfinite(timeout) or timeout <= 0:
         raise ValueError("must be a positive number")
+    if timeout > MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS:
+        raise ValueError(
+            "must be less than or equal to "
+            f"{MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS:g}",
+        )
     return timeout

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import math
 from typing import Any
 
+from pydantic import Field
+from pydantic.fields import FieldInfo
+
 DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
 MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 24 * 60 * 60
 MCP_TOOL_CALL_TIMEOUT_FIELD = "tool_call_timeout"
@@ -14,6 +17,17 @@ MCP_TOOL_CALL_TIMEOUT_DESCRIPTION = (
     "transports, the SSE read budget is raised to at least this value; HTTP "
     "connect, write, and pool timeouts are unchanged."
 )
+
+
+def mcp_tool_call_timeout_field(default: Any) -> FieldInfo:
+    """Build the shared Pydantic field for MCP tool-call deadlines."""
+    return Field(
+        default=default,
+        gt=0,
+        le=MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+        allow_inf_nan=False,
+        description=MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
+    )
 
 
 def get_mcp_tool_call_timeout(endpoint: dict[str, Any]) -> float:

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -32,7 +32,7 @@ def is_mcp_request_timeout(exc: BaseException) -> bool:
     ):
         return True
     sub_excs = getattr(exc, "exceptions", None)
-    return bool(sub_excs) and any(
+    return bool(sub_excs) and all(
         is_mcp_request_timeout(item) for item in sub_excs
     )
 

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Shared MCP tool-call timeout parsing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
+MCP_TOOL_CALL_TIMEOUT_FIELD = "tool_call_timeout"
+LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD = "timeout"
+
+_MISSING = object()
+
+
+def get_mcp_tool_call_timeout(endpoint: dict[str, Any]) -> float:
+    """Return a validated tool-call timeout from an MCP endpoint."""
+    if MCP_TOOL_CALL_TIMEOUT_FIELD in endpoint:
+        return parse_mcp_tool_call_timeout(
+            endpoint[MCP_TOOL_CALL_TIMEOUT_FIELD],
+        )
+    if LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD in endpoint:
+        return parse_mcp_tool_call_timeout(
+            endpoint[LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD],
+        )
+    return DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+
+
+def parse_mcp_tool_call_timeout(value: Any = _MISSING) -> float:
+    """Parse a configured MCP tool-call timeout in seconds."""
+    if value is _MISSING:
+        return DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    if value is None:
+        raise ValueError("must be provided when present")
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError("must be a positive number")
+        raw_value = value.strip()
+    else:
+        raw_value = value
+    try:
+        timeout = float(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("must be a positive number") from exc
+    if timeout <= 0:
+        raise ValueError("must be a positive number")
+    return timeout

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
-from pydantic import Field
+from mcp.shared.exceptions import McpError
+from pydantic import BeforeValidator, Field
 from pydantic.fields import FieldInfo
 
 DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
@@ -21,19 +22,43 @@ MCP_TOOL_CALL_TIMEOUT_DESCRIPTION = (
 )
 
 
-def is_mcp_request_timeout(exc: BaseException) -> bool:
+def _reject_boolean_timeout(value: Any) -> Any:
+    if isinstance(value, bool):
+        raise ValueError("must be a positive number")
+    return value
+
+
+MCPToolCallTimeout = Annotated[
+    float,
+    BeforeValidator(_reject_boolean_timeout),
+]
+
+
+def is_mcp_request_timeout(
+    exc: BaseException,
+    *,
+    json_rpc_error_type: type[BaseException] | None = None,
+) -> bool:
     """Return whether an exception tree represents an MCP request timeout."""
-    if isinstance(exc, httpx.TimeoutException):
+    if isinstance(exc, httpx.ReadTimeout):
         return True
-    error = getattr(exc, "error", None)
+    if isinstance(exc, McpError):
+        error = getattr(exc, "error", None)
+        if getattr(error, "code", None) == MCP_REQUEST_TIMEOUT_CODE:
+            return True
     if (
-        getattr(exc, "code", None) == MCP_REQUEST_TIMEOUT_CODE
-        or getattr(error, "code", None) == MCP_REQUEST_TIMEOUT_CODE
+        json_rpc_error_type is not None
+        and isinstance(exc, json_rpc_error_type)
+        and getattr(exc, "code", None) == MCP_REQUEST_TIMEOUT_CODE
     ):
         return True
     sub_excs = getattr(exc, "exceptions", None)
     return bool(sub_excs) and all(
-        is_mcp_request_timeout(item) for item in sub_excs
+        is_mcp_request_timeout(
+            item,
+            json_rpc_error_type=json_rpc_error_type,
+        )
+        for item in sub_excs
     )
 
 
@@ -61,6 +86,7 @@ def parse_mcp_tool_call_timeout(value: Any) -> float:
     """Parse a configured MCP tool-call timeout in seconds."""
     if value is None:
         raise ValueError("must be provided when present")
+    _reject_boolean_timeout(value)
     if isinstance(value, str):
         if not value.strip():
             raise ValueError("must be a positive number")

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -9,9 +9,11 @@ from typing import Any
 DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
 MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 24 * 60 * 60
 MCP_TOOL_CALL_TIMEOUT_FIELD = "tool_call_timeout"
-LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD = "timeout"
-
-_MISSING = object()
+MCP_TOOL_CALL_TIMEOUT_DESCRIPTION = (
+    "Maximum duration of one MCP tools/call request in seconds. For HTTP "
+    "transports, the SSE read budget is raised to at least this value; HTTP "
+    "connect, write, and pool timeouts are unchanged."
+)
 
 
 def get_mcp_tool_call_timeout(endpoint: dict[str, Any]) -> float:
@@ -20,17 +22,11 @@ def get_mcp_tool_call_timeout(endpoint: dict[str, Any]) -> float:
         return parse_mcp_tool_call_timeout(
             endpoint[MCP_TOOL_CALL_TIMEOUT_FIELD],
         )
-    if LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD in endpoint:
-        return parse_mcp_tool_call_timeout(
-            endpoint[LEGACY_MCP_TOOL_CALL_TIMEOUT_FIELD],
-        )
     return DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
 
 
-def parse_mcp_tool_call_timeout(value: Any = _MISSING) -> float:
+def parse_mcp_tool_call_timeout(value: Any) -> float:
     """Parse a configured MCP tool-call timeout in seconds."""
-    if value is _MISSING:
-        return DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
     if value is None:
         raise ValueError("must be provided when present")
     if isinstance(value, str):

--- a/src/qwenpaw/mcp_timeout.py
+++ b/src/qwenpaw/mcp_timeout.py
@@ -6,17 +6,35 @@ from __future__ import annotations
 import math
 from typing import Any
 
+import httpx
 from pydantic import Field
 from pydantic.fields import FieldInfo
 
 DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 60 * 5
 MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS: float = 24 * 60 * 60
+MCP_REQUEST_TIMEOUT_CODE = 408
 MCP_TOOL_CALL_TIMEOUT_FIELD = "tool_call_timeout"
 MCP_TOOL_CALL_TIMEOUT_DESCRIPTION = (
     "Maximum duration of one MCP tools/call request in seconds. For HTTP "
     "transports, the SSE read budget is raised to at least this value; HTTP "
     "connect, write, and pool timeouts are unchanged."
 )
+
+
+def is_mcp_request_timeout(exc: BaseException) -> bool:
+    """Return whether an exception tree represents an MCP request timeout."""
+    if isinstance(exc, httpx.TimeoutException):
+        return True
+    error = getattr(exc, "error", None)
+    if (
+        getattr(exc, "code", None) == MCP_REQUEST_TIMEOUT_CODE
+        or getattr(error, "code", None) == MCP_REQUEST_TIMEOUT_CODE
+    ):
+        return True
+    sub_excs = getattr(exc, "exceptions", None)
+    return bool(sub_excs) and any(
+        is_mcp_request_timeout(item) for item in sub_excs
+    )
 
 
 def mcp_tool_call_timeout_field(default: Any) -> FieldInfo:

--- a/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
@@ -19,6 +19,7 @@ from qwenpaw.drivers.adapters.mcp_legacy_config import (
 from qwenpaw.drivers.contracts import CredentialRef
 from qwenpaw.drivers.credentials.bindings import resolve_binding
 from qwenpaw.drivers.credentials.types import ResolvedCredential
+from qwenpaw.mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
 
 # --- plan_env_ref_bindings unit behavior ---
 
@@ -63,6 +64,27 @@ def test_plan_multi_ref_is_reported_and_kept_plain() -> None:
 
 
 # --- end-to-end migration behavior ---
+
+
+def test_migration_reads_timeout_from_non_pydantic_config() -> None:
+    default_card, _ = legacy_mcp_client_to_driver(
+        "default",
+        SimpleNamespace(transport="stdio", command="run-server"),
+    )
+    configured_card, _ = legacy_mcp_client_to_driver(
+        "configured",
+        SimpleNamespace(
+            transport="stdio",
+            command="run-server",
+            tool_call_timeout=42,
+        ),
+    )
+
+    assert (
+        default_card.endpoint["tool_call_timeout"]
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
+    assert configured_card.endpoint["tool_call_timeout"] == 42
 
 
 def test_migration_links_header_env_ref_and_never_persists_key() -> None:

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -10,7 +10,9 @@ never repairs them.  ``upgrade_legacy_mcp_credentials`` re-runs the same
 * leave real secrets (no ``${WORD}``) byte-for-byte untouched,
 * be idempotent (skip credentials already resolved via ``env:``).
 """
+import inspect
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -51,12 +53,6 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
     migrated, _ = legacy_mcp_client_to_driver("slow-server", legacy)
     assert migrated.endpoint["tool_call_timeout"] == 5.0
 
-    legacy_alias = MCPClientConfig(
-        name="legacy-slow-server",
-        command="python",
-        timeout=6.0,
-    )
-    assert legacy_alias.tool_call_timeout == 6.0
     assert (
         MCPClientConfig(
             name="default-server",
@@ -64,13 +60,6 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
         ).tool_call_timeout
         == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
     )
-
-    created_alias = MCPClientCreateRequest(
-        name="slow-server",
-        command="python",
-        timeout=6.5,
-    )
-    assert created_alias.tool_call_timeout == 6.5
 
     created = MCPClientCreateRequest(
         name="slow-server",
@@ -95,13 +84,46 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
     )
     assert updated.endpoint["tool_call_timeout"] == 9.0
 
-    updated_alias = build_mcp_driver_card(
-        "slow-server",
-        MCPClientUpdateRequest(timeout=10.0),
-        "mcp/slow-server",
-        existing=updated,
+
+def test_legacy_timeout_name_is_not_coerced_to_tool_call_timeout() -> None:
+    assert (
+        MCPClientConfig(
+            name="http-server",
+            transport="streamable_http",
+            url="https://mcp.example.com",
+            timeout=6.0,
+        ).tool_call_timeout
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
     )
-    assert updated_alias.endpoint["tool_call_timeout"] == 10.0
+    assert (
+        MCPClientCreateRequest(
+            name="http-server",
+            transport="streamable_http",
+            url="https://mcp.example.com",
+            timeout=6.5,
+        ).tool_call_timeout
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
+    assert MCPClientUpdateRequest(timeout=10.0).tool_call_timeout is None
+
+
+def test_legacy_migration_treats_none_timeout_as_unset() -> None:
+    config = SimpleNamespace(
+        transport="streamable_http",
+        url="https://mcp.example.com",
+        headers={},
+        oauth=None,
+        tools=None,
+        tool_call_timeout=None,
+        timeout=6.0,
+    )
+
+    migrated, _ = legacy_mcp_client_to_driver("legacy-http", config)
+
+    assert (
+        migrated.endpoint["tool_call_timeout"]
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
 
 
 @pytest.mark.parametrize("value", [float("inf"), float("nan"), 0, -1])
@@ -112,17 +134,28 @@ def test_mcp_tool_call_timeout_rejects_non_finite_or_non_positive_values(
         parse_mcp_tool_call_timeout(value)
 
     with pytest.raises(ValidationError):
-        MCPClientConfig(name="bad-server", command="python", timeout=value)
+        MCPClientConfig(
+            name="bad-server",
+            command="python",
+            tool_call_timeout=value,
+        )
 
     with pytest.raises(ValidationError):
         MCPClientCreateRequest(
             name="bad-server",
             command="python",
-            timeout=value,
+            tool_call_timeout=value,
         )
 
     with pytest.raises(ValidationError):
-        MCPClientUpdateRequest(timeout=value)
+        MCPClientUpdateRequest(tool_call_timeout=value)
+
+
+def test_parse_mcp_tool_call_timeout_requires_a_value() -> None:
+    parameter = inspect.signature(parse_mcp_tool_call_timeout).parameters[
+        "value"
+    ]
+    assert parameter.default is inspect.Parameter.empty
 
 
 def test_mcp_tool_call_timeout_rejects_values_above_maximum() -> None:

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -19,6 +19,9 @@ from qwenpaw.app.mcp.schemas import (
     MCPClientUpdateRequest,
 )
 from qwenpaw.config.config import MCPClientConfig
+from qwenpaw.mcp_timeout import (
+    DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+)
 from qwenpaw.drivers.adapters.mcp_card_builder import (
     build_mcp_client_info_payload,
     build_mcp_driver_card,
@@ -38,33 +41,64 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
     legacy = MCPClientConfig(
         name="slow-server",
         command="python",
-        timeout=5.0,
+        tool_call_timeout=5.0,
     )
-    assert legacy.timeout == 5.0
+    assert legacy.tool_call_timeout == 5.0
 
     migrated, _ = legacy_mcp_client_to_driver("slow-server", legacy)
-    assert migrated.endpoint["timeout"] == 5.0
+    assert migrated.endpoint["tool_call_timeout"] == 5.0
+
+    legacy_alias = MCPClientConfig(
+        name="legacy-slow-server",
+        command="python",
+        timeout=6.0,
+    )
+    assert legacy_alias.tool_call_timeout == 6.0
+    assert (
+        MCPClientConfig(
+            name="default-server",
+            command="python",
+        ).tool_call_timeout
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
+
+    created_alias = MCPClientCreateRequest(
+        name="slow-server",
+        command="python",
+        timeout=6.5,
+    )
+    assert created_alias.tool_call_timeout == 6.5
 
     created = MCPClientCreateRequest(
         name="slow-server",
         command="python",
-        timeout=7.0,
+        tool_call_timeout=7.0,
     )
     card = build_mcp_driver_card(
         "slow-server",
         created,
         "mcp/slow-server",
     )
-    assert card.endpoint["timeout"] == 7.0
-    assert build_mcp_client_info_payload(card, None)["timeout"] == 7.0
+    assert card.endpoint["tool_call_timeout"] == 7.0
+    assert (
+        build_mcp_client_info_payload(card, None)["tool_call_timeout"] == 7.0
+    )
 
     updated = build_mcp_driver_card(
         "slow-server",
-        MCPClientUpdateRequest(timeout=9.0),
+        MCPClientUpdateRequest(tool_call_timeout=9.0),
         "mcp/slow-server",
         existing=card,
     )
-    assert updated.endpoint["timeout"] == 9.0
+    assert updated.endpoint["tool_call_timeout"] == 9.0
+
+    updated_alias = build_mcp_driver_card(
+        "slow-server",
+        MCPClientUpdateRequest(timeout=10.0),
+        "mcp/slow-server",
+        existing=updated,
+    )
+    assert updated_alias.endpoint["tool_call_timeout"] == 10.0
 
 
 def _write_card(

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -19,12 +19,14 @@ from pydantic import ValidationError
 
 from qwenpaw.app.mcp.schemas import (
     MCPClientCreateRequest,
+    MCPClientInfo,
     MCPClientUpdateRequest,
 )
 from qwenpaw.config.config import MCPClientConfig
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
     MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MCP_TOOL_CALL_TIMEOUT_DESCRIPTION,
     parse_mcp_tool_call_timeout,
 )
 from qwenpaw.drivers.adapters.mcp_card_builder import (
@@ -85,6 +87,23 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
     assert updated.endpoint["tool_call_timeout"] == 9.0
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        MCPClientInfo,
+        MCPClientCreateRequest,
+        MCPClientUpdateRequest,
+        MCPClientConfig,
+    ],
+)
+def test_mcp_timeout_schema_uses_shared_description(model) -> None:
+    timeout_schema = model.model_json_schema()["properties"][
+        "tool_call_timeout"
+    ]
+
+    assert timeout_schema["description"] == MCP_TOOL_CALL_TIMEOUT_DESCRIPTION
+
+
 def test_legacy_timeout_name_is_not_coerced_to_tool_call_timeout() -> None:
     assert (
         MCPClientConfig(
@@ -107,7 +126,41 @@ def test_legacy_timeout_name_is_not_coerced_to_tool_call_timeout() -> None:
     assert MCPClientUpdateRequest(timeout=10.0).tool_call_timeout is None
 
 
-def test_legacy_migration_treats_none_timeout_as_unset() -> None:
+def test_legacy_stdio_config_accepts_timeout_alias() -> None:
+    config = MCPClientConfig(
+        name="stdio-server",
+        command="python",
+        timeout=6.0,
+    )
+
+    assert config.tool_call_timeout == 6.0
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "name": "stdio-server",
+            "command": "python",
+            "tool_call_timeout": None,
+        },
+        {
+            "name": "http-server",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com",
+            "tool_call_timeout": None,
+            "timeout": 6.0,
+        },
+    ],
+)
+def test_legacy_config_treats_none_timeout_as_unset(config) -> None:
+    assert (
+        MCPClientConfig(**config).tool_call_timeout
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
+
+
+def test_legacy_http_migration_ignores_transport_timeout() -> None:
     config = SimpleNamespace(
         transport="streamable_http",
         url="https://mcp.example.com",
@@ -124,6 +177,23 @@ def test_legacy_migration_treats_none_timeout_as_unset() -> None:
         migrated.endpoint["tool_call_timeout"]
         == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
     )
+
+
+def test_legacy_stdio_migration_falls_back_from_none_to_timeout() -> None:
+    config = SimpleNamespace(
+        transport="stdio",
+        command="python",
+        args=[],
+        env={},
+        oauth=None,
+        tools=None,
+        tool_call_timeout=None,
+        timeout=6.0,
+    )
+
+    migrated, _ = legacy_mcp_client_to_driver("legacy-stdio", config)
+
+    assert migrated.endpoint["tool_call_timeout"] == 6.0
 
 
 @pytest.mark.parametrize("value", [float("inf"), float("nan"), 0, -1])

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -14,7 +14,17 @@ from pathlib import Path
 
 import pytest
 
+from qwenpaw.app.mcp.schemas import (
+    MCPClientCreateRequest,
+    MCPClientUpdateRequest,
+)
+from qwenpaw.config.config import MCPClientConfig
+from qwenpaw.drivers.adapters.mcp_card_builder import (
+    build_mcp_client_info_payload,
+    build_mcp_driver_card,
+)
 from qwenpaw.drivers.adapters.mcp_legacy_config import (
+    legacy_mcp_client_to_driver,
     upgrade_legacy_mcp_credentials,
 )
 from qwenpaw.drivers.contracts import CredentialRef, DriverCard, PolicyRule
@@ -22,6 +32,39 @@ from qwenpaw.drivers.credentials.store import AsyncCredentialStore
 from qwenpaw.drivers.credentials.types import CredentialRecord
 from qwenpaw.drivers.manager import DriverManager
 from qwenpaw.drivers.storage import card_path, dump_card, load_card
+
+
+def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
+    legacy = MCPClientConfig(
+        name="slow-server",
+        command="python",
+        timeout=5.0,
+    )
+    assert legacy.timeout == 5.0
+
+    migrated, _ = legacy_mcp_client_to_driver("slow-server", legacy)
+    assert migrated.endpoint["timeout"] == 5.0
+
+    created = MCPClientCreateRequest(
+        name="slow-server",
+        command="python",
+        timeout=7.0,
+    )
+    card = build_mcp_driver_card(
+        "slow-server",
+        created,
+        "mcp/slow-server",
+    )
+    assert card.endpoint["timeout"] == 7.0
+    assert build_mcp_client_info_payload(card, None)["timeout"] == 7.0
+
+    updated = build_mcp_driver_card(
+        "slow-server",
+        MCPClientUpdateRequest(timeout=9.0),
+        "mcp/slow-server",
+        existing=card,
+    )
+    assert updated.endpoint["timeout"] == 9.0
 
 
 def _write_card(

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -13,6 +13,7 @@ never repairs them.  ``upgrade_legacy_mcp_credentials`` re-runs the same
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from qwenpaw.app.mcp.schemas import (
     MCPClientCreateRequest,
@@ -21,6 +22,8 @@ from qwenpaw.app.mcp.schemas import (
 from qwenpaw.config.config import MCPClientConfig
 from qwenpaw.mcp_timeout import (
     DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS,
+    parse_mcp_tool_call_timeout,
 )
 from qwenpaw.drivers.adapters.mcp_card_builder import (
     build_mcp_client_info_payload,
@@ -99,6 +102,51 @@ def test_mcp_timeout_roundtrips_through_config_and_driver_card() -> None:
         existing=updated,
     )
     assert updated_alias.endpoint["tool_call_timeout"] == 10.0
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("nan"), 0, -1])
+def test_mcp_tool_call_timeout_rejects_non_finite_or_non_positive_values(
+    value,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_mcp_tool_call_timeout(value)
+
+    with pytest.raises(ValidationError):
+        MCPClientConfig(name="bad-server", command="python", timeout=value)
+
+    with pytest.raises(ValidationError):
+        MCPClientCreateRequest(
+            name="bad-server",
+            command="python",
+            timeout=value,
+        )
+
+    with pytest.raises(ValidationError):
+        MCPClientUpdateRequest(timeout=value)
+
+
+def test_mcp_tool_call_timeout_rejects_values_above_maximum() -> None:
+    too_large = MAX_MCP_TOOL_CALL_TIMEOUT_SECONDS + 1
+
+    with pytest.raises(ValueError):
+        parse_mcp_tool_call_timeout(too_large)
+
+    with pytest.raises(ValidationError):
+        MCPClientConfig(
+            name="bad-server",
+            command="python",
+            tool_call_timeout=too_large,
+        )
+
+    with pytest.raises(ValidationError):
+        MCPClientCreateRequest(
+            name="bad-server",
+            command="python",
+            tool_call_timeout=too_large,
+        )
+
+    with pytest.raises(ValidationError):
+        MCPClientUpdateRequest(tool_call_timeout=too_large)
 
 
 def _write_card(

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -221,6 +221,29 @@ def test_mcp_tool_call_timeout_rejects_non_finite_or_non_positive_values(
         MCPClientUpdateRequest(tool_call_timeout=value)
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_mcp_tool_call_timeout_rejects_boolean_values(value) -> None:
+    with pytest.raises(ValueError):
+        parse_mcp_tool_call_timeout(value)
+
+    with pytest.raises(ValidationError):
+        MCPClientConfig(
+            name="bad-server",
+            command="python",
+            tool_call_timeout=value,
+        )
+
+    with pytest.raises(ValidationError):
+        MCPClientCreateRequest(
+            name="bad-server",
+            command="python",
+            tool_call_timeout=value,
+        )
+
+    with pytest.raises(ValidationError):
+        MCPClientUpdateRequest(tool_call_timeout=value)
+
+
 def test_parse_mcp_tool_call_timeout_requires_a_value() -> None:
     parameter = inspect.signature(parse_mcp_tool_call_timeout).parameters[
         "value"

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -136,6 +136,16 @@ def test_legacy_stdio_config_accepts_timeout_alias() -> None:
     assert config.tool_call_timeout == 6.0
 
 
+def test_legacy_stdio_config_treats_none_timeout_as_unset() -> None:
+    config = MCPClientConfig(
+        name="stdio-server",
+        command="python",
+        timeout=None,
+    )
+
+    assert config.tool_call_timeout == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+
+
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
+++ b/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
@@ -590,6 +590,103 @@ async def test_call_tool_header_mismatch_retry(second_ok):
         await c.close()
 
 
+async def test_modern_call_tool_timeout_includes_initial_tool_listing(
+    monkeypatch,
+):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+
+    async def slow_list_tools():
+        await asyncio.sleep(0.05)
+        c._tools_listed = True
+        return []
+
+    async def successful_call(*_args, **_kwargs):
+        return {"content": [], "resultType": "complete"}
+
+    monkeypatch.setattr(c, "list_tools", slow_list_tools)
+    monkeypatch.setattr(c, "_rpc", successful_call)
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'modern' timed out after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+
+async def test_modern_call_tool_timeout_includes_header_refresh(monkeypatch):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+
+    async def header_mismatch(*_args, **_kwargs):
+        raise _JsonRpcError(
+            _JSONRPC_HEADER_MISMATCH,
+            "refresh headers",
+        )
+
+    async def slow_list_tools():
+        await asyncio.sleep(0.05)
+        return []
+
+    monkeypatch.setattr(c, "_rpc", header_mismatch)
+    monkeypatch.setattr(c, "list_tools", slow_list_tools)
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'modern' timed out after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+
+async def test_modern_call_tool_maps_http_timeout(monkeypatch):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+
+    async def read_timeout(*_args, **_kwargs):
+        raise httpx.ReadTimeout("read timed out")
+
+    monkeypatch.setattr(c, "_rpc", read_timeout)
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'modern' timed out after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+
+def test_modern_http_read_timeout_covers_tool_call_timeout():
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        sse_read_timeout=30,
+        tool_call_timeout=600,
+    )
+
+    assert c.sse_read_timeout == 600
+    assert c.tool_call_timeout == 600
+
+
 async def test_list_tools_max_pages_exceeded():
     n = {"v": 0}
 

--- a/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
+++ b/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
@@ -674,6 +674,97 @@ async def test_modern_call_tool_maps_http_timeout(monkeypatch):
         await c.call_tool("slow")
 
 
+@pytest.mark.parametrize(
+    "timeout_type",
+    [httpx.ConnectTimeout, httpx.WriteTimeout, httpx.PoolTimeout],
+)
+async def test_modern_call_tool_preserves_non_read_http_timeout(
+    monkeypatch,
+    timeout_type,
+):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+    error = timeout_type(
+        "transport timed out",
+        request=httpx.Request("POST", "http://mcp.test/mcp"),
+    )
+
+    async def transport_timeout(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(c, "_rpc", transport_timeout)
+
+    with pytest.raises(timeout_type) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is error
+
+
+async def test_modern_call_tool_does_not_map_arbitrary_code_408(monkeypatch):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+
+    class FakeCodeError(Exception):
+        code = 408
+
+    error = FakeCodeError("not an MCP timeout")
+
+    async def fake_code_error(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(c, "_rpc", fake_code_error)
+
+    with pytest.raises(FakeCodeError) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is error
+
+
+async def test_modern_call_tool_resets_http_client_after_deadline(monkeypatch):
+    c = _cli(
+        HttpStatelessClient,
+        "modern",
+        lambda request: _disc(_rid(request)),
+        tool_call_timeout=0.01,
+    )
+    await c.connect()
+    old_http = c._http
+    c._tools_listed = True
+
+    async def slow_call(*_args, **_kwargs):
+        await asyncio.sleep(0.05)
+
+    monkeypatch.setattr(c, "_rpc", slow_call)
+
+    try:
+        with pytest.raises(
+            TimeoutError,
+            match=r"timed out after 0\.01s",
+        ):
+            await c.call_tool("slow")
+
+        assert old_http is not None and old_http.is_closed
+        assert c._http is not None and c._http is not old_http
+        assert not c._http.is_closed
+        assert c.is_connected is True
+    finally:
+        await c.close()
+
+
 async def test_modern_call_tool_maps_grouped_http_timeout(monkeypatch):
     c = HttpStatelessClient(
         "modern",

--- a/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
+++ b/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
@@ -674,6 +674,59 @@ async def test_modern_call_tool_maps_http_timeout(monkeypatch):
         await c.call_tool("slow")
 
 
+async def test_modern_call_tool_maps_grouped_http_timeout(monkeypatch):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+
+    async def grouped_read_timeout(*_args, **_kwargs):
+        raise ExceptionGroup(
+            "streamable HTTP task group failed",
+            [httpx.ReadTimeout("read timed out")],
+        )
+
+    monkeypatch.setattr(c, "_rpc", grouped_read_timeout)
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'modern' timed out after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+
+@pytest.mark.parametrize("grouped", [False, True])
+async def test_modern_call_tool_maps_mcp_408(monkeypatch, grouped):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+
+    async def mcp_timeout(*_args, **_kwargs):
+        exc = _JsonRpcError(408, "request timed out")
+        if grouped:
+            raise ExceptionGroup("streamable HTTP task group failed", [exc])
+        raise exc
+
+    monkeypatch.setattr(c, "_rpc", mcp_timeout)
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'modern' timed out after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+
 def test_modern_http_read_timeout_covers_tool_call_timeout():
     c = HttpStatelessClient(
         "modern",

--- a/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
+++ b/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
@@ -700,6 +700,35 @@ async def test_modern_call_tool_maps_grouped_http_timeout(monkeypatch):
         await c.call_tool("slow")
 
 
+async def test_modern_call_tool_preserves_mixed_exception_group(monkeypatch):
+    c = HttpStatelessClient(
+        "modern",
+        "streamable_http",
+        "http://mcp.test/mcp",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    c._http = object()  # type: ignore[assignment]
+    c._tools_listed = True
+    timeout = httpx.ReadTimeout("read timed out")
+    non_timeout = ValueError("invalid response")
+    group = ExceptionGroup(
+        "streamable HTTP task group failed",
+        [timeout, non_timeout],
+    )
+
+    async def mixed_failure(*_args, **_kwargs):
+        raise group
+
+    monkeypatch.setattr(c, "_rpc", mixed_failure)
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is group
+    assert exc_info.value.exceptions == (timeout, non_timeout)
+
+
 @pytest.mark.parametrize("grouped", [False, True])
 async def test_modern_call_tool_maps_mcp_408(monkeypatch, grouped):
     c = HttpStatelessClient(

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -777,6 +777,81 @@ async def test_call_tool_maps_http_timeout_without_reconnect():
     assert not c._reload_event.is_set()
 
 
+@pytest.mark.parametrize(
+    "timeout_type",
+    [httpx.ConnectTimeout, httpx.WriteTimeout, httpx.PoolTimeout],
+)
+async def test_call_tool_reconnects_for_non_read_http_timeout(timeout_type):
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    error = timeout_type(
+        "transport timed out",
+        request=httpx.Request("POST", "http://x"),
+    )
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise error
+
+    session = FakeSession()
+    c.session = session  # type: ignore[assignment]
+
+    with pytest.raises(timeout_type) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is error
+    assert c.session is None
+    assert c.is_connected is False
+    assert c._reload_event.is_set()
+
+
+async def test_call_tool_does_not_treat_arbitrary_code_408_as_mcp_timeout():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+
+    class FakeCodeError(Exception):
+        code = 408
+
+    error = FakeCodeError("not an MCP timeout")
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise error
+
+    session = FakeSession()
+    c.session = session  # type: ignore[assignment]
+
+    with pytest.raises(FakeCodeError) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is error
+    assert c.session is session
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
 async def test_call_tool_maps_grouped_http_timeout_without_reconnect():
     c = HttpStatefulClient(
         "slow-client",
@@ -859,7 +934,7 @@ def test_http_client_read_timeout_covers_tool_call_timeout():
     )
 
     assert c.sse_read_timeout == 600
-    assert c.read_timeout_seconds == 600
+    assert not hasattr(c, "read_timeout_seconds")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -777,6 +777,43 @@ async def test_call_tool_maps_http_timeout_without_reconnect():
     assert not c._reload_event.is_set()
 
 
+async def test_call_tool_maps_grouped_http_timeout_without_reconnect():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise ExceptionGroup(
+                "streamable HTTP task group failed",
+                [httpx.ReadTimeout("read timed out")],
+            )
+
+    session = FakeSession()
+    c.session = session  # type: ignore[assignment]
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'slow-client' timed out "
+        "after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+    assert c.session is session
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
 def test_http_client_read_timeout_covers_tool_call_timeout():
     c = HttpStatefulClient(
         "slow-client",

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -814,6 +814,41 @@ async def test_call_tool_maps_grouped_http_timeout_without_reconnect():
     assert not c._reload_event.is_set()
 
 
+async def test_call_tool_preserves_mixed_exception_group():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+    timeout = httpx.ReadTimeout("read timed out")
+    non_timeout = ValueError("invalid response")
+    group = ExceptionGroup(
+        "streamable HTTP task group failed",
+        [timeout, non_timeout],
+    )
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise group
+
+    session = FakeSession()
+    c.session = session  # type: ignore[assignment]
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await c.call_tool("slow")
+
+    assert exc_info.value is group
+    assert exc_info.value.exceptions == (timeout, non_timeout)
+
+
 def test_http_client_read_timeout_covers_tool_call_timeout():
     c = HttpStatefulClient(
         "slow-client",

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -745,6 +745,51 @@ async def test_call_tool_maps_sdk_timeout_without_reconnect():
     assert not c._reload_event.is_set()
 
 
+async def test_call_tool_maps_http_timeout_without_reconnect():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise httpx.ReadTimeout("read timed out")
+
+    c.session = FakeSession()  # type: ignore[assignment]
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'slow-client' timed out "
+        "after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
+def test_http_client_read_timeout_covers_tool_call_timeout():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        sse_read_timeout=30,
+        tool_call_timeout=600,
+    )
+
+    assert c.sse_read_timeout == 600
+    assert c.read_timeout_seconds == 600
+
+
 @pytest.mark.parametrize(
     "endpoint",
     [
@@ -779,6 +824,7 @@ async def test_driver_handler_passes_tool_call_timeout(
 
     monkeypatch.setattr(mcp_handler, "StdIOStatefulClient", FakeClient)
     monkeypatch.setattr(mcp_handler, "HttpStatefulClient", FakeClient)
+    monkeypatch.setattr(mcp_handler, "HttpAutoClient", FakeClient)
 
     handler = object.__new__(MCPDriverHandler)
     handler._card = DriverCard(

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -18,17 +18,23 @@ behind the ``fail_under`` gate.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 import httpx
 import pytest
 from mcp.shared.exceptions import McpError
 from mcp.types import CONNECTION_CLOSED, ErrorData
 
+import qwenpaw.drivers.handlers.mcp as mcp_handler
 import qwenpaw.drivers.handlers.mcp_stateful_client as mod
+from qwenpaw.drivers.contracts import DriverCard
+from qwenpaw.drivers.errors import DriverCardError
+from qwenpaw.drivers.handlers.mcp import MCPDriverHandler
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
     HttpStatefulClient,
     _is_401_error,
     _is_transport_error,
 )
+from qwenpaw.mcp_timeout import DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
 
 
 def _client() -> HttpStatefulClient:
@@ -621,7 +627,13 @@ async def test_call_tool_handles_transport_error_and_marks_disconnected():
     c.is_connected = True
 
     class FakeSession:
-        async def call_tool(self, name: str, args: dict) -> None:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
             raise ConnectionResetError("pipe broke")
 
     c.session = FakeSession()  # type: ignore[assignment]
@@ -640,7 +652,13 @@ async def test_call_tool_does_not_reconnect_for_generic_server_error():
     )
 
     class FakeSession:
-        async def call_tool(self, name: str, args: dict) -> None:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
             raise error
 
     c.session = FakeSession()  # type: ignore[assignment]
@@ -661,6 +679,184 @@ async def test_call_tool_aborts_when_session_invalidated_mid_request():
             await asyncio.wait_for(c.call_tool("foo", {}), timeout=1)
         await t
         assert not c._reload_event.is_set() and bool(nxt) is c.is_connected
+
+
+async def test_call_tool_passes_sdk_read_timeout():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.read_timeout_seconds = None
+
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> str:
+            del args
+            self.read_timeout_seconds = read_timeout_seconds
+            return f"{name}:ok"
+
+    session = FakeSession()
+    c.session = session  # type: ignore[assignment]
+
+    assert await c.call_tool("healthy") == "healthy:ok"
+    assert session.read_timeout_seconds == timedelta(seconds=0.01)
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
+async def test_call_tool_maps_sdk_timeout_without_reconnect():
+    c = HttpStatefulClient(
+        "slow-client",
+        "streamable_http",
+        "http://x",
+        tool_call_timeout=0.01,
+    )
+    c.is_connected = True
+
+    class FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            args: dict,
+            read_timeout_seconds=None,
+        ) -> None:
+            del name, args, read_timeout_seconds
+            raise McpError(ErrorData(code=408, message="Timed out"))
+
+    c.session = FakeSession()  # type: ignore[assignment]
+
+    with pytest.raises(
+        TimeoutError,
+        match="MCP tool call 'slow' on client 'slow-client' timed out "
+        "after 0.01s",
+    ):
+        await c.call_tool("slow")
+
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        {
+            "transport": "stdio",
+            "command": "python",
+            "tool_call_timeout": 4.5,
+        },
+        {
+            "transport": "streamable_http",
+            "url": "http://x",
+            "tool_call_timeout": 4.5,
+        },
+    ],
+)
+async def test_driver_handler_passes_tool_call_timeout(
+    endpoint: dict,
+    monkeypatch,
+):
+    instances = []
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            instances.append(self)
+
+        async def connect(self) -> None:
+            pass
+
+        async def close(self, ignore_errors: bool = True) -> None:
+            pass
+
+    monkeypatch.setattr(mcp_handler, "StdIOStatefulClient", FakeClient)
+    monkeypatch.setattr(mcp_handler, "HttpStatefulClient", FakeClient)
+
+    handler = object.__new__(MCPDriverHandler)
+    handler._card = DriverCard(
+        name="slow-client",
+        protocol="mcp",
+        endpoint=endpoint,
+    )
+    handler._client = None
+
+    async def resolve_credentials():
+        return {}
+
+    handler._resolve_credentials = resolve_credentials
+
+    await handler._setup()
+
+    assert instances[0].kwargs["tool_call_timeout"] == 4.5
+
+
+async def test_driver_handler_uses_default_tool_call_timeout(monkeypatch):
+    instances = []
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            instances.append(self)
+
+        async def connect(self) -> None:
+            pass
+
+        async def close(self, ignore_errors: bool = True) -> None:
+            pass
+
+    monkeypatch.setattr(mcp_handler, "StdIOStatefulClient", FakeClient)
+
+    handler = object.__new__(MCPDriverHandler)
+    handler._card = DriverCard(
+        name="slow-client",
+        protocol="mcp",
+        endpoint={
+            "transport": "stdio",
+            "command": "python",
+        },
+    )
+    handler._client = None
+
+    async def resolve_credentials():
+        return {}
+
+    handler._resolve_credentials = resolve_credentials
+
+    await handler._setup()
+
+    assert (
+        instances[0].kwargs["tool_call_timeout"]
+        == DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECONDS
+    )
+
+
+@pytest.mark.parametrize("value", [0, -1, "", "not-a-number"])
+def test_validate_mcp_endpoint_rejects_invalid_tool_call_timeout(value):
+    with pytest.raises(DriverCardError, match="endpoint.tool_call_timeout"):
+        mcp_handler.validate_mcp_endpoint(
+            DriverCard(
+                name="slow-client",
+                protocol="mcp",
+                endpoint={
+                    "transport": "stdio",
+                    "command": "python",
+                    "tool_call_timeout": value,
+                },
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# connect / reload preconditions
+# ---------------------------------------------------------------------------
 
 
 async def test_connect_raises_when_already_connected():

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -31,6 +31,7 @@ from qwenpaw.drivers.errors import DriverCardError
 from qwenpaw.drivers.handlers.mcp import MCPDriverHandler
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
     HttpStatefulClient,
+    StdIOStatefulClient,
     _is_401_error,
     _is_transport_error,
 )
@@ -935,6 +936,46 @@ def test_http_client_read_timeout_covers_tool_call_timeout():
 
     assert c.sse_read_timeout == 600
     assert not hasattr(c, "read_timeout_seconds")
+
+
+async def test_stdio_client_passes_read_timeout_to_sdk_session(monkeypatch):
+    c = StdIOStatefulClient(
+        "stdio-client",
+        "run-server",
+        read_timeout_seconds=17,
+    )
+    captured: dict[str, object] = {}
+
+    class FakeSession:
+        def __init__(
+            self,
+            read_stream,
+            write_stream,
+            read_timeout_seconds=None,
+        ) -> None:
+            del read_stream, write_stream
+            captured["read_timeout_seconds"] = read_timeout_seconds
+
+        async def initialize(self):
+            return self
+
+        __aenter__ = initialize
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def setup(_stack):
+        return object(), object()
+
+    monkeypatch.setattr(mod, "ClientSession", FakeSession)
+    monkeypatch.setattr(c, "_setup_transport", setup)
+    task = asyncio.create_task(c._run_lifecycle())
+    try:
+        await asyncio.wait_for(c._ready_event.wait(), timeout=1)
+        assert captured["read_timeout_seconds"] == timedelta(seconds=17)
+    finally:
+        c._stop_event.set()
+        await asyncio.wait_for(task, timeout=1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add a positive per-client MCP tool-call deadline named `tool_call_timeout`, defaulting to 300 seconds. HTTP/SSE read budgets are raised to at least the configured deadline so values above 300 seconds are honored. The old `timeout` key is accepted only for legacy stdio configurations, where it is migrated to `tool_call_timeout`.

Closes #6724. Related to #3997.

## What Problem This Solves

A slow or wedged MCP server can currently block an agent turn indefinitely because per-client tool-call timeout values are discarded. This setting bounds one complete tool invocation, including implicit `tools/list`, header-refresh retries, and `tools/call`. It does not change HTTP connect, write, or pool timeouts.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Summary

- validate finite tool-call deadlines in `(0, 86400]`, with a shared schema field and 300-second default
- apply one deadline across modern Streamable-HTTP discovery, header refresh, retry, and tool invocation
- raise HTTP/SSE read budgets to at least `tool_call_timeout`
- map direct and grouped MCP 408 / httpx timeout failures to the contextual `TimeoutError` without reconnecting
- preserve mixed exception groups so non-timeout failures are not hidden
- migrate legacy `timeout` only for stdio configurations; HTTP transport timeout values are not reinterpreted
- treat `tool_call_timeout=None` as unset during legacy migration

## Testing

- 145 focused MCP stateful, dual-protocol, and legacy-upgrade tests passed
- pre-commit checks passed for all changed files, including mypy, black, flake8, pylint, AST, trailing whitespace, and private-key detection
- regression coverage includes direct/grouped/mixed timeout exceptions, HTTP read-budget propagation, implicit `tools/list`, header-refresh retry, alias boundaries, schema descriptions, and `None` migration

## Risk & Scope

- No real multi-minute MCP server was used; timeout behavior is covered through SDK and transport-level test doubles.
- Existing HTTP connect, write, and pool timeout semantics are unchanged.

## Checklist

- [x] Run and pass relevant pre-commit hooks
- [x] Run and pass relevant tests
- [x] Add/update regression coverage
- [x] Document the config field semantics