### PR TITLE
fix(console): preserve textarea target for IME events

### DIFF
--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import RichFileReferenceInput, {
   RichFileReferenceInputProvider,
@@ -72,6 +78,34 @@ describe("RichFileReferenceInput", () => {
       container.querySelector('[contenteditable="true"]'),
     ).toHaveTextContent("");
     expect(container.querySelector("textarea")).toHaveValue("");
+  });
+
+  it("forwards IME composition events with the hidden textarea target", async () => {
+    const observedLengths: number[] = [];
+    const { container } = render(
+      <RichFileReferenceInputProvider onOpenReference={vi.fn()}>
+        <RichFileReferenceInput
+          value="中文"
+          onChange={vi.fn()}
+          onCompositionEnd={(event) => {
+            const target = event.target as HTMLTextAreaElement;
+            observedLengths.push(
+              target.value.length,
+              event.currentTarget.value.length,
+            );
+          }}
+        />
+      </RichFileReferenceInputProvider>,
+    );
+    const editor = container.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement;
+
+    await act(async () => {
+      fireEvent.compositionEnd(editor, { data: "文" });
+    });
+
+    expect(observedLengths).toEqual([2, 2]);
   });
 
   it("turns a whole-line Monaco paste into an atomic line reference", async () => {

--- a/console/src/pages/Chat/RichFileReferenceInput.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.tsx
@@ -563,13 +563,34 @@ function EditorPastePlugin({
   return null;
 }
 
+function retargetCompositionEvent(
+  event: CompositionEvent<HTMLElement>,
+  textarea: HTMLTextAreaElement | null,
+): CompositionEvent<HTMLTextAreaElement> {
+  if (!textarea) {
+    return event as unknown as CompositionEvent<HTMLTextAreaElement>;
+  }
+
+  return new Proxy(event, {
+    get(target, property) {
+      if (property === "target" || property === "currentTarget") {
+        return textarea;
+      }
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as CompositionEvent<HTMLTextAreaElement>;
+}
+
 function EditableSurface({
+  textareaRef,
   onKeyDown,
   onFocus,
   onBlur,
   onCompositionStart,
   onCompositionEnd,
 }: {
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   onKeyDown?: TextAreaProps["onKeyDown"];
   onFocus?: TextAreaProps["onFocus"];
   onBlur?: TextAreaProps["onBlur"];
@@ -595,13 +616,11 @@ function EditableSurface({
       }
       onCompositionStart={(event) =>
         onCompositionStart?.(
-          event as unknown as CompositionEvent<HTMLTextAreaElement>,
+          retargetCompositionEvent(event, textareaRef.current),
         )
       }
       onCompositionEnd={(event) =>
-        onCompositionEnd?.(
-          event as unknown as CompositionEvent<HTMLTextAreaElement>,
-        )
+        onCompositionEnd?.(retargetCompositionEvent(event, textareaRef.current))
       }
     />
   );
@@ -681,6 +700,7 @@ const RichFileReferenceInput = forwardRef<unknown, TextAreaProps>(
           <PlainTextPlugin
             contentEditable={
               <EditableSurface
+                textareaRef={hiddenTextarea}
                 onKeyDown={onKeyDown}
                 onFocus={onFocus}
                 onBlur={onBlur}


### PR DESCRIPTION
## Description

Fixes #6885.

`RichFileReferenceInput` replaces the Sender textarea with a Lexical
`contenteditable`, but it forwarded Lexical composition events while exposing
textarea callback types. The shared Sender's `maxLength` path reads
`event.target.value.length` on `compositionEnd`; the actual target was a `div`,
so Chinese IME input could throw while an agent was running.

This change retargets composition start/end callbacks to the synchronized hidden
textarea. A proxy preserves the original React SyntheticEvent behavior while
presenting the textarea-compatible `target` and `currentTarget` contract. The
fix lives in the shared rich-input adapter, so it covers queued and normal Sender
flows rather than adding queue-specific handling.

**Related Issue:** Fixes #6885

**Security Considerations:** None. This only adapts frontend event forwarding;
it does not change input sanitization, storage, transport, or authorization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed: no user-facing API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This does not change a channel implementation or delivery
contract.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Added a CJK `compositionEnd` regression that reads both
  `event.target.value.length` and `event.currentTarget.value.length`, matching
  the downstream Sender contract that previously crashed.
- Rich input tests: 5/5 passed.
- Chat tests: 20 files, 190/190 passed.
- Full Console run with four workers: 222/223 files and 1686/1687 tests passed;
  one unrelated `SessionProjectDirectory` test hit its 5-second timeout. The
  complete file passed immediately in isolation (7/7), and it also passed in
  the earlier single-worker rerun of all timeout files (37/37).
- TypeScript/Prettier checks, production build, Monaco CSS verification, and
  repository-wide pre-commit all passed.

### Verification Matrix

- CJK IME composition callback: covered
- Sender `maxLength` target access: covered
- Queued and normal chat flows: covered by shared adapter
- Existing rich chips and paste behavior: unchanged; focused and Chat suites pass
- Backend, providers, and channels: not applicable
- Visual layout: unchanged; screenshot not applicable

## Evidence

```text
$ npm run test:run -- src/pages/Chat/RichFileReferenceInput.test.tsx --reporter=dot
Test Files  1 passed (1)
Tests       5 passed (5)

$ npm run test:run -- src/pages/Chat --reporter=dot
Test Files  20 passed (20)
Tests       190 passed (190)

$ npm run test:run -- --reporter=dot --maxWorkers=4
Test Files  1 failed | 222 passed (223)
Tests       1 failed | 1686 passed (1687)
# Only failure: unrelated SessionProjectDirectory 5-second timeout

$ npm run test:run -- src/features/project-directory/SessionProjectDirectory.test.tsx --reporter=dot --maxWorkers=1
Test Files  1 passed (1)
Tests       7 passed (7)

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ NODE_OPTIONS=--max-old-space-size=8192 npm run build
vite: built in 2m 11s
[verify-monaco-css] OK - Monaco stylesheet present in 35 CSS file(s).

$ pre-commit run --all-files
check python ast ... Passed
detect private key ... Passed
mypy ... Passed
black ... Passed
flake8 ... Passed
pylint ... Passed
prettier ... Passed
Lint GitHub Actions workflow files ... Passed
```

## Additional Notes

The adapter still emits the original composition event data and methods; only
the textarea-specific target fields are retargeted. No dependencies or generated
assets are included.
