### PR TITLE
fix(tests): skip qoder harness tests cleanly when the SDK is missing

### DIFF
--- a/tests/unit/harnesses/test_qoder_adapter.py
+++ b/tests/unit/harnesses/test_qoder_adapter.py
@@ -12,6 +12,14 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+# pylint: disable=wrong-import-position
+# flake8: noqa: E402,E501
+pytest.importorskip(
+    "qoder_agent_sdk",
+    reason="optional qoder_agent_sdk (qoder extra) is required",
+)
+
 from qoder_agent_sdk import (
     AssistantMessage,
     ModelInfo,

--- a/tests/unit/harnesses/test_qoder_discovery.py
+++ b/tests/unit/harnesses/test_qoder_discovery.py
@@ -7,6 +7,16 @@ from pathlib import Path
 
 import pytest
 
+# pylint: disable=wrong-import-position
+# flake8: noqa: E402,E501
+pytest.importorskip(
+    "qoder_agent_sdk",
+    reason=(
+        "importing qwenpaw.harnesses.qoder eagerly imports the optional "
+        "qoder_agent_sdk (qoder extra)"
+    ),
+)
+
 from qwenpaw.harnesses.qoder.discovery import (
     default_install_candidates,
     resolve_qoder_binary_info,

--- a/tests/unit/harnesses/test_qoder_event_mapper.py
+++ b/tests/unit/harnesses/test_qoder_event_mapper.py
@@ -3,6 +3,15 @@
 
 from __future__ import annotations
 
+import pytest
+
+# pylint: disable=wrong-import-position
+# flake8: noqa: E402,E501
+pytest.importorskip(
+    "qoder_agent_sdk",
+    reason="optional qoder_agent_sdk (qoder extra) is required",
+)
+
 from qoder_agent_sdk import (
     AssistantMessage,
     ResultMessage,


### PR DESCRIPTION
> **Submitted by**: 秦琼·CIOps@QPQAT

> **Plain-language summary**: This PR addresses the risk of "tests being silently skipped". In short: when an optional dependency (qoder SDK) is not installed, pytest collection aborts with an error; to work around the error, runners ignore the entire test directory — as a result, other valid tests in that directory are also quietly skipped, CI looks green but actually ran fewer tests. The fix is simple: add one line of `pytest.importorskip` so that when the dependency is missing, these tests are explicitly marked as "skipped" (countable and traceable) instead of making the entire directory disappear. No impact on CI — the CI environment has the SDK installed, so these tests run normally.

### Summary

Guard the three qoder harness unit-test files with
`pytest.importorskip("qoder_agent_sdk")` so that environments without
the optional `qoder` extra get an explicit, countable skip instead of
an aborted collection.

### Problem

`tests/unit/harnesses/test_qoder_adapter.py` and
`test_qoder_event_mapper.py` import `qoder_agent_sdk` at module level,
and `test_qoder_discovery.py` imports
`qwenpaw.harnesses.qoder.discovery`, whose package `__init__` eagerly
imports the adapter (and therefore the SDK). In any environment where
the optional SDK is not installed, collecting `tests/unit` aborts:

```text
ModuleNotFoundError: No module named 'qoder_agent_sdk'
!!! Interrupted: 1 error during collection !!!
```

Runners then resort to `--ignore tests/unit/harnesses`, which silently
hides every other test in that directory — a coverage blind spot.

### Fix

Add the same `pytest.importorskip` guard already used for the
openai / langfuse / acp optional-dependency tests (6+ existing call
sites). With the guard, a missing SDK yields `skipped` results that
remain visible and countable; with the SDK installed, nothing changes.

### CI impact: none

`tests.yml` and `full-tests-nightly.yml` install `.[dev,test,full]`;
the `test` extra has included `qoder-agent-sdk==1.0.9` since #6397, so
the guard never triggers in CI. Verified twice:

- nightly run 31207395095 (2026-08-07): all 26 qoder harness cases
  (adapter 16, event_mapper 4, discovery 6) PASSED on the unit-test
  matrix.
- fork PR yutai78786/QwenPaw#40, run 31369849732 (2026-08-10): 26/26
  PASSED, 0 skipped, on every unit-test platform (py3.11
  ubuntu/macos/windows and py3.13 ubuntu).

### Testing

- pre-commit with repo-pinned versions (black 23.3.0, flake8,
  pylint 3.0.2): clean, zero new findings.
- Mechanism proof (pytest 9.1.1, same major as CI): with the guard and
  the SDK absent, collection reports "1 skipped" and exits 0; without
  the guard, collection aborts with "Interrupted: 1 error during
  collection".
- Full CI matrix on fork PR yutai78786/QwenPaw#40 (see run above).