### PR TITLE
fix(cli): select prereleases from PyPI releases

### DIFF
--- a/src/qwenpaw/cli/update_cmd.py
+++ b/src/qwenpaw/cli/update_cmd.py
@@ -123,14 +123,6 @@ def _select_latest_version(
     include_prerelease: bool,
 ) -> str:
     """Return the newest published version from PyPI metadata."""
-    if include_prerelease:
-        version = str(data.get("info", {}).get("version", "")).strip()
-        if not version:
-            raise click.ClickException(
-                "Unable to determine the latest QwenPaw version.",
-            )
-        return version
-
     releases = data.get("releases") or {}
     candidates: list[Version] = []
     for version_str, files in releases.items():
@@ -140,7 +132,7 @@ def _select_latest_version(
             parsed = Version(version_str)
         except InvalidVersion:
             continue
-        if parsed.is_prerelease:
+        if parsed.is_prerelease and not include_prerelease:
             continue
         candidates.append(parsed)
 

--- a/src/qwenpaw/cli/update_cmd.py
+++ b/src/qwenpaw/cli/update_cmd.py
@@ -124,6 +124,11 @@ def _select_latest_version(
 ) -> str:
     """Return the newest published version from PyPI metadata."""
     releases = data.get("releases") or {}
+    if not isinstance(releases, dict):
+        raise click.ClickException(
+            "Received an invalid response from PyPI when checking for the "
+            "latest QwenPaw version.",
+        )
     candidates: list[Version] = []
     for version_str, files in releases.items():
         if not files:


### PR DESCRIPTION
## Summary

- select the latest version from the PyPI `releases` mapping when `--prerelease` is enabled
- include prerelease candidates only when explicitly requested
- keep the default stable-only update behavior unchanged

## Problem

PyPI `info.version` may still point to the latest stable release even when a newer prerelease exists. As a result, `qwenpaw update --prerelease` reported the stable version and exited without upgrading.

## Verification

- `uv run --frozen pytest -q tests/unit/cli/test_cli_update.py` (36 passed)
- `uv run --frozen pre-commit run --files src/qwenpaw/cli/update_cmd.py`