### PR TITLE
fix(media): prevent capability cache poisoning and preserve image versions

### DIFF
--- a/src/qwenpaw/agents/memory/proactive/proactive_utils.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_utils.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 """Utility functions for proactive messaging features."""
 
+from copy import deepcopy
 import json
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List, Optional, Any
 
 from agentscope.agent import Agent
-from agentscope.message import Msg, TextBlock, DataBlock, URLSource
+from agentscope.message import Msg, TextBlock
 
 if TYPE_CHECKING:
     from ....app.workspace import Workspace
@@ -262,13 +263,17 @@ async def _analyze_screen_activity(
             return None
 
         content = screenshot_result.content
+        image_block = None
         if isinstance(content, list):
             # content may be [DataBlock, TextBlock] - find the TextBlock
             result_text = ""
             for block in content:
                 if hasattr(block, "text"):
                     result_text = block.text
-                    break
+                source = getattr(block, "source", None)
+                media_type = getattr(source, "media_type", "") or ""
+                if media_type.startswith("image/"):
+                    image_block = block
         else:
             result_text = str(content)
 
@@ -281,8 +286,7 @@ async def _analyze_screen_activity(
                 )
                 return None
 
-            screenshot_path = result_json.get("path", "")
-            if not screenshot_path:
+            if image_block is None:
                 return None
 
             analysis_prompt = (
@@ -291,24 +295,12 @@ async def _analyze_screen_activity(
                 "currently engaged in."
             )
 
-            screenshot_url = screenshot_path
-            if not screenshot_url.startswith(
-                ("http://", "https://", "file://"),
-            ):
-                screenshot_url = f"file://{screenshot_url}"
             screenshot_msg = Msg(
                 name="System",
                 role="user",
                 content=[
                     TextBlock(type="text", text=analysis_prompt),
-                    DataBlock(
-                        type="data",
-                        source=URLSource(
-                            type="url",
-                            url=screenshot_url,
-                            media_type="image/png",
-                        ),
-                    ),
+                    deepcopy(image_block),
                 ],
             )
 

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -198,7 +198,9 @@ def _normalize_messages_for_formatter(
     )
 
 
-def _anthropic_media_dedup_key(source: Any) -> str | None:
+def _anthropic_media_dedup_key(
+    source: Any,
+) -> tuple[str, str, str] | None:
     """Return a hashable key identifying a media source for dedup.
 
     A user-uploaded image often re-appears inside ``view_image``'s
@@ -211,15 +213,14 @@ def _anthropic_media_dedup_key(source: Any) -> str | None:
     media_type = getattr(source, "media_type", "") or ""
     url = getattr(source, "url", None)
     if url is not None:
-        return f"url|{media_type}|{url}"
+        return ("url", media_type, str(url))
     data = getattr(source, "data", "") or ""
     if data:
-        try:
-            content = base64.b64decode(data, validate=True)
-        except (ValueError, TypeError):
-            content = data.encode("utf-8")
-        digest = hashlib.sha256(content).hexdigest()
-        return f"content|{media_type}|{digest}"
+        # Base64 is already a canonical immutable representation here.
+        # Using the string itself avoids decoding and hashing every media
+        # block again on every accumulated-history request. Python caches
+        # string hashes and set equality still compares the full content.
+        return ("base64", media_type, data)
     return None
 
 
@@ -1067,7 +1068,9 @@ def _create_file_block_support_formatter(
             source = getattr(block, "source", None)
             media_type = getattr(source, "media_type", "") or ""
 
-            seen: set[str] = getattr(self, "_seen_media_keys", None) or set()
+            seen: set[tuple[str, str, str]] = (
+                getattr(self, "_seen_media_keys", None) or set()
+            )
             self._seen_media_keys = seen
             key = _anthropic_media_dedup_key(source) if source else None
             if key is not None:

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -214,8 +214,42 @@ def _anthropic_media_dedup_key(source: Any) -> str | None:
         return f"url|{media_type}|{url}"
     data = getattr(source, "data", "") or ""
     if data:
-        return f"b64|{media_type}|{len(data)}|{data[:128]}"
+        try:
+            content = base64.b64decode(data, validate=True)
+        except (ValueError, TypeError):
+            content = data.encode("utf-8")
+        digest = hashlib.sha256(content).hexdigest()
+        return f"content|{media_type}|{digest}"
     return None
+
+
+_WIRE_MEDIA_BLOCK_TYPES = frozenset(
+    {
+        "audio",
+        "image",
+        "image_url",
+        "input_audio",
+        "input_image",
+        "input_video",
+        "video",
+        "video_url",
+    },
+)
+_WIRE_MEDIA_CONTAINER_KEYS = frozenset({"file_data", "inline_data"})
+
+
+def _count_wire_media_blocks(value: Any) -> int:
+    """Count provider-formatted media blocks in a nested payload."""
+    if isinstance(value, list):
+        return sum(_count_wire_media_blocks(item) for item in value)
+    if not isinstance(value, dict):
+        return 0
+
+    if value.get("type") in _WIRE_MEDIA_BLOCK_TYPES:
+        return 1
+    if any(key in value for key in _WIRE_MEDIA_CONTAINER_KEYS):
+        return 1
+    return sum(_count_wire_media_blocks(item) for item in value.values())
 
 
 def _video_oversize_placeholder(
@@ -1058,6 +1092,10 @@ def _create_file_block_support_formatter(
             reasoning_content relay, and provider-specific fixups.
             """
 
+            # A formatter failure must not leave media evidence from a
+            # previous request behind for the capability fallback layer.
+            self._qwenpaw_last_wire_media_count = 0
+
             # Per-wire-request dedup scope — second occurrence of the
             # same media source becomes a text placeholder.  Reset on
             # every call so state never leaks across requests.
@@ -1249,7 +1287,11 @@ def _create_file_block_support_formatter(
                         elif require_reasoning:
                             out_msg.setdefault("reasoning_content", " ")
 
-            return _strip_top_level_message_name(messages)
+            wire_messages = _strip_top_level_message_name(messages)
+            self._qwenpaw_last_wire_media_count = _count_wire_media_blocks(
+                wire_messages,
+            )
+            return wire_messages
 
         def convert_tool_result_to_string(
             self,

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -832,6 +832,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
         safety_markers = (
             "new_sensitive",
             "image is sensitive",
+            "sensitive content",
+            "content sensitivity",
             "content policy",
             "content_policy",
             "moderation",
@@ -874,7 +876,6 @@ class QwenPawAgent(CodingModeMixin, Agent):
             "invalid image",
             "invalid media",
             "mime",
-            "sensitive",
             "unsupported image format",
         )
         if any(signal in error_str for signal in invalid_asset_signals):

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -31,6 +31,7 @@ from agentscope.tool import Toolkit
 
 from .context.base import ContextManager
 from .skill_system import get_workspace_skills_dir
+from .utils.image_freezing import freeze_local_images_async
 from ..modes.coding import CodingModeMixin
 from ..utils.io_utils import run_sync_io
 from ..constant import (
@@ -67,6 +68,12 @@ _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
         r"\b(?:by|for)\b.{0,30}\b(?:model|deployment)\b",
         re.IGNORECASE,
     ),
+    re.compile(
+        r"\b(?:image|audio|video|media)\b.{0,60}"
+        r"\b(?:is|are)\s+not supported\b.{0,40}"
+        r"\b(?:model|deployment)\b",
+        re.IGNORECASE,
+    ),
     re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
     re.compile(
         r"\bvision\s+is\s+not\s+enabled\s+for\s+"
@@ -77,6 +84,54 @@ _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
         r"\bunsupported\s+modality\s*:?\s*(?:image|audio|video)\b",
         re.IGNORECASE,
     ),
+)
+
+_GLOBAL_MEDIA_CAPABILITY_PATTERNS = (
+    re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:this|the|selected)?\s*model\b.{0,80}"
+        r"\b(?:does not|doesn't|cannot|can't)\s+support\b.{0,40}"
+        r"\b(?:media|multimodal)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bmultimodal\s+(?:input|capability)?\s*"
+        r"(?:is\s+)?not\s+enabled\b.{0,40}"
+        r"\b(?:model|deployment)\b",
+        re.IGNORECASE,
+    ),
+)
+
+# These messages reject only the current media shape, not the model's
+# overall multimodal capability. They may justify a media-free retry, but
+# must never poison the model-wide ``rejects_media`` cache.
+_REQUEST_SCOPED_MEDIA_LIMIT_SIGNALS = (
+    "multiple image",
+    "multiple video",
+    "multiple audio",
+    "more than one image",
+    "more than 1 image",
+    "single image",
+    "image count",
+    "too many image",
+    "animated image",
+    "animated gif",
+    "animation",
+    "dimensions",
+    "dimension",
+    "resolution",
+    "image width",
+    "image height",
+    "pixel",
+    "megapixel",
+    "frame rate",
+    "sample rate",
+    "video duration",
+    "audio duration",
+    "larger than",
+    "smaller than",
+    "per image",
+    "file size",
 )
 
 
@@ -540,6 +595,11 @@ class QwenPawAgent(CodingModeMixin, Agent):
             and (count > 0)
         )
 
+    async def _prepare_model_input(self) -> dict[str, Any]:
+        """Freeze local images before they enter a provider request."""
+        await freeze_local_images_async(self.state.context)
+        return await super()._prepare_model_input()
+
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:
         """Return whether *exc* is a provider 400 for an oversized input.
@@ -749,6 +809,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 raise
 
             model_key = self._get_model_key()
+            learn_global_rejection = self._is_global_media_capability_error(e)
             logger.warning(
                 "_reasoning failed because the provider explicitly rejected "
                 "the model's media capability (%s); "
@@ -769,7 +830,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
                         final_msg = evt
                     else:
                         yield evt
-                if model_key:
+                if model_key and learn_global_rejection:
                     get_capability_cache().learn(
                         model_key,
                         "rejects_media",
@@ -845,7 +906,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
 
     @staticmethod
     def _is_explicit_media_capability_error(exc: Exception) -> bool:
-        """Return True only for an explicit model capability rejection."""
+        """Return whether an explicit media rejection permits fallback."""
         error_str = str(exc).lower()
 
         # Veto: content safety/moderation rejections are about a
@@ -884,6 +945,20 @@ class QwenPawAgent(CodingModeMixin, Agent):
         return any(
             pattern.search(error_str) is not None
             for pattern in _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS
+        )
+
+    @staticmethod
+    def _is_global_media_capability_error(exc: Exception) -> bool:
+        """Return whether an error proves model-wide media rejection."""
+        error_str = str(exc).lower()
+        if any(
+            signal in error_str
+            for signal in _REQUEST_SCOPED_MEDIA_LIMIT_SIGNALS
+        ):
+            return False
+        return any(
+            pattern.search(error_str) is not None
+            for pattern in _GLOBAL_MEDIA_CAPABILITY_PATTERNS
         )
 
     def _is_media_block(self, block: Any) -> bool:

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -55,7 +55,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_GLOBAL_MEDIA_CAPABILITY_PATTERNS = (
+    re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:this|the|selected)?\s*model\b.{0,80}"
+        r"\b(?:does not|doesn't|cannot|can't)\s+support\b.{0,40}"
+        r"\b(?:media|multimodal)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bmultimodal\s+(?:input|capability)?\s*"
+        r"(?:is\s+)?not\s+enabled\b.{0,40}"
+        r"\b(?:model|deployment)\b",
+        re.IGNORECASE,
+    ),
+)
+
+# A global capability rejection must also trigger the one-request fallback.
+# Keep the global patterns as an explicit subset so the two classifiers
+# cannot silently drift apart.
 _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
+    *_GLOBAL_MEDIA_CAPABILITY_PATTERNS,
     re.compile(
         r"\b(?:this|the|selected)?\s*model\b.{0,80}"
         r"\b(?:does not|doesn't|cannot|can't)\s+support\b.{0,40}"
@@ -74,7 +94,6 @@ _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
         r"\b(?:model|deployment)\b",
         re.IGNORECASE,
     ),
-    re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
     re.compile(
         r"\bvision\s+is\s+not\s+enabled\s+for\s+"
         r"(?:this\s+)?(?:model|deployment)\b",
@@ -82,22 +101,6 @@ _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
     ),
     re.compile(
         r"\bunsupported\s+modality\s*:?\s*(?:image|audio|video)\b",
-        re.IGNORECASE,
-    ),
-)
-
-_GLOBAL_MEDIA_CAPABILITY_PATTERNS = (
-    re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
-    re.compile(
-        r"\b(?:this|the|selected)?\s*model\b.{0,80}"
-        r"\b(?:does not|doesn't|cannot|can't)\s+support\b.{0,40}"
-        r"\b(?:media|multimodal)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"\bmultimodal\s+(?:input|capability)?\s*"
-        r"(?:is\s+)?not\s+enabled\b.{0,40}"
-        r"\b(?:model|deployment)\b",
         re.IGNORECASE,
     ),
 )

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -12,6 +12,7 @@ as constructor parameters and does not build them internally.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Literal, Optional, TYPE_CHECKING
@@ -51,6 +52,32 @@ if TYPE_CHECKING:
     from ..config.config import AgentProfileConfig
 
 logger = logging.getLogger(__name__)
+
+
+_EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS = (
+    re.compile(
+        r"\b(?:this|the|selected)?\s*model\b.{0,80}"
+        r"\b(?:does not|doesn't|cannot|can't)\s+support\b.{0,40}"
+        r"\b(?:images?|audios?|videos?|vision|media|multimodal)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:image|audio|video|media)\s+(?:input|modality)\b"
+        r".{0,40}\b(?:is|are)\s+not supported\b.{0,40}"
+        r"\b(?:by|for)\b.{0,30}\b(?:model|deployment)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bmodel\s+is\s+text[- ]only\b", re.IGNORECASE),
+    re.compile(
+        r"\bvision\s+is\s+not\s+enabled\s+for\s+"
+        r"(?:this\s+)?(?:model|deployment)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bunsupported\s+modality\s*:?\s*(?:image|audio|video)\b",
+        re.IGNORECASE,
+    ),
+)
 
 
 def _effective_artifact_retention_days(light_context_config: Any) -> int:
@@ -472,14 +499,46 @@ class QwenPawAgent(CodingModeMixin, Agent):
 
     def _uses_request_time_media_normalization(self) -> bool:
         """Return True when request-time normalization can handle media."""
-        return getattr(self, "formatter", None) is not None
+        return self._get_active_formatter() is not None
+
+    def _get_active_formatter(self) -> Any | None:
+        """Resolve the formatter through current and legacy model layouts."""
+        formatter = getattr(self, "formatter", None)
+        if formatter is not None:
+            return formatter
+
+        current = getattr(self, "model", None)
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            formatter = getattr(current, "formatter", None)
+            if formatter is not None:
+                return formatter
+            current = getattr(current, "_inner", None) or getattr(
+                current,
+                "_model",
+                None,
+            )
+        return None
 
     def _set_formatter_media_strip(self, enabled: bool) -> None:
         """Toggle request-time media stripping on the active formatter."""
-        formatter = getattr(self, "formatter", None)
+        formatter = self._get_active_formatter()
         if formatter is None:
             return
         setattr(formatter, "_qwenpaw_force_strip_media", enabled)
+
+    def _last_wire_request_had_media(self) -> bool:
+        """Return whether the last completed formatting emitted media."""
+        formatter = self._get_active_formatter()
+        if formatter is None:
+            return False
+        count = getattr(formatter, "_qwenpaw_last_wire_media_count", 0)
+        return (
+            isinstance(count, int)
+            and not isinstance(count, bool)
+            and (count > 0)
+        )
 
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:
@@ -683,18 +742,16 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 else:
                     yield evt
         except Exception as e:
-            if not self._is_bad_request_or_media_error(e):
+            if not (
+                self._last_wire_request_had_media()
+                and self._is_explicit_media_capability_error(e)
+            ):
                 raise
 
             model_key = self._get_model_key()
-            if model_key:
-                get_capability_cache().learn(
-                    model_key,
-                    "rejects_media",
-                    True,
-                )
             logger.warning(
-                "_reasoning failed with media error (%s); "
+                "_reasoning failed because the provider explicitly rejected "
+                "the model's media capability (%s); "
                 "stripping media and retrying.",
                 e,
             )
@@ -712,6 +769,12 @@ class QwenPawAgent(CodingModeMixin, Agent):
                         final_msg = evt
                     else:
                         yield evt
+                if model_key:
+                    get_capability_cache().learn(
+                        model_key,
+                        "rejects_media",
+                        True,
+                    )
             finally:
                 if self._uses_request_time_media_normalization():
                     self._set_formatter_media_strip(False)
@@ -779,15 +842,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
         return any(marker in error_str for marker in safety_markers)
 
     @staticmethod
-    def _is_bad_request_or_media_error(exc: Exception) -> bool:
-        """Return True only for errors that genuinely look media-related.
-
-        A bare 400 is no longer sufficient — provider gateways return
-        400 for many unrelated reasons (request too large, malformed
-        block fields, exceeded context length) and treating them all as
-        "media rejected" poisons the capability cache, causing
-        subsequent requests to silently drop user-uploaded images.
-        """
+    def _is_explicit_media_capability_error(exc: Exception) -> bool:
+        """Return True only for an explicit model capability rejection."""
         error_str = str(exc).lower()
 
         # Veto: content safety/moderation rejections are about a
@@ -812,16 +868,22 @@ class QwenPawAgent(CodingModeMixin, Agent):
         if any(sig in error_str for sig in size_signals):
             return False
 
-        # Match only when the error message itself names a media modality.
-        media_keywords = (
-            "image",
-            "audio",
-            "video",
-            "vision",
-            "multimodal",
-            "image_url",
+        invalid_asset_signals = (
+            "corrupt",
+            "decode",
+            "invalid image",
+            "invalid media",
+            "mime",
+            "sensitive",
+            "unsupported image format",
         )
-        return any(kw in error_str for kw in media_keywords)
+        if any(signal in error_str for signal in invalid_asset_signals):
+            return False
+
+        return any(
+            pattern.search(error_str) is not None
+            for pattern in _EXPLICIT_UNSUPPORTED_MEDIA_PATTERNS
+        )
 
     def _is_media_block(self, block: Any) -> bool:
         """Return True if *block* carries image/audio/video data."""

--- a/src/qwenpaw/agents/tools/desktop_screenshot.py
+++ b/src/qwenpaw/agents/tools/desktop_screenshot.py
@@ -13,7 +13,9 @@ from agentscope.message import ToolResultState
 from ...config.context import get_current_workspace_dir
 from ...constant import WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
+from ...utils.io_utils import run_sync_io
 from .file_io import _path_to_file_url
+from ..utils.image_freezing import freeze_local_images_async
 
 
 def _tool_error(msg: str) -> ToolChunk:
@@ -183,7 +185,13 @@ async def desktop_screenshot(
 
     # macOS: optional window selection via screencapture -w
     if system == "Darwin" and capture_window:
-        return await _capture_macos_screencapture(path, capture_window=True)
+        result = await _capture_macos_screencapture(
+            path,
+            capture_window=True,
+        )
+    else:
+        # Full-screen on all platforms (macOS, Linux, Windows) via mss.
+        result = await run_sync_io(_capture_mss, path)
 
-    # Full-screen on all platforms (macOS, Linux, Windows) via mss
-    return _capture_mss(path)
+    await freeze_local_images_async(result)
+    return result

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Load image or video files into the LLM context for analysis."""
 
-import base64
-from io import BytesIO
 import logging
 import mimetypes
 import os
@@ -13,19 +11,17 @@ from pathlib import Path
 from typing import Optional
 
 from agentscope.message import (
-    Base64Source,
     DataBlock,
     TextBlock,
     URLSource,
     ToolResultState,
 )
 from agentscope.tool import ToolChunk
-from PIL import Image, UnidentifiedImageError
 
-from ...providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.io_utils import run_sync_io
 from .file_io import _path_to_file_url, _resolve_file_path
+from ..utils.image_freezing import freeze_local_image
 
 logger = logging.getLogger(__name__)
 
@@ -54,18 +50,6 @@ _IMAGE_EXTENSIONS = {
     ".tiff",
     ".tif",
 }
-
-# Safe pass-through formats, not a declaration of model capability.
-_NATIVE_IMAGE_MEDIA_TYPES = frozenset(
-    {
-        "image/gif",
-        "image/jpeg",
-        "image/png",
-        "image/webp",
-    },
-)
-
-_PNG_CONVERTIBLE_IMAGE_FORMATS = frozenset({"BMP", "TIFF"})
 
 _VIDEO_EXTENSIONS = {
     ".mp4",
@@ -165,78 +149,19 @@ def _validate_media_path(
     return resolved, None
 
 
-def _freeze_local_image(
-    image_path: Path,
-) -> tuple[DataBlock | None, str | None]:
-    """Validate and freeze one local image as immutable base64 content."""
-    try:
-        file_size = image_path.stat().st_size
-        if file_size > MAX_INLINE_MEDIA_BYTES:
-            return (
-                None,
-                f"Error: {image_path.name} is {file_size} bytes and "
-                f"exceeds the {MAX_INLINE_MEDIA_BYTES}-byte image limit.",
-            )
-        with image_path.open("rb") as image_file:
-            image_bytes = image_file.read(MAX_INLINE_MEDIA_BYTES + 1)
-        if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
-            return (
-                None,
-                f"Error: {image_path.name} exceeds the "
-                f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
-            )
-
-        with Image.open(BytesIO(image_bytes)) as image:
-            normalized_format = (image.format or "").upper()
-            media_type = Image.MIME.get(normalized_format)
-            if media_type in _NATIVE_IMAGE_MEDIA_TYPES:
-                image.verify()
-                frozen_bytes = image_bytes
-            elif normalized_format in _PNG_CONVERTIBLE_IMAGE_FORMATS:
-                image.seek(0)
-                image.load()
-                has_alpha = (
-                    "A" in image.getbands() or "transparency" in image.info
-                )
-                target_mode = "RGBA" if has_alpha else "RGB"
-                with image.convert(target_mode) as converted:
-                    output = BytesIO()
-                    converted.save(output, format="PNG")
-                    frozen_bytes = output.getvalue()
-                media_type = "image/png"
-            else:
-                detected = media_type or image.format or "unknown"
-                return (
-                    None,
-                    f"Error: {image_path.name} uses unsupported image "
-                    f"format {detected}.",
-                )
-    except (
-        Image.DecompressionBombError,
-        OSError,
-        UnidentifiedImageError,
-        ValueError,
-    ) as exc:
-        return None, f"Error: {image_path.name} is not a valid image: {exc}"
-
-    if len(frozen_bytes) > MAX_INLINE_MEDIA_BYTES:
-        return (
-            None,
-            f"Error: converted {image_path.name} is "
-            f"{len(frozen_bytes)} bytes and exceeds the "
-            f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
-        )
-
-    encoded = base64.b64encode(frozen_bytes).decode("ascii")
-    return (
-        DataBlock(
-            source=Base64Source(
-                data=encoded,
-                media_type=media_type,
-            ),
-        ),
-        None,
+def _load_local_image(
+    image_path: str,
+) -> tuple[Path, DataBlock | None, ToolChunk | None, str | None]:
+    """Resolve, validate, and freeze one local image transaction."""
+    resolved, validation_error = _validate_media_path(
+        image_path,
+        _IMAGE_EXTENSIONS,
+        "image",
     )
+    if validation_error is not None:
+        return resolved, None, validation_error, None
+    frozen, freeze_error = freeze_local_image(resolved)
+    return resolved, frozen, None, freeze_error
 
 
 async def _probe_multimodal_if_needed(
@@ -480,18 +405,12 @@ async def view_image(image_path: str) -> ToolChunk:
             ],
         )
 
-    resolved, err = _validate_media_path(
+    resolved, frozen_image, validation_error, freeze_error = await run_sync_io(
+        _load_local_image,
         image_path,
-        _IMAGE_EXTENSIONS,
-        "image",
     )
-    if err is not None:
-        return err
-
-    frozen_image, freeze_error = await run_sync_io(
-        _freeze_local_image,
-        resolved,
-    )
+    if validation_error is not None:
+        return validation_error
     if freeze_error is not None or frozen_image is None:
         return ToolChunk(
             is_last=True,

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Load image or video files into the LLM context for analysis."""
 
+import base64
+from io import BytesIO
 import logging
 import mimetypes
 import os
@@ -10,11 +12,18 @@ from urllib.parse import unquote
 from pathlib import Path
 from typing import Optional
 
-from agentscope.message import DataBlock, TextBlock, URLSource
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+    URLSource,
+    ToolResultState,
+)
 from agentscope.tool import ToolChunk
-from agentscope.message import ToolResultState
+from PIL import Image, UnidentifiedImageError
 
 from ...runtime.tool_registry import tool_descriptor
+from ...utils.io_utils import run_sync_io
 from .file_io import _path_to_file_url, _resolve_file_path
 
 logger = logging.getLogger(__name__)
@@ -44,6 +53,18 @@ _IMAGE_EXTENSIONS = {
     ".tiff",
     ".tif",
 }
+
+# Safe pass-through formats, not a declaration of model capability.
+_NATIVE_IMAGE_MEDIA_TYPES = frozenset(
+    {
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    },
+)
+
+_PNG_CONVERTIBLE_IMAGE_FORMATS = frozenset({"BMP", "TIFF"})
 
 _VIDEO_EXTENSIONS = {
     ".mp4",
@@ -141,6 +162,72 @@ def _validate_media_path(
         )
 
     return resolved, None
+
+
+def _freeze_local_image(
+    image_path: Path,
+) -> tuple[DataBlock | None, str | None]:
+    """Validate and freeze one local image as immutable base64 content."""
+    try:
+        image_bytes = image_path.read_bytes()
+        with Image.open(BytesIO(image_bytes)) as image:
+            image_format = image.format
+            image.verify()
+    except (
+        Image.DecompressionBombError,
+        OSError,
+        UnidentifiedImageError,
+        ValueError,
+    ) as exc:
+        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+
+    normalized_format = (image_format or "").upper()
+    media_type = Image.MIME.get(normalized_format)
+    if media_type in _NATIVE_IMAGE_MEDIA_TYPES:
+        frozen_bytes = image_bytes
+    elif normalized_format in _PNG_CONVERTIBLE_IMAGE_FORMATS:
+        try:
+            with Image.open(BytesIO(image_bytes)) as image:
+                image.seek(0)
+                image.load()
+                has_alpha = (
+                    "A" in image.getbands() or "transparency" in image.info
+                )
+                target_mode = "RGBA" if has_alpha else "RGB"
+                with image.convert(target_mode) as converted:
+                    output = BytesIO()
+                    converted.save(output, format="PNG")
+                    frozen_bytes = output.getvalue()
+            media_type = "image/png"
+        except (
+            Image.DecompressionBombError,
+            OSError,
+            UnidentifiedImageError,
+            ValueError,
+        ) as exc:
+            return (
+                None,
+                f"Error: {image_path.name} could not be converted to "
+                f"PNG: {exc}",
+            )
+    else:
+        detected = media_type or image_format or "unknown"
+        return (
+            None,
+            f"Error: {image_path.name} uses unsupported image format "
+            f"{detected}.",
+        )
+
+    encoded = base64.b64encode(frozen_bytes).decode("ascii")
+    return (
+        DataBlock(
+            source=Base64Source(
+                data=encoded,
+                media_type=media_type,
+            ),
+        ),
+        None,
+    )
 
 
 async def _probe_multimodal_if_needed(
@@ -392,7 +479,21 @@ async def view_image(image_path: str) -> ToolChunk:
     if err is not None:
         return err
 
-    file_url = _path_to_file_url(str(resolved))
+    frozen_image, freeze_error = await run_sync_io(
+        _freeze_local_image,
+        resolved,
+    )
+    if freeze_error is not None or frozen_image is None:
+        return ToolChunk(
+            is_last=True,
+            state=ToolResultState.SUCCESS,
+            content=[
+                TextBlock(
+                    type="text",
+                    text=freeze_error or f"Error: failed to load {resolved}",
+                ),
+            ],
+        )
 
     text_msg = (
         fallback_hint if fallback_hint else f"Image loaded: {resolved.name}"
@@ -401,7 +502,7 @@ async def view_image(image_path: str) -> ToolChunk:
         is_last=True,
         state=ToolResultState.SUCCESS,
         content=[
-            _media_data_block(file_url, "image"),
+            frozen_image,
             TextBlock(type="text", text=text_msg),
         ],
     )

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -22,6 +22,7 @@ from agentscope.message import (
 from agentscope.tool import ToolChunk
 from PIL import Image, UnidentifiedImageError
 
+from ...providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.io_utils import run_sync_io
 from .file_io import _path_to_file_url, _resolve_file_path
@@ -169,25 +170,29 @@ def _freeze_local_image(
 ) -> tuple[DataBlock | None, str | None]:
     """Validate and freeze one local image as immutable base64 content."""
     try:
-        image_bytes = image_path.read_bytes()
-        with Image.open(BytesIO(image_bytes)) as image:
-            image_format = image.format
-            image.verify()
-    except (
-        Image.DecompressionBombError,
-        OSError,
-        UnidentifiedImageError,
-        ValueError,
-    ) as exc:
-        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+        file_size = image_path.stat().st_size
+        if file_size > MAX_INLINE_MEDIA_BYTES:
+            return (
+                None,
+                f"Error: {image_path.name} is {file_size} bytes and "
+                f"exceeds the {MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+            )
+        with image_path.open("rb") as image_file:
+            image_bytes = image_file.read(MAX_INLINE_MEDIA_BYTES + 1)
+        if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
+            return (
+                None,
+                f"Error: {image_path.name} exceeds the "
+                f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+            )
 
-    normalized_format = (image_format or "").upper()
-    media_type = Image.MIME.get(normalized_format)
-    if media_type in _NATIVE_IMAGE_MEDIA_TYPES:
-        frozen_bytes = image_bytes
-    elif normalized_format in _PNG_CONVERTIBLE_IMAGE_FORMATS:
-        try:
-            with Image.open(BytesIO(image_bytes)) as image:
+        with Image.open(BytesIO(image_bytes)) as image:
+            normalized_format = (image.format or "").upper()
+            media_type = Image.MIME.get(normalized_format)
+            if media_type in _NATIVE_IMAGE_MEDIA_TYPES:
+                image.verify()
+                frozen_bytes = image_bytes
+            elif normalized_format in _PNG_CONVERTIBLE_IMAGE_FORMATS:
                 image.seek(0)
                 image.load()
                 has_alpha = (
@@ -198,24 +203,28 @@ def _freeze_local_image(
                     output = BytesIO()
                     converted.save(output, format="PNG")
                     frozen_bytes = output.getvalue()
-            media_type = "image/png"
-        except (
-            Image.DecompressionBombError,
-            OSError,
-            UnidentifiedImageError,
-            ValueError,
-        ) as exc:
-            return (
-                None,
-                f"Error: {image_path.name} could not be converted to "
-                f"PNG: {exc}",
-            )
-    else:
-        detected = media_type or image_format or "unknown"
+                media_type = "image/png"
+            else:
+                detected = media_type or image.format or "unknown"
+                return (
+                    None,
+                    f"Error: {image_path.name} uses unsupported image "
+                    f"format {detected}.",
+                )
+    except (
+        Image.DecompressionBombError,
+        OSError,
+        UnidentifiedImageError,
+        ValueError,
+    ) as exc:
+        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+
+    if len(frozen_bytes) > MAX_INLINE_MEDIA_BYTES:
         return (
             None,
-            f"Error: {image_path.name} uses unsupported image format "
-            f"{detected}.",
+            f"Error: converted {image_path.name} is "
+            f"{len(frozen_bytes)} bytes and exceeds the "
+            f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
         )
 
     encoded = base64.b64encode(frozen_bytes).decode("ascii")

--- a/src/qwenpaw/agents/utils/image_freezing.py
+++ b/src/qwenpaw/agents/utils/image_freezing.py
@@ -170,7 +170,7 @@ def _freeze_data_block(value: Any) -> tuple[Any, int]:
         result["type"] = block_type
         result["source"] = frozen.source.model_dump(mode="json")
         return result, 1
-    frozen.name = value.name
+    frozen.name = getattr(value, "name", None)
     return frozen, 1
 
 

--- a/src/qwenpaw/agents/utils/image_freezing.py
+++ b/src/qwenpaw/agents/utils/image_freezing.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""Freeze local image references into immutable message content."""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+)
+from PIL import Image, UnidentifiedImageError
+
+from ...providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
+from ...utils.io_utils import run_sync_io
+
+_NATIVE_IMAGE_MEDIA_TYPES = frozenset(
+    {
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    },
+)
+_PNG_CONVERTIBLE_IMAGE_FORMATS = frozenset({"BMP", "TIFF"})
+
+
+def _local_path_from_url(url: str) -> Path | None:
+    """Resolve a local URL or path without treating remote URLs as local."""
+    parsed = urlparse(url)
+    if parsed.scheme == "file":
+        if (
+            len(parsed.netloc) == 2
+            and parsed.netloc[0].isalpha()
+            and parsed.netloc[1] == ":"
+        ):
+            raw_path = f"{parsed.netloc}{parsed.path}"
+        elif parsed.netloc and parsed.netloc.lower() != "localhost":
+            raw_path = f"//{parsed.netloc}{parsed.path}"
+        else:
+            raw_path = parsed.path
+        return Path(url2pathname(unquote(raw_path)))
+    if parsed.scheme == "":
+        return Path(unquote(url)).expanduser()
+    if len(parsed.scheme) == 1 and parsed.scheme.isalpha():
+        return Path(unquote(url))
+    return None
+
+
+def freeze_local_image(
+    image_path: Path,
+) -> tuple[DataBlock | None, str | None]:
+    """Validate and freeze one local image as immutable base64 content."""
+    try:
+        file_size = image_path.stat().st_size
+        if file_size > MAX_INLINE_MEDIA_BYTES:
+            return (
+                None,
+                f"Error: {image_path.name} is {file_size} bytes and "
+                f"exceeds the {MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+            )
+        with image_path.open("rb") as image_file:
+            image_bytes = image_file.read(MAX_INLINE_MEDIA_BYTES + 1)
+        if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
+            return (
+                None,
+                f"Error: {image_path.name} exceeds the "
+                f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+            )
+
+        with Image.open(BytesIO(image_bytes)) as image:
+            normalized_format = (image.format or "").upper()
+            media_type = Image.MIME.get(normalized_format)
+            if media_type in _NATIVE_IMAGE_MEDIA_TYPES:
+                image.verify()
+                frozen_bytes = image_bytes
+            elif normalized_format in _PNG_CONVERTIBLE_IMAGE_FORMATS:
+                image.seek(0)
+                image.load()
+                has_alpha = (
+                    "A" in image.getbands() or "transparency" in image.info
+                )
+                target_mode = "RGBA" if has_alpha else "RGB"
+                with image.convert(target_mode) as converted:
+                    output = BytesIO()
+                    converted.save(output, format="PNG")
+                    frozen_bytes = output.getvalue()
+                media_type = "image/png"
+            else:
+                detected = media_type or image.format or "unknown"
+                return (
+                    None,
+                    f"Error: {image_path.name} uses unsupported image "
+                    f"format {detected}.",
+                )
+    except (
+        Image.DecompressionBombError,
+        OSError,
+        UnidentifiedImageError,
+        ValueError,
+    ) as exc:
+        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+
+    if len(frozen_bytes) > MAX_INLINE_MEDIA_BYTES:
+        return (
+            None,
+            f"Error: converted {image_path.name} is "
+            f"{len(frozen_bytes)} bytes and exceeds the "
+            f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+        )
+
+    encoded = base64.b64encode(frozen_bytes).decode("ascii")
+    return (
+        DataBlock(
+            source=Base64Source(
+                data=encoded,
+                media_type=media_type,
+            ),
+        ),
+        None,
+    )
+
+
+def _replacement_text(value: Any, error: str) -> Any:
+    """Build a text replacement matching the original representation."""
+    text = f"[Image unavailable: {error}]"
+    if isinstance(value, dict):
+        return {"type": "text", "text": text}
+    return TextBlock(text=text)
+
+
+# pylint: disable-next=too-many-return-statements
+def _freeze_data_block(value: Any) -> tuple[Any, int]:
+    """Freeze one local image data block when applicable."""
+    if isinstance(value, dict):
+        block_type = value.get("type")
+        source = value.get("source")
+        if block_type not in ("data", "image") or not isinstance(
+            source,
+            dict,
+        ):
+            return value, 0
+        media_type = str(source.get("media_type", "") or "")
+        url = source.get("url") if source.get("type") == "url" else None
+    elif isinstance(value, DataBlock):
+        source = value.source
+        media_type = str(getattr(source, "media_type", "") or "")
+        url = getattr(source, "url", None)
+    else:
+        return value, 0
+
+    if not media_type.startswith("image/") or url is None:
+        return value, 0
+    local_path = _local_path_from_url(str(url))
+    if local_path is None:
+        return value, 0
+
+    frozen, error = freeze_local_image(local_path)
+    if frozen is None or error is not None:
+        return _replacement_text(value, error or "failed to load image"), 1
+
+    if isinstance(value, dict):
+        result = dict(value)
+        result["type"] = block_type
+        result["source"] = frozen.source.model_dump(mode="json")
+        return result, 1
+    frozen.name = value.name
+    return frozen, 1
+
+
+def _freeze_value(value: Any) -> tuple[Any, int]:
+    """Recursively freeze local images in messages and tool results."""
+    replacement, count = _freeze_data_block(value)
+    if count:
+        return replacement, count
+
+    if isinstance(value, list):
+        total = 0
+        for index, item in enumerate(value):
+            value[index], frozen = _freeze_value(item)
+            total += frozen
+        return value, total
+
+    if isinstance(value, dict):
+        total = 0
+        for key in ("content", "output"):
+            nested = value.get(key)
+            if isinstance(nested, list):
+                value[key], frozen = _freeze_value(nested)
+                total += frozen
+        return value, total
+
+    total = 0
+    for attribute in ("content", "output"):
+        nested = getattr(value, attribute, None)
+        if isinstance(nested, list):
+            nested, frozen = _freeze_value(nested)
+            setattr(value, attribute, nested)
+            total += frozen
+    return value, total
+
+
+def freeze_local_images(value: Any) -> int:
+    """Freeze all local image references reachable from *value*."""
+    _, count = _freeze_value(value)
+    return count
+
+
+async def freeze_local_images_async(value: Any) -> int:
+    """Freeze local images in a worker thread."""
+    return await run_sync_io(freeze_local_images, value)
+
+
+__all__ = [
+    "freeze_local_image",
+    "freeze_local_images",
+    "freeze_local_images_async",
+]

--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -18,6 +18,7 @@ from agentscope.message import Msg, TextBlock, URLSource
 from ...app.channels.utils import file_url_to_local_path
 from ...config import load_config
 from .file_handling import download_file_from_base64, download_file_from_url
+from .image_freezing import freeze_local_images_async
 
 logger = logging.getLogger(__name__)
 
@@ -544,6 +545,8 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
                     i + 1,
                     TextBlock(type="text", text=text),
                 )
+
+    await freeze_local_images_async(messages)
 
 
 def is_first_user_interaction(messages: list) -> bool:

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -2,12 +2,14 @@
 """Tests for model_factory message normalization integration."""
 
 # pylint: disable=protected-access,redefined-outer-name
+import base64
 import json
 from types import SimpleNamespace
 
 import pytest
 from agentscope.formatter import OpenAIChatFormatter
 from agentscope.message import (
+    Base64Source,
     DataBlock,
     HintBlock,
     Msg,
@@ -31,12 +33,24 @@ except ImportError:
 
 from qwenpaw.agents import model_factory
 from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
-from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
+from qwenpaw.providers.capping_formatter import (
+    _CappingAnthropicFormatter,
+    _CappingOpenAIFormatter,
+)
 from qwenpaw.utils.tool_call_extra import persist_tool_call_extras
 
 
 def _data_block(media_type: str, url: str) -> DataBlock:
     return DataBlock(source=URLSource(url=url, media_type=media_type))
+
+
+def _base64_data_block(media_type: str, content: bytes) -> DataBlock:
+    return DataBlock(
+        source=Base64Source(
+            media_type=media_type,
+            data=base64.b64encode(content).decode("ascii"),
+        ),
+    )
 
 
 def _media_messages() -> list[Msg]:
@@ -179,6 +193,86 @@ def test_force_strip_media_flag_overrides_multimodal_support(
 
     assert normalized[0].content[0].type == "text"
     assert normalized[0].content[0].text == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_anthropic_dedup_uses_complete_media_content(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingAnthropicFormatter,
+    )
+    formatter = formatter_class()
+    first = _base64_data_block("image/png", b"version-one")
+    second = _base64_data_block("image/png", b"version-two")
+    msg = Msg(name="user", role="user", content=[first, second])
+
+    formatted = await formatter.format([msg])
+
+    content = formatted[0]["content"]
+    assert [item["type"] for item in content] == ["image", "image"]
+    assert formatter._qwenpaw_last_wire_media_count == 2
+
+
+@pytest.mark.asyncio
+async def test_anthropic_dedup_omits_identical_media(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingAnthropicFormatter,
+    )
+    formatter = formatter_class()
+    first = _base64_data_block("image/png", b"same-version")
+    second = _base64_data_block("image/png", b"same-version")
+    msg = Msg(name="user", role="user", content=[first, second])
+
+    formatted = await formatter.format([msg])
+
+    content = formatted[0]["content"]
+    assert [item["type"] for item in content] == ["image", "text"]
+    assert "omitted" in content[1]["text"]
+    assert formatter._qwenpaw_last_wire_media_count == 1
+
+
+@pytest.mark.asyncio
+async def test_formatter_resets_wire_media_count_before_failure(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingAnthropicFormatter,
+    )
+    formatter = formatter_class()
+    valid = Msg(
+        name="user",
+        role="user",
+        content=[_base64_data_block("image/png", b"valid")],
+    )
+    await formatter.format([valid])
+    assert formatter._qwenpaw_last_wire_media_count == 1
+
+    async def fail_format(_self, _msgs):
+        raise RuntimeError("formatter failed")
+
+    monkeypatch.setattr(_CappingAnthropicFormatter, "format", fail_format)
+    with pytest.raises(RuntimeError, match="formatter failed"):
+        await formatter.format([valid])
+
+    assert formatter._qwenpaw_last_wire_media_count == 0
 
 
 def test_formatter_flags_returned_correctly() -> None:

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -53,6 +53,15 @@ def _base64_data_block(media_type: str, content: bytes) -> DataBlock:
     )
 
 
+def test_anthropic_dedup_key_uses_immutable_base64_directly() -> None:
+    block = _base64_data_block("image/png", b"immutable-content")
+
+    key = model_factory._anthropic_media_dedup_key(block.source)
+
+    assert key == ("base64", "image/png", block.source.data)
+    assert key[2] is block.source.data
+
+
 def _media_messages() -> list[Msg]:
     """Create a list of messages with media blocks for testing."""
     return [

--- a/tests/unit/agents/tools/test_desktop_screenshot.py
+++ b/tests/unit/agents/tools/test_desktop_screenshot.py
@@ -8,9 +8,13 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agentscope.message import Base64Source
+from PIL import Image
 
 from qwenpaw.agents.tools.desktop_screenshot import (
+    _tool_ok,
     _capture_macos_screencapture,
+    desktop_screenshot,
 )
 
 
@@ -43,3 +47,27 @@ async def test_macos_screencapture_kills_proc_on_cancel(tmp_path):
     assert "timed out" in result.content[0].text.lower()
     proc.kill.assert_called_once()
     proc.wait.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_desktop_screenshot_freezes_local_image(tmp_path):
+    """A captured screenshot is immutable before tool return."""
+    image_path = tmp_path / "desktop.png"
+
+    def capture(path):
+        Image.new("RGB", (2, 2), color="red").save(path)
+        return _tool_ok(path, f"Desktop screenshot saved to {path}")
+
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "qwenpaw.agents.tools.desktop_screenshot._capture_mss",
+            side_effect=capture,
+        ),
+    ):
+        result = await desktop_screenshot(str(image_path))
+
+    assert isinstance(result.content[0].source, Base64Source)
+    first_data = result.content[0].source.data
+    Image.new("RGB", (2, 2), color="blue").save(image_path)
+    assert result.content[0].source.data == first_data

--- a/tests/unit/agents/tools/test_view_media.py
+++ b/tests/unit/agents/tools/test_view_media.py
@@ -12,9 +12,13 @@ Covers:
 """
 # pylint: disable=protected-access,unused-argument
 
+import base64
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from agentscope.message import Base64Source
+from PIL import Image
 
 from qwenpaw.agents.tools.view_media import (
     _IMAGE_EXTENSIONS,
@@ -276,10 +280,130 @@ class TestViewImage:
     async def test_local_image_file(self, mock_support, tmp_path):
         mock_support.return_value = True
         img = tmp_path / "photo.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
+        Image.new("RGB", (2, 2), color="red").save(img)
         result = await view_image(str(img))
         types = [getattr(b, "type", None) for b in result.content]
         assert "data" in types
+        image_block = next(
+            block for block in result.content if block.type == "data"
+        )
+        assert isinstance(image_block.source, Base64Source)
+        assert image_block.source.media_type == "image/png"
+        assert base64.b64decode(image_block.source.data) == img.read_bytes()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("suffix", "image_format"),
+        [(".bmp", "BMP"), (".tiff", "TIFF")],
+    )
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_local_image_converts_to_png(
+        self,
+        mock_support,
+        tmp_path,
+        suffix,
+        image_format,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / f"photo{suffix}"
+        Image.new("RGB", (2, 2), color="green").save(
+            img,
+            format=image_format,
+        )
+
+        result = await view_image(str(img))
+
+        image_block = next(
+            block for block in result.content if block.type == "data"
+        )
+        assert isinstance(image_block.source, Base64Source)
+        assert image_block.source.media_type == "image/png"
+        converted_bytes = base64.b64decode(image_block.source.data)
+        with Image.open(BytesIO(converted_bytes)) as converted:
+            assert converted.format == "PNG"
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_tiff_with_jpeg_suffix_converts_to_png(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "misleading.jpg"
+        Image.new("RGB", (2, 2), color="yellow").save(
+            img,
+            format="TIFF",
+        )
+
+        result = await view_image(str(img))
+
+        image_block = next(
+            block for block in result.content if block.type == "data"
+        )
+        assert image_block.source.media_type == "image/png"
+        converted_bytes = base64.b64decode(image_block.source.data)
+        with Image.open(BytesIO(converted_bytes)) as converted:
+            assert converted.format == "PNG"
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_local_image_uses_detected_mime(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "misleading.jpg"
+        Image.new("RGB", (2, 2), color="blue").save(img, format="PNG")
+
+        result = await view_image(str(img))
+
+        image_block = next(
+            block for block in result.content if block.type == "data"
+        )
+        assert image_block.source.media_type == "image/png"
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_invalid_local_image_returns_error(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "broken.png"
+        img.write_bytes(b"not-an-image")
+
+        result = await view_image(str(img))
+
+        assert len(result.content) == 1
+        assert "not a valid image" in result.content[0].text
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_overwritten_path_preserves_each_version(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "preview.png"
+        Image.new("RGB", (2, 2), color="red").save(img)
+        first = await view_image(str(img))
+        first_block = next(
+            block for block in first.content if block.type == "data"
+        )
+        first_data = first_block.source.data
+
+        Image.new("RGB", (2, 2), color="blue").save(img)
+        second = await view_image(str(img))
+        second_block = next(
+            block for block in second.content if block.type == "data"
+        )
+
+        assert first_block.source.data == first_data
+        assert second_block.source.data != first_data
 
     @pytest.mark.asyncio
     @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")

--- a/tests/unit/agents/tools/test_view_media.py
+++ b/tests/unit/agents/tools/test_view_media.py
@@ -31,6 +31,7 @@ from qwenpaw.agents.tools.view_media import (
     view_image,
     view_video,
 )
+from qwenpaw.providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +380,47 @@ class TestViewImage:
 
         assert len(result.content) == 1
         assert "not a valid image" in result.content[0].text
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_oversized_local_image_is_rejected_before_decode(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "oversized.png"
+        img.write_bytes(b"x" * (MAX_INLINE_MEDIA_BYTES + 1))
+
+        result = await view_image(str(img))
+
+        assert len(result.content) == 1
+        assert "exceeds" in result.content[0].text
+        assert str(MAX_INLINE_MEDIA_BYTES) in result.content[0].text
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_converted_png_must_fit_image_limit(
+        self,
+        mock_support,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        img = tmp_path / "compressed.tiff"
+        channels = [Image.effect_noise((1000, 1000), 100) for _ in range(3)]
+        Image.merge("RGB", channels).save(
+            img,
+            format="TIFF",
+            compression="jpeg",
+            quality=75,
+        )
+        assert img.stat().st_size <= MAX_INLINE_MEDIA_BYTES
+
+        result = await view_image(str(img))
+
+        assert len(result.content) == 1
+        assert "converted" in result.content[0].text
+        assert "exceeds" in result.content[0].text
 
     @pytest.mark.asyncio
     @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")

--- a/tests/unit/agents/tools/test_view_media.py
+++ b/tests/unit/agents/tools/test_view_media.py
@@ -20,6 +20,7 @@ import pytest
 from agentscope.message import Base64Source
 from PIL import Image
 
+from qwenpaw.agents.utils import image_freezing
 from qwenpaw.agents.tools.view_media import (
     _IMAGE_EXTENSIONS,
     _VIDEO_EXTENSIONS,
@@ -403,6 +404,7 @@ class TestViewImage:
     async def test_converted_png_must_fit_image_limit(
         self,
         mock_support,
+        monkeypatch,
         tmp_path,
     ):
         mock_support.return_value = True
@@ -414,7 +416,19 @@ class TestViewImage:
             compression="jpeg",
             quality=75,
         )
-        assert img.stat().st_size <= MAX_INLINE_MEDIA_BYTES
+        with Image.open(img) as image:
+            image.load()
+            converted = BytesIO()
+            image.convert("RGB").save(converted, format="PNG")
+        source_size = img.stat().st_size
+        converted_size = len(converted.getvalue())
+        assert source_size < converted_size
+        image_limit = (source_size + converted_size) // 2
+        monkeypatch.setattr(
+            image_freezing,
+            "MAX_INLINE_MEDIA_BYTES",
+            image_limit,
+        )
 
         result = await view_image(str(img))
 

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -9,7 +9,14 @@ Covers:
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agentscope.message import DataBlock, Msg, TextBlock, URLSource
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    Msg,
+    TextBlock,
+    URLSource,
+)
+from PIL import Image
 
 from qwenpaw.agents.utils.message_processing import (
     _process_audio_block,
@@ -264,3 +271,37 @@ class TestProcessAudioDataBlock:
         assert content == [
             {"type": "text", "text": "[Voice message]: legacy voice"},
         ]
+
+
+class TestProcessLocalImageDataBlock:
+    """Local Console image blocks are frozen before entering context."""
+
+    @pytest.mark.asyncio
+    async def test_overwritten_path_preserves_first_version(self, tmp_path):
+        image_path = tmp_path / "upload.png"
+        Image.new("RGB", (2, 2), color="red").save(image_path)
+        first_block = DataBlock(
+            source=URLSource(
+                url=image_path.resolve().as_uri(),
+                media_type="image/png",
+            ),
+        )
+        first_msg = Msg(name="user", role="user", content=[first_block])
+
+        await process_file_and_media_blocks_in_message(first_msg)
+        first_source = first_msg.content[0].source
+
+        Image.new("RGB", (2, 2), color="blue").save(image_path)
+        second_block = DataBlock(
+            source=URLSource(
+                url=image_path.resolve().as_uri(),
+                media_type="image/png",
+            ),
+        )
+        second_msg = Msg(name="user", role="user", content=[second_block])
+        await process_file_and_media_blocks_in_message(second_msg)
+
+        assert isinstance(first_source, Base64Source)
+        assert isinstance(second_msg.content[0].source, Base64Source)
+        assert first_msg.content[0].source.data == first_source.data
+        assert second_msg.content[0].source.data != first_source.data


### PR DESCRIPTION
## Description

Prevent transient media errors from incorrectly disabling multimodal support, and freeze local images as validated Base64 content so overwritten paths cannot corrupt historical image versions. Media deduplication now uses SHA-256 content hashes instead of mutable paths.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
