### PR TITLE
feat(channels): support interactive configurators for plugin channels

### DIFF
--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -2,14 +2,18 @@
 """CLI channel: list and interactively configure channels in config.json."""
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Optional
 
 import click
+from fastapi import FastAPI
 from qwenpaw.exceptions import (
     AppBaseException,
 )
 
+from ..app.channels.registry import get_channel_registry
+from ..config import get_available_channels, load_config
 from ..config.config import (
     Config,
     ConsoleConfig,
@@ -24,10 +28,10 @@ from ..config.config import (
     load_agent_config,
     save_agent_config,
 )
+from ..config.utils import get_plugins_dir
+from ..plugins.loader import PluginLoader
 from .utils import prompt_confirm, prompt_path, prompt_select
 from .http import client, print_json, resolve_base_url
-from ..config import get_available_channels
-from ..app.channels.registry import get_channel_registry
 
 
 # Fields that contain secrets — display masked in ``list``
@@ -624,6 +628,26 @@ _ALL_CHANNEL_CONFIGURATORS = {
     "voice": ("Twilio", configure_voice),
 }
 
+_CLI_CHANNEL_PLUGINS_LOADED = False
+
+
+def _load_channel_plugins_for_cli() -> None:
+    """Load installed channel plugins before building the CLI menu."""
+    global _CLI_CHANNEL_PLUGINS_LOADED
+    if _CLI_CHANNEL_PLUGINS_LOADED:
+        return
+
+    config = load_config()
+    loader = PluginLoader([get_plugins_dir()])
+    loader.registry.set_plugin_http_app(FastAPI())
+    asyncio.run(
+        loader.load_all_plugins(
+            configs=config.plugins,
+            types=["channel"],
+        ),
+    )
+    _CLI_CHANNEL_PLUGINS_LOADED = True
+
 
 def _plugin_configure(
     _key: str,
@@ -730,6 +754,7 @@ def configure_channels_interactive(config: Config) -> None:
 
     Mutates *config.channels* in-place.
     """
+    _load_channel_plugins_for_cli()
     configurators = get_channel_configurators()
     registry = get_channel_registry()
     click.echo("\n=== Channel Configuration ===")

--- a/tests/unit/cli/test_channels_cmd.py
+++ b/tests/unit/cli/test_channels_cmd.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,redefined-outer-name
+"""Tests for interactive plugin channel configuration."""
+
+import json
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.cli import channels_cmd
+from qwenpaw.plugins.registry import PluginRegistry
+
+
+@pytest.fixture()
+def fresh_plugin_registry():
+    """Provide an isolated plugin registry for CLI loading tests."""
+    old_instance = PluginRegistry._instance
+    old_loaded = channels_cmd._CLI_CHANNEL_PLUGINS_LOADED
+    PluginRegistry._instance = None
+    channels_cmd._CLI_CHANNEL_PLUGINS_LOADED = False
+    registry = PluginRegistry()
+    try:
+        yield registry
+    finally:
+        sys.modules.pop("plugin_interactive_channel", None)
+        PluginRegistry._instance = old_instance
+        channels_cmd._CLI_CHANNEL_PLUGINS_LOADED = old_loaded
+
+
+def _write_channel_plugin(plugin_root: Path) -> None:
+    """Write a plugin with custom and fallback channel configurators."""
+    plugin_dir = plugin_root / "interactive-channel"
+    plugin_dir.mkdir()
+    manifest = {
+        "id": "interactive-channel",
+        "name": "Interactive Channel",
+        "version": "1.0.0",
+        "type": "channel",
+        "entry": {"backend": "plugin.py"},
+        "qwenpaw_version": {"min": "0.1.0", "max": "99.0.0"},
+    }
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(
+        """
+from fastapi import APIRouter
+
+from qwenpaw.app.channels.base import BaseChannel
+
+
+class InteractiveChannel(BaseChannel):
+    channel = "interactive_channel"
+    display_name = "Interactive Channel"
+
+    @classmethod
+    def get_configurator(cls):
+        def configure(current):
+            current.enabled = True
+            current.binding_method = "qrcode"
+            return current
+
+        return configure
+
+
+class FallbackChannel(BaseChannel):
+    channel = "fallback_channel"
+    display_name = "Fallback Channel"
+
+
+class TestPlugin:
+    def register(self, api):
+        api.register_channel(channel_class=InteractiveChannel)
+        api.register_channel(channel_class=FallbackChannel)
+        router = APIRouter()
+        api.register_http_router(router, prefix="/interactive-channel")
+
+
+plugin = TestPlugin()
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def loaded_channel_plugin(tmp_path, fresh_plugin_registry):
+    """Load the test channel plugin into an isolated registry."""
+    _write_channel_plugin(tmp_path)
+
+    with (
+        patch.object(channels_cmd, "get_plugins_dir", return_value=tmp_path),
+        patch.object(channels_cmd, "load_config") as load_config,
+    ):
+        load_config.return_value.plugins = {}
+        channels_cmd._load_channel_plugins_for_cli()
+
+    return fresh_plugin_registry
+
+
+def test_cli_loads_plugin_channel_custom_configurator(
+    loaded_channel_plugin,
+):
+    """Installed plugin channels expose their custom CLI configurator."""
+    configurators = channels_cmd.get_channel_configurators()
+    _, configure = configurators["interactive_channel"]
+    updated = configure({"enabled": False})
+
+    assert updated == {
+        "enabled": True,
+        "binding_method": "qrcode",
+    }
+    assert loaded_channel_plugin.get_channel_registration(
+        "interactive_channel",
+    )
+
+
+def test_plugin_channel_without_custom_configurator_uses_fallback(
+    loaded_channel_plugin,
+):
+    """Plugin channels without the hook keep the basic CLI prompts."""
+    configurators = channels_cmd.get_channel_configurators()
+    _, configure = configurators["fallback_channel"]
+    with (
+        patch.object(channels_cmd, "prompt_confirm", return_value=True),
+        patch.object(channels_cmd.click, "prompt", return_value="[BOT]"),
+    ):
+        updated = configure({"enabled": False, "bot_prefix": ""})
+
+    assert updated == {"enabled": True, "bot_prefix": "[BOT]"}
+    assert loaded_channel_plugin.get_channel_registration(
+        "fallback_channel",
+    )
+
+
+def test_interactive_config_loads_plugins_before_building_menu():
+    """The interactive flow loads plugins before reading configurators."""
+    calls = []
+
+    def load_plugins():
+        calls.append("load")
+
+    def get_configurators():
+        calls.append("configurators")
+        return {}
+
+    with (
+        patch.object(
+            channels_cmd,
+            "_load_channel_plugins_for_cli",
+            side_effect=load_plugins,
+        ),
+        patch.object(
+            channels_cmd,
+            "get_channel_configurators",
+            side_effect=get_configurators,
+        ),
+        patch.object(channels_cmd, "get_channel_registry", return_value={}),
+        patch.object(channels_cmd, "prompt_select", return_value="exit"),
+    ):
+        channels_cmd.configure_channels_interactive(channels_cmd.Config())
+
+    assert calls == ["load", "configurators"]


### PR DESCRIPTION
## Summary

Restore support for plugin channel `get_configurator()` in the interactive
channel configuration flow.

## Changes

- Load installed `channel` plugins before building the CLI channel menu.
- Use a temporary FastAPI application so plugins registering HTTP routers can
  load successfully in CLI context.
- Invoke a plugin channel's optional `get_configurator()` when provided.
- Preserve the existing `enabled` and `bot_prefix` fallback for plugins without
  a custom configurator.
- Add tests covering custom configurators, fallback behavior, HTTP router
  registration, and plugin-loading order.

## Verification

- `132 passed` for the relevant CLI, workspace, and plugin tests.
- All pre-commit hooks passed.

**Related Issue:** Relates to #6924 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
