### PR TITLE
fix(memory): simplify long-term memory guidance

### DIFF
--- a/src/qwenpaw/agents/memory/prompts.py
+++ b/src/qwenpaw/agents/memory/prompts.py
@@ -1,77 +1,33 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa: E501
-# pylint: disable=line-too-long
-"""Dream memory optimization prompts."""
+"""Memory guidance prompts."""
 
-
-# Memory guidance prompts - explains how agent should use memory files
-MEMORY_RETRIEVAL_GUIDANCE_ZH = """\
-### 🔍 检索工具
-`memory_search` 用于查你**精选的长期记忆** — 持久的偏好、用户/画像事实、已确定的决策与未完成的待办。当问题取决于这些内容时，优先用它：
-1. 对 MEMORY.md 和 `{daily_dir}/*.md` 运行 `memory_search`
-2. 要读某一天的笔记，直接用 `read_file` 打开 `{daily_dir}/YYYY-MM-DD.md`
-"""
-
-MEMORY_RETRIEVAL_GUIDANCE_EN = """\
-### 🔍 Retrieval Tool
-`memory_search` is your lookup for **curated long-term memory** — durable preferences, profile/personal facts, settled decisions, and open to-dos. Reach for it first when a question turns on one of these:
-1. Run `memory_search` over MEMORY.md and `{daily_dir}/*.md`.
-2. To read a specific day's notes, open `{daily_dir}/YYYY-MM-DD.md` directly with `read_file`."""
-
-
-MEMORY_GUIDANCE_ZH_TEMPLATE = """\
-## 记忆
-
-每次会话都是全新的；工作目录下的文件是你的记忆延续。
-
-- **MEMORY.md** — 长期记忆：持久的事实、偏好与决策。这是你精选、提炼的记忆（不是原始日志）；后台有一个定期运行的总结进程（dream），会自动把每日笔记里值得长期保留的内容整理进来。
-- **每日笔记**（`{daily_dir}/YYYY-MM-DD.md`）— 运行中的上下文与观察；这是轻量的短期记录，也是上述总结进程的来源。
-- **重要：** 避免覆盖 — 先 `read_file`，再用 `write_file` / `edit_file`。除非用户明确要求，否则不要记录敏感信息。
-
-因此你通常不必手动维护 MEMORY.md。只有当用户明确要求你记住某事，或形成了值得长期保留的决策或偏好时，才直接编辑它。
-
-{retrieval_guidance}"""
-
-MEMORY_GUIDANCE_EN_TEMPLATE = """\
-## Memory
-
-Each session is fresh; the working-directory files are your memory continuity.
-
-- **MEMORY.md** — long-term memory: durable facts, preferences, and decisions. Your curated, distilled memory (not a raw log); a background summarization job (the periodic "dream" process) automatically consolidates worthwhile daily-note content into it.
-- **Daily notes** (`{daily_dir}/YYYY-MM-DD.md`) — running context and observations; the lightweight short-term log that the summarization job draws from.
-- **Important:** Avoid overwriting — `read_file` first, then `write_file` / `edit_file`. Unless the user explicitly asks, do not record sensitive information.
-
-So you usually don't need to maintain MEMORY.md by hand. Edit it directly only when the user explicitly asks you to remember something, or a decision or preference worth keeping long-term is settled.
-
-{retrieval_guidance}"""
-
-MEMORY_GUIDANCE_TEMPLATES = {
-    "zh": MEMORY_GUIDANCE_ZH_TEMPLATE,
-    "en": MEMORY_GUIDANCE_EN_TEMPLATE,
+MEMORY_GUIDANCE = {
+    "zh": (
+        "# 长期记忆\n\n"
+        "工作目录下保存着你的个人知识库。当问题涉及用户过去的事实、偏好、"
+        "决策或经验时，先使用 `memory_search` 检索相关信息。检索结果中会包含"
+        "相关内容片段及其文件路径；如果片段不足以回答问题，再使用 `read_file` "
+        "按路径渐进式展开，只读取当前任务所需的内容。"
+    ),
+    "en": (
+        "# Long-term Memory\n\n"
+        "Your personal knowledge base is stored in the working directory. "
+        "When a question involves the user's past facts, preferences, "
+        "decisions, or experience, first use `memory_search` to retrieve "
+        "relevant information. Search results include relevant excerpts and "
+        "their file paths; if an excerpt is insufficient, use `read_file` on "
+        "its path to progressively expand the "
+        "context, reading only what the current task requires."
+    ),
 }
 
 
 def build_memory_guidance_prompt(
     language: str = "zh",
     *,
-    daily_dir: str,
     memory_search_enabled: bool = True,
 ) -> str:
-    """Build memory guidance using the configured daily memory directory."""
-    retrieval_templates = {
-        "zh": MEMORY_RETRIEVAL_GUIDANCE_ZH,
-        "en": MEMORY_RETRIEVAL_GUIDANCE_EN,
-    }
-    retrieval_guidance = ""
-    if memory_search_enabled:
-        retrieval_guidance = retrieval_templates.get(
-            language,
-            MEMORY_RETRIEVAL_GUIDANCE_EN,
-        ).format(daily_dir=daily_dir)
-    return MEMORY_GUIDANCE_TEMPLATES.get(
-        language,
-        MEMORY_GUIDANCE_EN_TEMPLATE,
-    ).format(
-        daily_dir=daily_dir,
-        retrieval_guidance=retrieval_guidance,
-    )
+    """Build guidance for the memory capabilities exposed to the agent."""
+    if not memory_search_enabled:
+        return ""
+    return MEMORY_GUIDANCE.get(language, MEMORY_GUIDANCE["en"])

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -225,7 +225,6 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         cfg = agent_config.running.reme_light_memory_config
         return build_memory_guidance_prompt(
             agent_config.language,
-            daily_dir=cfg.daily_dir,
             memory_search_enabled=cfg.memory_search_enabled,
         )
 

--- a/tests/unit/agents/memory/test_reme_daily_paper.py
+++ b/tests/unit/agents/memory/test_reme_daily_paper.py
@@ -152,7 +152,6 @@ def test_memory_prompt_omits_disabled_search_tool() -> None:
         language="en",
         running=SimpleNamespace(
             reme_light_memory_config=SimpleNamespace(
-                daily_dir="memory",
                 memory_search_enabled=False,
             ),
         ),
@@ -168,7 +167,7 @@ def test_memory_prompt_omits_disabled_search_tool() -> None:
         prompt = manager.get_memory_prompt()
 
     assert "memory_search" not in prompt
-    assert "memory/YYYY-MM-DD.md" in prompt
+    assert prompt == ""
 
 
 def test_memory_prompt_includes_enabled_search_tool() -> None:
@@ -178,7 +177,6 @@ def test_memory_prompt_includes_enabled_search_tool() -> None:
         language="en",
         running=SimpleNamespace(
             reme_light_memory_config=SimpleNamespace(
-                daily_dir="memory",
                 memory_search_enabled=True,
             ),
         ),
@@ -191,7 +189,7 @@ def test_memory_prompt_includes_enabled_search_tool() -> None:
         prompt = manager.get_memory_prompt()
 
     assert "memory_search" in prompt
-    assert "memory/*.md" in prompt
+    assert "personal knowledge base" in prompt
 
 
 def test_reme_declares_its_enabled_cron_jobs() -> None:


### PR DESCRIPTION
## 背景

当前 ReMeLight 注入给 Agent 的记忆提示词会直接描述 `MEMORY.md`、每日笔记以及 Dream 的内部存储行为，并错误暗示 Dream 会将每日笔记自动整理进 `MEMORY.md`。实际上，Agent 无需感知这些存储实现细节：启用的 workspace system-prompt 文件会直接进入上下文，而可检索的记忆应统一表现为个人知识库能力。

Closes #6853

## 修改内容

- 将中英文记忆提示统一精简为“长期记忆 / Long-term Memory”能力说明。
- 不再向 Agent 暴露 `MEMORY.md`、daily 目录、digest 目录及 Dream 流程等实现细节。
- 明确在问题涉及用户过去的事实、偏好、决策或经验时，优先调用 `memory_search` 检索个人知识库。
- 明确 `memory_search` 返回相关内容片段及文件路径；当片段不足时，再通过 `read_file` 按路径渐进式展开。
- 强调只读取当前任务需要的内容，避免无目的地加载大量知识库文件。
- 当 `memory_search` 被禁用时，不注入任何相关提示，避免引导模型调用不可用工具。
- 移除 `build_memory_guidance_prompt` 不再需要的 `daily_dir` 参数，并同步调整 ReMeLight manager 调用。

## 为什么这样修改

`MEMORY.md` 更接近由用户维护、可选择直接加载到上下文中的少量重要长期信息；Dream 生成的 digest 则属于规模更大的个人知识库，通过搜索按需召回。对 Agent 来说，重要的是如何使用已经暴露的能力，而不是底层文件的组织方式。

新的提示词遵循如下使用路径：

1. 使用 `memory_search` 找到与当前问题相关的记忆片段；
2. 根据搜索结果中的文件路径，在确有需要时调用 `read_file`；
3. 渐进式补充上下文，只读取完成当前任务所需的信息。

这样既消除了错误的自动同步描述，也让提示词更短、更稳定，不再与具体目录结构耦合。

## 测试

- 更新现有提示词测试，覆盖启用和关闭 `memory_search` 两种情况。
- 验证英文提示包含个人知识库语义。
- 运行：`pytest -q tests/unit/agents/memory/test_reme_daily_paper.py`（10 passed）
- 运行相关文件 Ruff lint 与 `git diff --check`，均通过。