### PR TITLE
feat(computer-use): improve native input workflows

### DIFF
--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -88,7 +88,7 @@ core-foundation = { version = "0.10", features = ["link"] }
 # `highsierra` gates the non-variadic scroll-event constructor, which is the
 # only way to synthesise a scroll without hand-writing variadic FFI. It gates
 # nothing else.
-core-graphics = { version = "0.24", features = ["link", "highsierra"] }
+core-graphics = { version = "0.24", features = ["link", "highsierra", "elcapitan"] }
 accessibility = "0.2"
 accessibility-sys = "0.2"
 jpeg-encoder = "0.6"

--- a/console/src-tauri/src/computer_use_runtime.rs
+++ b/console/src-tauri/src/computer_use_runtime.rs
@@ -5,6 +5,8 @@
 //! spawn flag remain Windows specific (macOS relies on the helper's own
 //! parent-death watch for reaping).
 
+#[cfg(target_os = "macos")]
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -51,8 +53,6 @@ const CONTROL_MAX_MESSAGE_BYTES: usize = 4096;
 #[cfg(not(all(not(debug_assertions), target_os = "macos")))]
 const HELPER_READY_PREFIX: &str = "QWENPAW_COMPUTER_USE_READY ";
 const HELPER_READY_TIMEOUT: Duration = Duration::from_secs(8);
-#[cfg(target_os = "macos")]
-const FOCUS_LEASE_IDLE_TIMEOUT: Duration = Duration::from_secs(12);
 const CONTROL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(not(all(not(debug_assertions), target_os = "macos")))]
 const MAX_CAPTURED_HELPER_STDERR_CHARS: usize = 4096;
@@ -76,15 +76,9 @@ struct RuntimeInner {
     capability: Option<RuntimeCapability>,
     helper_pid: Option<u32>,
     #[cfg(target_os = "macos")]
-    focus_lease: Option<FocusLease>,
-}
-
-#[cfg(target_os = "macos")]
-struct FocusLease {
-    id: String,
-    helper_pid: u32,
-    host_was_visible: bool,
-    expires_at: Instant,
+    focus_leases: HashSet<String>,
+    #[cfg(target_os = "macos")]
+    restore_host_after_focus: bool,
 }
 
 #[derive(Clone)]
@@ -106,8 +100,6 @@ struct ControlRequest {
     action: String,
     #[serde(default)]
     helper_pid: Option<u32>,
-    #[serde(default)]
-    target_pid: Option<i32>,
     #[serde(default)]
     lease_id: Option<String>,
 }
@@ -226,8 +218,8 @@ pub(crate) fn ensure(app: &tauri::AppHandle) -> Result<(), String> {
                 log::warn!("[computer-use] helper exited before next acquire: {status}");
                 inner.helper_pid.take();
                 #[cfg(target_os = "macos")]
-                if let Some(lease) = inner.focus_lease.take() {
-                    release_focus_lease(app, lease);
+                if clear_focus_leases(&mut inner) {
+                    show_host_window(app);
                 }
             }
             Err(error) => {
@@ -757,12 +749,12 @@ fn stop_helper(app: &tauri::AppHandle) -> Result<(), String> {
     let capability = inner.capability.take();
     let helper_pid = inner.helper_pid.take();
     #[cfg(target_os = "macos")]
-    let focus_lease = inner.focus_lease.take();
+    let restore_host = clear_focus_leases(&mut inner);
     drop(inner);
 
     #[cfg(target_os = "macos")]
-    if let Some(lease) = focus_lease {
-        release_focus_lease(app, lease);
+    if restore_host {
+        show_host_window(app);
     }
 
     if let Some(mut child) = child {
@@ -962,28 +954,19 @@ fn cleanup_endpoint(endpoint: &str) {
 fn begin_focus_lease(
     app: &tauri::AppHandle,
     helper_pid: u32,
-    _target_pid: i32,
+    lease_id: &str,
 ) -> Result<String, &'static str> {
-    expire_focus_lease(app);
     let state = app.state::<ComputerUseRuntimeState>();
-    let stale_lease = {
-        let mut inner = state.inner.lock().map_err(|_| "runtime_unavailable")?;
+    {
+        let inner = state.inner.lock().map_err(|_| "runtime_unavailable")?;
         if inner.helper_pid != Some(helper_pid) || inner.child.is_none() {
             return Err("stale_helper");
         }
-        if inner
-            .focus_lease
-            .as_ref()
-            .is_some_and(|lease| lease.helper_pid != helper_pid)
-        {
-            inner.focus_lease.take()
-        } else {
-            None
+        // The helper supplies the identifier, so retrying a control request
+        // after a lost response cannot create an assertion that no turn owns.
+        if inner.focus_leases.contains(lease_id) {
+            return Ok(lease_id.to_string());
         }
-    };
-    if let Some(lease) = stale_lease {
-        log::warn!("[computer-use] releasing a stale foreground lease");
-        release_focus_lease(app, lease);
     }
 
     let window = app.get_webview_window("main");
@@ -1021,22 +1004,9 @@ fn begin_focus_lease(
             return Err("runtime_unavailable");
         }
     };
-    if let Some(lease) = inner.focus_lease.as_mut() {
-        // begin_focus is idempotent for the managed helper. Keeping one lease
-        // across adjacent actions preserves transient UI state such as an
-        // inline editor, and also makes a lost control response safe to retry.
-        lease.host_was_visible |= host_is_visible;
-        lease.expires_at = Instant::now() + FOCUS_LEASE_IDLE_TIMEOUT;
-        return Ok(lease.id.clone());
-    }
-    let id = random_hex(16);
-    inner.focus_lease = Some(FocusLease {
-        id: id.clone(),
-        helper_pid,
-        host_was_visible: host_is_visible,
-        expires_at: Instant::now() + FOCUS_LEASE_IDLE_TIMEOUT,
-    });
-    Ok(id)
+    inner.restore_host_after_focus |= host_is_visible;
+    inner.focus_leases.insert(lease_id.to_string());
+    Ok(lease_id.to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -1047,41 +1017,25 @@ fn end_focus_lease(
 ) -> Result<(), &'static str> {
     let state = app.state::<ComputerUseRuntimeState>();
     let mut inner = state.inner.lock().map_err(|_| "runtime_unavailable")?;
-    let Some(lease) = inner.focus_lease.as_mut() else {
-        return Ok(());
-    };
-    if lease.helper_pid != helper_pid || lease.id != lease_id {
-        return Err("stale_lease");
+    if inner.helper_pid != Some(helper_pid) || inner.child.is_none() {
+        return Err("stale_helper");
     }
-    // Drop marks the end of one native action, not the end of the whole
-    // interaction. Keep the host hidden until the lease goes idle so adjacent
-    // actions preserve transient target state such as a menu or inline editor.
-    lease.expires_at = Instant::now() + FOCUS_LEASE_IDLE_TIMEOUT;
+    inner.focus_leases.remove(lease_id);
+    let restore_host = inner.focus_leases.is_empty() && inner.restore_host_after_focus;
+    if restore_host {
+        inner.restore_host_after_focus = false;
+    }
+    drop(inner);
+    if restore_host {
+        show_host_window(app);
+    }
     Ok(())
 }
 
 #[cfg(target_os = "macos")]
-fn expire_focus_lease(app: &tauri::AppHandle) {
-    let state = app.state::<ComputerUseRuntimeState>();
-    let lease = state.inner.lock().ok().and_then(|mut inner| {
-        inner
-            .focus_lease
-            .as_ref()
-            .is_some_and(|lease| Instant::now() >= lease.expires_at)
-            .then(|| inner.focus_lease.take())
-            .flatten()
-    });
-    if let Some(lease) = lease {
-        log::debug!("[computer-use] releasing idle foreground lease");
-        release_focus_lease(app, lease);
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn release_focus_lease(app: &tauri::AppHandle, lease: FocusLease) {
-    if lease.host_was_visible {
-        show_host_window(app);
-    }
+fn clear_focus_leases(inner: &mut RuntimeInner) -> bool {
+    inner.focus_leases.clear();
+    std::mem::take(&mut inner.restore_host_after_focus)
 }
 
 #[cfg(target_os = "macos")]
@@ -1105,21 +1059,21 @@ fn reap_exited_helper(app: &tauri::AppHandle) {
         inner.child.take();
         inner.helper_pid.take();
         #[cfg(target_os = "macos")]
-        let focus_lease = inner.focus_lease.take();
+        let restore_host = clear_focus_leases(&mut inner);
         #[cfg(not(target_os = "macos"))]
-        let focus_lease = ();
-        Some((status, capability, focus_lease))
+        let restore_host = ();
+        Some((status, capability, restore_host))
     });
-    let Some((status, capability, focus_lease)) = reaped else {
+    let Some((status, capability, restore_host)) = reaped else {
         return;
     };
     log::warn!("[computer-use] helper exited: {status}");
     #[cfg(target_os = "macos")]
-    if let Some(lease) = focus_lease {
-        release_focus_lease(app, lease);
+    if restore_host {
+        show_host_window(app);
     }
     #[cfg(not(target_os = "macos"))]
-    let _ = focus_lease;
+    let _ = restore_host;
     if let Some(capability) = capability {
         cleanup_endpoint(&capability.pipe_name);
     }
@@ -1133,8 +1087,6 @@ fn serve_control(
 ) {
     while !stop.load(Ordering::Acquire) {
         reap_exited_helper(&app);
-        #[cfg(target_os = "macos")]
-        expire_focus_lease(&app);
         match listener.accept() {
             Ok((stream, address)) if address.ip().is_loopback() => {
                 if let Err(err) = serve_control_connection(stream, &app, &token) {
@@ -1179,9 +1131,9 @@ fn serve_control_connection(
                 }
             },
             #[cfg(target_os = "macos")]
-            "begin_focus" => match (request.helper_pid, request.target_pid) {
-                (Some(helper_pid), Some(target_pid)) if target_pid > 0 => {
-                    match begin_focus_lease(app, helper_pid, target_pid) {
+            "begin_focus" => match (request.helper_pid, request.lease_id.as_deref()) {
+                (Some(helper_pid), Some(lease_id)) if !lease_id.is_empty() => {
+                    match begin_focus_lease(app, helper_pid, lease_id) {
                         Ok(lease_id) => ControlResponse::lease(lease_id),
                         Err(error) => ControlResponse::error(error),
                     }

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -13,14 +13,17 @@ use std::sync::Mutex;
 
 use super::app_identity::{launch_at, resolve_launch_target};
 use super::approval::request_approval;
-use super::state::{Observation, PendingAction, ServerState, WindowInfo, INPUT_GUARD_GRACE_MS};
-#[cfg(target_os = "macos")]
-use super::target_is_frontmost;
+use super::state::{
+    accessibility_revision, Observation, PendingAction, ServerState, WindowInfo,
+    INPUT_GUARD_GRACE_MS,
+};
 use super::{
     click, close_window, desktop_locked, drag, ensure_permissions, input_sequence, invoke_element,
     last_input_age_ms, list_apps, list_windows, observe_window, press_key, resolve_window, scroll,
     set_value, type_text, validate_observation, InputStep, PROTOCOL_VERSION,
 };
+#[cfg(target_os = "macos")]
+use super::{element_requires_frontmost, target_is_frontmost};
 
 const MAX_SEQUENCE_STEPS: usize = 20;
 const MAX_SEQUENCE_TEXT_CHARS: usize = 512;
@@ -218,15 +221,24 @@ pub(super) fn dispatch_request(
     // Mutations are serialized across agent sessions. Human input is a
     // separate concern: this lock cannot prevent it, so only operations that
     // actually require foreground input apply the recent-input guard below.
+    let mut needs_user_idle = requires_user_idle(method, &window);
+    #[cfg(target_os = "macos")]
+    if method == "invoke_element" {
+        needs_user_idle |=
+            element_requires_frontmost(observation(state, observation_id)?, &params)?;
+    }
     let _desktop = if changes_window_state(method) {
         let held = take_desktop()?;
-        if requires_user_idle(method, &window) {
+        if needs_user_idle {
             enforce_input_guard(state)?;
         }
         Some(held)
     } else {
         None
     };
+    if needs_user_idle {
+        state.ensure_interaction_session()?;
+    }
     // Approval may wait for user input, so freshness must be checked only
     // after approval and the desktop guard, immediately before the action.
     if requires_stable_observation(method) {
@@ -241,6 +253,9 @@ pub(super) fn dispatch_request(
             "requires_observe": true,
         }));
     }
+    let previous_revision = observation_id
+        .and_then(|id| state.observations.get(id))
+        .and_then(|observation| observation.accessibility_revision);
     let mut pending_action: Option<PendingAction> = None;
     let mut completed_pending_action = false;
     let mut result = match method {
@@ -299,7 +314,7 @@ pub(super) fn dispatch_request(
     if !changes_window_state(method) {
         return Ok(result);
     }
-    state.note_action(window.hwnd);
+    state.note_action(&window);
     if completed_pending_action {
         state.clear_pending_action();
     }
@@ -318,7 +333,8 @@ pub(super) fn dispatch_request(
         refresh_after_action(state, &window)
     };
     let has_refreshed_observation = refreshed.is_some();
-    let mut response = action_receipt(result, refreshed);
+    let changed = accessibility_changed(previous_revision, refreshed.as_ref());
+    let mut response = action_receipt(result, refreshed, changed);
     if let Some(pending) = state.pending_action().filter(|pending| {
         should_attach_pending_action(has_refreshed_observation, pending.hwnd, window.hwnd)
     }) {
@@ -447,7 +463,18 @@ fn should_attach_pending_action(
 /// Combine the dispatch result with the post-action observation when the
 /// original window remains available. The old observation is never restored:
 /// only the new identifier in this response can authorize the next action.
-fn action_receipt(mut result: Value, refreshed: Option<Value>) -> Value {
+fn accessibility_changed(previous: Option<[u8; 32]>, refreshed: Option<&Value>) -> Option<bool> {
+    let current = refreshed?
+        .get("accessibility")
+        .and_then(accessibility_revision)?;
+    Some(previous? != current)
+}
+
+fn action_receipt(
+    mut result: Value,
+    refreshed: Option<Value>,
+    accessibility_changed: Option<bool>,
+) -> Value {
     let Some(mut observation) = refreshed else {
         if let Some(object) = result.as_object_mut() {
             if object.remove("applied").is_some() {
@@ -471,6 +498,9 @@ fn action_receipt(mut result: Value, refreshed: Option<Value>) -> Value {
     action.remove("next_action");
     if let Some(response) = observation.as_object_mut() {
         response.extend(std::mem::take(action));
+        if let Some(changed) = accessibility_changed {
+            response.insert("accessibility_changed".to_string(), json!(changed));
+        }
     }
     observation
 }
@@ -642,11 +672,50 @@ mod tests {
 
     #[test]
     fn an_action_without_a_refresh_requires_window_discovery() {
-        let result = action_receipt(json!({"applied": true}), None);
+        let result = action_receipt(json!({"applied": true}), None, None);
 
         assert_eq!(result.get("dispatched"), Some(&json!(true)));
         assert_eq!(result.get("requires_observe"), Some(&json!(true)));
         assert_eq!(result.get("next_action"), Some(&json!("list_windows")));
+    }
+
+    #[test]
+    fn refreshed_actions_report_accessibility_changes() {
+        let before = accessibility_revision(&json!({
+            "available": true,
+            "elements": ["before"],
+        }));
+        let refreshed = json!({
+            "accessibility": {
+                "available": true,
+                "elements": ["after"],
+            },
+        });
+
+        assert_eq!(accessibility_changed(before, Some(&refreshed)), Some(true));
+        assert_eq!(
+            accessibility_changed(
+                accessibility_revision(&refreshed["accessibility"]),
+                Some(&refreshed),
+            ),
+            Some(false),
+        );
+    }
+
+    #[test]
+    fn unavailable_accessibility_has_no_change_claim() {
+        let before = accessibility_revision(&json!({
+            "available": true,
+            "elements": ["before"],
+        }));
+        let refreshed = json!({
+            "accessibility": {
+                "available": false,
+                "elements": [],
+            },
+        });
+
+        assert_eq!(accessibility_changed(before, Some(&refreshed)), None);
     }
 
     #[test]

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -259,7 +259,7 @@ pub(super) fn dispatch_request(
         .and_then(|id| state.observations.get(id))
         .and_then(|observation| observation.accessibility_revision);
     #[cfg(target_os = "macos")]
-    let transient_text_candidate = matches!(method, "click" | "invoke_element")
+    let transient_text_candidate = requests_transient_text(method, &params)
         && element_is_transient_menu_item(observation(state, observation_id)?, &params)?;
     let mut pending_action: Option<PendingAction> = None;
     let mut completed_pending_action = false;
@@ -395,6 +395,12 @@ fn mark_transient_text_ready(state: &mut ServerState, refreshed: Option<&Value>)
     };
     observation.transient_text_ready = true;
     true
+}
+
+#[cfg(target_os = "macos")]
+fn requests_transient_text(method: &str, params: &serde_json::Map<String, Value>) -> bool {
+    method == "invoke_element"
+        && params.get("expects_text_input").and_then(Value::as_bool) == Some(true)
 }
 
 /// Observe the action's target without turning an already-dispatched action
@@ -725,6 +731,29 @@ mod tests {
         assert!(!take_transient_text_ready(&mut state, Some("other")).unwrap());
         assert!(take_transient_text_ready(&mut state, Some("observed")).unwrap());
         assert!(!take_transient_text_ready(&mut state, Some("observed")).unwrap());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn only_explicit_text_edit_invocation_requests_transient_input() {
+        let ordinary = json!({"element_id": "ax-1"});
+        let text_edit = json!({
+            "element_id": "ax-1",
+            "expects_text_input": true,
+        });
+
+        assert!(!requests_transient_text(
+            "invoke_element",
+            ordinary.as_object().unwrap(),
+        ));
+        assert!(!requests_transient_text(
+            "click",
+            text_edit.as_object().unwrap(),
+        ));
+        assert!(requests_transient_text(
+            "invoke_element",
+            text_edit.as_object().unwrap(),
+        ));
     }
 
     #[test]

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -13,6 +13,8 @@ use std::sync::Mutex;
 
 use super::app_identity::{launch_at, resolve_launch_target};
 use super::approval::request_approval;
+#[cfg(target_os = "macos")]
+use super::platform_macos::element_is_transient_menu_item;
 use super::state::{
     accessibility_revision, Observation, PendingAction, ServerState, WindowInfo,
     INPUT_GUARD_GRACE_MS,
@@ -256,6 +258,9 @@ pub(super) fn dispatch_request(
     let previous_revision = observation_id
         .and_then(|id| state.observations.get(id))
         .and_then(|observation| observation.accessibility_revision);
+    #[cfg(target_os = "macos")]
+    let transient_text_candidate = matches!(method, "click" | "invoke_element")
+        && element_is_transient_menu_item(observation(state, observation_id)?, &params)?;
     let mut pending_action: Option<PendingAction> = None;
     let mut completed_pending_action = false;
     let mut result = match method {
@@ -282,7 +287,21 @@ pub(super) fn dispatch_request(
             }
             result
         }
-        "type_text" => type_text(observation(state, observation_id)?, &params),
+        "type_text" => {
+            #[cfg(target_os = "macos")]
+            {
+                let transient_text_ready = take_transient_text_ready(state, observation_id)?;
+                type_text(
+                    observation(state, observation_id)?,
+                    &params,
+                    transient_text_ready,
+                )
+            }
+            #[cfg(windows)]
+            {
+                type_text(observation(state, observation_id)?, &params)
+            }
+        }
         "invoke_element" => {
             let pending = state.pending_action();
             let result = invoke_element(observation(state, observation_id)?, &params, pending);
@@ -334,13 +353,48 @@ pub(super) fn dispatch_request(
     };
     let has_refreshed_observation = refreshed.is_some();
     let changed = accessibility_changed(previous_revision, refreshed.as_ref());
+    #[cfg(target_os = "macos")]
+    let transient_text_ready = transient_text_candidate
+        && changed == Some(true)
+        && mark_transient_text_ready(state, refreshed.as_ref());
     let mut response = action_receipt(result, refreshed, changed);
+    #[cfg(target_os = "macos")]
+    if transient_text_ready {
+        if let Some(object) = response.as_object_mut() {
+            object.insert("transient_text_ready".to_string(), json!(true));
+            object.insert("next_action".to_string(), json!("type"));
+        }
+    }
     if let Some(pending) = state.pending_action().filter(|pending| {
         should_attach_pending_action(has_refreshed_observation, pending.hwnd, window.hwnd)
     }) {
         attach_pending_action(&mut response, pending);
     }
     Ok(response)
+}
+
+#[cfg(target_os = "macos")]
+fn take_transient_text_ready(
+    state: &mut ServerState,
+    observation_id: Option<&str>,
+) -> Result<bool, (&'static str, String)> {
+    let observation = observation_mut(state, observation_id)?;
+    Ok(std::mem::take(&mut observation.transient_text_ready))
+}
+
+#[cfg(target_os = "macos")]
+fn mark_transient_text_ready(state: &mut ServerState, refreshed: Option<&Value>) -> bool {
+    let Some(observation_id) = refreshed
+        .and_then(|value| value.get("observation_id"))
+        .and_then(Value::as_str)
+    else {
+        return false;
+    };
+    let Some(observation) = state.observations.get_mut(observation_id) else {
+        return false;
+    };
+    observation.transient_text_ready = true;
+    true
 }
 
 /// Observe the action's target without turning an already-dispatched action
@@ -517,6 +571,19 @@ fn observation<'a>(
     ))
 }
 
+#[cfg(target_os = "macos")]
+fn observation_mut<'a>(
+    state: &'a mut ServerState,
+    id: Option<&str>,
+) -> Result<&'a mut Observation, (&'static str, String)> {
+    let id = id.ok_or(("invalid_request", "observation_id is required.".to_string()))?;
+    state.observations.get_mut(id).ok_or((
+        "stale_observation",
+        "Observation is stale or already consumed; observe the window again and use its new observation_id."
+            .to_string(),
+    ))
+}
+
 /// Refuse an action that would disturb a machine a person is using.
 ///
 /// Two conditions, checked together because they answer the same question: the
@@ -638,8 +705,26 @@ mod tests {
             display_width: 100,
             display_height: 100,
             accessibility_revision: None,
+            #[cfg(target_os = "macos")]
+            transient_text_ready: false,
             elements: Default::default(),
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn transient_text_capability_is_observation_bound_and_one_shot() {
+        let mut state = ServerState::default();
+        let mut observed = observation(1);
+        observed.transient_text_ready = true;
+        state.observations.insert("observed".to_string(), observed);
+        state
+            .observations
+            .insert("other".to_string(), observation(1));
+
+        assert!(!take_transient_text_ready(&mut state, Some("other")).unwrap());
+        assert!(take_transient_text_ready(&mut state, Some("observed")).unwrap());
+        assert!(!take_transient_text_ready(&mut state, Some("observed")).unwrap());
     }
 
     #[test]

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -17,10 +17,13 @@ use super::state::{Observation, PendingAction, ServerState, WindowInfo, INPUT_GU
 #[cfg(target_os = "macos")]
 use super::target_is_frontmost;
 use super::{
-    click, close_window, desktop_locked, drag, ensure_permissions, invoke_element,
+    click, close_window, desktop_locked, drag, ensure_permissions, input_sequence, invoke_element,
     last_input_age_ms, list_apps, list_windows, observe_window, press_key, resolve_window, scroll,
-    set_value, type_text, validate_observation, PROTOCOL_VERSION,
+    set_value, type_text, validate_observation, InputStep, PROTOCOL_VERSION,
 };
+
+const MAX_SEQUENCE_STEPS: usize = 20;
+const MAX_SEQUENCE_TEXT_CHARS: usize = 512;
 
 /// How recently a person must have used the keyboard or mouse for an action to
 /// be refused as racing them.
@@ -47,6 +50,7 @@ const SERVED_METHODS: &[&str] = &[
     "observe_window",
     "press_key",
     "scroll",
+    "sequence",
     "set_value",
     "type_text",
 ];
@@ -141,6 +145,11 @@ pub(super) fn dispatch_request(
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
+    let sequence_steps = if method == "sequence" {
+        Some(parse_input_steps(&params)?)
+    } else {
+        None
+    };
     let meta = message
         .get("meta")
         .and_then(Value::as_object)
@@ -244,6 +253,20 @@ pub(super) fn dispatch_request(
         "scroll" => scroll(observation(state, observation_id)?, &params),
         "drag" => drag(observation(state, observation_id)?, &params),
         "press_key" => press_key(observation(state, observation_id)?, &params),
+        "sequence" => {
+            let result = input_sequence(
+                observation(state, observation_id)?,
+                sequence_steps.as_deref().unwrap_or_default(),
+            );
+            if result
+                .as_ref()
+                .err()
+                .is_some_and(|error| error.0 == "user_intervention")
+            {
+                state.invalidate_observations();
+            }
+            result
+        }
         "type_text" => type_text(observation(state, observation_id)?, &params),
         "invoke_element" => {
             let pending = state.pending_action();
@@ -289,7 +312,11 @@ pub(super) fn dispatch_request(
     // window, so the response itself carries the only identifier valid for
     // the next action. If the action removed or replaced that window, retain
     // the dispatch receipt and direct the caller to discover the new target.
-    let refreshed = refresh_after_action(state, &window);
+    let refreshed = if method == "sequence" {
+        refresh_after_sequence(state, &window)?
+    } else {
+        refresh_after_action(state, &window)
+    };
     let has_refreshed_observation = refreshed.is_some();
     let mut response = action_receipt(result, refreshed);
     if let Some(pending) = state.pending_action().filter(|pending| {
@@ -309,6 +336,78 @@ fn refresh_after_action(state: &mut ServerState, previous: &WindowInfo) -> Optio
     }
     state.settle_before_observe(current.hwnd);
     observe_window(state, &current).ok()
+}
+
+fn refresh_after_sequence(
+    state: &mut ServerState,
+    previous: &WindowInfo,
+) -> Result<Option<Value>, (&'static str, String)> {
+    let Ok(current) = resolve_window(&previous.hwnd.to_string()) else {
+        return Ok(None);
+    };
+    if current.app_id != previous.app_id {
+        return Ok(None);
+    }
+    state.settle_before_observe(current.hwnd);
+    enforce_input_guard(state)?;
+    Ok(observe_window(state, &current).ok())
+}
+
+fn parse_input_steps(
+    params: &serde_json::Map<String, Value>,
+) -> Result<Vec<InputStep>, (&'static str, String)> {
+    let steps = params
+        .get("steps")
+        .and_then(Value::as_array)
+        .filter(|steps| !steps.is_empty() && steps.len() <= MAX_SEQUENCE_STEPS)
+        .ok_or((
+            "invalid_request",
+            "steps must contain 1 to 20 input steps.".to_string(),
+        ))?;
+    let mut parsed = Vec::with_capacity(steps.len());
+    let mut text_chars = 0;
+    for (index, step) in steps.iter().enumerate() {
+        let step = step.as_object().ok_or((
+            "invalid_request",
+            format!("steps[{index}] must be an object."),
+        ))?;
+        let action = step.get("action").and_then(Value::as_str).unwrap_or("");
+        let (field, value) = match action {
+            "type" => ("text", step.get("text").and_then(Value::as_str)),
+            "press_key" => ("key", step.get("key").and_then(Value::as_str)),
+            _ => {
+                return Err((
+                    "invalid_request",
+                    format!("steps[{index}] must use type or press_key."),
+                ))
+            }
+        };
+        let value = value
+            .filter(|value| !value.is_empty() && (action == "type" || !value.trim().is_empty()))
+            .ok_or((
+                "invalid_request",
+                format!("steps[{index}] requires non-empty {field}."),
+            ))?;
+        if step.len() != 2 {
+            return Err((
+                "invalid_request",
+                format!("steps[{index}] accepts only action and {field}."),
+            ));
+        }
+        if action == "type" {
+            text_chars += value.chars().count();
+            if text_chars > MAX_SEQUENCE_TEXT_CHARS {
+                return Err((
+                    "invalid_request",
+                    "Sequence text is limited to 512 characters.".to_string(),
+                ));
+            }
+            parsed.push(InputStep::Type(value.to_string()));
+        } else {
+            parsed.push(InputStep::PressKey(value.to_string()));
+        }
+    }
+    Ok(parsed)
 }
 
 /// Keep an incomplete native edit from being crossed with another mutation.
@@ -447,6 +546,7 @@ fn changes_window_state(method: &str) -> bool {
             | "scroll"
             | "drag"
             | "press_key"
+            | "sequence"
             | "type_text"
             | "invoke_element"
             | "set_value"
@@ -484,7 +584,7 @@ fn requires_user_idle(method: &str, window: &WindowInfo) -> bool {
 fn requires_user_idle_on_mac(method: &str, target_is_frontmost: bool) -> bool {
     matches!(
         method,
-        "click" | "scroll" | "drag" | "press_key" | "type_text" | "launch_app"
+        "click" | "scroll" | "drag" | "press_key" | "sequence" | "type_text" | "launch_app"
     ) || (matches!(method, "invoke_element" | "set_value" | "close_window") && target_is_frontmost)
 }
 
@@ -509,6 +609,34 @@ mod tests {
             display_height: 100,
             accessibility_revision: None,
             elements: Default::default(),
+        }
+    }
+
+    #[test]
+    fn input_sequence_contract_is_bounded_and_keyboard_only() {
+        let value = json!({
+            "steps": [
+                {"action": "type", "text": "INV-001"},
+                {"action": "press_key", "key": "TAB"},
+            ]
+        });
+        let steps = parse_input_steps(value.as_object().unwrap()).unwrap();
+
+        assert_eq!(
+            steps,
+            vec![
+                InputStep::Type("INV-001".to_string()),
+                InputStep::PressKey("TAB".to_string()),
+            ]
+        );
+
+        for invalid in [
+            json!({"steps": []}),
+            json!({"steps": [{"action": "click", "x": 1, "y": 1}]}),
+            json!({"steps": [{"action": "type", "text": "x", "extra": true}]}),
+            json!({"steps": [{"action": "type", "text": "x".repeat(513)}]}),
+        ] {
+            assert!(parse_input_steps(invalid.as_object().unwrap()).is_err());
         }
     }
 
@@ -578,6 +706,7 @@ mod tests {
             "scroll",
             "drag",
             "press_key",
+            "sequence",
             "type_text",
             "invoke_element",
             "set_value",
@@ -623,7 +752,14 @@ mod tests {
                 "{method} must not race a user in the target app"
             );
         }
-        for method in ["click", "drag", "type_text", "press_key", "launch_app"] {
+        for method in [
+            "click",
+            "drag",
+            "type_text",
+            "press_key",
+            "sequence",
+            "launch_app",
+        ] {
             assert!(
                 requires_user_idle_on_mac(method, false),
                 "{method} must guard its foreground input"

--- a/console/src-tauri/src/computer_use_server/mod.rs
+++ b/console/src-tauri/src/computer_use_server/mod.rs
@@ -22,6 +22,12 @@ pub(super) use connection::run;
 pub(crate) use crate::computer_use_protocol::VERSION as PROTOCOL_VERSION;
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 
+#[derive(Debug, PartialEq)]
+enum InputStep {
+    Type(String),
+    PressKey(String),
+}
+
 // Platform leaves expose the same function surface (window discovery, capture,
 // UI automation, input); only the implementation differs. The shared layers
 // above never name a platform-specific type directly. Each platform keeps its
@@ -30,9 +36,9 @@ const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 mod platform_windows;
 #[cfg(windows)]
 use platform_windows::{
-    click, close_window, desktop_locked, drag, ensure_permissions, invoke_element, is_forbidden,
-    last_input_age_ms, list_apps, list_windows, observe_window, press_key, resolve_window, scroll,
-    set_value, type_text, validate_observation,
+    click, close_window, desktop_locked, drag, ensure_permissions, input_sequence, invoke_element,
+    is_forbidden, last_input_age_ms, list_apps, list_windows, observe_window, press_key,
+    resolve_window, scroll, set_value, type_text, validate_observation,
 };
 
 #[cfg(target_os = "macos")]
@@ -40,7 +46,7 @@ mod platform_macos;
 #[cfg(target_os = "macos")]
 use platform_macos::{
     app_id_from_bundle_path, click, close_window, desktop_locked, drag, ensure_permissions,
-    invoke_element, is_forbidden, last_input_age_ms, list_apps, list_windows, observe_window,
-    press_key, resolve_window, scroll, set_value, target_is_frontmost, type_text,
+    input_sequence, invoke_element, is_forbidden, last_input_age_ms, list_apps, list_windows,
+    observe_window, press_key, resolve_window, scroll, set_value, target_is_frontmost, type_text,
     validate_observation,
 };

--- a/console/src-tauri/src/computer_use_server/mod.rs
+++ b/console/src-tauri/src/computer_use_server/mod.rs
@@ -45,8 +45,8 @@ use platform_windows::{
 mod platform_macos;
 #[cfg(target_os = "macos")]
 use platform_macos::{
-    app_id_from_bundle_path, click, close_window, desktop_locked, drag, ensure_permissions,
-    input_sequence, invoke_element, is_forbidden, last_input_age_ms, list_apps, list_windows,
-    observe_window, press_key, resolve_window, scroll, set_value, target_is_frontmost, type_text,
-    validate_observation,
+    app_id_from_bundle_path, click, close_window, desktop_locked, drag, element_requires_frontmost,
+    ensure_permissions, input_sequence, invoke_element, is_forbidden, last_input_age_ms, list_apps,
+    list_windows, observe_window, press_key, resolve_window, scroll, set_value,
+    target_is_frontmost, type_text, validate_observation,
 };

--- a/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
@@ -67,6 +67,39 @@ pub(crate) fn element_requires_frontmost(
     Ok(matches!(element.scope, ElementScope::AppSurface { .. }))
 }
 
+/// Whether an observed element is a command in the currently open transient
+/// menu rather than a control in the content window or the closed menu bar.
+///
+/// A successful command can create a native field editor that is visible but
+/// never appears under the window's AX tree. Dispatch uses this capability,
+/// not an application name or localized command title, to issue a tightly
+/// scoped text-input capability on the refreshed observation.
+pub(crate) fn element_is_transient_menu_item(
+    observation: &Observation,
+    params: &Map<String, Value>,
+) -> Result<bool, (&'static str, String)> {
+    let Some(element_id) = params.get("element_id").and_then(Value::as_str) else {
+        return Ok(false);
+    };
+    let element = observation.elements.get(element_id).ok_or((
+        "element_not_found",
+        "Element is not available in this observation.".to_string(),
+    ))?;
+    let role = element
+        .element
+        .attribute(&AXAttribute::role())
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    Ok(role == "AXMenuItem"
+        && matches!(
+            &element.scope,
+            ElementScope::AppSurface {
+                kind: AppSurfaceKind::Transient,
+                ..
+            }
+        ))
+}
+
 pub(crate) fn element_point(
     observation: &Observation,
     params: &Map<String, Value>,

--- a/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
@@ -306,7 +306,7 @@ fn click_action(element: &AxElement, actions: &[String]) -> Option<&'static str>
         .map(|value| value.to_string())
         .unwrap_or_default();
     if matches!(role.as_str(), "AXMenuItem" | "AXMenuBarItem") {
-        action_named(actions, AX_PICK_ACTION).or_else(|| action_named(actions, kAXPressAction))
+        action_named(actions, kAXPressAction).or_else(|| action_named(actions, AX_PICK_ACTION))
     } else {
         action_named(actions, kAXPressAction)
     }
@@ -412,6 +412,19 @@ pub(crate) fn show_accessibility_menu(
         .element
         .perform_action(&CFString::from_static_string(AX_SHOW_MENU_ACTION))
     {
+        let app = AXUIElement::application(observation.window.owner_pid);
+        let _ = app.set_messaging_timeout(super::AX_MESSAGING_TIMEOUT_SECONDS);
+        if active_menu(
+            &app,
+            observation.window.owner_pid,
+            observation.window.hwnd as i64,
+        )
+        .is_some()
+        {
+            return Ok(Some(
+                json!({"applied": true, "native_action": AX_SHOW_MENU_ACTION}),
+            ));
+        }
         log::debug!(
             "[computer-use] {AX_SHOW_MENU_ACTION} unavailable; using verified pointer fallback: {error:?}"
         );

--- a/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs
@@ -27,6 +27,9 @@ const AX_CONFIRM_ACTION: &str = "AXConfirm";
 const AX_OPEN_ACTION: &str = "AXOpen";
 const AX_PICK_ACTION: &str = "AXPick";
 const AX_SHOW_MENU_ACTION: &str = "AXShowMenu";
+const AX_SELECTED_TEXT_ATTRIBUTE: &str = "AXSelectedText";
+const AX_SELECTED_TEXT_RANGE_ATTRIBUTE: &str = "AXSelectedTextRange";
+const AX_NUMBER_OF_CHARACTERS_ATTRIBUTE: &str = "AXNumberOfCharacters";
 
 /// Native accessibility element handle for the shared observation store.
 pub(crate) struct AxElement {
@@ -34,10 +37,34 @@ pub(crate) struct AxElement {
     scope: ElementScope,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum ElementScope {
     Window(u32),
-    AppSurface(u32),
+    AppSurface {
+        root: AXUIElement,
+        kind: AppSurfaceKind,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum AppSurfaceKind {
+    MenuBar,
+    Transient,
+}
+
+pub(crate) fn element_requires_frontmost(
+    observation: &Observation,
+    params: &Map<String, Value>,
+) -> Result<bool, (&'static str, String)> {
+    let element_id = params
+        .get("element_id")
+        .and_then(Value::as_str)
+        .ok_or(("invalid_request", "element_id is required.".to_string()))?;
+    let element = observation.elements.get(element_id).ok_or((
+        "element_not_found",
+        "Element is not available in this observation.".to_string(),
+    ))?;
+    Ok(matches!(element.scope, ElementScope::AppSurface { .. }))
 }
 
 pub(crate) fn element_point(
@@ -85,31 +112,6 @@ pub(crate) fn element_point_by_id(
     ))
 }
 
-/// Return the native window whose interactive accessibility element occupies
-/// a screen point.
-///
-/// CoreGraphics includes non-interactive overlays (watermarks, HUDs and
-/// recording indicators) in its visual z-order. Accessibility hit testing
-/// follows the element that would actually receive input, so element clicks
-/// are not rejected merely because a transparent overlay is painted above
-/// them.
-pub(crate) fn interactive_window_at_point(point: CGPoint) -> Option<i64> {
-    let mut current = interactive_element_at_point(point)?;
-    for _ in 0..64 {
-        let mut window_id = 0;
-        if unsafe { _AXUIElementGetWindow(current.as_concrete_TypeRef(), &mut window_id) } == 0
-            && window_id != 0
-        {
-            return Some(i64::from(window_id));
-        }
-        let parent = current
-            .attribute(&AXAttribute::new(&CFString::from_static_string("AXParent")))
-            .ok()?;
-        current = parent.downcast_into::<AXUIElement>()?;
-    }
-    None
-}
-
 fn interactive_element_at_point(point: CGPoint) -> Option<AXUIElement> {
     let system = AXUIElement::system_wide();
     let mut hit_ref: AXUIElementRef = std::ptr::null_mut();
@@ -125,6 +127,28 @@ fn interactive_element_at_point(point: CGPoint) -> Option<AXUIElement> {
         .then(|| unsafe { AXUIElement::wrap_under_create_rule(hit_ref) })
 }
 
+/// Require a pointer hit to resolve to the observed element or one of its
+/// descendants. Checking only the process would allow another window or menu
+/// from the same application to receive the click.
+pub(crate) fn validate_element_hit(
+    observation: &Observation,
+    element_id: &str,
+    point: CGPoint,
+) -> Result<(), (&'static str, String)> {
+    let observed = accessibility_element_by_id(observation, element_id)?;
+    let hit = interactive_element_at_point(point).ok_or((
+        "target_not_at_point",
+        "No interactive element is available at the target point.".to_string(),
+    ))?;
+    if !is_descendant_of(&hit, &observed.element) {
+        return Err((
+            "target_not_at_point",
+            "The target point no longer contains the observed element.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Return the frontmost transient menu owned by the target application.
 ///
 /// Context menus are separate application surfaces on macOS: they are not
@@ -134,8 +158,14 @@ fn interactive_element_at_point(point: CGPoint) -> Option<AXUIElement> {
 /// testing then resolves the actual menu instead of depending on the pointer
 /// landing inside a menu that macOS may offset from the click point.
 fn active_menu(app: &AXUIElement, expected_pid: i32, content_window: i64) -> Option<AXUIElement> {
-    if focused_window_id(app) != u32::try_from(content_window).ok() {
+    let target_window = u32::try_from(content_window).ok()?;
+    if focused_window_id(app) != Some(target_window) && main_window_id(app) != Some(target_window) {
         return None;
+    }
+    if let Some(menu) = ax_element(app, "AXShownMenuUIElement")
+        .and_then(|element| menu_ancestor(element, expected_pid))
+    {
+        return Some(menu);
     }
     transient_surface_points(expected_pid, content_window)
         .into_iter()
@@ -143,7 +173,10 @@ fn active_menu(app: &AXUIElement, expected_pid: i32, content_window: i64) -> Opt
 }
 
 fn menu_at_point(point: CGPoint, expected_pid: i32) -> Option<AXUIElement> {
-    let mut current = interactive_element_at_point(point)?;
+    menu_ancestor(interactive_element_at_point(point)?, expected_pid)
+}
+
+fn menu_ancestor(mut current: AXUIElement, expected_pid: i32) -> Option<AXUIElement> {
     for _ in 0..64 {
         let mut pid = 0;
         if unsafe { AXUIElementGetPid(current.as_concrete_TypeRef(), &mut pid) } != 0
@@ -172,11 +205,11 @@ pub(crate) fn invoke_accessibility_element(
     pending: Option<&PendingAction>,
 ) -> Result<Value, (&'static str, String)> {
     let element = accessibility_element(observation, params)?;
-    let actions = action_names(&element.element);
     // Some editable controls expose a separate semantic completion action.
     // Committing through AX is more reliable than a synthetic Return key whose
     // focus may have moved since the observation was captured.
-    let action = if let Some(pending) = pending {
+    if let Some(pending) = pending {
+        let actions = action_names(&element.element);
         if pending.hwnd != observation.window.hwnd
             || pending.element.element.as_CFType() != element.element.as_CFType()
         {
@@ -199,30 +232,64 @@ pub(crate) fn invoke_accessibility_element(
                 "The pending edit no longer exposes its semantic completion action.".to_string(),
             ));
         }
-        AX_CONFIRM_ACTION
-    } else if actions.iter().any(|action| action == kAXPressAction) {
-        let role = element
-            .element
-            .attribute(&AXAttribute::role())
-            .map(|value| value.to_string())
-            .unwrap_or_default();
-        if matches!(role.as_str(), "AXMenuItem" | "AXMenuBarItem")
-            && actions.iter().any(|action| action == AX_PICK_ACTION)
-        {
-            AX_PICK_ACTION
-        } else {
-            kAXPressAction
-        }
-    } else if actions.iter().any(|action| action == AX_OPEN_ACTION) {
-        AX_OPEN_ACTION
-    } else if actions.iter().any(|action| action == AX_CONFIRM_ACTION) {
-        AX_CONFIRM_ACTION
+        return perform_element_action(element, AX_CONFIRM_ACTION);
+    }
+    perform_primary_action(element)?.ok_or((
+        "unsupported_operation",
+        "The element does not expose a supported primary action.".to_string(),
+    ))
+}
+
+/// Perform an element's advertised primary activation, if it has one.
+///
+/// A single left click and an explicit invoke share this capability lookup.
+/// Secondary actions remain explicit, and callers can keep a verified pointer
+/// fallback when no primary accessibility action exists.
+pub(crate) fn activate_accessibility_element(
+    observation: &Observation,
+    params: &Map<String, Value>,
+) -> Result<Option<Value>, (&'static str, String)> {
+    let element = accessibility_element(observation, params)?;
+    let actions = action_names(&element.element);
+    click_action(element, &actions)
+        .map(|action| perform_element_action(element, action))
+        .transpose()
+}
+
+fn perform_primary_action(element: &AxElement) -> Result<Option<Value>, (&'static str, String)> {
+    let actions = action_names(&element.element);
+    let action = click_action(element, &actions)
+        .or_else(|| action_named(&actions, AX_OPEN_ACTION))
+        .or_else(|| action_named(&actions, AX_CONFIRM_ACTION));
+    action
+        .map(|action| perform_element_action(element, action))
+        .transpose()
+}
+
+fn click_action(element: &AxElement, actions: &[String]) -> Option<&'static str> {
+    let role = element
+        .element
+        .attribute(&AXAttribute::role())
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    if matches!(role.as_str(), "AXMenuItem" | "AXMenuBarItem") {
+        action_named(actions, AX_PICK_ACTION).or_else(|| action_named(actions, kAXPressAction))
     } else {
-        return Err((
-            "unsupported_operation",
-            "The element does not expose a supported primary action.".to_string(),
-        ));
-    };
+        action_named(actions, kAXPressAction)
+    }
+}
+
+fn action_named(actions: &[String], expected: &'static str) -> Option<&'static str> {
+    actions
+        .iter()
+        .any(|action| action == expected)
+        .then_some(expected)
+}
+
+fn perform_element_action(
+    element: &AxElement,
+    action: &'static str,
+) -> Result<Value, (&'static str, String)> {
     element
         .element
         .perform_action(&CFString::from_static_string(action))
@@ -233,6 +300,70 @@ pub(crate) fn invoke_accessibility_element(
             )
         })?;
     Ok(json!({"applied": true, "native_action": action}))
+}
+
+pub(super) enum FocusedTextInput {
+    Inserted,
+    Keyboard,
+}
+
+/// Insert text semantically, or confirm that native keyboard input has a
+/// current editable target in the observed window.
+///
+/// Capability checks, rather than application or control-name exceptions,
+/// keep this valid for transient editors in any application while refusing to
+/// type into focused lists, rows, and other non-editable surfaces.
+pub(super) fn insert_focused_text(
+    observation: &Observation,
+    text: &str,
+) -> Result<FocusedTextInput, (&'static str, String)> {
+    let pid = (observation.window.owner_pid > 0)
+        .then_some(observation.window.owner_pid)
+        .ok_or((
+            "window_not_found",
+            "Could not resolve the window's process.".to_string(),
+        ))?;
+    let target_window = u32::try_from(observation.window.hwnd).map_err(|_| {
+        (
+            "stale_window",
+            "The observed window identifier is invalid.".to_string(),
+        )
+    })?;
+    let app = AXUIElement::application(pid);
+    let _ = app.set_messaging_timeout(super::AX_MESSAGING_TIMEOUT_SECONDS);
+    let focused = ax_element(&app, "AXFocusedUIElement").ok_or((
+        "focus_not_editable",
+        "The observed window has no focused text input.".to_string(),
+    ))?;
+    if owning_window_id(&focused) != Some(target_window) {
+        return Err((
+            "focus_failed",
+            "Keyboard focus no longer belongs to the observed window.".to_string(),
+        ));
+    }
+    if !observation
+        .elements
+        .values()
+        .any(|candidate| candidate.element.as_CFType() == focused.as_CFType())
+    {
+        return Err((
+            "stale_observation",
+            "The current keyboard focus was not part of the observation; observe again."
+                .to_string(),
+        ));
+    }
+
+    let selected_text = AXAttribute::new(&CFString::from_static_string(AX_SELECTED_TEXT_ATTRIBUTE));
+    if !focused.is_settable(&selected_text).unwrap_or(false) {
+        return supports_keyboard_text_input(&focused)
+            .then_some(FocusedTextInput::Keyboard)
+            .ok_or((
+                "focus_not_editable",
+                "The focused element does not expose text editing capabilities.".to_string(),
+            ));
+    }
+    insert_selected_text(&focused, &selected_text, text)?;
+    Ok(FocusedTextInput::Inserted)
 }
 
 /// Open an element's native context menu when the application exposes one.
@@ -313,7 +444,7 @@ pub(crate) fn set_value(
         hwnd: observation.window.hwnd,
         element: AxElement {
             element: element.element.clone(),
-            scope: element.scope,
+            scope: element.scope.clone(),
         },
         expected_value: actual.clone(),
     });
@@ -332,6 +463,72 @@ pub(crate) fn set_value(
     ))
 }
 
+fn insert_selected_text(
+    focused: &AXUIElement,
+    selected_text: &AXAttribute<CFType>,
+    text: &str,
+) -> Result<(), (&'static str, String)> {
+    let before = ax_string_allow_empty(&focused, "AXValue").ok_or((
+        "postcondition_unavailable",
+        "The focused editor does not expose a readable value.".to_string(),
+    ))?;
+    let replaced = ax_string_allow_empty(&focused, "AXSelectedText").ok_or((
+        "postcondition_unavailable",
+        "The focused editor does not expose its selected text.".to_string(),
+    ))?;
+    focused
+        .set_attribute(&selected_text, CFString::new(text).as_CFType())
+        .map_err(|error| {
+            (
+                "action_failed",
+                format!("Accessibility text insertion failed: {error:?}"),
+            )
+        })?;
+
+    let actual = ax_string_allow_empty(&focused, "AXValue").ok_or((
+        "postcondition_failed",
+        "The focused editor stopped exposing its value after insertion.".to_string(),
+    ))?;
+    let expected_length = before
+        .chars()
+        .count()
+        .saturating_sub(replaced.chars().count())
+        + text.chars().count();
+    if actual.chars().count() != expected_length || !actual.contains(text) {
+        return Err((
+            "postcondition_failed",
+            "The focused editor did not retain the inserted text.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn supports_keyboard_text_input(element: &AXUIElement) -> bool {
+    let attribute_names = element
+        .attribute_names()
+        .map(|names| {
+            names
+                .iter()
+                .map(|name| name.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let exposes_text_selection = attribute_names.iter().any(|name| {
+        matches!(
+            name.as_str(),
+            AX_SELECTED_TEXT_ATTRIBUTE
+                | AX_SELECTED_TEXT_RANGE_ATTRIBUTE
+                | AX_NUMBER_OF_CHARACTERS_ATTRIBUTE
+        )
+    });
+    let selected_range = AXAttribute::new(&CFString::from_static_string(
+        AX_SELECTED_TEXT_RANGE_ATTRIBUTE,
+    ));
+    exposes_text_selection
+        && (element.is_settable(&AXAttribute::value()).unwrap_or(false)
+            || element.is_settable(&selected_range).unwrap_or(false))
+}
+
 fn accessibility_element<'a>(
     observation: &'a Observation,
     params: &Map<String, Value>,
@@ -340,6 +537,13 @@ fn accessibility_element<'a>(
         .get("element_id")
         .and_then(Value::as_str)
         .ok_or(("invalid_request", "element_id is required.".to_string()))?;
+    accessibility_element_by_id(observation, element_id)
+}
+
+fn accessibility_element_by_id<'a>(
+    observation: &'a Observation,
+    element_id: &str,
+) -> Result<&'a AxElement, (&'static str, String)> {
     let element = observation.elements.get(element_id).ok_or((
         "element_not_found",
         "Element is not available in this observation.".to_string(),
@@ -350,15 +554,15 @@ fn accessibility_element<'a>(
             "The observed window is no longer valid; observe it again.".to_string(),
         )
     })?;
-    let in_scope = match element.scope {
+    let in_scope = match &element.scope {
         ElementScope::Window(window_id) => {
-            window_id == target_window && owning_window_id(&element.element) == Some(target_window)
+            *window_id == target_window && owning_window_id(&element.element) == Some(target_window)
         }
-        ElementScope::AppSurface(window_id) => {
-            window_id == target_window
-                && target_is_frontmost(&observation.window)
-                && focused_window_id(&AXUIElement::application(observation.window.owner_pid))
-                    == Some(target_window)
+        ElementScope::AppSurface { root, kind } => {
+            target_is_frontmost(&observation.window)
+                && current_app_surface_root(observation, *kind)
+                    .is_some_and(|current| current.as_CFType() == root.as_CFType())
+                && is_descendant_of(&element.element, root)
         }
     };
     if !in_scope {
@@ -384,7 +588,7 @@ pub(crate) fn validate_observation(
         "stale_observation",
         "The observation had no accessibility revision; observe the window again.".to_string(),
     ))?;
-    let (current, _) = collect_accessibility(&observation.window).map_err(|error| {
+    let (current, _, _) = collect_accessibility(&observation.window).map_err(|error| {
         (
             "stale_observation",
             format!("The observed accessibility surface is unavailable: {error}"),
@@ -401,7 +605,7 @@ pub(crate) fn validate_observation(
 
 pub(super) fn collect_accessibility(
     window: &WindowInfo,
-) -> Result<(Value, HashMap<String, AxElement>), String> {
+) -> Result<(Value, HashMap<String, AxElement>, bool), String> {
     let target_window = u32::try_from(window.hwnd)
         .map_err(|_| "Accessibility window identifier is invalid.".to_string())?;
     let pid = (window.owner_pid > 0)
@@ -425,11 +629,15 @@ pub(super) fn collect_accessibility(
     // can never describe another application's UI.
     let mut focused: Option<(String, AXUIElement)> = None;
     let mut visited = Vec::new();
-    if let Some(menu) = active_menu(&app, pid, window.hwnd as i64) {
+    let transient = if let Some(menu) = active_menu(&app, pid, window.hwnd as i64) {
         // Match the application surface a person is acting on: while a context
         // menu is open, its commands are the complete actionable state. The
         // underlying window and closed menu-bar descendants would only add
         // stale or ambiguous targets.
+        let scope = ElementScope::AppSurface {
+            root: menu.clone(),
+            kind: AppSurfaceKind::Transient,
+        };
         walk_accessibility(
             &menu,
             0,
@@ -439,9 +647,11 @@ pub(super) fn collect_accessibility(
             &mut focused,
             focused_target.as_ref(),
             &mut visited,
-            ElementScope::AppSurface(target_window),
+            &scope,
         );
+        true
     } else {
+        let window_scope = ElementScope::Window(target_window);
         walk_accessibility(
             &root,
             0,
@@ -451,13 +661,17 @@ pub(super) fn collect_accessibility(
             &mut focused,
             focused_target.as_ref(),
             &mut visited,
-            ElementScope::Window(target_window),
+            &window_scope,
         );
         // The menu bar belongs to the application rather than the content
         // window. Publish only its first level while it is closed; descendants
         // become actionable only when their menu is the active surface above.
         if focused_window_id(&app) == Some(target_window) {
             if let Some(menu_bar) = ax_element(&app, "AXMenuBar") {
+                let menu_scope = ElementScope::AppSurface {
+                    root: menu_bar.clone(),
+                    kind: AppSurfaceKind::MenuBar,
+                };
                 walk_accessibility(
                     &menu_bar,
                     0,
@@ -467,36 +681,35 @@ pub(super) fn collect_accessibility(
                     &mut focused,
                     focused_target.as_ref(),
                     &mut visited,
-                    ElementScope::AppSurface(target_window),
+                    &menu_scope,
                 );
             }
         }
-        // Sheets, popovers and inline editors may move keyboard focus to an
-        // application-owned branch outside the observed window. Merge only
-        // that active branch; walking the whole application would duplicate
-        // every window and exhaust the observation limit.
+        // AppKit field editors may own keyboard focus without appearing in
+        // their window's children. Publish that exact focused subtree after
+        // verifying its owning window; walking an already-visited ancestor
+        // would return before reaching the missing transient element.
         if let Some(target) = focused_target.as_ref() {
             if !visited
                 .iter()
                 .any(|seen| seen.as_CFType() == target.as_CFType())
+                && owning_window_id(target) == Some(target_window)
             {
-                if owning_window_id(target) == Some(target_window) {
-                    let branch = top_level_branch(&app, target);
-                    walk_accessibility(
-                        &branch,
-                        0,
-                        40,
-                        &mut elements,
-                        &mut descriptions,
-                        &mut focused,
-                        focused_target.as_ref(),
-                        &mut visited,
-                        ElementScope::Window(target_window),
-                    );
-                }
+                walk_accessibility(
+                    target,
+                    0,
+                    40,
+                    &mut elements,
+                    &mut descriptions,
+                    &mut focused,
+                    focused_target.as_ref(),
+                    &mut visited,
+                    &window_scope,
+                );
             }
         }
-    }
+        false
+    };
     // Summary fields are best-effort: a missing one is simply omitted so an
     // observation never fails because a control withheld its text.
     let mut accessibility = serde_json::Map::new();
@@ -511,7 +724,36 @@ pub(super) fn collect_accessibility(
         }
     }
     accessibility.insert("elements".to_string(), json!(descriptions));
-    Ok((Value::Object(accessibility), elements))
+    Ok((Value::Object(accessibility), elements, transient))
+}
+
+fn current_app_surface_root(
+    observation: &Observation,
+    kind: AppSurfaceKind,
+) -> Option<AXUIElement> {
+    let app = AXUIElement::application(observation.window.owner_pid);
+    let _ = app.set_messaging_timeout(super::AX_MESSAGING_TIMEOUT_SECONDS);
+    match kind {
+        AppSurfaceKind::Transient => active_menu(
+            &app,
+            observation.window.owner_pid,
+            observation.window.hwnd as i64,
+        ),
+        AppSurfaceKind::MenuBar => {
+            let target_window = u32::try_from(observation.window.hwnd).ok()?;
+            if active_menu(
+                &app,
+                observation.window.owner_pid,
+                observation.window.hwnd as i64,
+            )
+            .is_some()
+                || focused_window_id(&app) != Some(target_window)
+            {
+                return None;
+            }
+            ax_element(&app, "AXMenuBar")
+        }
+    }
 }
 
 /// Read a string-valued accessibility attribute, if the element exposes one.
@@ -560,6 +802,11 @@ fn focused_window_id(app: &AXUIElement) -> Option<u32> {
     owning_window_id(&focused)
 }
 
+fn main_window_id(app: &AXUIElement) -> Option<u32> {
+    let main = ax_element(app, "AXMainWindow")?;
+    owning_window_id(&main)
+}
+
 fn owning_window_id(element: &AXUIElement) -> Option<u32> {
     let mut current = element.clone();
     for _ in 0..64 {
@@ -577,6 +824,26 @@ fn owning_window_id(element: &AXUIElement) -> Option<u32> {
     None
 }
 
+/// Compare AX object identity while walking an element's parent chain.
+/// AX may return different wrappers for the same remote object, so pointer
+/// equality is not sufficient here.
+pub(crate) fn is_descendant_of(element: &AXUIElement, ancestor: &AXUIElement) -> bool {
+    let mut current = element.clone();
+    for _ in 0..64 {
+        if current.as_CFType() == ancestor.as_CFType() {
+            return true;
+        }
+        let Some(parent) = ax_element(&current, "AXParent") else {
+            return false;
+        };
+        if parent.as_CFType() == current.as_CFType() {
+            return false;
+        }
+        current = parent;
+    }
+    false
+}
+
 fn walk_accessibility(
     element: &AXUIElement,
     depth: usize,
@@ -586,7 +853,7 @@ fn walk_accessibility(
     focused: &mut Option<(String, AXUIElement)>,
     focused_target: Option<&AXUIElement>,
     visited: &mut Vec<AXUIElement>,
-    scope: ElementScope,
+    scope: &ElementScope,
 ) {
     if depth > max_depth || descriptions.len() >= 300 {
         return;
@@ -677,7 +944,7 @@ fn walk_accessibility(
             element_id,
             AxElement {
                 element: element.clone(),
-                scope,
+                scope: scope.clone(),
             },
         );
     }
@@ -773,23 +1040,6 @@ fn ax_size(element: &AXUIElement, attribute: &'static str) -> Option<CGSize> {
         )
     }
     .then_some(size)
-}
-
-fn top_level_branch(app: &AXUIElement, target: &AXUIElement) -> AXUIElement {
-    let mut current = target.clone();
-    for _ in 0..20 {
-        let Ok(parent) = current.attribute(&AXAttribute::parent()) else {
-            break;
-        };
-        if parent.as_CFType() == app.as_CFType() {
-            break;
-        }
-        if parent.as_CFType() == current.as_CFType() {
-            break;
-        }
-        current = parent;
-    }
-    current
 }
 
 fn action_names(element: &AXUIElement) -> Vec<String> {

--- a/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
@@ -37,8 +37,22 @@ pub(crate) fn observe_window(
     let (capture_width, capture_height) = point_bounds
         .map(|bounds| bounded_capture_dimensions(bounds[2], bounds[3]))
         .unwrap_or((SCREENSHOT_MAX_EDGE as usize, SCREENSHOT_MAX_EDGE as usize));
-    let capture = capture_window_image(window_id, capture_width, capture_height);
     let accessibility = collect_accessibility(window);
+    // Menus and similar transient surfaces are separate Window Server objects.
+    // A desktop-independent capture of the content window would show a
+    // different interface from the AX tree below, so expose the authoritative
+    // accessibility state without a misleading screenshot.
+    let has_transient_surface = accessibility
+        .as_ref()
+        .is_ok_and(|(_, _, transient)| *transient);
+    let capture = if has_transient_surface {
+        Err(
+            "The active transient surface is available through accessibility but is not part of the selected window capture."
+                .to_string(),
+        )
+    } else {
+        capture_window_image(window_id, capture_width, capture_height)
+    };
     if let (Err(capture_error), Err(accessibility_error)) = (&capture, &accessibility) {
         return Err((
             "capture_failed",
@@ -47,7 +61,7 @@ pub(crate) fn observe_window(
     }
 
     let (accessibility, elements) = match accessibility {
-        Ok(result) => result,
+        Ok((accessibility, elements, _)) => (accessibility, elements),
         Err(reason) => (
             json!({"available": false, "reason": reason, "elements": []}),
             Default::default(),

--- a/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
@@ -133,6 +133,7 @@ pub(crate) fn observe_window(
             display_width,
             display_height,
             accessibility_revision,
+            transient_text_ready: false,
             elements,
         },
     );

--- a/console/src-tauri/src/computer_use_server/platform_macos/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/input.rs
@@ -26,7 +26,10 @@ use objc2_app_kit::{
 };
 use serde_json::{json, Map, Value};
 
-use super::super::state::{map_point, Observation, PendingAction, WindowInfo};
+use super::super::state::{
+    map_point, Observation, PendingAction, WindowInfo, INPUT_GUARD_GRACE_MS,
+};
+use super::super::InputStep;
 use super::accessibility_tree::{
     element_point, element_point_by_id, find_ax_window, interactive_window_at_point,
     invoke_accessibility_element, show_accessibility_menu,
@@ -309,6 +312,69 @@ pub(crate) fn press_key(
         parse_key(key).ok_or(("invalid_request", format!("Unsupported key: {key}")))?;
     let _focus_lease = set_focus(&observation.window)?;
     let source = event_source()?;
+    post_key_event(&source, keycode, flags)?;
+    Ok(json!({"applied": true}))
+}
+
+enum PreparedStep {
+    Type(String),
+    PressKey(u16, CGEventFlags),
+}
+
+pub(crate) fn input_sequence(
+    observation: &Observation,
+    steps: &[InputStep],
+) -> Result<Value, (&'static str, String)> {
+    let prepared = prepare_sequence(steps)?;
+    let _focus_lease = set_focus(&observation.window)?;
+    let source = event_source()?;
+    let mut completed = 0;
+    for step in prepared {
+        ensure_sequence_idle()?;
+        let result = match step {
+            PreparedStep::Type(text) => post_sequence_text(&source, &text),
+            PreparedStep::PressKey(keycode, flags) => post_key_event(&source, keycode, flags),
+        };
+        if let Err(error) = result {
+            if error.0 == "user_intervention" {
+                return Err(error);
+            }
+            return Ok(sequence_failure(completed, error));
+        }
+        completed += 1;
+    }
+    ensure_sequence_idle()?;
+    Ok(json!({"applied": true, "completed_steps": completed}))
+}
+
+fn prepare_sequence(steps: &[InputStep]) -> Result<Vec<PreparedStep>, (&'static str, String)> {
+    steps
+        .iter()
+        .map(|step| match step {
+            InputStep::Type(text) => Ok(PreparedStep::Type(text.clone())),
+            InputStep::PressKey(key) => parse_key(key)
+                .map(|(keycode, flags)| PreparedStep::PressKey(keycode, flags))
+                .ok_or(("invalid_request", format!("Unsupported key: {key}"))),
+        })
+        .collect()
+}
+
+fn post_sequence_text(source: &CGEventSource, text: &str) -> Result<(), (&'static str, String)> {
+    for character in text.chars() {
+        ensure_sequence_idle()?;
+        let value = character.to_string();
+        post_text_event(source, &value, true)?;
+        post_text_event(source, "", false)?;
+        std::thread::sleep(std::time::Duration::from_millis(TEXT_INPUT_INTERVAL_MS));
+    }
+    Ok(())
+}
+
+fn post_key_event(
+    source: &CGEventSource,
+    keycode: u16,
+    flags: CGEventFlags,
+) -> Result<(), (&'static str, String)> {
     let down = CGEvent::new_keyboard_event(source.clone(), keycode, true).map_err(|_| {
         (
             "input_failed",
@@ -317,7 +383,7 @@ pub(crate) fn press_key(
     })?;
     down.set_flags(flags);
     down.post(CGEventTapLocation::HID);
-    let up = CGEvent::new_keyboard_event(source, keycode, false).map_err(|_| {
+    let up = CGEvent::new_keyboard_event(source.clone(), keycode, false).map_err(|_| {
         (
             "input_failed",
             "Could not create the key event.".to_string(),
@@ -325,7 +391,29 @@ pub(crate) fn press_key(
     })?;
     up.set_flags(flags);
     up.post(CGEventTapLocation::HID);
-    Ok(json!({"applied": true}))
+    Ok(())
+}
+
+fn ensure_sequence_idle() -> Result<(), (&'static str, String)> {
+    if last_input_age_ms().is_some_and(|age| age < INPUT_GUARD_GRACE_MS) {
+        return Err((
+            "user_intervention",
+            "Recent user input was detected; observe again before continuing.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn sequence_failure(completed: usize, error: (&'static str, String)) -> Value {
+    json!({
+        "completed_steps": completed,
+        "error": {
+            "code": error.0,
+            "message": error.1,
+            "step_index": completed,
+            "outcome": "unknown",
+        },
+    })
 }
 
 /// Parse a key spec such as "cmd+shift+a" or "Return" into a virtual key code

--- a/console/src-tauri/src/computer_use_server/platform_macos/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/input.rs
@@ -31,12 +31,13 @@ use super::super::state::{
 };
 use super::super::InputStep;
 use super::accessibility_tree::{
-    element_point, element_point_by_id, find_ax_window, interactive_window_at_point,
-    invoke_accessibility_element, show_accessibility_menu,
+    activate_accessibility_element, element_point, element_point_by_id, element_requires_frontmost,
+    find_ax_window, insert_focused_text, invoke_accessibility_element, is_descendant_of,
+    show_accessibility_menu, validate_element_hit, FocusedTextInput,
 };
 use super::{
     bounds_from_dict, dict_i64, integer_param, window_bounds,
-    CGEventSourceSecondsSinceLastEventType, CGSessionCopyCurrentDictionary, HostFocusLease,
+    CGEventSourceSecondsSinceLastEventType, CGSessionCopyCurrentDictionary,
 };
 
 /// How long to wait for a raised window to actually hold focus before
@@ -118,24 +119,29 @@ pub(crate) fn click(
         .get("button")
         .and_then(Value::as_str)
         .unwrap_or("left");
-    if params.contains_key("element_id") && button == "right" {
-        ensure_observed_geometry(observation)?;
-        let _focus_lease = set_focus(&observation.window)?;
-        ensure_observed_geometry(observation)?;
-        if let Some(result) = show_accessibility_menu(observation, params)? {
-            return Ok(result);
-        }
-    }
-    let (point, _focus_lease) = if params.contains_key("element_id") {
-        prepare_element_point(observation, params)?
-    } else {
-        prepare_point(observation, params, "x", "y")?
-    };
     let count = params
         .get("count")
         .and_then(Value::as_i64)
         .unwrap_or(1)
         .clamp(1, 3);
+    if params.contains_key("element_id") && button == "left" && count == 1 {
+        if let Some(result) = activate_accessibility_element(observation, params)? {
+            return Ok(result);
+        }
+    }
+    if params.contains_key("element_id") && button == "right" {
+        ensure_observed_geometry(observation)?;
+        set_focus(&observation.window)?;
+        ensure_observed_geometry(observation)?;
+        if let Some(result) = show_accessibility_menu(observation, params)? {
+            return Ok(result);
+        }
+    }
+    let point = if params.contains_key("element_id") {
+        prepare_element_point(observation, params)?
+    } else {
+        prepare_point(observation, params, "x", "y")?
+    };
     let (down, up, mouse_button) = match button {
         "right" => (
             CGEventType::RightMouseDown,
@@ -165,6 +171,9 @@ pub(crate) fn invoke_element(
     params: &Map<String, Value>,
     pending: Option<&PendingAction>,
 ) -> Result<Value, (&'static str, String)> {
+    if element_requires_frontmost(observation, params)? {
+        set_focus(&observation.window)?;
+    }
     // Menu items use AXPick when the application exposes it. Unlike a pointer
     // fallback, the semantic action also works when the command intentionally
     // has no persistent on-screen rectangle.
@@ -175,7 +184,7 @@ pub(crate) fn scroll(
     observation: &Observation,
     params: &Map<String, Value>,
 ) -> Result<Value, (&'static str, String)> {
-    let (point, _focus_lease) = prepare_point(observation, params, "x", "y")?;
+    let point = prepare_point(observation, params, "x", "y")?;
     let delta_y = integer_param(params, "delta_y")? as i32;
     let source = event_source()?;
     post_mouse(&source, CGEventType::MouseMoved, point, CGMouseButton::Left)?;
@@ -194,7 +203,7 @@ pub(crate) fn drag(
     observation: &Observation,
     params: &Map<String, Value>,
 ) -> Result<Value, (&'static str, String)> {
-    let (start, end, _focus_lease) = drag_points(observation, params)?;
+    let (start, end) = drag_points(observation, params)?;
     let source = event_source()?;
     post_mouse(&source, CGEventType::MouseMoved, start, CGMouseButton::Left)?;
     post_mouse(
@@ -226,28 +235,26 @@ pub(crate) fn drag(
 fn drag_points(
     observation: &Observation,
     params: &Map<String, Value>,
-) -> Result<(CGPoint, CGPoint, HostFocusLease), (&'static str, String)> {
+) -> Result<(CGPoint, CGPoint), (&'static str, String)> {
     let source_id = params.get("source_element_id").and_then(Value::as_str);
     let target_id = params.get("target_element_id").and_then(Value::as_str);
     match (source_id, target_id) {
         (Some(source_id), Some(target_id)) => {
             element_point_unchecked(observation, source_id)?;
             element_point_unchecked(observation, target_id)?;
-            let focus_lease = set_focus(&observation.window)?;
+            set_focus(&observation.window)?;
             Ok((
                 resolve_element_point_by_id(observation, source_id)?,
                 resolve_element_point_by_id(observation, target_id)?,
-                focus_lease,
             ))
         }
         (None, None) => {
             resolve_point(observation, params, "start_x", "start_y")?;
             resolve_point(observation, params, "end_x", "end_y")?;
-            let focus_lease = set_focus(&observation.window)?;
+            set_focus(&observation.window)?;
             Ok((
                 resolve_target_point(observation, params, "start_x", "start_y")?,
                 resolve_target_point(observation, params, "end_x", "end_y")?,
-                focus_lease,
             ))
         }
         _ => Err((
@@ -267,35 +274,78 @@ pub(crate) fn type_text(
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .ok_or(("invalid_request", "text is required.".to_string()))?;
-    let _focus_lease = set_focus(&observation.window)?;
+    let target_pid = set_focus(&observation.window)?;
+    match insert_focused_text(observation, text)? {
+        FocusedTextInput::Inserted => {
+            return Ok(json!({
+                "applied": true,
+                "effect": "observed",
+                "input_method": "accessibility",
+                "text_length": text.chars().count(),
+            }));
+        }
+        FocusedTextInput::Keyboard => {}
+    }
+
     let source = event_source()?;
-    // Some field editors ignore a multi-character Unicode payload on one key
-    // event. Pace complete key pairs so those editors receive normal text
-    // input without overwhelming controls that process events asynchronously.
+    // Accessibility does not publish every transient field editor. Send
+    // Unicode key pairs to the process that owns the observed window so a
+    // foreground change cannot redirect text to another application.
     for character in text.chars() {
         let value = character.to_string();
-        post_text_event(&source, &value, true)?;
-        post_text_event(&source, "", false)?;
+        post_text_event(&source, target_pid, &value, true)?;
+        post_text_event(&source, target_pid, "", false)?;
         std::thread::sleep(std::time::Duration::from_millis(TEXT_INPUT_INTERVAL_MS));
     }
-    Ok(json!({"applied": true, "text_length": text.chars().count()}))
+    Ok(json!({
+        "applied": true,
+        "effect": "unverified",
+        "input_method": "unicode",
+        "text_length": text.chars().count(),
+    }))
 }
 
 fn post_text_event(
     source: &CGEventSource,
+    target_pid: i32,
     value: &str,
     key_down: bool,
 ) -> Result<(), (&'static str, String)> {
     let event = CGEvent::new_keyboard_event(source.clone(), 0, key_down).map_err(|_| {
         (
             "input_failed",
-            "Could not create the keyboard event.".to_string(),
+            "Could not create the text event.".to_string(),
         )
     })?;
     if !value.is_empty() {
         event.set_string(value);
     }
-    event.post(CGEventTapLocation::HID);
+    event.post_to_pid(target_pid);
+    Ok(())
+}
+
+fn post_key_chord(
+    source: &CGEventSource,
+    target_pid: i32,
+    keycode: u16,
+    flags: CGEventFlags,
+) -> Result<(), (&'static str, String)> {
+    let down = CGEvent::new_keyboard_event(source.clone(), keycode, true).map_err(|_| {
+        (
+            "input_failed",
+            "Could not create the key event.".to_string(),
+        )
+    })?;
+    down.set_flags(flags);
+    down.post_to_pid(target_pid);
+    let up = CGEvent::new_keyboard_event(source.clone(), keycode, false).map_err(|_| {
+        (
+            "input_failed",
+            "Could not create the key event.".to_string(),
+        )
+    })?;
+    up.set_flags(flags);
+    up.post_to_pid(target_pid);
     Ok(())
 }
 
@@ -310,9 +360,9 @@ pub(crate) fn press_key(
         .ok_or(("invalid_request", "key is required.".to_string()))?;
     let (keycode, flags) =
         parse_key(key).ok_or(("invalid_request", format!("Unsupported key: {key}")))?;
-    let _focus_lease = set_focus(&observation.window)?;
+    let target_pid = set_focus(&observation.window)?;
     let source = event_source()?;
-    post_key_event(&source, keycode, flags)?;
+    post_key_chord(&source, target_pid, keycode, flags)?;
     Ok(json!({"applied": true}))
 }
 
@@ -326,14 +376,16 @@ pub(crate) fn input_sequence(
     steps: &[InputStep],
 ) -> Result<Value, (&'static str, String)> {
     let prepared = prepare_sequence(steps)?;
-    let _focus_lease = set_focus(&observation.window)?;
+    let target_pid = set_focus(&observation.window)?;
     let source = event_source()?;
     let mut completed = 0;
     for step in prepared {
         ensure_sequence_idle()?;
         let result = match step {
-            PreparedStep::Type(text) => post_sequence_text(&source, &text),
-            PreparedStep::PressKey(keycode, flags) => post_key_event(&source, keycode, flags),
+            PreparedStep::Type(text) => post_sequence_text(observation, &source, target_pid, &text),
+            PreparedStep::PressKey(keycode, flags) => {
+                post_key_chord(&source, target_pid, keycode, flags)
+            }
         };
         if let Err(error) = result {
             if error.0 == "user_intervention" {
@@ -359,38 +411,25 @@ fn prepare_sequence(steps: &[InputStep]) -> Result<Vec<PreparedStep>, (&'static 
         .collect()
 }
 
-fn post_sequence_text(source: &CGEventSource, text: &str) -> Result<(), (&'static str, String)> {
+fn post_sequence_text(
+    observation: &Observation,
+    source: &CGEventSource,
+    target_pid: i32,
+    text: &str,
+) -> Result<(), (&'static str, String)> {
+    if matches!(
+        insert_focused_text(observation, text)?,
+        FocusedTextInput::Inserted
+    ) {
+        return Ok(());
+    }
     for character in text.chars() {
         ensure_sequence_idle()?;
         let value = character.to_string();
-        post_text_event(source, &value, true)?;
-        post_text_event(source, "", false)?;
+        post_text_event(source, target_pid, &value, true)?;
+        post_text_event(source, target_pid, "", false)?;
         std::thread::sleep(std::time::Duration::from_millis(TEXT_INPUT_INTERVAL_MS));
     }
-    Ok(())
-}
-
-fn post_key_event(
-    source: &CGEventSource,
-    keycode: u16,
-    flags: CGEventFlags,
-) -> Result<(), (&'static str, String)> {
-    let down = CGEvent::new_keyboard_event(source.clone(), keycode, true).map_err(|_| {
-        (
-            "input_failed",
-            "Could not create the key event.".to_string(),
-        )
-    })?;
-    down.set_flags(flags);
-    down.post(CGEventTapLocation::HID);
-    let up = CGEvent::new_keyboard_event(source.clone(), keycode, false).map_err(|_| {
-        (
-            "input_failed",
-            "Could not create the key event.".to_string(),
-        )
-    })?;
-    up.set_flags(flags);
-    up.post(CGEventTapLocation::HID);
     Ok(())
 }
 
@@ -531,20 +570,19 @@ fn keycode_for(key: &str) -> Option<u16> {
     })
 }
 
-fn set_focus(window: &WindowInfo) -> Result<HostFocusLease, (&'static str, String)> {
+fn set_focus(window: &WindowInfo) -> Result<i32, (&'static str, String)> {
     let pid = (window.owner_pid > 0).then_some(window.owner_pid).ok_or((
         "window_not_found",
         "Could not resolve the window's process.".to_string(),
     ))?;
-    let focus_lease = HostFocusLease::begin(pid)?;
     let app = AXUIElement::application(pid);
     let _ = app.set_messaging_timeout(super::AX_MESSAGING_TIMEOUT_SECONDS);
     let ax_window = find_ax_window(&app, window.hwnd as u32).ok_or((
         "window_not_found",
         "Accessibility could not locate the window.".to_string(),
     ))?;
-    if window_holds_focus(&app, &ax_window) {
-        return Ok(focus_lease);
+    if super::target_is_frontmost(window) && window_holds_focus(&app, &ax_window) {
+        return Ok(pid);
     }
     let running_app =
         NSRunningApplication::runningApplicationWithProcessIdentifier(pid).ok_or((
@@ -573,8 +611,8 @@ fn set_focus(window: &WindowInfo) -> Result<HostFocusLease, (&'static str, Strin
     // application happens to be in front -- one this session may never have
     // been approved for.
     for _ in 0..FOCUS_POLL_ATTEMPTS {
-        if window_holds_focus(&app, &ax_window) {
-            return Ok(focus_lease);
+        if super::target_is_frontmost(window) && window_holds_focus(&app, &ax_window) {
+            return Ok(pid);
         }
         std::thread::sleep(std::time::Duration::from_millis(FOCUS_POLL_INTERVAL_MS));
     }
@@ -612,28 +650,6 @@ fn window_holds_focus(app: &AXUIElement, target: &AXUIElement) -> bool {
         if is_descendant_of(&element, target) {
             return true;
         }
-    }
-    false
-}
-
-fn is_descendant_of(element: &AXUIElement, ancestor: &AXUIElement) -> bool {
-    let mut current = element.clone();
-    for _ in 0..64 {
-        // AX may return a new reference for the same accessibility object.
-        // Pointer identity therefore produces false negatives after a window
-        // has successfully taken focus; CFEqual compares the AX objects.
-        if current.as_CFType() == ancestor.as_CFType() {
-            return true;
-        }
-        let Ok(parent) =
-            current.attribute(&AXAttribute::new(&CFString::from_static_string("AXParent")))
-        else {
-            return false;
-        };
-        let Some(parent) = parent.downcast_into::<AXUIElement>() else {
-            return false;
-        };
-        current = parent;
     }
     false
 }
@@ -691,29 +707,26 @@ fn prepare_point(
     params: &Map<String, Value>,
     x_key: &str,
     y_key: &str,
-) -> Result<(CGPoint, HostFocusLease), (&'static str, String)> {
+) -> Result<CGPoint, (&'static str, String)> {
     // Refuse stale geometry before changing focus, then verify it again once
     // activation has completed. The final hit test must happen after focus so
     // a foreground QwenPaw window does not make every background target fail.
     resolve_point(observation, params, x_key, y_key)?;
-    let focus_lease = set_focus(&observation.window)?;
-    Ok((
-        resolve_target_point(observation, params, x_key, y_key)?,
-        focus_lease,
-    ))
+    set_focus(&observation.window)?;
+    resolve_target_point(observation, params, x_key, y_key)
 }
 
 fn prepare_element_point(
     observation: &Observation,
     params: &Map<String, Value>,
-) -> Result<(CGPoint, HostFocusLease), (&'static str, String)> {
+) -> Result<CGPoint, (&'static str, String)> {
     let element_id = params
         .get("element_id")
         .and_then(Value::as_str)
         .ok_or(("invalid_request", "element_id is required.".to_string()))?;
     element_point_unchecked(observation, element_id)?;
-    let focus_lease = set_focus(&observation.window)?;
-    Ok((resolve_element_point(observation, params)?, focus_lease))
+    set_focus(&observation.window)?;
+    resolve_element_point(observation, params)
 }
 
 fn resolve_element_point(
@@ -721,19 +734,23 @@ fn resolve_element_point(
     params: &Map<String, Value>,
 ) -> Result<CGPoint, (&'static str, String)> {
     ensure_observed_geometry(observation)?;
+    let element_id = params
+        .get("element_id")
+        .and_then(Value::as_str)
+        .ok_or(("invalid_request", "element_id is required.".to_string()))?;
     let (x, y) = element_point(observation, params)?;
     let point = CGPoint { x, y };
-    verify_target_point(observation, point)
+    validate_element_hit(observation, element_id, point)?;
+    Ok(point)
 }
 
 fn resolve_element_point_by_id(
     observation: &Observation,
     element_id: &str,
 ) -> Result<CGPoint, (&'static str, String)> {
-    verify_target_point(
-        observation,
-        element_point_unchecked(observation, element_id)?,
-    )
+    let point = element_point_unchecked(observation, element_id)?;
+    validate_element_hit(observation, element_id, point)?;
+    Ok(point)
 }
 
 fn element_point_unchecked(
@@ -763,25 +780,6 @@ fn ensure_observed_geometry(observation: &Observation) -> Result<(), (&'static s
         ));
     }
     Ok(())
-}
-
-fn verify_target_point(
-    observation: &Observation,
-    point: CGPoint,
-) -> Result<CGPoint, (&'static str, String)> {
-    match interactive_window_at_point(point) {
-        Some(window_id) if window_id == observation.window.hwnd as i64 => Ok(point),
-        Some(window_id) => Err((
-            "target_not_at_point",
-            format!(
-                "Another window owns the interactive element at the target point ({window_id})."
-            ),
-        )),
-        None => Err((
-            "target_not_at_point",
-            "No interactive element is available at the target point.".to_string(),
-        )),
-    }
 }
 
 fn resolve_target_point(

--- a/console/src-tauri/src/computer_use_server/platform_macos/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/input.rs
@@ -174,9 +174,9 @@ pub(crate) fn invoke_element(
     if element_requires_frontmost(observation, params)? {
         set_focus(&observation.window)?;
     }
-    // Menu items use AXPick when the application exposes it. Unlike a pointer
-    // fallback, the semantic action also works when the command intentionally
-    // has no persistent on-screen rectangle.
+    // Menu items use their advertised semantic action. Unlike a pointer
+    // fallback, this also works when the command intentionally has no
+    // persistent on-screen rectangle.
     invoke_accessibility_element(observation, params, pending)
 }
 
@@ -302,7 +302,11 @@ pub(crate) fn type_text(
         }
         Ok(FocusedTextInput::Keyboard) => false,
         Err(error)
-            if transient_text_ready && matches!(error.0, "focus_failed" | "stale_observation") =>
+            if transient_text_ready
+                && matches!(
+                    error.0,
+                    "focus_failed" | "focus_not_editable" | "stale_observation"
+                ) =>
         {
             true
         }
@@ -363,16 +367,10 @@ fn post_text_event(
 
 fn post_key_chord(
     source: &CGEventSource,
-    window: &WindowInfo,
+    target_pid: i32,
     keycode: u16,
     flags: CGEventFlags,
 ) -> Result<(), (&'static str, String)> {
-    if !super::target_is_frontmost(window) {
-        return Err((
-            "focus_failed",
-            "The target application lost focus before keyboard input.".to_string(),
-        ));
-    }
     let down = CGEvent::new_keyboard_event(source.clone(), keycode, true).map_err(|_| {
         (
             "input_failed",
@@ -380,10 +378,7 @@ fn post_key_chord(
         )
     })?;
     down.set_flags(flags);
-    // Shortcuts must enter the same event path as a physical keyboard. Direct
-    // process delivery can invoke an application command without establishing
-    // the native responder or field editor that command normally creates.
-    down.post(CGEventTapLocation::HID);
+    down.post_to_pid(target_pid);
     let up = CGEvent::new_keyboard_event(source.clone(), keycode, false).map_err(|_| {
         (
             "input_failed",
@@ -391,15 +386,7 @@ fn post_key_chord(
         )
     })?;
     up.set_flags(flags);
-    // Always release the key even if the command changed application state;
-    // omitting key-up would leave the input session in an inconsistent state.
-    up.post(CGEventTapLocation::HID);
-    if !super::target_is_frontmost(window) {
-        return Err((
-            "focus_failed",
-            "The target application lost focus during keyboard input.".to_string(),
-        ));
-    }
+    up.post_to_pid(target_pid);
     Ok(())
 }
 
@@ -414,9 +401,9 @@ pub(crate) fn press_key(
         .ok_or(("invalid_request", "key is required.".to_string()))?;
     let (keycode, flags) =
         parse_key(key).ok_or(("invalid_request", format!("Unsupported key: {key}")))?;
-    set_focus(&observation.window)?;
+    let target_pid = set_focus(&observation.window)?;
     let source = event_source()?;
-    post_key_chord(&source, &observation.window, keycode, flags)?;
+    post_key_chord(&source, target_pid, keycode, flags)?;
     Ok(json!({"applied": true}))
 }
 
@@ -438,7 +425,7 @@ pub(crate) fn input_sequence(
         let result = match step {
             PreparedStep::Type(text) => post_sequence_text(observation, &source, target_pid, &text),
             PreparedStep::PressKey(keycode, flags) => {
-                post_key_chord(&source, &observation.window, keycode, flags)
+                post_key_chord(&source, target_pid, keycode, flags)
             }
         };
         if let Err(error) = result {

--- a/console/src-tauri/src/computer_use_server/platform_macos/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/input.rs
@@ -268,15 +268,31 @@ fn drag_points(
 pub(crate) fn type_text(
     observation: &Observation,
     params: &Map<String, Value>,
+    transient_text_ready: bool,
 ) -> Result<Value, (&'static str, String)> {
     let text = params
         .get("text")
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .ok_or(("invalid_request", "text is required.".to_string()))?;
-    let target_pid = set_focus(&observation.window)?;
-    match insert_focused_text(observation, text)? {
-        FocusedTextInput::Inserted => {
+    let target_pid = if transient_text_ready {
+        if !super::target_is_frontmost(&observation.window) {
+            return Err((
+                "focus_failed",
+                "The target application lost focus before text input.".to_string(),
+            ));
+        }
+        (observation.window.owner_pid > 0)
+            .then_some(observation.window.owner_pid)
+            .ok_or((
+                "window_not_found",
+                "Could not resolve the window's process.".to_string(),
+            ))?
+    } else {
+        set_focus(&observation.window)?
+    };
+    let transient_editor = match insert_focused_text(observation, text) {
+        Ok(FocusedTextInput::Inserted) => {
             return Ok(json!({
                 "applied": true,
                 "effect": "observed",
@@ -284,23 +300,39 @@ pub(crate) fn type_text(
                 "text_length": text.chars().count(),
             }));
         }
-        FocusedTextInput::Keyboard => {}
-    }
+        Ok(FocusedTextInput::Keyboard) => false,
+        Err(error)
+            if transient_text_ready && matches!(error.0, "focus_failed" | "stale_observation") =>
+        {
+            true
+        }
+        Err(error) => return Err(error),
+    };
 
     let source = event_source()?;
-    // Accessibility does not publish every transient field editor. Send
-    // Unicode key pairs to the process that owns the observed window so a
-    // foreground change cannot redirect text to another application.
+    // Accessibility does not publish every transient field editor. Normal
+    // keyboard-capable controls remain process-targeted; a transient native
+    // field editor receives HID events without raising its window because a
+    // focus change can commit that editor before input reaches it. Recheck the
+    // frontmost application before each character so input cannot spill into
+    // another app.
     for character in text.chars() {
+        if transient_editor && !super::target_is_frontmost(&observation.window) {
+            return Err((
+                "focus_failed",
+                "The target application lost focus during text input.".to_string(),
+            ));
+        }
         let value = character.to_string();
-        post_text_event(&source, target_pid, &value, true)?;
-        post_text_event(&source, target_pid, "", false)?;
+        post_text_event(&source, target_pid, &value, true, transient_editor)?;
+        post_text_event(&source, target_pid, "", false, transient_editor)?;
         std::thread::sleep(std::time::Duration::from_millis(TEXT_INPUT_INTERVAL_MS));
     }
     Ok(json!({
         "applied": true,
         "effect": "unverified",
         "input_method": "unicode",
+        "transient_editor": transient_editor,
         "text_length": text.chars().count(),
     }))
 }
@@ -310,6 +342,7 @@ fn post_text_event(
     target_pid: i32,
     value: &str,
     key_down: bool,
+    post_to_hid: bool,
 ) -> Result<(), (&'static str, String)> {
     let event = CGEvent::new_keyboard_event(source.clone(), 0, key_down).map_err(|_| {
         (
@@ -320,16 +353,26 @@ fn post_text_event(
     if !value.is_empty() {
         event.set_string(value);
     }
-    event.post_to_pid(target_pid);
+    if post_to_hid {
+        event.post(CGEventTapLocation::HID);
+    } else {
+        event.post_to_pid(target_pid);
+    }
     Ok(())
 }
 
 fn post_key_chord(
     source: &CGEventSource,
-    target_pid: i32,
+    window: &WindowInfo,
     keycode: u16,
     flags: CGEventFlags,
 ) -> Result<(), (&'static str, String)> {
+    if !super::target_is_frontmost(window) {
+        return Err((
+            "focus_failed",
+            "The target application lost focus before keyboard input.".to_string(),
+        ));
+    }
     let down = CGEvent::new_keyboard_event(source.clone(), keycode, true).map_err(|_| {
         (
             "input_failed",
@@ -337,7 +380,10 @@ fn post_key_chord(
         )
     })?;
     down.set_flags(flags);
-    down.post_to_pid(target_pid);
+    // Shortcuts must enter the same event path as a physical keyboard. Direct
+    // process delivery can invoke an application command without establishing
+    // the native responder or field editor that command normally creates.
+    down.post(CGEventTapLocation::HID);
     let up = CGEvent::new_keyboard_event(source.clone(), keycode, false).map_err(|_| {
         (
             "input_failed",
@@ -345,7 +391,15 @@ fn post_key_chord(
         )
     })?;
     up.set_flags(flags);
-    up.post_to_pid(target_pid);
+    // Always release the key even if the command changed application state;
+    // omitting key-up would leave the input session in an inconsistent state.
+    up.post(CGEventTapLocation::HID);
+    if !super::target_is_frontmost(window) {
+        return Err((
+            "focus_failed",
+            "The target application lost focus during keyboard input.".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -360,9 +414,9 @@ pub(crate) fn press_key(
         .ok_or(("invalid_request", "key is required.".to_string()))?;
     let (keycode, flags) =
         parse_key(key).ok_or(("invalid_request", format!("Unsupported key: {key}")))?;
-    let target_pid = set_focus(&observation.window)?;
+    set_focus(&observation.window)?;
     let source = event_source()?;
-    post_key_chord(&source, target_pid, keycode, flags)?;
+    post_key_chord(&source, &observation.window, keycode, flags)?;
     Ok(json!({"applied": true}))
 }
 
@@ -384,7 +438,7 @@ pub(crate) fn input_sequence(
         let result = match step {
             PreparedStep::Type(text) => post_sequence_text(observation, &source, target_pid, &text),
             PreparedStep::PressKey(keycode, flags) => {
-                post_key_chord(&source, target_pid, keycode, flags)
+                post_key_chord(&source, &observation.window, keycode, flags)
             }
         };
         if let Err(error) = result {
@@ -426,8 +480,8 @@ fn post_sequence_text(
     for character in text.chars() {
         ensure_sequence_idle()?;
         let value = character.to_string();
-        post_text_event(source, target_pid, &value, true)?;
-        post_text_event(source, target_pid, "", false)?;
+        post_text_event(source, target_pid, &value, true, false)?;
+        post_text_event(source, target_pid, "", false, false)?;
         std::thread::sleep(std::time::Duration::from_millis(TEXT_INPUT_INTERVAL_MS));
     }
     Ok(())

--- a/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
@@ -25,6 +25,7 @@ use objc2_app_kit::NSWorkspace;
 use serde_json::{Map, Value};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 mod accessibility_tree;
@@ -33,7 +34,9 @@ mod input;
 mod permissions;
 mod window;
 
-pub(super) use accessibility_tree::{set_value, validate_observation, AxElement};
+pub(super) use accessibility_tree::{
+    element_requires_frontmost, set_value, validate_observation, AxElement,
+};
 pub(super) use capture::observe_window;
 pub(super) use input::{
     click, desktop_locked, drag, input_sequence, invoke_element, last_input_age_ms, press_key,
@@ -51,6 +54,7 @@ pub(super) use window::{
 const AX_MESSAGING_TIMEOUT_SECONDS: f32 = 2.0;
 const CONTROL_MAX_MESSAGE_BYTES: usize = 4096;
 const CONTROL_TIMEOUT: Duration = Duration::from_secs(2);
+static NEXT_FOCUS_LEASE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Whether physical user input would currently target this window's app.
 pub(super) fn target_is_frontmost(window: &super::state::WindowInfo) -> bool {
@@ -59,17 +63,24 @@ pub(super) fn target_is_frontmost(window: &super::state::WindowInfo) -> bool {
         .is_some_and(|application| application.processIdentifier() == window.owner_pid)
 }
 
-/// A host-owned lease for actions that must preserve foreground focus.
-/// Drop restores host visibility without activating it and leaves a short
-/// idempotency window; the desktop also expires the lease if this process dies.
+/// A host-owned assertion that keeps the desktop UI from taking foreground.
+///
+/// The server state owns one assertion for the whole Computer Use turn. Drop
+/// therefore has a real lifecycle boundary: end_turn, connection loss, user
+/// intervention, or helper exit, rather than a guessed delay between actions.
 pub(super) struct HostFocusLease {
     id: String,
 }
 
 impl HostFocusLease {
-    pub(super) fn begin(target_pid: i32) -> Result<Self, (&'static str, String)> {
-        let response = host_control_request("begin_focus", Some(target_pid), None)?;
-        let id = response
+    pub(super) fn begin() -> Result<Self, (&'static str, String)> {
+        let id = format!(
+            "{}-{}",
+            std::process::id(),
+            NEXT_FOCUS_LEASE_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        let response = host_control_request("begin_focus", Some(&id))?;
+        let issued_id = response
             .get("lease_id")
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
@@ -77,19 +88,24 @@ impl HostFocusLease {
                 "focus_failed",
                 "Desktop host did not issue a foreground lease.".to_string(),
             ))?;
-        Ok(Self { id: id.to_string() })
+        if issued_id != id {
+            return Err((
+                "focus_failed",
+                "Desktop host issued an invalid foreground lease.".to_string(),
+            ));
+        }
+        Ok(Self { id })
     }
 }
 
 impl Drop for HostFocusLease {
     fn drop(&mut self) {
-        let _ = host_control_request("end_focus", None, Some(&self.id));
+        let _ = host_control_request("end_focus", Some(&self.id));
     }
 }
 
 fn host_control_request(
     action: &str,
-    target_pid: Option<i32>,
     lease_id: Option<&str>,
 ) -> Result<Value, (&'static str, String)> {
     let host = std::env::var("QWENPAW_COMPUTER_USE_CONTROL_HOST").unwrap_or_default();
@@ -107,7 +123,6 @@ fn host_control_request(
         "token": token,
         "action": action,
         "helper_pid": std::process::id(),
-        "target_pid": target_pid,
         "lease_id": lease_id,
     });
     let payload = serde_json::to_vec(&request).map_err(|error| {

--- a/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
@@ -36,7 +36,8 @@ mod window;
 pub(super) use accessibility_tree::{set_value, validate_observation, AxElement};
 pub(super) use capture::observe_window;
 pub(super) use input::{
-    click, desktop_locked, drag, invoke_element, last_input_age_ms, press_key, scroll, type_text,
+    click, desktop_locked, drag, input_sequence, invoke_element, last_input_age_ms, press_key,
+    scroll, type_text,
 };
 pub(super) use permissions::ensure_for as ensure_permissions;
 pub(super) use window::{

--- a/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/mod.rs
@@ -35,7 +35,8 @@ mod permissions;
 mod window;
 
 pub(super) use accessibility_tree::{
-    element_requires_frontmost, set_value, validate_observation, AxElement,
+    element_is_transient_menu_item, element_requires_frontmost, set_value, validate_observation,
+    AxElement,
 };
 pub(super) use capture::observe_window;
 pub(super) use input::{

--- a/console/src-tauri/src/computer_use_server/platform_windows/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/input.rs
@@ -18,10 +18,12 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     BringWindowToTop, GetAncestor, GetForegroundWindow, GetWindowThreadProcessId, IsWindow,
-    SetCursorPos, SetForegroundWindow, ShowWindow, WindowFromPoint, GA_ROOT, SW_RESTORE,
+    SetCursorPos, SetForegroundWindow, ShowWindow, WindowFromPoint, GA_ROOT, GA_ROOTOWNER,
+    SW_RESTORE,
 };
 
 use super::super::state::{map_point, Observation, WindowInfo};
+use super::super::InputStep;
 use super::uia::{element_point, element_point_by_id};
 use super::window::get_visible_window_rect;
 
@@ -136,10 +138,7 @@ pub(crate) fn type_text(
         .ok_or(("invalid_request", "text is required.".to_string()))?;
     set_focus(&observation.window)?;
     let mut inputs = Vec::with_capacity(text.encode_utf16().count() * 2);
-    for unit in text.encode_utf16() {
-        inputs.push(unicode_input(unit, KEYEVENTF_UNICODE));
-        inputs.push(unicode_input(unit, KEYEVENTF_UNICODE | KEYEVENTF_KEYUP));
-    }
+    append_text_inputs(&mut inputs, text);
     send_inputs(&inputs)?;
     Ok(json!({"applied": true, "text_length": text.chars().count()}))
 }
@@ -157,14 +156,65 @@ pub(crate) fn press_key(
     let keys = parse_key_sequence(key)?;
     set_focus(&observation.window)?;
     let mut inputs = Vec::with_capacity(keys.len() * 2);
-    for value in &keys {
+    append_key_inputs(&mut inputs, &keys);
+    send_inputs(&inputs)?;
+    Ok(json!({"applied": true, "key": key}))
+}
+
+pub(crate) fn input_sequence(
+    observation: &Observation,
+    steps: &[InputStep],
+) -> Result<Value, (&'static str, String)> {
+    let (inputs, ends) = build_sequence_inputs(steps)?;
+    set_focus(&observation.window)?;
+    let applied = send_inputs_count(&inputs);
+    if applied == inputs.len() {
+        return Ok(json!({"applied": true, "completed_steps": steps.len()}));
+    }
+    let completed = completed_steps(&ends, applied);
+    Ok(json!({
+        "completed_steps": completed,
+        "error": {
+            "code": "input_failed",
+            "message": "Windows rejected part of the input sequence.",
+            "step_index": completed,
+            "outcome": "unknown",
+        },
+    }))
+}
+
+fn build_sequence_inputs(
+    steps: &[InputStep],
+) -> Result<(Vec<INPUT>, Vec<usize>), (&'static str, String)> {
+    let mut inputs = Vec::new();
+    let mut ends = Vec::with_capacity(steps.len());
+    for step in steps {
+        match step {
+            InputStep::Type(text) => append_text_inputs(&mut inputs, text),
+            InputStep::PressKey(key) => {
+                let keys = parse_key_sequence(key)?;
+                append_key_inputs(&mut inputs, &keys);
+            }
+        }
+        ends.push(inputs.len());
+    }
+    Ok((inputs, ends))
+}
+
+fn append_text_inputs(inputs: &mut Vec<INPUT>, text: &str) {
+    for unit in text.encode_utf16() {
+        inputs.push(unicode_input(unit, KEYEVENTF_UNICODE));
+        inputs.push(unicode_input(unit, KEYEVENTF_UNICODE | KEYEVENTF_KEYUP));
+    }
+}
+
+fn append_key_inputs(inputs: &mut Vec<INPUT>, keys: &[VIRTUAL_KEY]) {
+    for value in keys {
         inputs.push(virtual_key_input(*value, Default::default()));
     }
     for value in keys.iter().rev() {
         inputs.push(virtual_key_input(*value, KEYEVENTF_KEYUP));
     }
-    send_inputs(&inputs)?;
-    Ok(json!({"applied": true, "key": key}))
 }
 
 fn parse_key_sequence(value: &str) -> Result<Vec<VIRTUAL_KEY>, (&'static str, String)> {
@@ -288,14 +338,21 @@ fn virtual_key_input(
 }
 
 fn send_inputs(inputs: &[INPUT]) -> Result<(), (&'static str, String)> {
-    let applied = unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) };
-    if applied != inputs.len() as u32 {
+    if send_inputs_count(inputs) != inputs.len() {
         return Err((
             "input_failed",
             "Windows rejected keyboard input.".to_string(),
         ));
     }
     Ok(())
+}
+
+fn send_inputs_count(inputs: &[INPUT]) -> usize {
+    unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) as usize }
+}
+
+fn completed_steps(ends: &[usize], applied: usize) -> usize {
+    ends.iter().take_while(|end| **end <= applied).count()
 }
 
 fn verify_point(
@@ -355,8 +412,7 @@ fn validate_target_point(
     point: POINT,
 ) -> Result<POINT, (&'static str, String)> {
     let hit = unsafe { WindowFromPoint(point) };
-    let root = unsafe { GetAncestor(hit, GA_ROOT) };
-    if root.0 != observation.window.hwnd as *mut _ {
+    if !matches_target_window(HWND(observation.window.hwnd as _), hit) {
         return Err((
             "target_not_at_point",
             "Target window is no longer at this point.".to_string(),
@@ -372,6 +428,9 @@ pub(crate) fn set_focus(window: &WindowInfo) -> Result<(), (&'static str, String
             "window_not_found",
             "Target window no longer exists.".to_string(),
         ));
+    }
+    if foreground_matches(hwnd) {
+        return Ok(());
     }
     unsafe {
         let _ = ShowWindow(hwnd, SW_RESTORE);
@@ -404,18 +463,33 @@ fn try_set_foreground(hwnd: HWND) -> bool {
     }
 }
 
-/// Accept activation when the target window is in the foreground, or when a
-/// child popup it owns (such as an open drop-down) currently holds it. Owned
-/// modal dialogs are separate top-level windows, so callers activate them by
-/// their own handle.
+/// Accept activation when the target, one of its child popups, or an owned
+/// top-level window currently holds the foreground.
 fn foreground_matches(hwnd: HWND) -> bool {
-    unsafe {
-        let foreground = GetForegroundWindow();
-        if foreground == hwnd {
-            return true;
-        }
-        !foreground.0.is_null() && GetAncestor(foreground, GA_ROOT) == hwnd
+    matches_target_window(hwnd, unsafe { GetForegroundWindow() })
+}
+
+fn matches_target_window(target: HWND, candidate: HWND) -> bool {
+    if candidate.0.is_null() {
+        return false;
     }
+    unsafe {
+        window_relation_matches(
+            target,
+            GetAncestor(candidate, GA_ROOT),
+            GetAncestor(target, GA_ROOTOWNER),
+            GetAncestor(candidate, GA_ROOTOWNER),
+        )
+    }
+}
+
+fn window_relation_matches(
+    target: HWND,
+    candidate_root: HWND,
+    target_root_owner: HWND,
+    candidate_root_owner: HWND,
+) -> bool {
+    candidate_root == target || (target_root_owner == target && candidate_root_owner == target)
 }
 
 /// The foreground lock rejects background processes, so temporarily join
@@ -502,6 +576,10 @@ fn integer_param(params: &Map<String, Value>, name: &str) -> Result<i32, (&'stat
 mod tests {
     use super::*;
 
+    fn hwnd(value: isize) -> HWND {
+        HWND(value as *mut std::ffi::c_void)
+    }
+
     #[test]
     fn function_and_keypad_keys_map_to_expected_codes() {
         assert_eq!(virtual_key("F1").unwrap(), VIRTUAL_KEY(0x70));
@@ -534,5 +612,42 @@ mod tests {
         assert!(parse_key_sequence("CTRL+SHIFT+F5").is_ok());
         assert!(parse_key_sequence("A+B+C+D+E").is_err());
         assert!(parse_key_sequence("").is_err());
+    }
+
+    #[test]
+    fn sequence_inputs_keep_step_boundaries() {
+        let steps = vec![
+            InputStep::Type("A".to_string()),
+            InputStep::PressKey("TAB".to_string()),
+            InputStep::Type("🙂".to_string()),
+        ];
+
+        let (inputs, ends) = build_sequence_inputs(&steps).unwrap();
+
+        assert_eq!(ends, vec![2, 4, 8]);
+        assert_eq!(inputs.len(), 8);
+        assert_eq!(completed_steps(&ends, 3), 1);
+        assert_eq!(completed_steps(&ends, 4), 2);
+    }
+
+    #[test]
+    fn sequence_keys_are_validated_before_input_is_built() {
+        let steps = vec![
+            InputStep::Type("already valid".to_string()),
+            InputStep::PressKey("NO_SUCH_KEY".to_string()),
+        ];
+
+        assert!(build_sequence_inputs(&steps).is_err());
+    }
+
+    #[test]
+    fn input_target_relationships_are_scoped() {
+        let owner = hwnd(1);
+        let modal = hwnd(2);
+        let sibling = hwnd(3);
+        assert!(window_relation_matches(owner, owner, owner, owner));
+        assert!(window_relation_matches(owner, modal, owner, owner));
+        assert!(!window_relation_matches(modal, owner, owner, owner));
+        assert!(!window_relation_matches(modal, sibling, owner, owner));
     }
 }

--- a/console/src-tauri/src/computer_use_server/platform_windows/mod.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/mod.rs
@@ -14,7 +14,7 @@ mod window;
 
 pub(super) use capture::observe_window;
 pub(super) use input::{
-    click, desktop_locked, drag, last_input_age_ms, press_key, scroll, type_text,
+    click, desktop_locked, drag, input_sequence, last_input_age_ms, press_key, scroll, type_text,
 };
 pub(super) use uia::{invoke_element, set_value, validate_observation};
 pub(super) use window::{close_window, is_forbidden, list_apps, list_windows, resolve_window};

--- a/console/src-tauri/src/computer_use_server/state.rs
+++ b/console/src-tauri/src/computer_use_server/state.rs
@@ -135,6 +135,10 @@ pub(super) struct Observation {
     /// Digest of the normalized accessibility surface the model observed.
     /// Kept native-side so callers cannot copy or forge a revision token.
     pub(super) accessibility_revision: Option<[u8; 32]>,
+    /// Whether this exact macOS surface can accept one text action through an
+    /// application-owned editor that is absent from its accessibility tree.
+    #[cfg(target_os = "macos")]
+    pub(super) transient_text_ready: bool,
     pub(super) elements: HashMap<String, NativeElement>,
 }
 
@@ -368,6 +372,8 @@ mod tests {
             display_width: display.0,
             display_height: display.1,
             accessibility_revision: None,
+            #[cfg(target_os = "macos")]
+            transient_text_ready: false,
             elements: HashMap::new(),
         }
     }

--- a/console/src-tauri/src/computer_use_server/state.rs
+++ b/console/src-tauri/src/computer_use_server/state.rs
@@ -14,6 +14,34 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
+use super::platform_macos::HostFocusLease;
+
+/// Platform resources retained while one agent turn interacts with the desktop.
+///
+/// The lifecycle is shared even though the native resource is not: macOS keeps
+/// the desktop host from reclaiming focus, while Windows already targets and
+/// verifies the foreground window for each action.
+struct InteractionSession {
+    #[cfg(target_os = "macos")]
+    _host_focus: HostFocusLease,
+}
+
+impl InteractionSession {
+    fn begin() -> Result<Self, (&'static str, String)> {
+        #[cfg(target_os = "macos")]
+        {
+            return Ok(Self {
+                _host_focus: HostFocusLease::begin()?,
+            });
+        }
+        #[cfg(windows)]
+        {
+            Ok(Self {})
+        }
+    }
+}
+
 /// Native accessibility element handle stored with an observation.
 /// Windows uses a UI Automation element; macOS uses an AXUIElement wrapper.
 #[cfg(windows)]
@@ -148,14 +176,15 @@ pub(super) struct ServerState {
     pending_action: Option<PendingAction>,
     last_action_at: HashMap<isize, Instant>,
     global_action_at: Option<Instant>,
+    interaction_session: Option<InteractionSession>,
 }
 
 impl ServerState {
-    /// A desktop mutation makes every snapshot of that window stale.
-    pub(super) fn note_action(&mut self, hwnd: isize) {
+    /// A desktop mutation makes every snapshot of that application stale.
+    pub(super) fn note_action(&mut self, window: &WindowInfo) {
         self.observations
-            .retain(|_, observation| observation.window.hwnd != hwnd);
-        self.last_action_at.insert(hwnd, Instant::now());
+            .retain(|_, observation| observation.window.app_id != window.app_id);
+        self.last_action_at.insert(window.hwnd, Instant::now());
     }
 
     pub(super) fn note_global_action(&mut self) {
@@ -192,6 +221,14 @@ impl ServerState {
         self.pending_action = None;
         self.last_action_at.clear();
         self.global_action_at = None;
+        self.interaction_session = None;
+    }
+
+    pub(super) fn ensure_interaction_session(&mut self) -> Result<(), (&'static str, String)> {
+        if self.interaction_session.is_none() {
+            self.interaction_session = Some(InteractionSession::begin()?);
+        }
+        Ok(())
     }
 
     /// Discard point-in-time state after input outside the current action.
@@ -202,6 +239,7 @@ impl ServerState {
     pub(super) fn invalidate_observations(&mut self) {
         self.observations.clear();
         self.pending_action = None;
+        self.interaction_session = None;
     }
 }
 

--- a/plugins/bundle/computer-use/computer_use/client.py
+++ b/plugins/bundle/computer-use/computer_use/client.py
@@ -57,6 +57,7 @@ _OBSERVED_METHODS = frozenset(
         "invoke_element",
         "press_key",
         "scroll",
+        "sequence",
         "set_value",
         "type_text",
     },

--- a/plugins/bundle/computer-use/computer_use/dispatch.py
+++ b/plugins/bundle/computer-use/computer_use/dispatch.py
@@ -44,6 +44,7 @@ ComputerUseAction = Literal[
     "press_key",
     "sequence",
     "invoke",
+    "begin_text_edit",
     "set_value",
     "wait",
     "stop",
@@ -466,17 +467,21 @@ def _native_request(
             {"text": text},
             False,
         )
-    if action in {"invoke", "set_value"}:
+    if action in {"invoke", "begin_text_edit", "set_value"}:
         element_id = str(values["element_id"] or "").strip()
         if not element_id:
             raise ValueError(
                 f"{action} requires element_id from observe_window.",
             )
         params = {"element_id": element_id}
+        if action == "begin_text_edit":
+            params["expects_text_input"] = True
         if action == "set_value":
             params["value"] = str(values["value"] or "")
         return (
-            f"{action}_element" if action == "invoke" else action,
+            "invoke_element"
+            if action in {"invoke", "begin_text_edit"}
+            else action,
             params,
             False,
         )
@@ -491,5 +496,5 @@ def _native_request(
         "Unknown action. Valid actions: list_apps, list_windows, "
         "observe_window, launch_app, close_window, click, "
         "double_click, right_click, scroll, drag, type, press_key, invoke, "
-        "set_value, sequence, wait, stop.",
+        "begin_text_edit, set_value, sequence, wait, stop.",
     )

--- a/plugins/bundle/computer-use/computer_use/dispatch.py
+++ b/plugins/bundle/computer-use/computer_use/dispatch.py
@@ -42,6 +42,7 @@ ComputerUseAction = Literal[
     "drag",
     "type",
     "press_key",
+    "sequence",
     "invoke",
     "set_value",
     "wait",
@@ -49,7 +50,7 @@ ComputerUseAction = Literal[
 ]
 
 
-def _check_rate_limit() -> None:
+def _check_rate_limit(cost: int = 1) -> None:
     # The tool can be entered from more than one event loop -- the host runs
     # per-workspace loops on their own threads -- so the guard is a threading
     # lock rather than an asyncio one, which serialises only within a single
@@ -62,12 +63,49 @@ def _check_rate_limit() -> None:
         _action_times[:] = [
             value for value in _action_times if now - value < 60
         ]
-        if len(_action_times) >= _MAX_ACTIONS_PER_MINUTE:
+        if len(_action_times) + cost > _MAX_ACTIONS_PER_MINUTE:
             raise ComputerUseProtocolError(
                 "rate_limited",
                 "Computer Use rate limit exceeded; wait before continuing.",
             )
-        _action_times.append(now)
+        _action_times.extend([now] * cost)
+
+
+def _sequence_steps(steps: Any) -> list[dict[str, str]]:
+    """Validate the bounded keyboard-only sequence contract."""
+    if isinstance(steps, str):
+        try:
+            steps = json.loads(steps)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "sequence steps must be a JSON array.",
+            ) from error
+    if not isinstance(steps, list) or not 1 <= len(steps) <= 20:
+        raise ValueError("sequence requires 1 to 20 steps.")
+    normalized = []
+    text_length = 0
+    for index, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            raise ValueError(f"sequence step {index} must be an object.")
+        action = str(step.get("action") or "").strip().lower()
+        if action not in {"type", "press_key"}:
+            raise ValueError(f"sequence step {index} must use type or press_key.")
+        field = "text" if action == "type" else "key"
+        value = step.get(field)
+        if (
+            not isinstance(value, str)
+            or not value
+            or (action == "press_key" and not value.strip())
+        ):
+            raise ValueError(f"sequence step {index} requires non-empty {field}.")
+        if set(step) != {"action", field}:
+            raise ValueError(f"sequence step {index} accepts only action and {field}.")
+        if action == "type":
+            text_length += len(value)
+            if text_length > 512:
+                raise ValueError("sequence text is limited to 512 characters.")
+        normalized.append({"action": action, field: value})
+    return normalized
 
 
 def _without_screenshot_urls(payload: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -190,11 +228,14 @@ def _response(
 
 
 def _error(code: str, message: str) -> ToolChunk:
+    payload = {
+        "ok": False,
+        "error": {"code": code, "message": message},
+    }
+    if code == "user_intervention":
+        payload["requires_observe"] = True
     return _response(
-        {
-            "ok": False,
-            "error": {"code": code, "message": message},
-        },
+        payload,
         state=ToolResultState.ERROR,
     )
 
@@ -229,6 +270,7 @@ async def computer_use(
     text: str = "",
     value: str = "",
     key: str = "",
+    steps: list[dict[str, Any]] | str | None = None,
     wait_ms: int = 500,
     timeout_ms: int = 10000,
 ) -> ToolChunk:
@@ -244,7 +286,6 @@ async def computer_use(
     # tell apart, so they are reported individually rather than merged.
     # pylint: disable=too-many-return-statements
     try:
-        _check_rate_limit()
         action = str(action or "").strip().lower()
         if not action:
             raise ValueError("action is required.")
@@ -255,6 +296,7 @@ async def computer_use(
                 "panel to allow desktop automation.",
             )
         if action == "wait":
+            _check_rate_limit()
             await asyncio.sleep(max(0, min(wait_ms, 30_000)) / 1000)
             return _response(
                 {"ok": True, "action": action, "waited_ms": wait_ms},
@@ -262,6 +304,7 @@ async def computer_use(
 
         client = get_computer_use_client()
         if action == "stop":
+            _check_rate_limit()
             await client.stop_turn()
             return _response({"ok": True, "action": action})
 
@@ -284,16 +327,23 @@ async def computer_use(
             text=text,
             value=value,
             key=key,
+            steps=steps,
         )
+        if method == "sequence":
+            _check_rate_limit(len(params["steps"]))
+        else:
+            _check_rate_limit()
         result = await client.execute(
             method,
             params,
             deadline_ms=max(100, min(timeout_ms, 30_000)),
         )
-        payload = {"ok": True, "action": action, **result}
+        failed = action == "sequence" and isinstance(result.get("error"), Mapping)
+        payload = {"ok": not failed, "action": action, **result}
         return _response(
             payload,
             include_images=include_images or bool(result.get("screenshots")),
+            state=ToolResultState.ERROR if failed else ToolResultState.SUCCESS,
         )
     except ComputerUseProtocolError as error:
         return _error(error.code, str(error))
@@ -412,9 +462,11 @@ def _native_request(
         if not key:
             raise ValueError("press_key requires key.")
         return action, {"key": key}, False
+    if action == "sequence":
+        return action, {"steps": _sequence_steps(values.get("steps"))}, False
     raise ValueError(
         "Unknown action. Valid actions: list_apps, list_windows, "
         "observe_window, launch_app, close_window, click, "
         "double_click, right_click, scroll, drag, type, press_key, invoke, "
-        "set_value, wait, stop.",
+        "set_value, sequence, wait, stop.",
     )

--- a/plugins/bundle/computer-use/computer_use/dispatch.py
+++ b/plugins/bundle/computer-use/computer_use/dispatch.py
@@ -89,7 +89,9 @@ def _sequence_steps(steps: Any) -> list[dict[str, str]]:
             raise ValueError(f"sequence step {index} must be an object.")
         action = str(step.get("action") or "").strip().lower()
         if action not in {"type", "press_key"}:
-            raise ValueError(f"sequence step {index} must use type or press_key.")
+            raise ValueError(
+                f"sequence step {index} must use type or press_key.",
+            )
         field = "text" if action == "type" else "key"
         value = step.get(field)
         if (
@@ -97,9 +99,13 @@ def _sequence_steps(steps: Any) -> list[dict[str, str]]:
             or not value
             or (action == "press_key" and not value.strip())
         ):
-            raise ValueError(f"sequence step {index} requires non-empty {field}.")
+            raise ValueError(
+                f"sequence step {index} requires non-empty {field}.",
+            )
         if set(step) != {"action", field}:
-            raise ValueError(f"sequence step {index} accepts only action and {field}.")
+            raise ValueError(
+                f"sequence step {index} accepts only action and {field}.",
+            )
         if action == "type":
             text_length += len(value)
             if text_length > 512:
@@ -108,16 +114,28 @@ def _sequence_steps(steps: Any) -> list[dict[str, str]]:
     return normalized
 
 
-def _without_screenshot_urls(payload: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Replace inline screenshot data with a placeholder for text output.
+def _without_screenshot_urls(
+    payload: Mapping[str, Any],
+    *,
+    attached: bool,
+) -> Mapping[str, Any]:
+    """Remove image data from text output, retaining metadata when attached.
 
     Screenshots are attached as image blocks; repeating the base64 data
     URL inside the JSON text block would double a multi-megabyte payload
-    and pollute the model's text context.
+    and pollute the model's text context. Post-action observations remain
+    available natively but omit their image metadata until an explicit visual
+    observation requests the attachment.
     """
     screenshots = payload.get("screenshots")
     if not isinstance(screenshots, list):
         return payload
+    if not attached:
+        return {
+            key: value
+            for key, value in payload.items()
+            if key != "screenshots"
+        }
     sanitized: list[Any] = []
     for screenshot in screenshots:
         if isinstance(screenshot, Mapping) and "url" in screenshot:
@@ -218,7 +236,9 @@ def _response(
         TextBlock(
             type="text",
             text=json.dumps(
-                _with_compact_elements(_without_screenshot_urls(payload)),
+                _with_compact_elements(
+                    _without_screenshot_urls(payload, attached=include_images),
+                ),
                 ensure_ascii=False,
                 separators=(",", ":"),
             ),
@@ -338,11 +358,14 @@ async def computer_use(
             params,
             deadline_ms=max(100, min(timeout_ms, 30_000)),
         )
-        failed = action == "sequence" and isinstance(result.get("error"), Mapping)
+        failed = action == "sequence" and isinstance(
+            result.get("error"),
+            Mapping,
+        )
         payload = {"ok": not failed, "action": action, **result}
         return _response(
             payload,
-            include_images=include_images or bool(result.get("screenshots")),
+            include_images=include_images,
             state=ToolResultState.ERROR if failed else ToolResultState.SUCCESS,
         )
     except ComputerUseProtocolError as error:

--- a/plugins/bundle/computer-use/computer_use/protocol.py
+++ b/plugins/bundle/computer-use/computer_use/protocol.py
@@ -35,6 +35,7 @@ NATIVE_METHODS = frozenset(
         "observe_window",
         "press_key",
         "scroll",
+        "sequence",
         "set_value",
         "type_text",
     },

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -9,6 +9,18 @@ metadata:
 
 # Computer Use
 
+## Tool Boundaries
+
+Read this Skill completely before Windows automation work, before reporting
+Computer Use unavailable, and before falling back to another Windows
+automation method. During a Computer Use workflow, do not switch to PowerShell
+UI Automation; keep Windows UI automation on the native desktop runtime.
+
+Use Computer Use when command-line tools or structured integrations are not
+enough, including tasks that require the live GUI or visual verification. Keep
+data operations on a purpose-built integration when it can complete and verify
+them.
+
 Use this tool only through its native desktop runtime. It operates on one
 approved application at a time and never accepts a free-form screen target.
 
@@ -215,8 +227,34 @@ the requested state change in the replacement observation.
 They bring that window to the foreground themselves, so do not add a click
 merely to focus the window. If a control inside the window must first be
 selected, click it, inspect the replacement observation, then type or press the
-key with that new identifier. Send the smallest useful batch and confirm what
-arrived in the replacement observation.
+key with that new identifier.
+
+Use `sequence` for deterministic keyboard input that stays in the same window
+and does not depend on an intermediate screen change. It accepts 1 to 20
+`type` or `press_key` steps, with at most 512 typed characters in total, and
+returns one replacement observation after the sequence.
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    {"action": "type", "text": "INV-001"},
+    {"action": "press_key", "key": "TAB"},
+    {"action": "type", "text": "125.50"}
+  ]
+}
+```
+
+Do not put clicks, waits, dialogs, or actions that require checking a changed
+screen into a sequence. Split at those boundaries and inspect the replacement
+observation first. `completed_steps` counts input steps dispatched by the
+runtime; it does not verify the application's business result. On a sequence
+error, inspect the replacement observation before deciding what to send next.
+After user intervention, stop and observe the window again first.
+
+Key names and shortcuts belong in `press_key`, never in `type`. If a key such
+as `F5` opens a dialog or moves focus to another interface, send it as a
+standalone action and observe the result before typing into that interface.
 
 Use `type` only when `accessibility.focused_element` identifies the intended
 editable control. A missing focus summary, a focused list, or a selected row is

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -110,8 +110,10 @@ exact element. `[settable]` explicitly confirms that `set_value` is
 supported; runtimes that do not publish capability markers may omit it.
 `[resource-backed]` means the displayed value names an object owned by the
 application. Do not use `set_value` on it: changing its accessibility label can
-repaint the text without changing the underlying object. Select the object and
-invoke the application's edit or rename command instead.
+repaint the text without changing the underlying object. Select it, observe
+again, then use an observed application command that explicitly describes the
+requested edit; a context menu exposed by `right_click` is one such route. Do
+not infer editing behavior from a generic accessibility action or shortcut.
 `[actions=...]` lists the accessibility actions the element exposes; never
 guess a semantic action when that list is present.
 
@@ -203,7 +205,9 @@ only when the surrounding application state shows the requested value. Do not su
 claim success or start another operation while confirmation remains pending.
 On macOS, only use `set_value` when `[settable]` is present. A
 `[resource-backed]` label must first be selected and put into edit mode through
-an explicit application command, such as an accessible edit or rename command.
+an observed application command, such as an accessible context-menu edit or
+rename command. Do not treat `AXConfirm` or `ENTER` as that command unless the
+application explicitly identifies it with the requested edit semantics.
 Some native editors are transient and appear only as the current focused AX
 element. Type when the replacement observation identifies that editable focus.
 If the command response instead contains `transient_text_ready: true`, the
@@ -214,6 +218,10 @@ window first. Its `effect` is unverified, so complete the edit with the
 application's documented command and observe the durable application state
 before continuing. Without editable focus or that explicit capability, stop
 rather than sending text to the surrounding view.
+If the completed resource is temporarily absent from the replacement
+accessibility listing, observe again without mutating anything. Repeat the edit
+only after a fresh observation proves that the old durable value remains; do
+not turn an application's transitional state into a duplicate write.
 Use the application's documented completion action when one is required, and
 verify the durable result. Do not guess completion commands or repeat an
 unverified write.

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -246,8 +246,8 @@ what arrived in the replacement observation.
 
 Use `sequence` for deterministic keyboard input that stays in the same window
 and does not depend on an intermediate screen change. It accepts 1 to 20
-`type` or `press_key` steps, with at most 512 typed characters in total, and
-returns one replacement observation after the sequence.
+`type` or `press_key` steps, with at most 512 typed characters in total. After
+it runs, use the replacement observation when the response includes one.
 
 ```json
 {
@@ -264,8 +264,9 @@ Do not put clicks, waits, dialogs, or actions that require checking a changed
 screen into a sequence. Split at those boundaries and inspect the replacement
 observation first. `completed_steps` counts input steps dispatched by the
 runtime; it does not verify the application's business result. On a sequence
-error, inspect the replacement observation before deciding what to send next.
-After user intervention, stop and observe the window again first.
+error, inspect any replacement observation in the response. If the response
+includes `requires_observe` or `next_action`, follow it before sending more
+input. After user intervention, stop and observe the window again first.
 
 Key names and shortcuts belong in `press_key`, never in `type`. If a key such
 as `F5` opens a dialog or moves focus to another interface, send it as a

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -138,29 +138,40 @@ for its actionable element to appear.
 
 Every successful action that can change the desktop invalidates its input
 observation. When the target remains open, the same response includes its
-settled screenshot and accessibility state, while the runtime installs the
-replacement observation internally. Inspect that state before the next
-action. Fields such as `dispatched: true` alone only confirm that native input
-was sent. If an action reports `next_action: list_windows`, the original
-window was closed or replaced; list windows and observe the new target. When
-an action opens a separate window or dialog, list windows and observe that
-target before acting. Standard macOS sheets are observed as their own target.
+settled accessibility state, while the runtime installs the replacement
+observation internally. Inspect that state before the next action.
+`accessibility_changed: false` means the refreshed AX surface did not change;
+it is evidence that an AX-visible transition did not occur, but it does not
+rule out a visual-only change. Action responses omit their screenshot
+attachment by default. Call `observe_window` with the returned window ID when
+AX is insufficient and visual confirmation is necessary. Fields such as
+`dispatched: true` alone only confirm that native input was sent. For text
+input, `effect: observed` means the native adapter also verified the editable
+buffer; `effect: unverified` requires confirmation from the replacement
+accessibility state or a fresh visual observation before claiming success. If
+an action reports `next_action: list_windows`, the original window was closed
+or replaced; list windows and observe the new target. When an action opens a
+separate window or dialog, list windows and observe that target before acting.
+Standard macOS sheets are observed as their own target.
 
 ## Choose One Target Channel
 
 Use UI Automation when the desired element is present in
 `accessibility.elements`. Locate it by its `control_type_name` and `name`,
-then act on it by `element_id`. Use `invoke` for a `Button`, `MenuItem`, or
-similar control; use `set_value` for an `Edit` or `ComboBox` that holds text.
-This is preferred over keystrokes when a matching element exists.
-Menu commands may remain semantically invokable even when the application does
-not publish a stable rectangle for them; invoke the matching enabled
-`MenuItem`, then verify its replacement observation instead of substituting a
-coordinate click.
+then act on it by `element_id`. Use `click` for ordinary visible controls,
+including buttons and menu items, and use `set_value` for an `Edit` or
+`ComboBox` that holds text. This is preferred over keystrokes when a matching
+element exists. Use `invoke` only when a normal click is unavailable and the
+element explicitly lists a suitable accessibility action, or when completing
+the pending semantic edit described below.
+
+For an application menu, click the observed top-level `MenuItem` by
+`element_id`, inspect its replacement observation, and then click the desired
+command from that open menu. Never act on a closed menu's unobserved children.
 
 ```json
 {
-  "action": "invoke",
+  "action": "click",
   "element_id": "uia-12"
 }
 ```
@@ -192,13 +203,14 @@ only when the surrounding application state shows the requested value. Do not su
 claim success or start another operation while confirmation remains pending.
 On macOS, only use `set_value` when `[settable]` is present. A
 `[resource-backed]` label must first be selected and put into edit mode through
-an explicit application command, such as an accessible edit or rename menu
-item. Use the replacement observation returned after invoking that command.
-Some inline editors are visible
-before macOS publishes their accessibility element; when you just invoked an
-explicit edit command and the screenshot clearly shows that editor, typing one
-value is allowed even if `focused_element` is temporarily absent. Verify the
-value in the replacement observation before confirming it.
+an explicit application command, such as an accessible edit or rename command.
+Some native editors are transient and appear only as the current focused AX
+element. Type only when the replacement observation identifies that editable
+focus; the runtime will reject keyboard fallback unless the focused element
+still belongs to the observed window and exposes text-editing capabilities.
+Use the application's documented completion action when one is required, and
+verify the durable result. Do not guess completion commands or repeat an
+unverified write.
 
 Use visual coordinates only when UI Automation is unavailable or unsuitable.
 Every visual action uses the current observation retained by the runtime.
@@ -227,7 +239,10 @@ the requested state change in the replacement observation.
 They bring that window to the foreground themselves, so do not add a click
 merely to focus the window. If a control inside the window must first be
 selected, click it, inspect the replacement observation, then type or press the
-key with that new identifier.
+key with that new identifier. On macOS, `type` uses semantic insertion for an
+accessible editor and process-targeted Unicode events for transient editors
+that do not expose a text buffer. Send the smallest useful batch and confirm
+what arrived in the replacement observation.
 
 Use `sequence` for deterministic keyboard input that stays in the same window
 and does not depend on an intermediate screen change. It accepts 1 to 20
@@ -258,11 +273,10 @@ standalone action and observe the result before typing into that interface.
 
 Use `type` only when `accessibility.focused_element` identifies the intended
 editable control. A missing focus summary, a focused list, or a selected row is
-not an editor. In those cases, wait for or select the correct control, or try
-`set_value` once on the matching editable element; an unsupported-operation
-response means that path is unavailable. If a fresh observation does not show
-the text where expected, the input did not succeed; do not continue with a
-confirm key.
+not an editor. Wait for or select the correct control, or try `set_value` once
+on the matching editable element; an unsupported-operation response means that
+path is unavailable. If a fresh observation does not show the text where
+expected, do not claim that it succeeded.
 
 `press_key` takes a single key or a chord of up to four names joined with `+`.
 Recognized names include modifiers (`CTRL`, `ALT`, `SHIFT`, `WIN`), letters and
@@ -270,6 +284,14 @@ digits, function keys (`F1`-`F12`), the numeric keypad (`NUMPAD0`-`NUMPAD9`),
 and editing or navigation keys such as `ENTER`, `TAB`, `ESC`, `SPACE`,
 `BACKSPACE`, `DELETE`, `INSERT`, `HOME`, `END`, `PAGEUP`, `PAGEDOWN`, and the
 arrow keys `UP`/`DOWN`/`LEFT`/`RIGHT`.
+
+When a command is expected to expose a temporary editor, menu, sheet, or
+dialog that the next action depends on, enter that state through a matching
+enabled semantic element whenever one is available. A shortcut receipt proves
+only that input was dispatched; it does not prove that the dependent control
+was created. Do not type into that state unless the replacement observation
+shows the intended editable control. Otherwise stop instead of guessing
+another shortcut or typing into the surrounding view.
 
 A chord must end with a non-modifier key; never send a modifier by itself or
 try to hold it across calls. On macOS, express the Command key as `WIN`, for

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -205,9 +205,15 @@ On macOS, only use `set_value` when `[settable]` is present. A
 `[resource-backed]` label must first be selected and put into edit mode through
 an explicit application command, such as an accessible edit or rename command.
 Some native editors are transient and appear only as the current focused AX
-element. Type only when the replacement observation identifies that editable
-focus; the runtime will reject keyboard fallback unless the focused element
-still belongs to the observed window and exposes text-editing capabilities.
+element. Type when the replacement observation identifies that editable focus.
+If the command response instead contains `transient_text_ready: true`, the
+returned observation can accept one text action for an editor that the
+application did not publish through AX and reports `next_action: type`; send
+exactly one `type` action next, without observing, clicking, or changing the
+window first. Its `effect` is unverified, so complete the edit with the
+application's documented command and observe the durable application state
+before continuing. Without editable focus or that explicit capability, stop
+rather than sending text to the surrounding view.
 Use the application's documented completion action when one is required, and
 verify the durable result. Do not guess completion commands or repeat an
 unverified write.
@@ -273,11 +279,13 @@ as `F5` opens a dialog or moves focus to another interface, send it as a
 standalone action and observe the result before typing into that interface.
 
 Use `type` only when `accessibility.focused_element` identifies the intended
-editable control. A missing focus summary, a focused list, or a selected row is
-not an editor. Wait for or select the correct control, or try `set_value` once
-on the matching editable element; an unsupported-operation response means that
-path is unavailable. If a fresh observation does not show the text where
-expected, do not claim that it succeeded.
+editable control or the immediately preceding command returned
+`transient_text_ready: true`. A missing focus summary, a focused list, or a
+selected row is otherwise not an editor. Wait for or select the correct
+control, or try `set_value` once on the matching editable element; an
+unsupported-operation response means that path is unavailable. If a fresh
+observation does not show the text where expected, do not claim that it
+succeeded.
 
 `press_key` takes a single key or a chord of up to four names joined with `+`.
 Recognized names include modifiers (`CTRL`, `ALT`, `SHIFT`, `WIN`), letters and

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -165,7 +165,10 @@ including buttons and menu items, and use `set_value` for an `Edit` or
 `ComboBox` that holds text. This is preferred over keystrokes when a matching
 element exists. Use `invoke` only when a normal click is unavailable and the
 element explicitly lists a suitable accessibility action, or when completing
-the pending semantic edit described below.
+the pending semantic edit described below. Use `begin_text_edit` only on an
+observed command whose label explicitly describes entering text-edit mode.
+Unlike an ordinary click or invoke, it may authorize one following `type`
+action when a native transient editor cannot be represented through AX.
 
 For an application menu, click the observed top-level `MenuItem` by
 `element_id`, inspect its replacement observation, and then click the desired
@@ -206,8 +209,10 @@ claim success or start another operation while confirmation remains pending.
 On macOS, only use `set_value` when `[settable]` is present. A
 `[resource-backed]` label must first be selected and put into edit mode through
 an observed application command, such as an accessible context-menu edit or
-rename command. Do not treat `AXConfirm` or `ENTER` as that command unless the
-application explicitly identifies it with the requested edit semantics.
+rename command. Invoke that observed command with `begin_text_edit`; do not use
+it for an ordinary menu command. Do not treat `AXConfirm` or `ENTER` as an edit
+command unless the application explicitly identifies it with the requested
+edit semantics.
 Some native editors are transient and appear only as the current focused AX
 element. Type when the replacement observation identifies that editable focus.
 If the command response instead contains `transient_text_ready: true`, the

--- a/tests/unit/plugins/computer_use/test_computer_use_protocol.py
+++ b/tests/unit/plugins/computer_use/test_computer_use_protocol.py
@@ -355,7 +355,7 @@ async def test_function_tool_preserves_intervention_error_state(
     assert '"requires_observe":true' in response.content[-1].text
 
 
-def test_uia_input_leaves_observation_to_client() -> None:
+def test_semantic_actions_leave_observation_to_client() -> None:
     method, params, _ = _native_request(
         "invoke",
         element_id="uia-7",
@@ -363,6 +363,17 @@ def test_uia_input_leaves_observation_to_client() -> None:
 
     assert method == "invoke_element"
     assert params == {"element_id": "uia-7"}
+
+    method, params, _ = _native_request(
+        "begin_text_edit",
+        element_id="uia-8",
+    )
+
+    assert method == "invoke_element"
+    assert params == {
+        "element_id": "uia-8",
+        "expects_text_input": True,
+    }
 
 
 class _FakeTransport(ComputerUseTransport):

--- a/tests/unit/plugins/computer_use/test_computer_use_protocol.py
+++ b/tests/unit/plugins/computer_use/test_computer_use_protocol.py
@@ -129,6 +129,64 @@ def test_close_window_maps_to_the_native_method() -> None:
     assert include_images is False
 
 
+def test_sequence_maps_a_bounded_keyboard_batch() -> None:
+    steps = [
+        {"action": "type", "text": "INV-001"},
+        {"action": "press_key", "key": "TAB"},
+    ]
+
+    method, params, include_images = _native_request("sequence", steps=steps)
+
+    assert method == "sequence"
+    assert params == {"steps": steps}
+    assert include_images is False
+
+
+def test_sequence_accepts_a_json_encoded_batch() -> None:
+    steps = json.dumps(
+        [
+            {"action": "type", "text": "INV-001"},
+            {"action": "press_key", "key": "TAB"},
+        ],
+    )
+
+    method, params, include_images = _native_request("sequence", steps=steps)
+
+    assert method == "sequence"
+    assert params["steps"][0]["text"] == "INV-001"
+    assert include_images is False
+
+
+def test_sequence_tool_schema_accepts_array_or_json_string() -> None:
+    import jsonschema
+
+    schema = FunctionTool(computer_use).input_schema
+    steps = [{"action": "type", "text": "INV-001"}]
+
+    jsonschema.validate({"action": "sequence", "steps": steps}, schema)
+    jsonschema.validate(
+        {"action": "sequence", "steps": json.dumps(steps)},
+        schema,
+    )
+
+
+@pytest.mark.parametrize(
+    "steps",
+    [
+        [],
+        "not-json",
+        [{"action": "click", "x": 1, "y": 1}],
+        [{"action": "type", "text": "x", "extra": True}],
+        [{"action": "press_key", "key": " "}],
+        [{"action": "type", "text": "x"}] * 21,
+        [{"action": "type", "text": "x" * 513}],
+    ],
+)
+def test_sequence_rejects_inputs_outside_its_contract(steps: Any) -> None:
+    with pytest.raises(ValueError):
+        _native_request("sequence", steps=steps)
+
+
 def test_client_injects_its_private_observation() -> None:
     client = ComputerUseClient("session-1")
     client._observation_id = "observation-1"
@@ -136,6 +194,24 @@ def test_client_injects_its_private_observation() -> None:
     params = client._native_params("close_window", {})
 
     assert params == {"observation_id": "observation-1"}
+
+
+def test_partial_sequence_result_advances_the_private_observation() -> None:
+    client = ComputerUseClient("session-1")
+    client._observation_id = "observation-1"
+
+    result = client._accept_result(
+        "sequence",
+        {
+            "observation_id": "observation-2",
+            "completed_steps": 1,
+            "error": {"code": "input_failed"},
+        },
+    )
+
+    assert client._observation_id == "observation-2"
+    assert "observation_id" not in result
+    assert result["completed_steps"] == 1
 
 
 def test_client_rejects_action_before_observe() -> None:
@@ -183,6 +259,62 @@ def test_native_error_marks_the_tool_call_as_failed() -> None:
     assert '"ok":false' in response.content[-1].text
 
 
+def test_sequence_steps_count_against_the_action_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dispatch_module, "_action_times", [])
+    monkeypatch.setattr(dispatch_module, "_MAX_ACTIONS_PER_MINUTE", 3)
+
+    dispatch_module._check_rate_limit(3)
+
+    with pytest.raises(ComputerUseProtocolError) as refusal:
+        dispatch_module._check_rate_limit()
+    assert refusal.value.code == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_partial_sequence_is_an_error_with_a_fresh_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Enabled:
+        @staticmethod
+        def is_enabled() -> bool:
+            return True
+
+    class _PartialClient:
+        @staticmethod
+        async def execute(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "completed_steps": 1,
+                "error": {"code": "input_failed", "step_index": 1},
+                "screenshots": [],
+            }
+
+    monkeypatch.setattr(dispatch_module, "_check_rate_limit", lambda *_: None)
+    monkeypatch.setattr(
+        dispatch_module,
+        "get_computer_use_feature_state",
+        lambda: _Enabled(),
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "get_computer_use_client",
+        lambda: _PartialClient(),
+    )
+
+    response = await computer_use(
+        action="sequence",
+        steps=[
+            {"action": "type", "text": "A"},
+            {"action": "press_key", "key": "TAB"},
+        ],
+    )
+
+    assert response.state == ToolResultState.ERROR
+    assert '"ok":false' in response.content[-1].text
+    assert '"completed_steps":1' in response.content[-1].text
+
+
 @pytest.mark.asyncio
 async def test_function_tool_preserves_intervention_error_state(
     monkeypatch: pytest.MonkeyPatch,
@@ -220,6 +352,7 @@ async def test_function_tool_preserves_intervention_error_state(
     assert response.is_last is True
     assert response.state == ToolResultState.ERROR
     assert '"code":"user_intervention"' in response.content[-1].text
+    assert '"requires_observe":true' in response.content[-1].text
 
 
 def test_uia_input_leaves_observation_to_client() -> None:


### PR DESCRIPTION
## Description

Improve native Computer Use input reliability and reduce round trips in desktop workflows.

- Add a bounded keyboard-only `sequence` action with per-step rate limiting, partial completion reporting, and refreshed observation handling.
- Keep Windows input targeted when an approved root window owns the active modal.
- Harden macOS capture, accessibility, focus, and text input for sheets and transient editors.
- Align the Computer Use Skill guidance and add protocol and dispatch coverage.

**Related Issue:** N/A

**Security Considerations:** No new permissions or external access; input remains within the existing approved app and window boundary.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
PYTHONPATH=src python -m pytest tests/unit/plugins/computer_use -q --basetemp .tmp_pr_pytest
cargo test --manifest-path console/src-tauri/Cargo.toml --bin qwenpaw-computer-use-helper -j 1
rustfmt --edition 2021 --check \
  console/src-tauri/src/computer_use_runtime.rs \
  console/src-tauri/src/computer_use_server/dispatch.rs \
  console/src-tauri/src/computer_use_server/mod.rs \
  console/src-tauri/src/computer_use_server/platform_macos/accessibility_tree.rs \
  console/src-tauri/src/computer_use_server/platform_macos/capture.rs \
  console/src-tauri/src/computer_use_server/platform_macos/input.rs \
  console/src-tauri/src/computer_use_server/platform_macos/mod.rs \
  console/src-tauri/src/computer_use_server/platform_windows/input.rs \
  console/src-tauri/src/computer_use_server/platform_windows/mod.rs \
  console/src-tauri/src/computer_use_server/state.rs
git diff --check upstream/main...HEAD
```

## Evidence

```text
Computer Use Python tests: 104 passed in 16.72s
Native helper tests: 45 passed; 0 failed
Changed Rust files: rustfmt --check passed
PR diff: git diff --check passed
```

## Additional Notes

- Draft because the macOS native build and real-device smoke test are still pending.
- Full-workspace `cargo fmt --check` currently reports formatting differences in `backend.rs`, `backend_download.rs`, and `lib.rs`, which are outside this PR; the changed Rust files pass `rustfmt --check`.
- Suggested review order: sequence protocol and Python dispatch, Windows owned-modal targeting, macOS interaction-state changes, then Skill guidance.
