### PR TITLE
fix(tools):  correct read_file tool description

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -114,10 +114,13 @@ async def read_file(  # pylint: disable=too-many-return-statements
     start_line: Optional[int | str] = None,
     end_line: Optional[int | str] = None,
 ) -> ToolChunk:
-    """Read a file. Relative paths resolve from WORKING_DIR.
+    """Read a text file. Relative paths resolve from WORKING_DIR.
 
     Use start_line/end_line to read a specific line range (output includes
-    line numbers). Omit both to read the full file.
+    line numbers). Omit both to read from the start. If output is truncated,
+    the tail says which start_line to resume from. Images, PDFs and other
+    binaries come back as unusable bytes rather than an error. Use view_image
+    for images.
 
     Args:
         file_path (`str`):


### PR DESCRIPTION
## Description

The original tool description of `read_file` doesn't match the actual tool behavior. Two mismatches:
1. "Read a file": This tool is only designed for text files. The binary files return mangled bytes with state=success. In practice, QwenPaw-9B tends to use `read_file` instead of `view_image` to read .png files.
2. "Omit both to read the full file": L205 truncates the output instead of returning the full file.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

New tool description is tested on QwenPaw-9B and the read_file behavior works well.

## Evidence

```bash
pre-commit run --files src/qwenpaw/agents/tools/file_io.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

pytest tests/unit/agents/tools/test_file_io.py -q
........................................                                 [100%]
40 passed in 3.84s
```

## Additional Notes

[Optional: any other context]
