### PR TITLE
fix: accept project paths after global CLI options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx>=0.27.0",
     "websockets>=15.0.1,<16",
     "packaging>=24.0",
+    "click>=8.1,<9",
     "discord-py>=2.3",
     "dingtalk-stream>=0.24.3",
     "alibabacloud-dingtalk>=2.2.42",

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -64,15 +64,21 @@ class LazyGroup(click.Group):
         self.lazy_subcommands = lazy_subcommands or {}
 
     def parse_args(self, ctx, args):
-        """Treat ``qwenpaw .`` as bare TUI launch with a project dir."""
+        """Treat the first positional path as a bare TUI project directory."""
         args = list(args)
-        # Registered commands win; otherwise path-like first tokens launch TUI.
+        parser = self.make_parser(ctx)
+        _, remaining_args, _ = parser.parse_args(args=list(args))
+        project_index = len(args) - len(remaining_args)
+        project = remaining_args[0] if remaining_args else None
+
+        # Registered commands win; otherwise the first positional path starts
+        # the TUI, even when global options appear before it.
         if (
-            args
-            and args[0] not in self.list_commands(ctx)
-            and _looks_like_project_path(args[0])
+            project is not None
+            and project not in self.list_commands(ctx)
+            and _looks_like_project_path(project)
         ):
-            ctx.meta["tui_project"] = args.pop(0)
+            ctx.meta["tui_project"] = args.pop(project_index)
         return super().parse_args(ctx, args)
 
     def list_commands(self, ctx):

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -66,8 +66,13 @@ class LazyGroup(click.Group):
     def parse_args(self, ctx, args):
         """Treat the first positional path as a bare TUI project directory."""
         args = list(args)
+        # Click 8.x exposes this parser; pyproject.toml pins Click below 9
+        # until a public replacement is available.
         parser = self.make_parser(ctx)
         _, remaining_args, _ = parser.parse_args(args=list(args))
+        # Group parsing stops at the first positional argument because
+        # allow_interspersed_args is False, so remaining_args is a suffix of
+        # the original argument list.
         project_index = len(args) - len(remaining_args)
         project = remaining_args[0] if remaining_args else None
 

--- a/tests/unit/cli/test_cli_version.py
+++ b/tests/unit/cli/test_cli_version.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from importlib.metadata import version as package_version
+
+from packaging.version import Version
+
 from click.testing import CliRunner
 
 from qwenpaw.__version__ import __version__
@@ -10,3 +14,9 @@ def test_cli_version_option_outputs_current_version() -> None:
 
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+def test_click_version_is_supported_for_lazy_group_parser() -> None:
+    click_version = Version(package_version("click"))
+
+    assert Version("8.1") <= click_version < Version("9")

--- a/tests/unit/cli/tui/test_launch.py
+++ b/tests/unit/cli/tui/test_launch.py
@@ -16,6 +16,7 @@ import sys
 
 import pytest
 
+from click import get_current_context
 from click.testing import CliRunner
 
 from qwenpaw.cli.tui import launch
@@ -303,6 +304,58 @@ def test_bare_qwenpaw_project_launches_tui(monkeypatch):
     assert result.exit_code == 0
     assert launched["called"] is True
     assert launched["kwargs"]["project"] == "."
+
+
+@pytest.mark.parametrize(
+    ("cli_args", "expected_project"),
+    [
+        (["--port", "6066", "."], "."),
+        (["--port=6066", "."], "."),
+        ([".", "--port", "6066"], "."),
+        (["--port", "6066", "tui"], None),
+    ],
+)
+def test_project_path_with_global_port_launches_tui(
+    monkeypatch,
+    cli_args,
+    expected_project,
+):
+    """A global port option does not hide the implicit project path."""
+    from qwenpaw.cli.main import cli
+
+    launched = {}
+
+    def fake_run_tui(*args, **kwargs):
+        launched["port"] = get_current_context().obj["port"]
+        launched["project"] = kwargs["project"]
+
+    monkeypatch.setattr("qwenpaw.cli.tui.launch.run_tui", fake_run_tui)
+    result = CliRunner().invoke(cli, cli_args)
+    assert result.exit_code == 0
+    assert launched == {
+        "port": 6066,
+        "project": expected_project,
+    }
+
+
+def test_path_like_global_option_value_is_not_project(monkeypatch, tmp_path):
+    """A path-like option value is skipped when locating the project."""
+    from qwenpaw.cli.main import cli
+
+    launched = {}
+
+    def fake_run_tui(*args, **kwargs):
+        launched["host"] = get_current_context().obj["host"]
+        launched["project"] = kwargs["project"]
+
+    monkeypatch.setattr("qwenpaw.cli.tui.launch.run_tui", fake_run_tui)
+    host = str(tmp_path)
+    result = CliRunner().invoke(cli, ["--host", host, "."])
+    assert result.exit_code == 0
+    assert launched == {
+        "host": host,
+        "project": ".",
+    }
 
 
 def test_bare_qwenpaw_unknown_command_still_errors(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes an issue where `qwenpaw --port 6066 .` failed with:

```text
Error: No such command "."
```

Project paths can now be used after global CLI options when launching the TUI.

## Root Cause

`LazyGroup.parse_args` only inspected `args[0]` to detect an implicit project
path.

For:

```text
qwenpaw --port 6066 .
```

the first argument was `--port`, so `.` was passed to Click as a command name.

## Changes

- Use Click's parser to identify the first positional argument after global
  options.
- Preserve registered command precedence.
- Preserve support for project paths before or after global options.
- Prevent path-like option values from being mistaken for project paths.
- Add regression tests for:
  - `--port 6066 .`
  - `--port=6066 .`
  - `. --port 6066`
  - `--port 6066 tui`
  - Path-like `--host` values
  -- Add an explicit `click>=8.1,<9` dependency constraint because the
  implicit TUI path parser currently relies on Click 8.x parser behavior.
- Document the `allow_interspersed_args=False` prerequisite for calculating the
  positional project path index.
- Add a Click version compatibility test covering the supported `8.1 <= Click < 9`
  range.

## Validation

- TUI launch tests: `23 passed`
- CLI unit tests: `260 passed`
- The remaining 2 CLI test failures require Windows symbolic-link privileges
  and are unrelated to this change.
- Black check passed.
- Flake8 check passed.
- Mypy check passed.
- Pylint check passed with a score of `10.00/10`.

## Expected Behavior

The following command now launches the TUI with the current directory as the
project directory:

```bash
QWENPAW_WORKING_DIR=~/.qwenpaw-ai-test qwenpaw --port 6066 .
```