### PR TITLE
fix(console): group daily memory notes by path date

### DIFF
--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -44,7 +44,11 @@ import {
   filesWorkspaceScopeKey,
   type FilesWorkspaceScope,
 } from "./filesWorkspaceScope";
-import { buildMemoryTree, type MemoryTreeEntry } from "./memoryTree";
+import {
+  buildDailyMemoryTree,
+  buildMemoryTree,
+  type MemoryTreeEntry,
+} from "./memoryTree";
 import type {
   DirectoryEntry,
   FileTarget,
@@ -521,16 +525,18 @@ export default function FilesNavigator({
     setLoading(true);
     try {
       const files = await workspaceApi.listMemoryFiles(section);
-      const tree = buildMemoryTree(
-        files.map((file) => ({
-          name: file.filename.split("/").pop() ?? file.filename,
-          path: file.filename,
-          kind: "file" as const,
-          size: file.size,
-          modified_at: file.modified_time,
-          preview_kind: "text" as const,
-        })),
-      );
+      const entries = files.map((file) => ({
+        name: file.filename.split("/").pop() ?? file.filename,
+        path: file.filename,
+        kind: "file" as const,
+        size: file.size,
+        modified_at: file.modified_time,
+        preview_kind: "text" as const,
+      }));
+      const tree =
+        section === "daily"
+          ? buildDailyMemoryTree(entries)
+          : buildMemoryTree(entries);
       if (section === "daily") setDailyFiles(tree);
       else setDigestFiles(tree);
     } finally {

--- a/console/src/features/files-workspace/memoryTree.test.ts
+++ b/console/src/features/files-workspace/memoryTree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { DirectoryEntry } from "./types";
-import { buildMemoryTree } from "./memoryTree";
+import { buildDailyMemoryTree, buildMemoryTree } from "./memoryTree";
 
 function file(
   path: string,
@@ -64,5 +64,52 @@ describe("buildMemoryTree", () => {
       "a.md",
       "b.md",
     ]);
+  });
+});
+
+describe("buildDailyMemoryTree", () => {
+  it("groups a daily root file with notes in its matching date directory", () => {
+    const tree = buildDailyMemoryTree([
+      file("2026-08-10/today.md", "2026-08-10T08:00:00Z"),
+      file("2026-08-10.md", "2026-08-10T09:00:00Z"),
+      file("2026-08-09/session.md", "2026-08-11T08:00:00Z"),
+      file("2026-08-09.md", "2026-08-09T09:00:00Z"),
+    ]);
+
+    expect(tree.map((entry) => entry.name)).toEqual([
+      "2026-08-10",
+      "2026-08-09",
+    ]);
+    expect(tree[0].children?.map((entry) => entry.path)).toEqual([
+      "2026-08-10.md",
+      "2026-08-10/today.md",
+    ]);
+    expect(tree[1].children?.map((entry) => entry.path)).toEqual([
+      "2026-08-09.md",
+      "2026-08-09/session.md",
+    ]);
+  });
+
+  it("sorts date entries by their path date instead of modification time", () => {
+    const tree = buildDailyMemoryTree([
+      file("2026-08-08.md", "2026-08-12T00:00:00Z"),
+      file("2026-08-10.md", "2026-08-10T00:00:00Z"),
+      file("2026-08-09/note.md", "2026-08-11T00:00:00Z"),
+    ]);
+
+    expect(tree.map((entry) => entry.name)).toEqual([
+      "2026-08-10.md",
+      "2026-08-09",
+      "2026-08-08.md",
+    ]);
+  });
+
+  it("keeps non-date memory paths in the tree", () => {
+    const tree = buildDailyMemoryTree([
+      file("2026-08-10.md"),
+      file("notes/topic.md"),
+    ]);
+
+    expect(tree.map((entry) => entry.name)).toEqual(["2026-08-10.md", "notes"]);
   });
 });

--- a/console/src/features/files-workspace/memoryTree.ts
+++ b/console/src/features/files-workspace/memoryTree.ts
@@ -4,6 +4,9 @@ export interface MemoryTreeEntry extends DirectoryEntry {
   children?: MemoryTreeEntry[];
 }
 
+const DAILY_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
+const DAILY_DIRECTORY_PATTERN = /^(\d{4}-\d{2}-\d{2})$/;
+
 function modifiedTimestamp(value: string): number {
   const timestamp = Date.parse(value);
   return Number.isNaN(timestamp) ? 0 : timestamp;
@@ -66,4 +69,51 @@ export function buildMemoryTree(files: DirectoryEntry[]): MemoryTreeEntry[] {
   };
   sortEntries(root);
   return root;
+}
+
+export function buildDailyMemoryTree(
+  files: DirectoryEntry[],
+): MemoryTreeEntry[] {
+  const tree = buildMemoryTree(files);
+  const dateGroups = new Map<
+    string,
+    { file?: MemoryTreeEntry; directory?: MemoryTreeEntry }
+  >();
+  const otherEntries: MemoryTreeEntry[] = [];
+
+  tree.forEach((entry) => {
+    const match =
+      entry.kind === "file"
+        ? entry.name.match(DAILY_FILE_PATTERN)
+        : entry.name.match(DAILY_DIRECTORY_PATTERN);
+    if (!match) {
+      otherEntries.push(entry);
+      return;
+    }
+
+    const date = match[1];
+    const group = dateGroups.get(date) ?? {};
+    if (entry.kind === "file") group.file = entry;
+    else group.directory = entry;
+    dateGroups.set(date, group);
+  });
+
+  const dailyEntries = Array.from(dateGroups.entries())
+    .sort(([left], [right]) => right.localeCompare(left))
+    .map(([, group]) => {
+      if (!group.file) return group.directory as MemoryTreeEntry;
+      if (!group.directory) return group.file;
+
+      return {
+        ...group.directory,
+        modified_at:
+          modifiedTimestamp(group.file.modified_at) >
+          modifiedTimestamp(group.directory.modified_at)
+            ? group.file.modified_at
+            : group.directory.modified_at,
+        children: [group.file, ...(group.directory.children ?? [])],
+      };
+    });
+
+  return [...dailyEntries, ...otherEntries];
 }


### PR DESCRIPTION
## 问题背景

日记视图会同时展示两类按日期组织的记忆文件：

- 顶层日记文件，例如 `2026-08-09.md`
- 日期目录中的会话笔记，例如 `2026-08-09/session.md`

当前文件工作区使用通用目录树构建器处理日记数据。通用构建器会把顶层文件和同名日期目录视为两个互不相关的根节点，并按照文件或目录的最新修改时间排序。

因此，同一天的文件和目录可能被其他日期的节点隔开。例如，目录内某篇旧日期笔记在次日被修改后，界面可能显示为：

```text
2026-08-10.md
2026-08-10/
2026-08-09/
2026-08-09.md
```

这会让 `2026-08-09/` 看起来像是被归到了错误日期，也导致同一天的日记内容无法作为一个整体浏览。

## 根因分析

问题并不是遗留 `listDailyMemory()` 中 `date` 字段的提取方式。当前文件工作区实际通过 `listMemoryFiles("daily")` 获取数据，然后调用通用的 `buildMemoryTree()`；当前页面不会使用 `DailyMemoryFile.date`。

真正原因是文件工作区重构后，日记视图和知识库视图共用了相同的路径树及“按修改时间排序”逻辑，丢失了旧日记页面特有的日期分组语义。

## 修改内容

本 PR 新增日记专用的 `buildDailyMemoryTree()`，并仅在 `daily` section 中使用：

1. 识别根节点中的 `YYYY-MM-DD.md` 文件和 `YYYY-MM-DD/` 目录。
2. 当同一日期同时存在顶层文件和目录时，将二者合并为一个日期目录节点：
   - `YYYY-MM-DD.md` 作为该日期组的第一个子项；
   - `YYYY-MM-DD/` 中的笔记继续保留原有目录层级。
3. 日期节点严格按照路径中的日期倒序排列，不再受文件修改时间影响。
4. 仅存在顶层文件或仅存在日期目录时，保留原有节点形态。
5. 非日期格式的日记路径继续保留在树中。
6. `digest` 等知识库视图仍使用原来的通用目录树逻辑，不改变其按修改时间排序的行为。

## 修复后的效果

对于以下文件：

```text
2026-08-10.md
2026-08-10/today.md
2026-08-09.md
2026-08-09/session.md
```

日记视图会生成两个按日期倒序排列的根节点：

```text
2026-08-10/
  2026-08-10.md
  today.md
2026-08-09/
  2026-08-09.md
  session.md
```

即使 `2026-08-09/session.md` 的修改时间晚于 8 月 10 日，它仍然归属于 `2026-08-09`，不会影响日期组的顺序。

## 测试

新增回归测试覆盖：

- 顶层日期文件与同日期目录合并；
- 修改时间晚于其他日期时仍按路径日期排序；
- 非日期格式的记忆路径不丢失；
- 原有通用目录树行为保持不变。

本地验证结果：

```text
npm run test:run -- src/features/files-workspace
Test Files  8 passed (8)
Tests       42 passed (42)

npx tsc -b --noEmit
npx eslint src/features/files-workspace/memoryTree.ts src/features/files-workspace/memoryTree.test.ts src/features/files-workspace/FilesNavigator.tsx
npx prettier --check src/features/files-workspace/memoryTree.ts src/features/files-workspace/memoryTree.test.ts src/features/files-workspace/FilesNavigator.tsx
```

Closes #6883
