### PR TITLE
fix(console): stabilize chat wheel scrolling

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -113,6 +113,7 @@ import RichFileReferenceInput, {
   RichFileReferenceInputProvider,
 } from "./RichFileReferenceInput";
 import type { ParsedFileReference } from "./fileReferenceFormatting";
+import { scrollReverseMessageList } from "./messageScroll";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -2769,6 +2770,30 @@ export default function ChatPage() {
   );
 
   const compactSender = filesDrawerState.kind === "workspace";
+  const chatMessagesAreaRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = chatMessagesAreaRef.current;
+    if (!root) return;
+
+    const handleMessagesWheel = (event: WheelEvent) => {
+      const handled = scrollReverseMessageList(
+        root,
+        event.target,
+        event.deltaY,
+        event.deltaMode,
+      );
+      if (handled) event.preventDefault();
+    };
+
+    root.addEventListener("wheel", handleMessagesWheel, {
+      capture: true,
+      passive: false,
+    });
+    return () => {
+      root.removeEventListener("wheel", handleMessagesWheel, true);
+    };
+  }, []);
 
   const options = useMemo(() => {
     const i18nConfig = getDefaultConfig(t);
@@ -3540,6 +3565,7 @@ export default function ChatPage() {
         }
       >
         <div
+          ref={chatMessagesAreaRef}
           className={
             isWideMode
               ? `${styles.chatMessagesArea} ${styles.wideMode}`

--- a/console/src/pages/Chat/messageScroll.test.ts
+++ b/console/src/pages/Chat/messageScroll.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getNextReverseScrollTop,
+  scrollReverseMessageList,
+} from "./messageScroll";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("getNextReverseScrollTop", () => {
+  it("moves a reverse list toward the newest message", () => {
+    expect(getNextReverseScrollTop(-420, 1200, 500, 120, 0)).toBe(-300);
+  });
+
+  it("clamps downward scrolling to the newest message", () => {
+    expect(getNextReverseScrollTop(-40, 1200, 500, 120, 0)).toBe(0);
+  });
+
+  it("clamps upward scrolling to the oldest message", () => {
+    expect(getNextReverseScrollTop(-650, 1200, 500, -120, 0)).toBe(-700);
+  });
+
+  it("normalizes line and page wheel deltas", () => {
+    expect(getNextReverseScrollTop(-400, 1200, 500, 2, 1)).toBe(-368);
+    expect(getNextReverseScrollTop(-600, 1200, 500, 1, 2)).toBe(-100);
+  });
+});
+
+function setElementMetrics(
+  element: HTMLElement,
+  scrollHeight: number,
+  clientHeight: number,
+): void {
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, value: scrollHeight },
+    clientHeight: { configurable: true, value: clientHeight },
+  });
+}
+
+function createReverseScroller(): {
+  content: HTMLElement;
+  root: HTMLElement;
+  scroller: HTMLElement;
+} {
+  const root = document.createElement("div");
+  const scroller = document.createElement("div");
+  const content = document.createElement("div");
+
+  scroller.className =
+    "qwenpaw-bubble-list-order-desc " +
+    "qwenpaw-chat-anywhere-message-list-bubble-scroll";
+  scroller.append(content);
+  root.append(scroller);
+  document.body.append(root);
+  setElementMetrics(scroller, 1200, 500);
+
+  return { content, root, scroller };
+}
+
+describe("scrollReverseMessageList", () => {
+  it("applies wheel movement to the SDK reverse scroller", () => {
+    const { content, root, scroller } = createReverseScroller();
+    scroller.scrollTop = -420;
+
+    expect(scrollReverseMessageList(root, content, 120, 0)).toBe(true);
+    expect(scroller.scrollTop).toBe(-300);
+  });
+
+  it("handles subpixel trackpad movement over SVG message content", () => {
+    const { content, root, scroller } = createReverseScroller();
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    content.append(svg);
+    scroller.scrollTop = -10;
+
+    expect(scrollReverseMessageList(root, svg, 0.5, 0)).toBe(true);
+    expect(scroller.scrollTop).toBe(-9.5);
+  });
+
+  it("does not capture wheel input already handled by a nested scroller", () => {
+    const { content, root, scroller } = createReverseScroller();
+    const nestedScroller = document.createElement("div");
+    nestedScroller.style.overflowY = "auto";
+    nestedScroller.append(content);
+    scroller.append(nestedScroller);
+    setElementMetrics(nestedScroller, 400, 200);
+    nestedScroller.scrollTop = 50;
+    scroller.scrollTop = -420;
+
+    expect(scrollReverseMessageList(root, content, 100, 0)).toBe(false);
+    expect(scroller.scrollTop).toBe(-420);
+  });
+
+  it("ignores wheel input outside the message scroller", () => {
+    const { root, scroller } = createReverseScroller();
+    const outside = document.createElement("div");
+    root.append(outside);
+    scroller.scrollTop = -420;
+
+    expect(scrollReverseMessageList(root, outside, 100, 0)).toBe(false);
+    expect(scroller.scrollTop).toBe(-420);
+  });
+});

--- a/console/src/pages/Chat/messageScroll.ts
+++ b/console/src/pages/Chat/messageScroll.ts
@@ -1,0 +1,84 @@
+const REVERSE_MESSAGE_SCROLL_SELECTOR =
+  '[class*="chat-anywhere-message-list-bubble-scroll"]' +
+  '[class*="bubble-list-order-desc"]';
+
+const LINE_HEIGHT_PX = 16;
+const SCROLL_TOLERANCE_PX = 1;
+
+function wheelDeltaInPixels(
+  deltaY: number,
+  deltaMode: number,
+  clientHeight: number,
+): number {
+  if (deltaMode === 1) return deltaY * LINE_HEIGHT_PX;
+  if (deltaMode === 2) return deltaY * clientHeight;
+  return deltaY;
+}
+
+export function getNextReverseScrollTop(
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+  deltaY: number,
+  deltaMode: number,
+): number {
+  const maxScrollDistance = Math.max(scrollHeight - clientHeight, 0);
+  const pixelDelta = wheelDeltaInPixels(deltaY, deltaMode, clientHeight);
+
+  return Math.min(0, Math.max(-maxScrollDistance, scrollTop + pixelDelta));
+}
+
+function canConsumeVerticalWheel(
+  element: HTMLElement,
+  deltaY: number,
+): boolean {
+  const overflowY = window.getComputedStyle(element).overflowY;
+  if (overflowY !== "auto" && overflowY !== "scroll") return false;
+
+  const maxScrollTop = element.scrollHeight - element.clientHeight;
+  if (maxScrollTop <= SCROLL_TOLERANCE_PX) return false;
+
+  if (deltaY < 0) return element.scrollTop > SCROLL_TOLERANCE_PX;
+  return element.scrollTop < maxScrollTop - SCROLL_TOLERANCE_PX;
+}
+
+function hasScrollableChildBeforeScroller(
+  target: Element,
+  scroller: HTMLElement,
+  deltaY: number,
+): boolean {
+  let current: HTMLElement | null =
+    target instanceof HTMLElement ? target : target.parentElement;
+
+  while (current && current !== scroller) {
+    if (canConsumeVerticalWheel(current, deltaY)) return true;
+    current = current.parentElement;
+  }
+
+  return false;
+}
+
+export function scrollReverseMessageList(
+  root: HTMLElement,
+  target: EventTarget | null,
+  deltaY: number,
+  deltaMode: number,
+): boolean {
+  if (!(target instanceof Element) || deltaY === 0) return false;
+
+  const scroller = target.closest<HTMLElement>(REVERSE_MESSAGE_SCROLL_SELECTOR);
+  if (!scroller || !root.contains(scroller)) return false;
+  if (hasScrollableChildBeforeScroller(target, scroller, deltaY)) return false;
+
+  const nextScrollTop = getNextReverseScrollTop(
+    scroller.scrollTop,
+    scroller.scrollHeight,
+    scroller.clientHeight,
+    deltaY,
+    deltaMode,
+  );
+  if (nextScrollTop === scroller.scrollTop) return false;
+
+  scroller.scrollTop = nextScrollTop;
+  return true;
+}


### PR DESCRIPTION
## Summary

- normalize wheel deltas for the reverse-ordered chat message list
- preserve scrolling inside nested areas while supporting mouse, trackpad, and SVG targets
- use a non-passive wheel listener so users can reliably return to the newest message after dynamic Thinking content changes height

## Testing

- 593 test suites passed
- 1694 tests passed, 0 failed, 0 skipped
- production build passed
- manually verified that after Thinking content expansion moves the chat away from the bottom, users can scroll back to the latest message normally

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
