### PR TITLE
fix(config): return 422 for invalid channel payloads (#6910)

### DIFF
--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -13,7 +13,7 @@ from fastapi import (
     Query,
     Request,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ...agents.acp.core import ACPAgentConfig, ACPConfig
 from ...agents.acp.node_runtime import (
@@ -405,7 +405,16 @@ async def put_channel(
 
     config_class = _channel_config_class(channel_name)
     if config_class is not None:
-        channel_config = config_class(**single_channel_config)
+        try:
+            channel_config = config_class(**single_channel_config)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=exc.errors(
+                    include_url=False,
+                    include_context=False,
+                ),
+            ) from exc
     else:
         # For custom channels, just use the dict
         channel_config = single_channel_config

--- a/tests/unit/app/routers/test_config_router.py
+++ b/tests/unit/app/routers/test_config_router.py
@@ -263,13 +263,7 @@ def test_put_onebot_channel_rejects_invalid_value(
     fake_agent_workspace,
     patch_get_agent,
 ):
-    """An invalid value is refused instead of reaching the disk.
-
-    The rejection currently surfaces as a 500 because the model error
-    propagates; 422 is accepted too so that turning it into a proper
-    validation response stays a green change.  A 404 would mean the
-    route never ran, which must not pass for this guard.
-    """
+    """An invalid value returns validation details without reaching disk."""
     lenient_client = TestClient(app, raise_server_exceptions=False)
 
     with patch("qwenpaw.config.config.save_agent_config") as save_mock:
@@ -278,7 +272,10 @@ def test_put_onebot_channel_rejects_invalid_value(
             json={"enabled": True, "ws_port": "not-a-port"},
         )
 
-    assert response.status_code in (422, 500)
+    assert response.status_code == 422
+    error = response.json()["detail"][0]
+    assert error["type"] == "int_parsing"
+    assert error["loc"] == ["ws_port"]
     save_mock.assert_not_called()
     assert isinstance(
         fake_agent_workspace.config.channels.onebot,


### PR DESCRIPTION
## Description

Fixes #6910.

The single-channel config endpoint dynamically constructs the selected
Pydantic model from an untyped JSON body. Invalid values raised an unhandled
`ValidationError`, so a client input error returned HTTP 500 even though no
configuration was persisted.

This change maps that model error to HTTP 422 with structured field details,
matching the complete-channel endpoint's validation contract. It excludes
Pydantic's non-serializable error context while retaining the error type,
location, message, and submitted input.

**Related Issue:** Fixes #6910

**Security Considerations:** None. Invalid configuration remains rejected
before persistence or channel reload.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran all applicable pre-commit hooks on the changed files
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed; existing API error contract)
- [x] Ready for review

## Testing

The regression calls the real FastAPI route with
`{"enabled": true, "ws_port": "not-a-port"}` and verifies:

- the response is HTTP 422, not HTTP 500;
- the detail identifies `ws_port` with Pydantic's `int_parsing` error;
- `save_agent_config()` is not called;
- the existing typed OneBot config remains intact.

## Evidence

Before this change, the focused regression failed:

```text
E assert 500 == 422
1 failed
```

The direct API probe now reports:

```text
status=422
detail=[{
  'type': 'int_parsing',
  'loc': ['ws_port'],
  'msg': 'Input should be a valid integer, unable to parse string as an integer',
  'input': 'not-a-port'
}]
save_called=False
```

Post-rebase verification on current `main` (`a0cfbf3f`):

```text
pytest -q tests/unit
6619 passed, 16 skipped

pytest -q tests/unit/app/routers/test_config_router.py \
  tests/unit/config/test_channel_shape_consistency.py
44 passed

pytest -q tests/integration/test_channel_config.py \
  tests/integration/test_channels_config.py
18 passed, 1 xpassed

SKIP=actionlint pre-commit run --files \
  src/qwenpaw/app/routers/config.py \
  tests/unit/app/routers/test_config_router.py
Python AST, encoding, private-key detection, whitespace, trailing commas,
Mypy, Black, Flake8, and Pylint: Passed
```

## Additional Notes

The change intentionally leaves plugin channel dictionaries untyped; only
built-in channel models can raise the handled Pydantic error. The
implementation was AI-assisted and personally reproduced, reviewed, and
verified against the exact revisions and commands above.
