### PR TITLE
feat(console): add hidden-folders toggle to project directory picker

### DIFF
--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -180,6 +180,37 @@ describe("SessionProjectDirectory", () => {
     });
   });
 
+  it("re-browses the current directory when hidden folders are toggled", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={scope} />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "projectDirectory.sessionTitle",
+      }),
+    );
+    await waitFor(() => {
+      expect(mockBrowseDirs).toHaveBeenCalledWith(
+        "/projects/agentscope",
+        false,
+      );
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "codingMode.openDirHiddenFolders",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockBrowseDirs).toHaveBeenLastCalledWith("/projects", true);
+    });
+    expect(screen.getByRole("button", { name: /agentscope/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   it("applies the path that owns the visible selection state", async () => {
     const user = userEvent.setup();
     mockSetSessionDirectory.mockResolvedValue({

--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -211,6 +211,89 @@ describe("SessionProjectDirectory", () => {
     );
   });
 
+  it("discards stale browse responses when toggle completes out of order", async () => {
+    const user = userEvent.setup();
+
+    // We will control resolve order manually.
+    let resolvers: Array<{
+      resolve: (v: {
+        current: string;
+        parent: string;
+        dirs: { name: string; path: string }[];
+      }) => void;
+      showHidden: boolean;
+    }> = [];
+    mockBrowseDirs.mockImplementation(
+      (_path: string | undefined, showHidden: boolean) =>
+        new Promise((resolve) => {
+          resolvers.push({
+            resolve: resolve as never,
+            showHidden,
+          });
+        }),
+    );
+
+    renderWithProviders(<SessionProjectDirectory scope={scope} />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "projectDirectory.sessionTitle",
+      }),
+    );
+
+    // Wait for the initial browse request (show_hidden=false).
+    await waitFor(() => {
+      expect(resolvers.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Toggle hidden ON → second request (show_hidden=true).
+    await user.click(
+      screen.getByRole("button", {
+        name: "codingMode.openDirHiddenFolders",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(resolvers.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // Resolve in REVERSE order: true first, then false.
+    const trueReq = resolvers.find((r) => r.showHidden)!;
+    const falseReq = resolvers.find((r) => !r.showHidden)!;
+
+    act(() => {
+      trueReq.resolve({
+        current: "/projects",
+        parent: "/",
+        dirs: [
+          { name: ".secret", path: "/projects/.secret" },
+          { name: "custom", path: "/projects/custom" },
+        ],
+      });
+    });
+
+    // After the newer (true) response resolves, .secret should be visible.
+    await waitFor(() => {
+      expect(screen.getByText(".secret")).toBeInTheDocument();
+    });
+
+    // Now resolve the stale false request.
+    act(() => {
+      falseReq.resolve({
+        current: "/projects",
+        parent: "/",
+        dirs: [{ name: "custom", path: "/projects/custom" }],
+      });
+    });
+
+    // The stale response must NOT overwrite the newer result.
+    // The toggle button should still show pressed=true and .secret should remain.
+    expect(
+      screen.getByRole("button", { name: "codingMode.openDirHiddenFolders" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText(".secret")).toBeInTheDocument();
+  });
+
   it("applies the path that owns the visible selection state", async () => {
     const user = userEvent.setup();
     mockSetSessionDirectory.mockResolvedValue({

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -69,6 +69,10 @@ export default function SessionProjectDirectory({
   // of the panel-open effect, which would otherwise re-run on every toggle and
   // navigate back to the project directory.
   const showHiddenRef = useRef(false);
+  // Monotonically increasing sequence number for browse requests.
+  // Only the most recent request is allowed to update state, preventing stale
+  // responses from overwriting newer results when requests complete out of order.
+  const browseSeq = useRef(0);
   const announceChanged = () => {
     notifyProjectDirectoryChanged(scope);
     onChanged?.();
@@ -119,19 +123,25 @@ export default function SessionProjectDirectory({
 
   const browse = useCallback(
     async (path?: string, selectCurrent = false) => {
+      const seq = ++browseSeq.current;
       setBrowseLoading(true);
       try {
         const next = await projectDirectoryApi.browseDirs(
           path,
           showHiddenRef.current,
         );
+        if (seq !== browseSeq.current) return;
         setBrowser(next);
         if (selectCurrent) {
           updateDraft(next.current);
           setSelectedRecentPath(null);
         }
+      } catch {
+        // Stale or failed requests are silently discarded; only the latest
+        // request is allowed to clear the loading indicator.
+        if (seq !== browseSeq.current) return;
       } finally {
-        setBrowseLoading(false);
+        if (seq === browseSeq.current) setBrowseLoading(false);
       }
     },
     [updateDraft],

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -5,6 +5,8 @@ import {
   ChevronDown,
   ChevronRight,
   CircleAlert,
+  Eye,
+  EyeOff,
   Folder,
   FolderOpen,
   LoaderCircle,
@@ -62,6 +64,11 @@ export default function SessionProjectDirectory({
   );
   const [browser, setBrowser] = useState<BrowseDirsResponse | null>(null);
   const [browseLoading, setBrowseLoading] = useState(false);
+  const [showHidden, setShowHidden] = useState(false);
+  // Mirrored in a ref so `browse` keeps a stable identity: it is a dependency
+  // of the panel-open effect, which would otherwise re-run on every toggle and
+  // navigate back to the project directory.
+  const showHiddenRef = useRef(false);
   const announceChanged = () => {
     notifyProjectDirectoryChanged(scope);
     onChanged?.();
@@ -114,7 +121,10 @@ export default function SessionProjectDirectory({
     async (path?: string, selectCurrent = false) => {
       setBrowseLoading(true);
       try {
-        const next = await projectDirectoryApi.browseDirs(path);
+        const next = await projectDirectoryApi.browseDirs(
+          path,
+          showHiddenRef.current,
+        );
         setBrowser(next);
         if (selectCurrent) {
           updateDraft(next.current);
@@ -173,6 +183,13 @@ export default function SessionProjectDirectory({
   const clearDraft = () => {
     updateDraft("");
     setSelectedRecentPath(null);
+  };
+
+  const toggleHidden = () => {
+    const next = !showHidden;
+    showHiddenRef.current = next;
+    setShowHidden(next);
+    void browse(browser?.current ?? draft);
   };
 
   const save = async () => {
@@ -377,6 +394,14 @@ export default function SessionProjectDirectory({
                   />
                 }
                 onClick={() => void browse(browser?.current ?? draft)}
+              />
+              <Button
+                type={showHidden ? "primary" : "text"}
+                size="small"
+                aria-label={t("codingMode.openDirHiddenFolders")}
+                aria-pressed={showHidden}
+                icon={showHidden ? <Eye size={14} /> : <EyeOff size={14} />}
+                onClick={toggleHidden}
               />
             </div>
           </div>


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

<img width="504" height="142" alt="image" src="https://github.com/user-attachments/assets/1ae4f023-8847-4997-952c-9f3dc3a51a3c" />

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
