### PR TITLE
fix(scroll): drop orphaned tool messages at the rebuild seam (#6541)

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -1814,6 +1814,21 @@ class ScrollContextManager:
                 + render_live_turn_banner()
             )
             memory = f"<system-info>\n{body}\n</system-info>"
+        # Pairing invariant at the rebuild seam: every context Scroll
+        # reassembles must be free of orphaned tool messages (a
+        # ``tool_result`` whose ``tool_call`` was evicted, or a
+        # ``tool_call`` whose results were lost).  Providers with strict
+        # pairing validation (e.g. DeepSeek and other OpenAI-compatible
+        # APIs) reject such sequences with 400 "Messages with role 'tool'
+        # must be a response to a preceding message with 'tool_calls'"
+        # (issue #6541).  compress() already sanitizes the tail before
+        # calling us, but this seam is also reached by
+        # reconcile_loaded_context() and any future rebuild path, so the
+        # invariant is enforced here instead of trusting every caller.
+        # The user-role placeholder itself carries no tool blocks and is
+        # pairing-neutral; its role stays ``user`` deliberately (Anthropic
+        # rejects mid-context system messages — see eviction_index.py).
+        tail = _remove_unpaired_tool_messages(tail)
         placeholder = UserMsg(
             name="memory",
             content=memory,

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -2254,3 +2254,173 @@ def test_tool_input_round_trips_to_db(store: HistoryStore):
         "WHERE tool_call_id='call-9'",
     ).fetchone()
     assert row["tool_input"] == '{"pattern": "x"}'
+
+
+# -- issue #6541: rebuild-seam pairing invariant ---------------------------
+#
+# The DeepSeek/OpenAI-compatible 400 behind issue #6541 ("Messages with role
+# 'tool' must be a response to a preceding message with 'tool_calls'") is an
+# orphaned-tool-message failure, not a placeholder-role failure: the
+# compression placeholder carries no tool blocks, so its role cannot affect
+# tool pairing.  Every context Scroll reassembles must therefore be free of
+# orphaned tool messages; ``_rebuild_context`` enforces that invariant at the
+# seam shared by compress() and reconcile_loaded_context().
+
+
+def _standalone_tool_result(tcid: str) -> Msg:
+    """A tool result separated from its (already evicted) tool_call."""
+    return Msg(
+        name="a",
+        role="assistant",
+        content=[
+            ToolResultBlock(
+                type="tool_result",
+                id=tcid,
+                name="grep",
+                output=[TextBlock(type="text", text="RESULT")],
+            ),
+        ],
+    )
+
+
+def _unpaired_tool_call(tcid: str) -> Msg:
+    """An assistant tool_call whose results never arrived / were lost."""
+    return Msg(
+        name="a",
+        role="assistant",
+        content=[
+            TextBlock(type="text", text="calling a tool"),
+            ToolCallBlock(type="tool_call", id=tcid, name="grep", input="{}"),
+        ],
+    )
+
+
+def _tool_block_ids(msg: Msg) -> list:
+    ids: list = []
+    content = getattr(msg, "content", None)
+    if not isinstance(content, list):
+        return ids
+    for block in content:
+        btype = (
+            block.get("type")
+            if isinstance(block, dict)
+            else getattr(block, "type", None)
+        )
+        if btype in ("tool_call", "tool_use", "tool_result"):
+            bid = (
+                block.get("id")
+                if isinstance(block, dict)
+                else getattr(block, "id", None)
+            )
+            ids.append((btype, bid))
+    return ids
+
+
+def test_rebuild_seam_drops_orphan_tool_result(store: HistoryStore):
+    """An evicted tool_call must not leave its result behind in the tail."""
+    mgr = make_manager(store)
+    agent = FakeAgent([user("live request")])
+    tail = [
+        _standalone_tool_result("call-evicted"),
+        user("live request"),
+        assistant_with_tool("call-live"),
+    ]
+    mgr._rebuild_context(agent, tail)
+    ctx = agent.state.context
+
+    assert len(ctx) == 3  # placeholder + user + paired tool turn
+    assert ctx[0].name == "memory"  # placeholder kept
+    surviving = [
+        (kind, bid) for msg in ctx for kind, bid in _tool_block_ids(msg)
+    ]
+    assert ("tool_result", "call-evicted") not in surviving
+    assert ("tool_call", "call-live") in surviving
+    assert ("tool_result", "call-live") in surviving
+
+
+def test_rebuild_seam_drops_unpaired_tool_call(store: HistoryStore):
+    """A tool_call without results is dropped instead of reaching the API."""
+    mgr = make_manager(store)
+    agent = FakeAgent([user("live request")])
+    tail = [
+        user("live request"),
+        assistant_with_tool("call-live"),
+        _unpaired_tool_call("call-dangling"),
+    ]
+    mgr._rebuild_context(agent, tail)
+    ctx = agent.state.context
+
+    surviving = [
+        (kind, bid) for msg in ctx for kind, bid in _tool_block_ids(msg)
+    ]
+    assert ("tool_call", "call-dangling") not in surviving
+    assert ("tool_call", "call-live") in surviving
+    assert ("tool_result", "call-live") in surviving
+
+
+def test_rebuild_seam_keeps_placeholder_user_role(store: HistoryStore):
+    """The placeholder stays role=user.
+
+    Anthropic rejects mid-context system messages, and
+    ``_prepare_model_input()`` always prepends the system prompt, so a
+    system-role placeholder would 400 Anthropic on every compression.
+    """
+    mgr = make_manager(store)
+    agent = FakeAgent([user("live request")])
+    mgr._rebuild_context(agent, [user("live request")])
+    placeholder = agent.state.context[0]
+    assert placeholder.role == "user"
+    assert placeholder.name == "memory"
+    assert (
+        placeholder.metadata.get(QWENPAW_MESSAGE_TAG_KEY)
+        == SCROLL_MEMORY_MESSAGE_TAG
+    )
+
+
+async def test_rebuilt_context_wire_passes_tool_pairing(
+    store: HistoryStore,
+):
+    """Wire-level regression guard for issue #6541.
+
+    The rebuilt context, normalized and formatted for an OpenAI-compatible
+    provider (DeepSeek's family), must satisfy the strict tool-pairing rule
+    whose violation produced the reported 400: every role=tool message must
+    sit right after the assistant message whose tool_calls carry its id.
+    """
+    from agentscope.formatter import OpenAIChatFormatter
+
+    from qwenpaw.agents.utils.message_request_normalizer import (
+        normalize_messages_for_model_request,
+    )
+
+    mgr = make_manager(store)
+    tail = [
+        _standalone_tool_result("call-evicted"),  # hostile input
+        user("live request"),
+        assistant_with_tool("call-live"),
+    ]
+    agent = FakeAgent(list(tail))
+    mgr._rebuild_context(agent, tail)
+
+    normalized = normalize_messages_for_model_request(
+        agent.state.context,
+        supports_multimodal=True,
+        target_family="openai",
+    )
+    wire = await OpenAIChatFormatter().format(normalized)
+
+    for i, msg in enumerate(wire):
+        if msg.get("role") != "tool":
+            continue
+        tcid = msg.get("tool_call_id")
+        j = i - 1
+        while j >= 0 and wire[j].get("role") == "tool":
+            j -= 1
+        assert j >= 0, f"wire[{i}] tool message has no predecessor"
+        caller = wire[j]
+        assert (
+            caller.get("role") == "assistant"
+        ), f"wire[{i}] tool message preceded by {caller.get('role')}"
+        assert any(
+            tc.get("id") == tcid for tc in caller.get("tool_calls") or ()
+        ), f"wire[{i}] tool_call_id {tcid} missing from predecessor"


### PR DESCRIPTION
> **Submitted by**: 狄仁杰·Repairer@QPQAT

## Summary

Redone per review feedback (thanks @niceIrene). This PR no longer touches the placeholder role. It enforces the tool-message pairing invariant at Scroll's context-rebuild seam, so orphaned `role="tool"` messages — the actual cause of the DeepSeek/OpenAI-compatible 400 in #6541 — cannot survive a rebuild.

## Revised root cause analysis

The reported 400 — `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'` — is an **orphaned-tool-message failure**, not a placeholder-role failure:

- The compression placeholder carries no tool blocks, so its role cannot affect tool-call/tool-result pairing validation.
- Request-time normalization (`normalize_messages_for_model_request`) already collapses consecutive user messages, so the placeholder never even forms two adjacent user messages on the wire.
- The corrupted sessions in #6541 contain orphaned `tool_result` blocks whose `tool_call` was evicted (see workaround steps 3–4 in the issue report).

The previous commit on this branch (the `UserMsg` → `SystemMsg` swap) was rejected in review and has been removed: Anthropic rejects mid-context system messages, and `_prepare_model_input()` always prepends the system prompt, so a system-role placeholder would sit mid-list and 400 Anthropic on every compression. The placeholder keeps its deliberate `user` role (see the design note in `eviction_index.py`).

## Fix

`_rebuild_context()` now runs `_remove_unpaired_tool_messages()` over the tail before reassembling `[placeholder] + tail`. `compress()` already sanitizes the tail, but the rebuild seam is shared with `reconcile_loaded_context()` (and any future rebuild path); enforcing the invariant at the seam guarantees every context Scroll reassembles is free of orphaned tool messages — without touching the placeholder design.

## Tests

New in `tests/unit/agents/context/test_scroll_manager.py`:

- `test_rebuild_seam_drops_orphan_tool_result` — an evicted tool_call must not leave its result behind in the tail
- `test_rebuild_seam_drops_unpaired_tool_call` — a dangling tool_call is dropped instead of reaching the API
- `test_rebuild_seam_keeps_placeholder_user_role` — pins the deliberate user role (Anthropic guard)
- `test_rebuilt_context_wire_passes_tool_pairing` — wire-level guard: formatted through the OpenAI-compatible path, every `role=tool` wire message sits right after the assistant message whose `tool_calls` carry its id

## Verification

- 463 passed across `tests/unit/agents/context/`, `tests/unit/app/chats/test_utils.py`, `tests/unit/agents/test_command_handler_scroll.py`, `tests/unit/agents/test_react_agent_scroll_seen.py`
- `pre-commit` clean on changed files (check-ast, mypy, black, flake8, pylint)
- Wire-level probes over the real compress pipeline (self-paired turns, 1.x flat tool-message style, interrupted turns with pending calls, duplicate call ids) all produce pairing-valid wire after rebuild
- Live DeepSeek API end-to-end is not possible in this environment (no API key); the wire-level pairing assertions cover the exact failure mode instead
