### PR TITLE
fix(#6826): display actual assistant reply completion time in chat history

### DIFF
--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -153,6 +153,19 @@ const parseTimestamp = (msg: Record<string, unknown>): number => {
   return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
 };
 
+/**
+ * Parse metadata.finished_at string to unix seconds (0 when absent).
+ * `finished_at` is stamped when the reply actually ended; `timestamp` is
+ * the created_at alias pinned at the first saved segment, which can be far
+ * earlier for turns with long tool calls.
+ */
+const parseFinishedAt = (msg: Record<string, unknown>): number => {
+  const ts = (msg.metadata as Record<string, unknown>)?.finished_at;
+  if (!ts || typeof ts !== "string") return 0;
+  const ms = new Date(ts.replace(" ", "T")).getTime();
+  return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
+};
+
 /** Extract plain text from a message's content array. */
 const extractTextFromContent = (content: unknown): string => {
   if (typeof content === "string") return content;
@@ -283,6 +296,13 @@ const buildResponseCard = (
 
   const firstTs = parseTimestamp(outputMessages[0]);
   const lastTs = parseTimestamp(outputMessages[outputMessages.length - 1]);
+  // Prefer the real reply-end time (finished_at) over timestamp so turns
+  // with long tool calls show the true completion time (#6826). Falls
+  // back to timestamp for legacy sessions without the stamp.
+  const finishedAt = outputMessages.reduce(
+    (max, m) => Math.max(max, parseFinishedAt(m)),
+    0,
+  );
 
   const normalizedMessages = outputMessages.map((msg) => ({
     ...msg,
@@ -305,7 +325,7 @@ const buildResponseCard = (
           created_at: firstTs || fallbackNow,
           sequence_number: maxSeq + 1,
           error: null,
-          completed_at: lastTs || fallbackNow,
+          completed_at: finishedAt || lastTs || fallbackNow,
           usage: turnUsage?.usage ?? null,
           context_usage: turnUsage?.context_usage ?? null,
         },
@@ -1674,6 +1694,7 @@ export const __test__ = {
   contentToRequestParts,
   extractTextFromContent,
   parseTimestamp,
+  parseFinishedAt,
   isLocalTimestamp,
   isGenerating,
   resolveRealId,

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -145,13 +145,19 @@ function generateId(): string {
   return `${Date.now()}-${randomBase36(9)}`;
 }
 
-/** Parse metadata.timestamp string (e.g. "2026-05-27 10:44:53.362") to unix seconds. */
-const parseTimestamp = (msg: Record<string, unknown>): number => {
-  const ts = (msg.metadata as Record<string, unknown>)?.timestamp;
+/**
+ * Parse a metadata time string (e.g. "2026-05-27 10:44:53.362") to unix
+ * seconds; returns 0 when the value is absent or not parseable.
+ */
+const metadataTimeToSeconds = (ts: unknown): number => {
   if (!ts || typeof ts !== "string") return 0;
   const ms = new Date(ts.replace(" ", "T")).getTime();
   return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
 };
+
+/** Parse metadata.timestamp string (e.g. "2026-05-27 10:44:53.362") to unix seconds. */
+const parseTimestamp = (msg: Record<string, unknown>): number =>
+  metadataTimeToSeconds((msg.metadata as Record<string, unknown>)?.timestamp);
 
 /**
  * Parse metadata.finished_at string to unix seconds (0 when absent).
@@ -159,12 +165,8 @@ const parseTimestamp = (msg: Record<string, unknown>): number => {
  * the created_at alias pinned at the first saved segment, which can be far
  * earlier for turns with long tool calls.
  */
-const parseFinishedAt = (msg: Record<string, unknown>): number => {
-  const ts = (msg.metadata as Record<string, unknown>)?.finished_at;
-  if (!ts || typeof ts !== "string") return 0;
-  const ms = new Date(ts.replace(" ", "T")).getTime();
-  return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
-};
+const parseFinishedAt = (msg: Record<string, unknown>): number =>
+  metadataTimeToSeconds((msg.metadata as Record<string, unknown>)?.finished_at);
 
 /** Extract plain text from a message's content array. */
 const extractTextFromContent = (content: unknown): string => {

--- a/console/src/pages/Chat/tests/testFinishedAt.test.ts
+++ b/console/src/pages/Chat/tests/testFinishedAt.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #6826 — assistant completion time regression tests.
+ *
+ * Issue #6826: "对话中助手消息结束时间显示异常". When an assistant turn
+ * contains long tool calls, the displayed completion time was pinned to
+ * ``metadata.timestamp`` (the created_at alias — the first-segment save
+ * time), not the moment the reply actually ended. A 2-minute tool turn
+ * showed a completion time only seconds after the user sent the message.
+ *
+ * The backend now stamps ``finished_at`` on REPLY_END and exposes it in
+ * message metadata (see ``src/qwenpaw/runtime/executor.py`` and
+ * ``src/qwenpaw/app/chats/utils.py``). These tests pin the frontend half:
+ * ``buildResponseCard`` must prefer ``metadata.finished_at`` for
+ * ``completed_at`` and fall back to ``timestamp`` when it is absent
+ * (legacy sessions).
+ */
+import { describe, it, expect } from "vitest";
+
+// Pure data transforms — no mocks needed; import directly.
+import { __test__ } from "../sessionApi";
+
+const { buildResponseCard, parseFinishedAt } = __test__;
+
+function outputMsg(metadata: Record<string, unknown>, seq = 1) {
+  return {
+    id: `m-${seq}`,
+    role: "assistant",
+    type: "message",
+    sequence_number: seq,
+    content: [{ type: "text", text: "ok" }],
+    metadata,
+  };
+}
+
+function cardData(card: ReturnType<typeof buildResponseCard>) {
+  const cards = card.cards ?? [];
+  return (cards[0] as { data: Record<string, unknown> }).data;
+}
+
+describe("parseFinishedAt", () => {
+  it("parses a finished_at string to unix seconds", () => {
+    const msg = { metadata: { finished_at: "2026-08-12T17:00:00+08:00" } };
+    expect(parseFinishedAt(msg)).toBe(
+      Math.floor(new Date("2026-08-12T17:00:00+08:00").getTime() / 1000),
+    );
+  });
+
+  it("returns 0 when finished_at is absent", () => {
+    expect(parseFinishedAt({ metadata: {} })).toBe(0);
+    expect(parseFinishedAt({ metadata: { finished_at: null } })).toBe(0);
+    expect(parseFinishedAt({})).toBe(0);
+  });
+});
+
+describe("buildResponseCard completed_at (issue #6826)", () => {
+  it("prefers finished_at over timestamp for completed_at", () => {
+    // created_at (timestamp) pinned at first segment; finished_at ~2min later.
+    const created = "2026-08-12T17:00:00+08:00";
+    const finished = "2026-08-12T17:02:00+08:00";
+    const msgs = [
+      outputMsg({ timestamp: created, finished_at: finished }, 1),
+      outputMsg({ timestamp: created, finished_at: finished }, 2),
+    ];
+    const data = cardData(buildResponseCard(msgs as never));
+    expect(data.completed_at).toBe(Math.floor(new Date(finished).getTime() / 1000));
+    // created_at still reflects the first segment.
+    expect(data.created_at).toBe(Math.floor(new Date(created).getTime() / 1000));
+  });
+
+  it("falls back to timestamp when finished_at is absent (legacy)", () => {
+    const created = "2026-08-12T17:00:00+08:00";
+    const msgs = [outputMsg({ timestamp: created }, 1)];
+    const data = cardData(buildResponseCard(msgs as never));
+    expect(data.completed_at).toBe(Math.floor(new Date(created).getTime() / 1000));
+  });
+
+  it("uses the max finished_at across messages in a turn", () => {
+    const early = "2026-08-12T17:01:00+08:00";
+    const late = "2026-08-12T17:03:00+08:00";
+    const msgs = [
+      outputMsg({ timestamp: early, finished_at: early }, 1),
+      outputMsg({ timestamp: early, finished_at: late }, 2),
+    ];
+    const data = cardData(buildResponseCard(msgs as never));
+    expect(data.completed_at).toBe(Math.floor(new Date(late).getTime() / 1000));
+  });
+});

--- a/console/src/pages/Chat/tests/testFinishedAt.test.ts
+++ b/console/src/pages/Chat/tests/testFinishedAt.test.ts
@@ -62,16 +62,22 @@ describe("buildResponseCard completed_at (issue #6826)", () => {
       outputMsg({ timestamp: created, finished_at: finished }, 2),
     ];
     const data = cardData(buildResponseCard(msgs as never));
-    expect(data.completed_at).toBe(Math.floor(new Date(finished).getTime() / 1000));
+    expect(data.completed_at).toBe(
+      Math.floor(new Date(finished).getTime() / 1000),
+    );
     // created_at still reflects the first segment.
-    expect(data.created_at).toBe(Math.floor(new Date(created).getTime() / 1000));
+    expect(data.created_at).toBe(
+      Math.floor(new Date(created).getTime() / 1000),
+    );
   });
 
   it("falls back to timestamp when finished_at is absent (legacy)", () => {
     const created = "2026-08-12T17:00:00+08:00";
     const msgs = [outputMsg({ timestamp: created }, 1)];
     const data = cardData(buildResponseCard(msgs as never));
-    expect(data.completed_at).toBe(Math.floor(new Date(created).getTime() / 1000));
+    expect(data.completed_at).toBe(
+      Math.floor(new Date(created).getTime() / 1000),
+    );
   });
 
   it("uses the max finished_at across messages in a turn", () => {

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -554,11 +554,23 @@ def agentscope_msg_to_message(
         if ts_value:
             ts_value = _normalize_msg_timestamp(ts_value, user_tz)
 
+        # ``finished_at`` marks when the reply actually completed (stamped
+        # on REPLY_END by the runtime executor).  ``timestamp`` is the
+        # created_at alias — the first-segment save time — which can be
+        # far earlier for turns with long tool calls.  Expose both so the
+        # frontend can display the true completion time; ``finished_at``
+        # stays None for messages that never received a stamp (e.g. legacy
+        # sessions), letting consumers fall back to ``timestamp``.
+        finished_value = getattr(msg, "finished_at", None)
+        if finished_value:
+            finished_value = _normalize_msg_timestamp(finished_value, user_tz)
+
         metadata = {
             "original_id": msg.id,
             "original_name": msg.name,
             "metadata": msg.metadata,
             "timestamp": ts_value,
+            "finished_at": finished_value or None,
         }
 
         if isinstance(msg.content, str):

--- a/src/qwenpaw/runtime/executor.py
+++ b/src/qwenpaw/runtime/executor.py
@@ -8,6 +8,7 @@ and delegates each ``EventType`` event to ``Envelope.translate_event()``.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any, AsyncGenerator
 
 from .envelope import Envelope
@@ -53,8 +54,63 @@ class AgentExecutor:
                     yield obj
                 continue
 
+            self._maybe_stamp_finished_at(event)
+
             async for obj in self._envelope.translate_event(event):
                 yield obj
+
+    def _maybe_stamp_finished_at(self, event: Any) -> None:
+        """Backfill ``finished_at`` on the reply's assistant message.
+
+        agentscope only stamps ``Msg.finished_at`` via
+        ``Msg.append_event(REPLY_END)``, a path that only agentscope's own
+        app service invokes.  QwenPaw persists context through
+        ``_save_to_context``, which never writes ``finished_at`` and pins
+        ``created_at`` at the first saved segment of the reply.  The
+        session snapshot therefore records no real completion time, and
+        history rebuilt from the API falls back to ``created_at`` for the
+        assistant completion time — under-reporting turns that include
+        long tool calls (issue #6826).
+
+        ``REPLY_END`` is emitted after every ``_save_to_context`` call of
+        the reply, so stamping here lands in the session snapshot that is
+        persisted at turn end.  Best-effort by design: any failure is
+        logged and swallowed so the SSE stream is never affected.
+        """
+        try:
+            from agentscope.event import EventType
+
+            if getattr(event, "type", None) != EventType.REPLY_END.value:
+                return
+            context = getattr(
+                getattr(self._agent, "state", None),
+                "context",
+                None,
+            )
+            if not context:
+                return
+            reply_id = getattr(event, "reply_id", None)
+            target = None
+            if reply_id is not None:
+                for msg in reversed(context):
+                    if getattr(msg, "id", None) == reply_id:
+                        target = msg
+                        break
+            if target is None:
+                last = context[-1]
+                if getattr(last, "role", None) == "assistant":
+                    target = last
+            if target is None or getattr(target, "finished_at", None):
+                return
+            target.finished_at = (
+                getattr(event, "created_at", None)
+                or datetime.now().isoformat()
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                "executor: failed to stamp finished_at on REPLY_END",
+                exc_info=True,
+            )
 
 
 __all__ = ["AgentExecutor"]

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -414,6 +414,58 @@ def test_agentscope_msg_to_message_timestamp_uses_process_local_tz():
 # ---------------------------------------------------------------------------
 
 
+def test_agentscope_msg_to_message_exposes_finished_at():
+    """Issue #6826: the API must expose the real reply-end time so the
+    frontend can display it instead of the created_at alias."""
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "done"}],
+        created_at="2026-08-10T12:52:57.000000",
+        finished_at="2026-08-10T12:54:03.000000",
+    )
+    shanghai = ZoneInfo("Asia/Shanghai")
+    with (
+        patch(
+            "qwenpaw.app.chats.utils.load_config",
+            return_value=SimpleNamespace(user_timezone="Asia/Shanghai"),
+        ),
+        patch(
+            "qwenpaw.app.chats.utils._process_local_tz",
+            return_value=shanghai,
+        ),
+    ):
+        [message] = agentscope_msg_to_message(msg)
+
+    assert message.metadata["finished_at"] == "2026-08-10T12:54:03+08:00"
+    # timestamp (created_at alias) keeps its existing behaviour.
+    assert message.metadata["timestamp"] == "2026-08-10T12:52:57+08:00"
+
+
+def test_agentscope_msg_to_message_finished_at_none_when_absent():
+    """Legacy sessions without the stamp fall back to timestamp."""
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "legacy"}],
+        created_at="2026-08-10T12:52:57.000000",
+    )
+    shanghai = ZoneInfo("Asia/Shanghai")
+    with (
+        patch(
+            "qwenpaw.app.chats.utils.load_config",
+            return_value=SimpleNamespace(user_timezone="Asia/Shanghai"),
+        ),
+        patch(
+            "qwenpaw.app.chats.utils._process_local_tz",
+            return_value=shanghai,
+        ),
+    ):
+        [message] = agentscope_msg_to_message(msg)
+
+    assert message.metadata["finished_at"] is None
+
+
 def test_clean_title_strips_quotes_and_punctuation():
     assert _clean_title('"Hello World,"') == "Hello World"
 

--- a/tests/unit/runtime/test_executor_finished_at.py
+++ b/tests/unit/runtime/test_executor_finished_at.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Tests for the REPLY_END ``finished_at`` backfill in AgentExecutor.
 
 Regression tests for issue #6826: assistant messages persisted via
@@ -147,7 +148,10 @@ async def test_run_stamps_finished_at_on_reply_end() -> None:
             return
             yield  # pragma: no cover
 
-        async def translate_event(self, event: Any) -> AsyncGenerator[Any, None]:
+        async def translate_event(
+            self,
+            event: Any,
+        ) -> AsyncGenerator[Any, None]:
             del event
             return
             yield  # pragma: no cover

--- a/tests/unit/runtime/test_executor_finished_at.py
+++ b/tests/unit/runtime/test_executor_finished_at.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Tests for the REPLY_END ``finished_at`` backfill in AgentExecutor.
+
+Regression tests for issue #6826: assistant messages persisted via
+``_save_to_context`` never received a ``finished_at`` stamp, so history
+rebuilt from the API displayed ``created_at`` (the first-segment save
+time) as the assistant completion time — under-reporting turns with
+long tool calls.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+
+import pytest
+from agentscope.event import EventType
+
+from qwenpaw.runtime.executor import AgentExecutor
+
+
+def _msg(
+    msg_id: str = "reply-1",
+    role: str = "assistant",
+    finished_at: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(id=msg_id, role=role, finished_at=finished_at)
+
+
+def _agent(context: list[Any] | None) -> SimpleNamespace:
+    if context is None:
+        return SimpleNamespace(state=SimpleNamespace(context=[]))
+    return SimpleNamespace(state=SimpleNamespace(context=context))
+
+
+def _reply_end(
+    reply_id: str = "reply-1",
+    created_at: str = "2026-08-12T17:00:00.000000",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        type=EventType.REPLY_END.value,
+        reply_id=reply_id,
+        created_at=created_at,
+    )
+
+
+class TestMaybeStampFinishedAt:
+    def test_stamps_last_assistant_message_by_reply_id(self) -> None:
+        target = _msg("reply-1")
+        agent = _agent([_msg("user-0", role="user"), target])
+        executor = AgentExecutor(agent, envelope=None)
+
+        executor._maybe_stamp_finished_at(_reply_end("reply-1"))
+
+        assert target.finished_at == "2026-08-12T17:00:00.000000"
+
+    def test_prefers_reply_id_match_over_positional_last(self) -> None:
+        target = _msg("reply-1")
+        trailing = _msg("observed-later")
+        agent = _agent([target, trailing])
+        executor = AgentExecutor(agent, envelope=None)
+
+        executor._maybe_stamp_finished_at(_reply_end("reply-1"))
+
+        assert target.finished_at == "2026-08-12T17:00:00.000000"
+        assert trailing.finished_at is None
+
+    def test_falls_back_to_last_assistant_without_reply_id(self) -> None:
+        target = _msg("reply-1")
+        agent = _agent([_msg("user-0", role="user"), target])
+        executor = AgentExecutor(agent, envelope=None)
+
+        event = _reply_end("unknown-reply")
+        executor._maybe_stamp_finished_at(event)
+
+        assert target.finished_at == "2026-08-12T17:00:00.000000"
+
+    def test_does_not_overwrite_existing_finished_at(self) -> None:
+        target = _msg("reply-1", finished_at="2026-08-12T16:00:00.000000")
+        agent = _agent([target])
+        executor = AgentExecutor(agent, envelope=None)
+
+        executor._maybe_stamp_finished_at(_reply_end("reply-1"))
+
+        assert target.finished_at == "2026-08-12T16:00:00.000000"
+
+    def test_skips_when_last_message_is_not_assistant(self) -> None:
+        user_msg = _msg("user-9", role="user")
+        agent = _agent([user_msg])
+        executor = AgentExecutor(agent, envelope=None)
+
+        executor._maybe_stamp_finished_at(_reply_end("unknown-reply"))
+
+        assert user_msg.finished_at is None
+
+    def test_ignores_non_reply_end_events(self) -> None:
+        target = _msg("reply-1")
+        agent = _agent([target])
+        executor = AgentExecutor(agent, envelope=None)
+
+        event = SimpleNamespace(
+            type=EventType.TEXT_BLOCK_END.value,
+            reply_id="reply-1",
+            created_at="2026-08-12T17:00:00.000000",
+        )
+        executor._maybe_stamp_finished_at(event)
+
+        assert target.finished_at is None
+
+    def test_empty_context_is_noop(self) -> None:
+        executor = AgentExecutor(_agent(None), envelope=None)
+        executor._maybe_stamp_finished_at(_reply_end())
+
+    def test_agent_without_state_is_noop(self) -> None:
+        executor = AgentExecutor(SimpleNamespace(), envelope=None)
+        executor._maybe_stamp_finished_at(_reply_end())
+
+    def test_missing_created_at_falls_back_to_now(self) -> None:
+        target = _msg("reply-1")
+        agent = _agent([target])
+        executor = AgentExecutor(agent, envelope=None)
+
+        event = SimpleNamespace(
+            type=EventType.REPLY_END.value,
+            reply_id="reply-1",
+            created_at=None,
+        )
+        executor._maybe_stamp_finished_at(event)
+
+        assert target.finished_at  # stamped with datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_run_stamps_finished_at_on_reply_end() -> None:
+    """The stamp happens while driving the reply stream (issue #6826)."""
+    target = _msg("reply-1")
+    agent = _agent([_msg("user-0", role="user"), target])
+
+    async def reply_stream(inputs: Any) -> AsyncGenerator[Any, None]:
+        del inputs
+        yield _reply_end("reply-1")
+
+    agent.reply_stream = reply_stream
+
+    class _SilentEnvelope:
+        async def heartbeat(self) -> AsyncGenerator[Any, None]:
+            return
+            yield  # pragma: no cover
+
+        async def translate_event(self, event: Any) -> AsyncGenerator[Any, None]:
+            del event
+            return
+            yield  # pragma: no cover
+
+    executor = AgentExecutor(agent, _SilentEnvelope())
+    async for _ in executor.run([]):
+        pass
+
+    assert target.finished_at == "2026-08-12T17:00:00.000000"


### PR DESCRIPTION
> **Submitted by**: 狄仁杰·Repairer@QPQAT

## Summary

Fixes the assistant completion time shown in chat history for issue #6826.
When an assistant turn includes long-running tool calls, the page displayed
the completion time as the moment the **first reply segment was saved**
(seconds after the user's message) instead of when the reply actually ended;
after reloading or switching sessions the wrong time reappeared.

## Root Cause

A three-layer data gap — the data source never carried a "completion time":

1. **agentscope** persists conversation context via `_save_to_context`, which
   creates/extends the assistant `Msg` without ever writing `finished_at`
   (the only writer is `Msg.append_event(REPLY_END)`, a path invoked solely by
   agentscope's own app service). `created_at` is therefore pinned at the
   first-segment save of the reply.
2. **QwenPaw** `agentscope_msg_to_message` exposed only `msg.timestamp` (a
   compatibility alias of `created_at`) in message metadata, never
   `finished_at` — so every assistant message of a turn shared one identical,
   too-early timestamp.
3. **Console** `buildResponseCard` used the last output message's timestamp
   as the assistant `completed_at`.

Live-streaming display looked fine because the SSE envelope stamps
`completed_at` in real time; the bug only surfaced when history was rebuilt
from the API (reload / session switch).

## Fix

Plan A — backfill the real completion time at the source, expose it, prefer it:

- `src/qwenpaw/runtime/executor.py` — on `REPLY_END` (emitted after all
  context saves of the reply), stamp `finished_at` on the reply's assistant
  message in the agent context: matched by `reply_id` with a
  trailing-assistant fallback, never overwrites an existing value, and is
  wrapped in a broad-except guard so the SSE stream can never be affected.
  The stamp lands in the session snapshot persisted at turn end.
- `src/qwenpaw/app/chats/utils.py` — expose `finished_at` in message metadata
  (normalized to the user timezone like `timestamp`). Stays `None` when
  absent: pure increment, old clients and legacy sessions unaffected.
- `console/src/pages/Chat/sessionApi/index.ts` — add `parseFinishedAt`;
  `buildResponseCard` sets `completed_at` from `finished_at`, falling back to
  `timestamp` for legacy sessions without the stamp.

## Verification

- **End-to-end** on an isolated repro environment (port 9099, this branch
  installed with the rebuilt console): a turn running a 20s shell command
  yields `created_at=17:29:23.004310` vs `finished_at=17:29:45.298267` in the
  session file (22.3s gap — exactly what used to be displayed wrong); the API
  returns `finished_at` on every assistant message of the turn; the UI shows
  `17:29:45` live and **keeps it after reload and after switching away and
  back** (the wrong `17:29:23` no longer appears anywhere).
- **New unit tests**: `tests/unit/runtime/test_executor_finished_at.py`
  (10 cases: reply-id match, positional fallback, no overwrite, non-REPLY_END
  ignored, empty context, missing state, missing created_at, `run()` path),
  2 new metadata-exposure cases in `tests/unit/app/chats/test_utils.py`, and
  `console/src/pages/Chat/tests/testFinishedAt.test.ts` (5 cases: parsing,
  absence fallback, preference, legacy fallback, multi-message max).
- **Regression**: `tests/unit/runtime/` + `tests/unit/app/chats/` — 186
  passed; console session tests (`testFinishedAt` + `testLargeSession`) —
  34 passed.

Closes #6826
