### PR TITLE
fix(console): preserve long multiline tool output

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
@@ -13,8 +13,8 @@ vi.mock("./ToolCallSessionContext", () => ({
 vi.mock("../../../../hooks/useToolCallControl", () => ({
   useToolCallControl: () => ({
     bannerVisible: false,
-    offloadRemaining: null,
-    killRemaining: null,
+    offloadRemaining: 12,
+    killRemaining: 30,
     defaultPolicy: "keep_foreground",
     maxInternalTimeoutSecs: null,
     elapsed: 0,
@@ -38,6 +38,12 @@ const content: ToolCallContent = {
   params: {},
   result: "output",
   status: "done",
+};
+
+const runningContent: ToolCallContent = {
+  ...content,
+  params: { command: "python verbose_script.py" },
+  status: "calling",
 };
 
 describe("ToolCardShell lazy body", () => {
@@ -124,5 +130,22 @@ describe("ToolCardShell lazy body", () => {
     details!.open = false;
     fireEvent(details!, new Event("toggle"));
     expect(screen.getByText("Expensive output")).toBeInTheDocument();
+  });
+
+  it("groups Parameters and Runtime in one metadata panel", () => {
+    const { container } = render(
+      <ToolCardShell
+        content={runningContent}
+        icon={<span />}
+        title="Shell"
+        isStreaming
+        defaultExpanded
+      />,
+    );
+
+    const metadata = container.querySelector('[class*="toolCallMetadata"]');
+    expect(metadata).not.toBeNull();
+    expect(metadata).toHaveTextContent("Parameters");
+    expect(metadata).toHaveTextContent("Runtime");
   });
 });

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -211,11 +211,15 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
                   content={inputPreview}
                 />
               )}
-              {isLoading && staticMetadata && (
-                <DefaultBlock title="Parameters" content={staticMetadata} />
-              )}
-              {isLoading && dynamicMetadata && (
-                <DefaultBlock title="Runtime" content={dynamicMetadata} />
+              {isLoading && (staticMetadata || dynamicMetadata) && (
+                <div className={styles.toolCallMetadata}>
+                  {staticMetadata && (
+                    <DefaultBlock title="Parameters" content={staticMetadata} />
+                  )}
+                  {dynamicMetadata && (
+                    <DefaultBlock title="Runtime" content={dynamicMetadata} />
+                  )}
+                </div>
               )}
               {children}
             </>

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.less
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.less
@@ -8,6 +8,20 @@
   max-width: 100%;
 }
 
+.toolCallMetadata {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  margin: 4px 0;
+  box-sizing: border-box;
+}
+
+.toolCallMetadata > .defaultBlock {
+  margin: 0;
+}
+
 // Tool call — compact single-line (click to expand)
 .toolCallCompact {
   margin: 2px 0;

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.test.ts
@@ -40,4 +40,14 @@ describe("Tool card layout styles", () => {
     expect(rule).toMatch(/text-overflow:\s*ellipsis/);
     expect(rule).toMatch(/white-space:\s*nowrap/);
   });
+
+  it("uses a consistent grid gap for tool metadata panels", () => {
+    const rule = readRule(".toolCallMetadata");
+
+    expect(rule).not.toBe("");
+    expect(rule).toMatch(/display:\s*grid/);
+    expect(rule).toMatch(/gap:\s*6px/);
+    expect(rule).toMatch(/min-width:\s*0/);
+    expect(rule).toMatch(/max-width:\s*100%/);
+  });
 });

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -317,6 +317,38 @@
   }
 }
 
+/* Fix #6852: Preserve source newlines for the vendor Raw fallback and for
+ * leaf text blocks produced by XMarkdown. Applying pre-wrap to the Markdown
+ * root also renders inter-block whitespace and caused the #5596 regression.
+ * Keep code blocks and tables bounded with their own horizontal scroll.
+ */
+.chatMessagesArea :global {
+  [class*="bubble-start"] [class*="markdown"]:not(.x-markdown),
+  [class*="bubble-assistant"] [class*="markdown"]:not(.x-markdown),
+  [class*="bubble-start"] .x-markdown p,
+  [class*="bubble-start"] .x-markdown li,
+  [class*="bubble-assistant"] .x-markdown p,
+  [class*="bubble-assistant"] .x-markdown li {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  [class*="bubble-start"] .x-markdown pre,
+  [class*="bubble-start"] .x-markdown table,
+  [class*="bubble-assistant"] .x-markdown pre,
+  [class*="bubble-assistant"] .x-markdown table {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  [class*="bubble-start"] .x-markdown pre,
+  [class*="bubble-assistant"] .x-markdown pre {
+    white-space: pre;
+  }
+}
+/* End #6852 */
+
 /* Fix #6583: Keep enough attachment cards visible to verify a multi-file
  * selection, while bounding very large drops to three scrollable rows. */
 .chatMessagesArea :global {

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -24,6 +24,24 @@ describe("Chat message markdown layout styles", () => {
     expect(rule).toMatch(/min-width:\s*0/);
     expect(rule).toMatch(/max-width:\s*100%/);
   });
+
+  it("preserves multiline output without spacing normal markdown blocks", () => {
+    const marker = "Fix #6852";
+    const markerIndex = stylesSource.indexOf(marker);
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("/* End #6852 */", markerIndex),
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toContain('[class*="markdown"]:not(.x-markdown)');
+    expect(rule).toContain(".x-markdown p");
+    expect(rule).toContain(".x-markdown li");
+    expect(rule).toMatch(/white-space:\s*pre-wrap/);
+    expect(rule).toMatch(/overflow-wrap:\s*anywhere/);
+    expect(rule).toMatch(/overflow-x:\s*auto/);
+    expect(rule).toMatch(/max-width:\s*100%/);
+  });
 });
 
 describe("Chat attachment preview styles", () => {


### PR DESCRIPTION
## Summary

Fixes #6852 by improving the rendering of long multi-line assistant and tool output.

- Preserve source line breaks for raw fallback content and Markdown paragraph/list blocks.
- Avoid reintroducing the extra blank-line regression from #5596.
- Keep wide code blocks and tables contained with local horizontal scrolling.
- Group Parameters and Runtime panels in a consistent 6px grid layout.
- Add regression coverage for multiline rendering and tool metadata spacing.

## Verification

- `npm run test:run`: 223 test files, 1687 tests passed.
- `npm run build`: passed.
- Visually verified at desktop, 375px mobile, and landscape widths with no page-level horizontal overflow.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
