### PR TITLE
fix(xiaoyi): hide scroll headlines in messages

### DIFF
--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -1369,9 +1369,8 @@ class XiaoYiChannel(BaseChannel):
         - kind="reasoningText": For thinking/reasoning content
         - kind="text": For regular text content
         """
-        from ....schemas import (
-            MessageType,
-        )
+        from ....agents.context.scroll.serialize import strip_headline
+        from ....schemas import MessageType
 
         msg_type = getattr(message, "type", None)
         content = getattr(message, "content", None) or []
@@ -1383,7 +1382,7 @@ class XiaoYiChannel(BaseChannel):
             if not self._display_config.show_thinking:
                 return [], []
             for c in content:
-                text = getattr(c, "text", None)
+                text = strip_headline(getattr(c, "text", None))
                 if text:
                     # Add newline separator for each thinking content
                     parts.append(
@@ -1439,7 +1438,9 @@ class XiaoYiChannel(BaseChannel):
                                 isinstance(block, dict)
                                 and block.get("type") == "thinking"
                             ):
-                                thinking_text = block.get("thinking", "")
+                                thinking_text = strip_headline(
+                                    block.get("thinking", ""),
+                                )
                                 if thinking_text:
                                     # Add newline separator
                                     parts.append(
@@ -1453,7 +1454,13 @@ class XiaoYiChannel(BaseChannel):
             # Handle TEXT type (regular message content)
             # Add leading newline to separate from previous content
             if ctype == ContentType.TEXT and getattr(c, "text", None):
-                text = c.text
+                # XiaoYi formats normal text itself instead of going through
+                # MessageRenderer, so clean Scroll's display-only retrieval
+                # headline here as well. The original event remains intact for
+                # durable history and indexing.
+                text = strip_headline(c.text)
+                if not text:
+                    continue
                 # Add leading newlines if not already present
                 if not text.startswith("\n"):
                     text = "\n\n" + text

--- a/tests/unit/channels/test_xiaoyi.py
+++ b/tests/unit/channels/test_xiaoyi.py
@@ -1120,6 +1120,35 @@ class TestXiaoYiChannelPartsExtraction:
         assert result[0]["kind"] == "text"
         assert "\n\nHello World" in result[0]["text"]
 
+    @pytest.mark.parametrize(
+        "headline",
+        [
+            "⟦ 当前格式的内部检索标题 ⟧",
+            "<!-- ⟦ 旧格式的内部检索标题 ⟧ -->",
+        ],
+    )
+    def test_extract_xiaoyi_parts_hides_scroll_headline(
+        self,
+        xiaoyi_channel,
+        headline,
+    ):
+        """XiaoYi must not expose Scroll's display-only headline."""
+        from qwenpaw.schemas import ContentType, TextContent
+
+        mock_message = MagicMock()
+        mock_message.type = "message"
+        mock_message.content = [
+            TextContent(
+                type=ContentType.TEXT,
+                text=f"正常答复\n{headline}",
+            ),
+        ]
+
+        result, media = xiaoyi_channel._extract_xiaoyi_parts(mock_message)
+
+        assert media == []
+        assert result == [{"kind": "text", "text": "\n\n正常答复"}]
+
     def test_extract_xiaoyi_parts_empty_content(self, xiaoyi_channel):
         """_extract_xiaoyi_parts should handle empty content."""
         mock_message = MagicMock()


### PR DESCRIPTION
## Description

Prevent XiaoYi mobile clients from displaying Scroll's internal retrieval headlines.

XiaoYi formats regular and reasoning text through its own extraction path, bypassing the shared `MessageRenderer` cleanup. Apply `strip_headline()` before constructing XiaoYi message parts while preserving the original event for durable history and Scroll indexing.

Both formats are supported:

- Current: `⟦ … ⟧`
- Legacy: `<!-- ⟦ … ⟧ -->`

**Related Issue:** N/A

**Security Considerations:** No security impact.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Added a parameterized XiaoYi regression test covering both current and legacy headline formats.

```bash
.venv/bin/python -m pytest \
  tests/unit/channels/test_xiaoyi.py \
  tests/unit/agents/context/test_serialize.py -q