### PR TITLE
feat(channels): allow custom gateway endpoints for IM channels

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -251,7 +251,12 @@ class FeishuChannel(BaseChannel):
         self.bot_prefix = bot_prefix
         self.encrypt_key = encrypt_key or ""
         self.verification_token = verification_token or ""
-        self.domain = domain if domain in ("feishu", "lark") else "feishu"
+        # "feishu" / "lark", or a full http(s) base URL for custom /
+        # private gateways (e.g. a local mock in tests).
+        if domain in ("feishu", "lark") or str(domain).startswith("http"):
+            self.domain = domain
+        else:
+            self.domain = "feishu"
         self.share_session_in_group = share_session_in_group
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
@@ -293,6 +298,14 @@ class FeishuChannel(BaseChannel):
         # All interactive-card logic (outbound rendering + inbound
         # card.action.trigger dispatch) lives in the card handler.
         self._card_handler = FeishuCardHandler(self)
+
+    def _sdk_domain(self) -> str:
+        """SDK base URL: custom http(s) gateway, or the lark/feishu enum."""
+        if str(self.domain).startswith("http"):
+            return str(self.domain)
+        return (
+            lark.LARK_DOMAIN if self.domain == "lark" else lark.FEISHU_DOMAIN
+        )
 
     @classmethod
     def from_env(
@@ -502,11 +515,7 @@ class FeishuChannel(BaseChannel):
             if not token:
                 logger.warning("feishu: failed to get access token")
                 return None
-            base_url = (
-                "https://open.larksuite.com"
-                if self.domain == "lark"
-                else "https://open.feishu.cn"
-            )
+            base_url = self._sdk_domain()
             url = f"{base_url}/open-apis/bot/v3/info"
             response = await self._http_client.get(
                 url,
@@ -2532,11 +2541,7 @@ class FeishuChannel(BaseChannel):
                     self.app_secret,
                     event_handler=event_handler,
                     log_level=lark.LogLevel.INFO,
-                    domain=(
-                        lark.LARK_DOMAIN
-                        if self.domain == "lark"
-                        else lark.FEISHU_DOMAIN
-                    ),
+                    domain=self._sdk_domain(),
                 )
 
                 # Patch SDK to track last-received timestamp for
@@ -2757,9 +2762,7 @@ class FeishuChannel(BaseChannel):
         self._http_client = httpx.AsyncClient(
             timeout=30.0,
         )
-        sdk_domain = (
-            lark.LARK_DOMAIN if self.domain == "lark" else lark.FEISHU_DOMAIN
-        )
+        sdk_domain = self._sdk_domain()
         self._client = (
             lark.Client.builder()
             .app_id(self.app_id)

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -288,6 +288,11 @@ def _get_api_base() -> str:
     return os.getenv("QQ_API_BASE", DEFAULT_API_BASE).rstrip("/")
 
 
+def _get_token_url() -> str:
+    """Token endpoint (override with QQ_TOKEN_URL, e.g. for sandboxes)."""
+    return os.getenv("QQ_TOKEN_URL", TOKEN_URL)
+
+
 def _get_channel_url_sync(access_token: str) -> str:
     import urllib.error
     import urllib.request
@@ -720,7 +725,7 @@ class QQChannel(BaseChannel):
             import urllib.request
 
             req = urllib.request.Request(
-                TOKEN_URL,
+                _get_token_url(),
                 data=json.dumps(
                     {"appId": self.app_id, "clientSecret": self.client_secret},
                 ).encode(),
@@ -759,7 +764,7 @@ class QQChannel(BaseChannel):
             ):
                 return self._token_cache["token"]
         async with self._http.post(
-            TOKEN_URL,
+            _get_token_url(),
             json={"appId": self.app_id, "clientSecret": self.client_secret},
             headers={"Content-Type": "application/json"},
         ) as resp:

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -155,6 +155,7 @@ class WecomChannel(BaseChannel):
         streaming_enabled: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        ws_url: str = "",
     ):
         super().__init__(
             process,
@@ -186,6 +187,7 @@ class WecomChannel(BaseChannel):
         else:
             self._media_dir = DEFAULT_MEDIA_DIR
         self._max_reconnect_attempts = max_reconnect_attempts
+        self._ws_url = (ws_url or "").strip()
 
         self._client: Any = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -243,6 +245,7 @@ class WecomChannel(BaseChannel):
             max_reconnect_attempts=int(
                 os.getenv("WECOM_MAX_RECONNECT_ATTEMPTS", "-1"),
             ),
+            ws_url=os.getenv("WECOM_WS_URL", ""),
         )
 
     @classmethod
@@ -291,6 +294,7 @@ class WecomChannel(BaseChannel):
             access_control_group=bool(
                 getattr(config, "access_control_group", False),
             ),
+            ws_url=getattr(config, "ws_url", "") or "",
         )
 
     # ------------------------------------------------------------------
@@ -1568,6 +1572,7 @@ class WecomChannel(BaseChannel):
             secret=self.secret,
             max_reconnect_attempts=self._max_reconnect_attempts,
             logger=_SdkLoggerAdapter(_sdk_logger),
+            **({"ws_url": self._ws_url} if self._ws_url else {}),
         )
         self._client = WSClient(options)
 

--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -362,6 +362,7 @@ class XiaoYiChannel(BaseChannel):
         ak: str,
         sk: str,
         agent_id: str,
+        ws_url: str = "",
         task_timeout_ms: int = DEFAULT_TASK_TIMEOUT_MS,
         on_reply_sent: OnReplySent = None,
         display_config: ChannelDisplayConfig | None = None,
@@ -385,6 +386,7 @@ class XiaoYiChannel(BaseChannel):
         self.ak = ak
         self.sk = sk
         self.agent_id = agent_id
+        self.ws_url = (ws_url or "").strip()
         self.task_timeout_ms = task_timeout_ms
         self.bot_prefix = bot_prefix
 
@@ -452,6 +454,7 @@ class XiaoYiChannel(BaseChannel):
                 ak=config.get("ak", ""),
                 sk=config.get("sk", ""),
                 agent_id=config.get("agent_id", ""),
+                ws_url=config.get("ws_url", ""),
                 task_timeout_ms=config.get(
                     "task_timeout_ms",
                     DEFAULT_TASK_TIMEOUT_MS,
@@ -477,6 +480,7 @@ class XiaoYiChannel(BaseChannel):
             ak=config.ak,
             sk=config.sk,
             agent_id=config.agent_id,
+            ws_url=getattr(config, "ws_url", "") or "",
             task_timeout_ms=config.task_timeout_ms,
             on_reply_sent=on_reply_sent,
             display_config=display_config
@@ -589,8 +593,8 @@ class XiaoYiChannel(BaseChannel):
 
         logger.info(
             "XiaoYi: Connecting to %s + %s...",
-            DEFAULT_WS_URL,
-            DEFAULT_WS_URL_BACKUP,
+            self.ws_url or DEFAULT_WS_URL,
+            "" if self.ws_url else DEFAULT_WS_URL_BACKUP,
         )
 
         await self._start_connections()
@@ -610,7 +614,7 @@ class XiaoYiChannel(BaseChannel):
 
         self._conn_primary = XiaoYiConnection(
             server_name="primary",
-            ws_url=DEFAULT_WS_URL,
+            ws_url=self.ws_url or DEFAULT_WS_URL,
             ak=self.ak,
             sk=self.sk,
             agent_id=self.agent_id,
@@ -620,7 +624,7 @@ class XiaoYiChannel(BaseChannel):
 
         tasks = [self._conn_primary.connect()]
 
-        if DEFAULT_WS_URL_BACKUP:
+        if DEFAULT_WS_URL_BACKUP and not self.ws_url:
             self._conn_backup = XiaoYiConnection(
                 server_name="backup",
                 ws_url=DEFAULT_WS_URL_BACKUP,

--- a/src/qwenpaw/app/channels/yuanbao/auth.py
+++ b/src/qwenpaw/app/channels/yuanbao/auth.py
@@ -126,14 +126,21 @@ class TokenManager:
     async def _do_fetch(self) -> SignTokenResult:
         """Execute the sign-token API call with retry logic."""
         domain = self.api_domain
-        # Strip scheme if user accidentally included it
+        # Honor an explicit scheme (private gateways / mocks may be
+        # plain http); bare domains keep the https default.
+        scheme = "https"
         if domain.startswith("https://"):
             domain = domain.removeprefix("https://")
         elif domain.startswith("http://"):
+            scheme = "http"
             domain = domain.removeprefix("http://")
+            logger.warning(
+                "yuanbao: api_domain uses plain http; the sign-token "
+                "request (app_key + signature) will NOT be encrypted",
+            )
         # Strip trailing slash
         domain = domain.rstrip("/")
-        url = f"https://{domain}{SIGN_TOKEN_PATH}"
+        url = f"{scheme}://{domain}{SIGN_TOKEN_PATH}"
         session = await self._get_session()
 
         for attempt in range(SIGN_MAX_RETRIES + 1):

--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -137,6 +137,7 @@ class YuanbaoChannel(BaseChannel):
         app_id: str,
         app_secret: str,
         api_domain: str = DEFAULT_API_DOMAIN,
+        ws_url: str = "",
         bot_prefix: str = "",
         media_dir: str = "",
         workspace_dir: Path | None = None,
@@ -171,6 +172,7 @@ class YuanbaoChannel(BaseChannel):
         self.app_id = app_id
         self.app_secret = app_secret
         self.api_domain = api_domain or DEFAULT_API_DOMAIN
+        self.ws_url = (ws_url or "").strip() or DEFAULT_WS_URL
         self.bot_prefix = bot_prefix
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
@@ -279,6 +281,7 @@ class YuanbaoChannel(BaseChannel):
                     "api_domain",
                     DEFAULT_API_DOMAIN,
                 ),
+                ws_url=config.get("ws_url", ""),
                 bot_prefix=config.get("bot_prefix", ""),
                 media_dir=config.get("media_dir", ""),
                 on_reply_sent=on_reply_sent,
@@ -308,6 +311,7 @@ class YuanbaoChannel(BaseChannel):
             app_id=config.app_id,
             app_secret=config.app_secret,
             api_domain=config.api_domain,
+            ws_url=getattr(config, "ws_url", "") or "",
             bot_prefix=config.bot_prefix,
             media_dir=getattr(config, "media_dir", "") or "",
             on_reply_sent=on_reply_sent,
@@ -443,7 +447,7 @@ class YuanbaoChannel(BaseChannel):
         self._session = aiohttp.ClientSession()
         try:
             self._ws = await self._session.ws_connect(
-                DEFAULT_WS_URL,
+                self.ws_url,
                 timeout=aiohttp.ClientWSTimeout(
                     ws_close=float(SEND_TIMEOUT),
                 ),

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -279,7 +279,18 @@ class FeishuConfig(BaseChannelConfig):
     encrypt_key: str = ""
     verification_token: str = ""
     media_dir: Optional[str] = None
-    domain: Literal["feishu", "lark"] = "feishu"
+    # "feishu" / "lark", or a full http(s) base URL for custom gateways.
+    domain: str = "feishu"
+
+    @field_validator("domain")
+    @classmethod
+    def _check_domain(cls, v: str) -> str:
+        if v in ("feishu", "lark") or v.startswith(("http://", "https://")):
+            return v
+        raise ValueError(
+            "domain must be 'feishu', 'lark', or an http(s) base URL",
+        )
+
     streaming_enabled: bool = False
     share_session_in_group: bool = False
 
@@ -355,6 +366,7 @@ class WecomConfig(BaseChannelConfig):
 
     bot_id: str = ""
     secret: str = ""
+    ws_url: str = ""
     media_dir: Optional[str] = None
     welcome_text: str = ""
     # If True (default), all group members share one chat; set to
@@ -444,6 +456,8 @@ class XiaoYiConfig(BaseChannelConfig):
     ak: str = ""  # Access Key
     sk: str = ""  # Secret Key
     agent_id: str = ""  # Agent ID from XiaoYi platform
+    # Custom WS gateway (empty = official endpoints); disables backup.
+    ws_url: str = ""
     task_timeout_ms: int = 3600000  # 1 hour task timeout
 
 
@@ -457,6 +471,8 @@ class YuanbaoConfig(BaseChannelConfig):
     app_id: str = ""
     app_secret: str = ""
     api_domain: str = "bot.yuanbao.tencent.com"
+    # Custom WebSocket gateway (empty = official wss endpoint).
+    ws_url: str = ""
     media_dir: Optional[str] = None
     accept_bot_messages: bool = False
 


### PR DESCRIPTION
> **提交人**: 鬼谷子·Integrator@QPQAT

## Description

Five IM channels (Feishu, QQ, WeCom, XiaoYi, Yuanbao) hard-code their server endpoints, making it impossible to point them at private gateways or local test servers. Since the app runs as a standalone process, in-test monkeypatching is not an option, and network interception (hosts/proxy) cannot work for TLS WebSockets.

This adds opt-in injection seams; default behavior is unchanged when the new fields are empty.

**Why this change:**
- Integration tests need to point these channels at local mock servers for automated verification
- The app runs as a standalone process; in-test memory patching is not feasible
- Encrypted connections cannot be intercepted mid-flight
- Also useful for real-world private gateway deployments

**Related Issue:** N/A (feature enhancement, not a bug fix)

**Security Considerations:**
- All new fields are optional with empty defaults; behavior is identical to pre-change when not set
- Yuanbao channel logs a prominent warning if explicitly configured with http:// (unencrypted), since that request carries app_key + HMAC signature
- Feishu `domain` field changed from Literal to str, but retains field_validator rejecting invalid values (original behavior preserved)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks (N/A, no auto-fixes)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) (N/A, new fields optional with unchanged default behavior)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic (N/A, no complex internal logic in this change)

## Testing

**Local tests:**
```bash
# Channel contract tests + channel config integration tests
pytest tests/contract/channels/test_feishu_contract.py tests/contract/channels/test_qq_contract.py tests/integration/test_channel_config.py tests/integration/test_channels_config.py -v

# Result: 60 passed, 1 skipped, 1 xfail, 0 failed
```

**Fork CI (4-platform matrix, run 31390469053):**
- Unit Tests: py3.11-ubuntu / py3.13-ubuntu / py3.11-macos / py3.11-windows all green
- Contract Tests: all 4 platforms green
- Integrated Tests: each platform reports exactly one failure — `test_coding_mode_get_default_disabled` (failure signature `{'enabled': False, 'agent_id': 'default'}`)
  - **This failure = pre-existing nightly red (contract drift from upstream #6504, test case not updated), identical signature to the 5-day nightly red streak, not introduced by this PR**
  - All remaining 343/344 integration cases pass on each platform
  - The companion branch fix/nightly-coding-mode-contract fixing this red has 4-platform integrated tier all green (run 31390472091); once merged upstream, this PR's integrated tier will naturally turn green

## Evidence

**Local test output:**
```
$ pytest tests/contract/channels/test_feishu_contract.py tests/contract/channels/test_qq_contract.py tests/integration/test_channel_config.py tests/integration/test_channels_config.py -v
============================= test session starts ==============================
...
tests/contract/channels/test_feishu_contract.py::test_feishu_contract PASSED
tests/contract/channels/test_qq_contract.py::test_qq_contract PASSED
tests/integration/test_channel_config.py::test_channel_config_feishu PASSED
tests/integration/test_channel_config.py::test_channel_config_qq PASSED
tests/integration/test_channel_config.py::test_channel_config_wecom PASSED
tests/integration/test_channel_config.py::test_channel_config_xiaoyi PASSED
tests/integration/test_channel_config.py::test_channel_config_yuanbao PASSED
...
======================== 60 passed, 1 skipped, 1 xfail =========================
```

**Fork CI links:**
- Run 31390469053 (this PR): https://github.com/yutai78786/QwenPaw/actions/runs/31390469053
- Run 31390472091 (nightly fix, integrated tier all green): https://github.com/yutai78786/QwenPaw/actions/runs/31390472091

**Technical details:**
- Single commit: `feat(channels): allow custom gateway endpoints for IM channels`, 7 files +68/-24
  - feishu/channel.py: `domain` accepts full http(s) base URL in addition to "feishu"/"lark"; new `_sdk_domain()` unifies SDK/HTTP address retrieval
  - qq/channel.py: `QQ_TOKEN_URL` env var overrides token endpoint
  - wecom/channel.py: new optional `ws_url` (aibot SDK's WSClientOptions natively supports it)
  - xiaoyi/channel.py: new optional `ws_url`; when set, backup endpoint is disabled by design
  - yuanbao/channel.py + auth.py: new optional `ws_url`; `api_domain` respects explicit http(s) scheme (bare domain stays https), http downgrade logs warning
  - config/config.py: corresponding 4 channel config models add optional fields; FeishuConfig.domain changed from Literal to str + field_validator (preserves original invalid-value rejection behavior)
- Compatibility: all new fields optional with empty defaults; existing config files load unchanged
- Rebase note: original commit based on 7-30 upstream (fb96b391), conflict-free rebase to c52dffc1 (includes #6615's config.py auto-merge); patch content hunk-by-hunk identical to original commit

## Additional Notes

- This PR is the prerequisite for upstreaming the 18,000-line channel mock test suite (approved by maintainer on 2026-08-10 20:26 with precondition: "18k-line test upstreaming approved, PR #39 merges upstream first")
- The same src changes have been exercised by 318 passing integration cases in the companion channel-mock test suite health check (checkup_C1_run1.log)
