### PR TITLE
test(integration): drop stale project_dir assertion in coding-mode test

### DIFF
--- a/tests/integration/test_fork_and_coding_mode.py
+++ b/tests/integration/test_fork_and_coding_mode.py
@@ -98,7 +98,6 @@ def test_coding_mode_get_default_disabled(app_server) -> None:
     body = resp.json()
     assert body["enabled"] is False, body
     assert "agent_id" in body, body
-    assert "project_dir" in body, body
 
 
 @pytest.mark.integration


### PR DESCRIPTION
> **Submitted by**: 鬼谷子·Integrator@QPQAT

## What does this fix

Upstream PR #6504 ("unify project directory", merged Aug 6) changed the response of the "query coding-mode status" endpoint (`GET /api/coding-mode`) — it no longer returns the `project_dir` field. The frontend has already been adapted (the field was removed from the type definitions), but the corresponding integration test was not updated and still checks for this non-existent field.

Result: since Aug 4, this test has been failing on all 4 platforms (Ubuntu py3.11/py3.13, macOS py3.11, Windows py3.11) in the nightly suite, continuously red.

## Why this PR is needed

- The nightly suite shows a fixed red, masking other potential new issues — once red lights become "noise", real new defects are easily overlooked
- This is not a product defect; the test simply hasn't caught up with the API change — a one-line fix
- After this fix, the nightly suite returns to all-green, restoring the 4-platform integration baseline

## What changed

Only `tests/integration/test_fork_and_coding_mode.py` was modified — line 101 was deleted:

```python
# Delete this line (checks for the now-removed project_dir field):
assert "project_dir" in body, body
```

The remaining assertions are kept intact:
- `assert body["enabled"] is False` — verifies coding mode defaults to off ✅
- `assert "agent_id" in body` — verifies response includes agent_id ✅

No product code is changed; only the test is adapted to match the upstream API change that has already been merged.

## Expected outcome

- This test passes on all 4 CI platforms (verified: fork CI run 31390472091 all green ✅)
- The nightly integration suite returns to all-green
- No impact on other tests (all 9 coding-mode tests in the file pass locally)

## Verification

| Check | Result |
|-------|--------|
| Local pytest (full file, 9 tests) | ✅ All pass |
| Fork CI 4 platforms (run 31390472091) | ✅ All green |
| Impact scan (grep `project_dir` across repo) | Only this one assertion hits the contract |
| Upstream #6504 confirms intentional removal | ✅ Frontend adapted in sync, not a defect |