### PR TITLE
fix(sandbox): stop injecting PYTHONHOME into child processes

### DIFF
--- a/src/qwenpaw/sandbox/windows_unelevated_sandbox.py
+++ b/src/qwenpaw/sandbox/windows_unelevated_sandbox.py
@@ -1414,9 +1414,6 @@ class WindowsSandboxBase(ABC):
         env = dict(os.environ)
         if self._config.env_vars:
             env.update(self._config.env_vars)
-        python_dir = _get_python_install_dir()
-        if python_dir:
-            env.setdefault("PYTHONHOME", python_dir)
         return env
 
 

--- a/tests/unit/sandbox/test_windows_unelevated_sandbox.py
+++ b/tests/unit/sandbox/test_windows_unelevated_sandbox.py
@@ -319,6 +319,30 @@ class TestRandomCapSid:
 # ============================================================================
 
 
+class TestBaseEnvironment:
+    """Test the environment inherited by sandboxed child processes."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch(
+        "qwenpaw.sandbox.windows_unelevated_sandbox."
+        "_get_python_install_dir",
+        return_value=r"C:\QwenPaw\binaries\qwenpaw-backend",
+    )
+    def test_does_not_inject_pythonhome(self, mock_python_dir):
+        """A frozen backend directory must not become PYTHONHOME."""
+        config = SandboxConfig(
+            mode=SandboxMode.WINDOWS,
+            workspace_dir=r"C:\project",
+            allow_read_all=True,
+        )
+        sandbox = WindowsUnelevatedSandbox(config)
+
+        env = sandbox._build_base_env()
+
+        mock_python_dir.assert_not_called()
+        assert "PYTHONHOME" not in env
+
+
 class TestEnvBlock:
     """Test _make_env_block sorts entries and terminates correctly."""
 


### PR DESCRIPTION
## Description

Fixes #6697.

## Summary

- Stop Windows sandbox backends from deriving `PYTHONHOME` from the host executable.
- Prevent the frozen `qwenpaw-backend.exe` directory from being passed as
  `PYTHONHOME` to child processes.
- Add regression coverage for frozen desktop child environments.

## Problem

In packaged desktop builds, `sys.executable` points to
`qwenpaw-backend.exe`. The Windows sandbox base environment previously used
that executable's parent directory as `PYTHONHOME`.

That directory is a PyInstaller sidecar bundle rather than a CPython
installation, so Python child processes cannot locate `Lib/encodings` and fail
during startup.

## Testing

- `pytest tests/unit/sandbox/test_windows_unelevated_sandbox.py tests/unit/sandbox/test_windows_elevated_sandbox.py tests/unit/sandbox/test_windows_appcontainer_sandbox.py -q`
  - `130 passed`
- Black, Flake8, Mypy, and Pylint checks passed for changed files.