### PR TITLE
fix(files): repair previews and dark mode styling

### DIFF
--- a/console/src/pages/Coding/FilePreview.module.less
+++ b/console/src/pages/Coding/FilePreview.module.less
@@ -319,6 +319,28 @@
     background: #141816;
   }
 
+  .htmlWrap,
+  .htmlFrame {
+    background: #141816;
+  }
+
+  .htmlToolbar {
+    background: #1a1d1b;
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .htmlOpenButton {
+    color: rgba(255, 255, 255, 0.76);
+    background: #24211f;
+    border-color: rgba(255, 255, 255, 0.16);
+
+    &:hover {
+      color: #ff9b5c;
+      background: rgba(243, 107, 33, 0.14);
+      border-color: rgba(255, 145, 77, 0.7);
+    }
+  }
+
   .imageWrap {
     background: #141414;
   }

--- a/console/src/pages/Coding/TabbedEditor.module.less
+++ b/console/src/pages/Coding/TabbedEditor.module.less
@@ -453,6 +453,30 @@
     color: rgba(255, 255, 255, 0.45);
   }
 
+  .modeSwitch {
+    background: #24211f;
+    border-color: rgba(255, 255, 255, 0.12);
+
+    button {
+      color: rgba(255, 255, 255, 0.58);
+
+      &:hover {
+        color: rgba(255, 255, 255, 0.88);
+        background: rgba(255, 255, 255, 0.06);
+      }
+    }
+  }
+
+  .modeActive {
+    color: #ff9b5c !important;
+    background: rgba(243, 107, 33, 0.2) !important;
+  }
+
+  .textPreview {
+    color: rgba(255, 255, 255, 0.86);
+    background: #141816;
+  }
+
   .iconBtn {
     color: rgba(255, 255, 255, 0.55);
 

--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -460,13 +460,20 @@ async def download_workspace_file(
     workspace = await get_agent_for_request(request)
     files_root = await _resolve_files_root(request, workspace, root)
 
-    def _resolve_download() -> tuple[Path, os.stat_result]:
+    def _resolve_download() -> tuple[Path, os.stat_result, str, str]:
         target = resolve_workspace_path(files_root, path)
-        return target, target.stat()
+        info = target.stat()
+        filename = target.name.replace('"', "")
+        media_type = (
+            mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        )
+        return target, info, filename, media_type
 
     try:
         async with _FILESYSTEM_SEMAPHORE:
-            target, info = await asyncio.to_thread(_resolve_download)
+            target, info, filename, media_type = await asyncio.to_thread(
+                _resolve_download,
+            )
         if not stat.S_ISREG(info.st_mode):
             raise FileNotFoundError(path)
     except InvalidWorkspacePath as exc:
@@ -479,15 +486,11 @@ async def download_workspace_file(
             while chunk := handle.read(chunk_size):
                 yield chunk
 
-    filename = target.name.replace('"', "")
     quoted_filename = quote(filename)
     if quoted_filename == filename:
         content_disposition = f'attachment; filename="{filename}"'
     else:
         content_disposition = f"attachment; filename*=utf-8''{quoted_filename}"
-    media_type = (
-        mimetypes.guess_type(filename)[0] or "application/octet-stream"
-    )
     return StreamingResponse(
         _stream_file(),
         media_type=media_type,

--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -12,6 +12,7 @@ import copy
 import io
 import json
 import logging
+import mimetypes
 import secrets
 import shutil
 import stat
@@ -23,6 +24,7 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Literal
+from urllib.parse import quote
 
 from fastapi import (
     APIRouter,
@@ -478,12 +480,20 @@ async def download_workspace_file(
                 yield chunk
 
     filename = target.name.replace('"', "")
+    quoted_filename = quote(filename)
+    if quoted_filename == filename:
+        content_disposition = f'attachment; filename="{filename}"'
+    else:
+        content_disposition = f"attachment; filename*=utf-8''{quoted_filename}"
+    media_type = (
+        mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    )
     return StreamingResponse(
         _stream_file(),
-        media_type="application/octet-stream",
+        media_type=media_type,
         headers={
             "Accept-Ranges": "bytes",
-            "Content-Disposition": (f'attachment; filename="{filename}"'),
+            "Content-Disposition": content_disposition,
             "Content-Length": str(info.st_size),
             "ETag": file_etag(info),
         },


### PR DESCRIPTION
## Description

Fix workspace file previews that failed for Unicode PDF filenames and SVG files, and align the file preview surfaces with the Console dark theme.

The workspace download response now uses RFC 5987 encoding for non-ASCII filenames and derives the response media type from the filename. This prevents Starlette's Latin-1 header encoding error and lets browser Blob URLs retain usable PDF and SVG MIME types.

The Console also receives explicit dark-mode styles for the preview/edit switch, plain-text previews, and the HTML preview toolbar and open-in-browser button.

**Related Issue:** N/A

**Security Considerations:** Existing workspace path resolution and validation are unchanged. This only adjusts response metadata and presentation styles.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this bug fix)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Ran the existing workspace file router test suite in the `Codex-QwenPaw` Conda environment.
- Ran the existing `FilePreview` and `TabbedEditor` Vitest suites.
- Built the Console production bundle and verified the Monaco stylesheet.
- Ran pre-commit hooks against all changed files.

## Evidence

```text
$ conda run -n Codex-QwenPaw python -m pytest ../tests/unit/app/routers/test_workspace_files_router.py -q
...........                                                              [100%]
11 passed, 1 warning in 1.19s

$ npm test -- --run src/pages/Coding/FilePreview.test.tsx src/pages/Coding/TabbedEditor.test.tsx
Test Files  2 passed (2)
Tests       4 passed (4)

$ npm run build
✓ built in 32.97s
[verify-monaco-css] OK - Monaco stylesheet present in 35 CSS file(s).

$ conda run -n Codex-QwenPaw pre-commit run --files src/qwenpaw/app/routers/workspace.py console/src/pages/Coding/TabbedEditor.module.less console/src/pages/Coding/FilePreview.module.less
All applicable hooks passed, including mypy, black, flake8, and pylint.
```

## Additional Notes

No new test files were added. Existing build chunk-size and circular-chunk warnings remain unchanged.
