### PR TITLE
fix(acp): honor runtime model metadata

### DIFF
--- a/src/qwenpaw/agents/acp/runtime_provider.py
+++ b/src/qwenpaw/agents/acp/runtime_provider.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Any, Mapping
 from urllib.parse import urlparse
 
 from ...config.config import ModelSlotConfig
@@ -13,6 +14,45 @@ from ...providers.openai_provider import OpenAIProvider
 from ...providers.provider import ModelInfo
 
 RUNTIME_OPENAI_PROVIDER_ID = "runtime-openai"
+QWENPAW_MODEL_INFO_ENV = "QWENPAW_MODEL_INFO_JSON"
+
+
+def _optional_int(
+    model_info: Mapping[str, Any],
+    name: str,
+    minimum: int,
+) -> int | None:
+    """Read one optional integer with the downstream model constraint."""
+    value = model_info.get(name)
+    if value is None:
+        return None
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{QWENPAW_MODEL_INFO_ENV}.{name} must be an integer "
+            f"greater than or equal to {minimum}",
+        )
+    return value
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject non-standard JSON constants such as NaN and Infinity."""
+    raise ValueError(f"Invalid JSON constant: {value}")
+
+
+def _load_runtime_model_info(source: Mapping[str, str]) -> dict[str, Any]:
+    """Load optional runtime model metadata with strict validation."""
+    raw = str(source.get(QWENPAW_MODEL_INFO_ENV, "")).strip()
+    if not raw:
+        return {}
+    try:
+        model_info = json.loads(raw, parse_constant=_reject_json_constant)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(
+            f"{QWENPAW_MODEL_INFO_ENV} must be a JSON object",
+        ) from exc
+    if not isinstance(model_info, dict):
+        raise ValueError(f"{QWENPAW_MODEL_INFO_ENV} must be a JSON object")
+    return model_info
 
 
 @dataclass(frozen=True)
@@ -22,6 +62,8 @@ class OpenAIRuntimeProviderConfig:
     base_url: str
     api_key: str
     model: str
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
 
     @classmethod
     def from_env(
@@ -50,10 +92,22 @@ class OpenAIRuntimeProviderConfig:
                 "OPENAI_BASE_URL must be an absolute HTTP(S) URL",
             )
 
+        model_info = _load_runtime_model_info(source)
+
         return cls(
             base_url=base_url,
             api_key=values["OPENAI_API_KEY"],
             model=values["OPENAI_MODEL"],
+            max_input_tokens=_optional_int(
+                model_info,
+                "max_input_tokens",
+                1000,
+            ),
+            max_output_tokens=_optional_int(
+                model_info,
+                "max_output_tokens",
+                1,
+            ),
         )
 
     @property
@@ -66,6 +120,16 @@ class OpenAIRuntimeProviderConfig:
 
     def build_provider(self) -> OpenAIProvider:
         """Create the in-memory provider without writing credentials."""
+        model_kwargs: dict[str, Any] = {}
+        if self.max_input_tokens is not None:
+            model_kwargs.update(
+                {
+                    "max_input_length": self.max_input_tokens,
+                    "max_input_length_configured": True,
+                },
+            )
+        if self.max_output_tokens is not None:
+            model_kwargs["max_tokens"] = self.max_output_tokens
         return OpenAIProvider(
             id=RUNTIME_OPENAI_PROVIDER_ID,
             name="ACP Runtime OpenAI",
@@ -75,6 +139,7 @@ class OpenAIRuntimeProviderConfig:
                 ModelInfo(
                     id=self.model,
                     name=self.model,
+                    **model_kwargs,
                 ),
             ],
             require_api_key=True,

--- a/tests/unit/agents/test_acp_runtime_provider.py
+++ b/tests/unit/agents/test_acp_runtime_provider.py
@@ -12,6 +12,7 @@ import pytest
 from acp import RequestError, text_block
 
 from qwenpaw.agents.acp.runtime_provider import (
+    QWENPAW_MODEL_INFO_ENV,
     RUNTIME_OPENAI_PROVIDER_ID,
     OpenAIRuntimeProviderConfig,
 )
@@ -109,6 +110,58 @@ def test_runtime_provider_builds_openai_provider():
     assert provider.base_url == "https://policy.example.test/v1"
     assert provider.api_key == "execution-secret"
     assert provider.has_model("policy")
+
+
+def test_runtime_provider_applies_model_info():
+    config = OpenAIRuntimeProviderConfig.from_env(
+        {
+            "OPENAI_BASE_URL": "https://policy.example.test/v1",
+            "OPENAI_API_KEY": "execution-secret",
+            "OPENAI_MODEL": "policy",
+            QWENPAW_MODEL_INFO_ENV: (
+                '{"max_input_tokens":32768,"max_output_tokens":4096}'
+            ),
+        },
+    )
+
+    provider = config.build_provider()
+    model = provider.models[0]
+
+    assert config.max_input_tokens == 32768
+    assert config.max_output_tokens == 4096
+    assert model.max_input_length == 32768
+    assert model.max_input_length_configured is True
+    assert model.max_tokens == 4096
+    assert provider.get_context_size("policy") == 32768
+    assert (
+        provider.get_effective_generate_kwargs("policy")["max_tokens"] == 4096
+    )
+
+
+@pytest.mark.parametrize(
+    "model_info",
+    [
+        "[]",
+        "not-json",
+        '{"max_input_tokens":0}',
+        '{"max_input_tokens":999}',
+        '{"max_input_tokens":1.0}',
+        '{"max_input_tokens":"1000"}',
+        '{"max_input_tokens":Infinity}',
+        '{"max_output_tokens":NaN}',
+        '{"max_output_tokens":true}',
+    ],
+)
+def test_runtime_provider_rejects_invalid_model_info(model_info):
+    with pytest.raises(ValueError, match=QWENPAW_MODEL_INFO_ENV):
+        OpenAIRuntimeProviderConfig.from_env(
+            {
+                "OPENAI_BASE_URL": "https://policy.example.test/v1",
+                "OPENAI_API_KEY": "execution-secret",
+                "OPENAI_MODEL": "policy",
+                QWENPAW_MODEL_INFO_ENV: model_info,
+            },
+        )
 
 
 async def test_runtime_provider_is_registered_only_in_memory(monkeypatch):


### PR DESCRIPTION
## Description

Honor optional runtime model metadata when QwenPaw runs as a headless ACP agent with the `openai-env` provider.

- Read `QWENPAW_MODEL_INFO_JSON` from the process environment.
- Apply `max_input_tokens` to the in-memory model context limit.
- Apply `max_output_tokens` to the effective generation arguments.
- Keep runtime credentials and model metadata ephemeral without persisting provider configuration.
- Validate the payload as a strict JSON object with integer values matching downstream `ModelInfo` constraints.

**Related Issue:** N/A

**Security Considerations:** The payload is parsed locally from the process environment. Errors do not expose credentials or environment values. Non-standard JSON constants, booleans, floats, numeric strings, and out-of-range values are rejected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit on all changed files and it passes
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: no persistent config or CLI surface changed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] Contract test exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass
- [ ] Optional unit tests added for complex internal logic

## Testing

```bash
PYTHONPATH=src conda run -n Codex-QwenPaw python -m pytest \
  tests/unit/agents/test_acp_runtime_provider.py \
  tests/unit/providers/test_capping_formatter.py \
  tests/unit/runtime/test_message_convert.py \
  tests/unit/agents/test_model_factory_message_normalization.py -q
# 80 passed

conda run -n Codex-QwenPaw pre-commit run --files \
  src/qwenpaw/agents/acp/runtime_provider.py \
  tests/unit/agents/test_acp_runtime_provider.py
# all hooks passed
```

## Additional Notes

This change is intentionally limited to the QwenPaw ACP runtime-provider contract. Existing sandbox-file media handling remains unchanged, and this PR does not introduce remote resource downloading.