### PR TITLE
feat(desktop): remember window geometry

### DIFF
--- a/console/src-tauri/Cargo.lock
+++ b/console/src-tauri/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "uuid",
@@ -4169,6 +4170,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-window-state = "2"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "5"

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -12,6 +12,11 @@ mod tray;
 mod updates;
 
 use tauri::{Manager, RunEvent, WebviewWindow, WindowEvent};
+use tauri_plugin_window_state::StateFlags;
+
+fn window_state_flags() -> StateFlags {
+    StateFlags::POSITION | StateFlags::SIZE
+}
 
 /// Opens the WebView DevTools. Gated by the hidden 8-click logo gesture in the
 /// frontend so end users cannot open DevTools via the default context menu or
@@ -27,6 +32,11 @@ pub fn run() {
     let build_result = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(window_state_flags())
+                .build(),
+        )
         .plugin(
             tauri_plugin_updater::Builder::new()
                 .default_version_comparator(updates::is_remote_update_newer)
@@ -107,5 +117,19 @@ pub fn run() {
             eprintln!("[QwenPaw Desktop] Fatal startup error: {err}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tauri_plugin_window_state::StateFlags;
+
+    #[test]
+    fn window_state_persists_geometry_only() {
+        assert_eq!(
+            window_state_flags().bits(),
+            (StateFlags::POSITION | StateFlags::SIZE).bits(),
+        );
     }
 }


### PR DESCRIPTION
## Description

Persist the Tauri desktop window's position and size and restore that geometry on the next launch.

The implementation uses Tauri's official window-state plugin with an explicit `POSITION | SIZE` mask. It deliberately excludes visibility, minimized, maximized, decoration, and fullscreen state so the existing close-to-tray and reopen behavior remains unchanged.

Closes #4634.

## What Problem This Solves

QwenPaw Desktop currently starts from the fixed `1280 × 800` configuration on every launch. Users who resize or move the window must restore their preferred layout after each restart.

The issue's original pywebview proposal predates the distributed Tauri desktop app. This PR implements the behavior in the current desktop runtime rather than extending the legacy CLI webview path.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## Components Affected

- Tauri desktop shell
- Tests

## Testing

```text
cargo test --locked --lib
19 passed; 0 failed

cargo check --locked
Finished successfully

uvx pre-commit run --all-files
All hooks passed

git diff --check
Passed
```

## Evidence

- Added a regression test that asserts the plugin is restricted to position and size flags.
- Verified the official plugin observes move/resize events, restores state at window creation, and writes the cached state on application exit.
- Confirmed only one new locked crate (`tauri-plugin-window-state 2.4.1`) is introduced.
- Rechecked issue assignees, linked/exact PRs, semantic PR searches, and matching upstream branches immediately before publishing; no competing implementation was present.

## Checklist

- [x] The change is limited to the current Tauri desktop runtime.
- [x] Existing tray visibility and fullscreen behavior are not persisted.
- [x] `pre-commit run --all-files` passes.
- [x] Rust tests and compilation pass with the committed lockfile.
- [x] No documentation update is needed; this is transparent launch behavior.