### PR TITLE
fix(mcp): recover terminated sessions without dropping all tools

### DIFF
--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -28,7 +28,6 @@ from mcp.client.stdio import StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
-from mcp.types import CONNECTION_CLOSED
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +83,7 @@ def _is_transport_error(exc: BaseException) -> bool:
     if isinstance(exc, McpError):
         error = getattr(exc, "error", None)
         message = str(getattr(error, "message", exc)).strip().casefold()
-        return (
-            message in _TRANSPORT_MCP_MESSAGES
-            or getattr(error, "code", None) == CONNECTION_CLOSED
-        )
+        return message in _TRANSPORT_MCP_MESSAGES
 
     sub_excs = getattr(exc, "exceptions", None)
     if sub_excs:

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -77,16 +77,11 @@ def _is_transport_error(exc: BaseException) -> bool:
     if isinstance(exc, _TRANSPORT_ERRORS):
         return True
 
-    # Some MCP servers report an expired/dead stateful session as a JSON-RPC
-    # error instead of closing the underlying HTTP stream.  The transport is
-    # still unusable in that state and must be recreated, even though the SDK
-    # surfaces it as ``McpError`` rather than ``httpx.TransportError``.
+    # A terminated MCP session requires a new transport.
     if isinstance(exc, McpError):
         message = str(getattr(exc.error, "message", exc)).strip().casefold()
         return message == "session terminated"
 
-    # Preserve transport classification when SDK/anyio errors are wrapped in
-    # an ExceptionGroup by a task group.
     sub_excs = getattr(exc, "exceptions", None)
     if sub_excs:
         return any(_is_transport_error(item) for item in sub_excs)
@@ -370,9 +365,7 @@ class _MCPClientMixin:
                 if not self._handle_transport_error(exc):
                     raise
 
-                # Tool schemas are connection-independent.  Keep previously
-                # discovered tools registered while the lifecycle task
-                # replaces the dead session in the background.
+                # Keep known schemas available during reconnection.
                 if self._cached_tools is not None:
                     logger.warning(
                         "MCP client '%s' session failed during list_tools; "
@@ -381,8 +374,7 @@ class _MCPClientMixin:
                     )
                     return self._cached_tools
 
-                # A cold client has no schemas to fall back to.  Wait briefly
-                # for the lifecycle task and retry discovery exactly once.
+                # Cold discovery waits for reconnection and retries once.
                 try:
                     await asyncio.wait_for(
                         self._ready_event.wait(),
@@ -581,8 +573,7 @@ class _MCPClientMixin:
         task also writes ``session``), adding unnecessary complexity.
 
         Returns:
-            ``True`` when the exception represents a dead transport/session
-            and recovery state was applied; otherwise ``False``.
+            Whether recovery state was applied.
         """
         if not _is_transport_error(exc):
             return False

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -28,6 +28,7 @@ from mcp.client.stdio import StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
+from mcp.types import CONNECTION_CLOSED
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,9 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     ConnectionResetError,
     BrokenPipeError,
 )
+_TRANSPORT_MCP_MESSAGES = frozenset(
+    {"session terminated", "connection closed"},
+)
 
 
 # How long ``list_tools`` waits for an in-flight reconnect before raising.
@@ -77,10 +81,13 @@ def _is_transport_error(exc: BaseException) -> bool:
     if isinstance(exc, _TRANSPORT_ERRORS):
         return True
 
-    # A terminated MCP session requires a new transport.
     if isinstance(exc, McpError):
-        message = str(getattr(exc.error, "message", exc)).strip().casefold()
-        return message == "session terminated"
+        error = getattr(exc, "error", None)
+        message = str(getattr(error, "message", exc)).strip().casefold()
+        return (
+            message in _TRANSPORT_MCP_MESSAGES
+            or getattr(error, "code", None) == CONNECTION_CLOSED
+        )
 
     sub_excs = getattr(exc, "exceptions", None)
     if sub_excs:

--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -27,6 +27,7 @@ from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared.exceptions import McpError
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,23 @@ def _is_transport_error(exc: BaseException) -> bool:
     reconnect rather than treat the failure as permanent.  See
     ``_TRANSPORT_ERRORS`` for the full list of recognised exception types.
     """
-    return isinstance(exc, _TRANSPORT_ERRORS)
+    if isinstance(exc, _TRANSPORT_ERRORS):
+        return True
+
+    # Some MCP servers report an expired/dead stateful session as a JSON-RPC
+    # error instead of closing the underlying HTTP stream.  The transport is
+    # still unusable in that state and must be recreated, even though the SDK
+    # surfaces it as ``McpError`` rather than ``httpx.TransportError``.
+    if isinstance(exc, McpError):
+        message = str(getattr(exc.error, "message", exc)).strip().casefold()
+        return message == "session terminated"
+
+    # Preserve transport classification when SDK/anyio errors are wrapped in
+    # an ExceptionGroup by a task group.
+    sub_excs = getattr(exc, "exceptions", None)
+    if sub_excs:
+        return any(_is_transport_error(item) for item in sub_excs)
+    return False
 
 
 def _is_401_error(exc: BaseException) -> bool:
@@ -350,8 +367,37 @@ class _MCPClientMixin:
             try:
                 res = await self.session.list_tools()
             except Exception as exc:
-                self._handle_transport_error(exc)
-                raise
+                if not self._handle_transport_error(exc):
+                    raise
+
+                # Tool schemas are connection-independent.  Keep previously
+                # discovered tools registered while the lifecycle task
+                # replaces the dead session in the background.
+                if self._cached_tools is not None:
+                    logger.warning(
+                        "MCP client '%s' session failed during list_tools; "
+                        "serving cached schemas while reconnecting.",
+                        self.name,
+                    )
+                    return self._cached_tools
+
+                # A cold client has no schemas to fall back to.  Wait briefly
+                # for the lifecycle task and retry discovery exactly once.
+                try:
+                    await asyncio.wait_for(
+                        self._ready_event.wait(),
+                        timeout=_LIST_TOOLS_RECONNECT_WAIT,
+                    )
+                except asyncio.TimeoutError:
+                    raise exc from None
+
+                if not self.is_connected or self.session is None:
+                    raise exc from None
+                try:
+                    res = await self.session.list_tools()
+                except Exception as retry_exc:
+                    self._handle_transport_error(retry_exc)
+                    raise
             self._cached_tools = res.tools
             return res.tools
 
@@ -500,7 +546,7 @@ class _MCPClientMixin:
         await asyncio.gather(task, return_exceptions=True)
         self._clear_lifecycle_state(task)
 
-    def _handle_transport_error(self, exc: BaseException) -> None:
+    def _handle_transport_error(self, exc: BaseException) -> bool:
         """Mark the client as disconnected and schedule a reconnect when *exc*
         indicates a transport/stream failure rather than an MCP-level error.
 
@@ -533,9 +579,13 @@ class _MCPClientMixin:
         ``session`` reference is never reached before the lifecycle task
         replaces it.  Clearing it here would require a lock (the lifecycle
         task also writes ``session``), adding unnecessary complexity.
+
+        Returns:
+            ``True`` when the exception represents a dead transport/session
+            and recovery state was applied; otherwise ``False``.
         """
         if not _is_transport_error(exc):
-            return
+            return False
         logger.warning(
             "Transport error on MCP client '%s' (%s: %s); "
             "marking as disconnected and scheduling reconnect.",
@@ -560,6 +610,7 @@ class _MCPClientMixin:
         # session is left as-is; see docstring above.
         if not self._stop_event.is_set():
             self._reload_event.set()
+        return True
 
     async def _wait_for_reload_or_stop(self) -> None:
         """Wait for lifecycle control events without polling."""

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -424,11 +424,7 @@ class DriverManager:
                     request_context=request_context,
                 )
             except Exception as exc:
-                # Global capability discovery is best-effort: one unhealthy
-                # external service must not unregister every healthy Driver.
-                # The single-driver API intentionally keeps propagating the
-                # error so diagnostics and configuration endpoints can report
-                # the failing Driver to the caller.
+                # Keep healthy Drivers available during partial failures.
                 logger.warning(
                     "Failed to list capabilities for Driver '%s': %s",
                     handler.name,

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -419,9 +419,24 @@ class DriverManager:
         handlers = self._iter_handlers(protocol, scope_id=scope_id)
         capabilities: list[DriverCapability] = []
         for handler in handlers:
-            for capability in await handler.list_capabilities(
-                request_context=request_context,
-            ):
+            try:
+                handler_capabilities = await handler.list_capabilities(
+                    request_context=request_context,
+                )
+            except Exception as exc:
+                # Global capability discovery is best-effort: one unhealthy
+                # external service must not unregister every healthy Driver.
+                # The single-driver API intentionally keeps propagating the
+                # error so diagnostics and configuration endpoints can report
+                # the failing Driver to the caller.
+                logger.warning(
+                    "Failed to list capabilities for Driver '%s': %s",
+                    handler.name,
+                    exc,
+                    exc_info=True,
+                )
+                continue
+            for capability in handler_capabilities:
                 if kind is None or capability.kind == kind:
                     capabilities.append(capability)
         return sorted(capabilities, key=lambda item: item.capability_id)

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -98,6 +98,13 @@ def test_is_transport_error_rejects_other_mcp_errors():
     assert not _is_transport_error(exc)
 
 
+def test_is_transport_error_rejects_generic_server_error():
+    exc = McpError(
+        ErrorData(code=CONNECTION_CLOSED, message="Rate limit exceeded"),
+    )
+    assert not _is_transport_error(exc)
+
+
 def test_is_401_error_detects_plain_http_401():
     req = httpx.Request("GET", "http://x")
     resp = httpx.Response(401, request=req)
@@ -487,6 +494,26 @@ async def test_call_tool_handles_transport_error_and_marks_disconnected():
     # _handle_transport_error marked it for reconnect.
     assert c.is_connected is False
     assert c._reload_event.is_set()
+
+
+async def test_call_tool_does_not_reconnect_for_generic_server_error():
+    c = _client()
+    c.is_connected = True
+    error = McpError(
+        ErrorData(code=CONNECTION_CLOSED, message="Rate limit exceeded"),
+    )
+
+    class FakeSession:
+        async def call_tool(self, name: str, args: dict) -> None:
+            raise error
+
+    c.session = FakeSession()  # type: ignore[assignment]
+    with pytest.raises(McpError) as exc_info:
+        await c.call_tool("foo", {})
+
+    assert exc_info.value is error
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import asyncio
 import httpx
 import pytest
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
 
 import qwenpaw.drivers.handlers.mcp_stateful_client as mod
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
@@ -60,6 +62,16 @@ def test_is_transport_error_distinguishes_transport_from_mcp_errors():
     assert _is_transport_error(EOFError())
     # An MCP-level error (not a transport failure) must NOT classify.
     assert not _is_transport_error(ValueError("not transport"))
+
+
+def test_is_transport_error_recognizes_terminated_mcp_session():
+    exc = McpError(ErrorData(code=-32603, message="Session terminated"))
+    assert _is_transport_error(exc)
+
+
+def test_is_transport_error_rejects_other_mcp_errors():
+    exc = McpError(ErrorData(code=-32602, message="Invalid tool arguments"))
+    assert not _is_transport_error(exc)
 
 
 def test_is_401_error_detects_plain_http_401():
@@ -368,6 +380,61 @@ async def test_list_tools_serves_cache_when_disconnected():
     # flaky MCP client doesn't kill the user's turn.
     result = await c.list_tools()
     assert result == ["cached-tool"]
+
+
+async def test_list_tools_serves_cache_and_reconnects_on_terminated_session():
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+    c._cached_tools = ["cached-tool"]  # type: ignore[list-item]
+
+    class TerminatedSession:
+        async def list_tools(self):
+            raise McpError(
+                ErrorData(code=-32603, message="Session terminated"),
+            )
+
+    c.session = TerminatedSession()  # type: ignore[assignment]
+
+    result = await c.list_tools()
+
+    assert result == ["cached-tool"]
+    assert c.is_connected is False
+    assert not c._ready_event.is_set()
+    assert c._reload_event.is_set()
+
+
+async def test_list_tools_retries_once_after_terminated_cold_session():
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+
+    class TerminatedSession:
+        async def list_tools(self):
+            raise McpError(
+                ErrorData(code=-32603, message="Session terminated"),
+            )
+
+    class HealthySession:
+        async def list_tools(self):
+            return type("Result", (), {"tools": ["fresh-tool"]})()
+
+    c.session = TerminatedSession()  # type: ignore[assignment]
+
+    async def reconnect() -> None:
+        await c._reload_event.wait()
+        c.session = HealthySession()  # type: ignore[assignment]
+        c.is_connected = True
+        c._ready_event.set()
+
+    reconnect_task = asyncio.create_task(reconnect())
+    try:
+        result = await c.list_tools()
+    finally:
+        await reconnect_task
+
+    assert result == ["fresh-tool"]
+    assert c._cached_tools == ["fresh-tool"]
 
 
 async def test_list_tools_raises_on_cold_start_without_cache():

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -28,7 +28,7 @@ import asyncio
 import httpx
 import pytest
 from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData
+from mcp.types import CONNECTION_CLOSED, ErrorData
 
 import qwenpaw.drivers.handlers.mcp_stateful_client as mod
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
@@ -65,8 +65,32 @@ def test_is_transport_error_distinguishes_transport_from_mcp_errors():
 
 
 def test_is_transport_error_recognizes_terminated_mcp_session():
-    exc = McpError(ErrorData(code=-32603, message="Session terminated"))
+    exc = McpError(ErrorData(code=32600, message="Session terminated"))
     assert _is_transport_error(exc)
+
+
+def test_is_transport_error_recognizes_closed_mcp_connection():
+    exc = McpError(
+        ErrorData(code=CONNECTION_CLOSED, message="Connection closed"),
+    )
+    assert _is_transport_error(exc)
+
+
+def test_is_transport_error_rejects_mcp_read_timeout():
+    exc = McpError(ErrorData(code=408, message="Timed out while waiting"))
+    assert not _is_transport_error(exc)
+
+
+def test_is_transport_error_unwraps_exception_group():
+    exc = McpError(
+        ErrorData(code=CONNECTION_CLOSED, message="Connection closed"),
+    )
+    assert _is_transport_error(ExceptionGroup("task group", [exc]))
+
+
+def test_is_transport_error_handles_mcp_error_without_payload():
+    exc = McpError.__new__(McpError)
+    assert not _is_transport_error(exc)
 
 
 def test_is_transport_error_rejects_other_mcp_errors():
@@ -391,7 +415,7 @@ async def test_list_tools_serves_cache_and_reconnects_on_terminated_session():
     class TerminatedSession:
         async def list_tools(self):
             raise McpError(
-                ErrorData(code=-32603, message="Session terminated"),
+                ErrorData(code=32600, message="Session terminated"),
             )
 
     c.session = TerminatedSession()  # type: ignore[assignment]
@@ -412,7 +436,7 @@ async def test_list_tools_retries_once_after_terminated_cold_session():
     class TerminatedSession:
         async def list_tools(self):
             raise McpError(
-                ErrorData(code=-32603, message="Session terminated"),
+                ErrorData(code=32600, message="Session terminated"),
             )
 
     class HealthySession:

--- a/tests/unit/drivers/test_transient_scopes.py
+++ b/tests/unit/drivers/test_transient_scopes.py
@@ -41,6 +41,8 @@ class _FakeHandler(DriverHandler):
         request_context: dict[str, str] | None = None,
     ) -> list[DriverCapability]:
         del request_context
+        if self.card.endpoint.get("fail_list"):
+            raise RuntimeError(f"Failed to list capabilities for {self.name}")
         capability_id = format_capability_id(
             "fake",
             self.name,
@@ -80,12 +82,13 @@ def _card(
     name: str,
     *,
     fail: bool = False,
+    fail_list: bool = False,
     enabled: bool = True,
 ) -> DriverCard:
     return DriverCard(
         name=name,
         protocol="fake",
-        endpoint={"fail": fail},
+        endpoint={"fail": fail, "fail_list": fail_list},
         enabled=enabled,
     )
 
@@ -141,6 +144,31 @@ async def test_transient_drivers_are_additive_and_scope_isolated(
     assert names_without_scope == {"persistent"}
     assert names_in_a == {"persistent", "transient-a"}
     assert names_in_b == {"persistent", "transient-b"}
+
+
+async def test_list_capabilities_isolates_one_failing_driver(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.register_driver(_card("healthy"))
+    await manager.register_driver(_card("broken", fail_list=True))
+
+    capabilities = await manager.list_capabilities()
+
+    assert [item.driver_name for item in capabilities] == ["healthy"]
+
+
+async def test_single_driver_capability_query_still_reports_failure(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    await manager.register_driver(_card("broken", fail_list=True))
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to list capabilities for broken",
+    ):
+        await manager.list_driver_capabilities("broken")
 
 
 async def test_transient_invocation_rejects_another_scope(


### PR DESCRIPTION
## Description

- Treat `McpError: Session terminated` as a recoverable connection failure.
- Serve cached tool schemas during reconnection and retry once on cold discovery.
- Isolate capability discovery failures so one unhealthy driver does not remove all MCP tools.
- Preserve errors for direct single-driver queries.

Fixes #6732.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
