### PR TITLE
ci: run nightly full test sweep one hour earlier (18:17 -> 17:17 UTC)

### DIFF
--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -21,9 +21,9 @@ name: Full Tests Nightly
 
 on:
   schedule:
-    # 18:17 UTC daily ~= 02:17 Beijing the next day.
+    # 17:17 UTC daily ~= 01:17 Beijing the next day.
     # Off-the-hour to avoid the global GitHub Actions cron rush at :00 / :30.
-    - cron: '17 18 * * *'
+    - cron: '17 17 * * *'
   workflow_dispatch:
     inputs:
       coverage_platforms:


### PR DESCRIPTION
## Summary

Move the `Full Tests Nightly` schedule forward by one hour: daily **18:17 UTC -> 17:17 UTC** (02:17 -> 01:17 Beijing time, next day).

## What changed

Only `.github/workflows/full-tests-nightly.yml` (2 lines):

- `cron: '17 18 * * *'` -> `cron: '17 17 * * *'`
- Adjacent comment updated to match.

## Why

Deliver the nightly full-sweep results (unit + contract + full integration incl. p2 + E2E Playwright + frontend vitest + combined coverage report) one hour earlier.

## Risk assessment

- Pure trigger-time change: test scope, matrix, and gates are completely unchanged.
- The off-peak `:17` minute is preserved to avoid the global GitHub Actions cron rush at :00 / :30.
- No test-selection logic is touched, so there is no risk of introducing silent skips.

## Verification

- Local: YAML parse + cron field validation passed; the diff is exactly 2 lines.
- Fork: a full sweep was manually dispatched on the branch via `workflow_dispatch` (yutai78786/QwenPaw run 31572426366). At the time of opening this PR, 11/14 jobs are green; the remaining jobs (Windows integration, E2E Playwright, coverage summary) are still in progress and the final result will be reported here as a follow-up.

---
Qin Qiong · CIOps@QPQAT