### PR TITLE
Revert "fix(chats): handle dict-like model responses (#6813)"

### DIFF
--- a/src/qwenpaw/utils/model_response.py
+++ b/src/qwenpaw/utils/model_response.py
@@ -9,7 +9,6 @@ reply needs the same handling, so it lives here once.
 """
 from __future__ import annotations
 
-from collections.abc import AsyncIterable
 from typing import Any
 
 
@@ -71,7 +70,7 @@ async def consume_model_response(
     cumulative text — the last non-empty wins); others return one response.
     """
     response = await model(messages, **call_kwargs)
-    if not isinstance(response, AsyncIterable):
+    if not hasattr(response, "__aiter__"):
         return extract_response_text(response)
     text = ""
     async for chunk in response:

--- a/tests/unit/utils/test_model_response.py
+++ b/tests/unit/utils/test_model_response.py
@@ -4,7 +4,6 @@
 from types import SimpleNamespace
 
 import pytest
-from agentscope.model import ChatResponse
 
 from qwenpaw.utils.model_response import (
     consume_model_response,
@@ -56,16 +55,6 @@ def test_extract_response_text(response, expected):
 async def test_consume_non_streaming():
     async def model(messages, **kw):
         return SimpleNamespace(text="done")
-
-    assert await consume_model_response(model, []) == "done"
-
-
-async def test_consume_agentscope_chat_response():
-    async def model(messages, **kw):
-        return ChatResponse(
-            content=[{"type": "text", "text": "done"}],
-            is_last=True,
-        )
 
     assert await consume_model_response(model, []) == "done"
 


### PR DESCRIPTION
Reverts agentscope-ai/QwenPaw#6816.\n\nThe merge commit being reverted is `021f35f0d0bd9159943e0a639cfa3d943f65320e`, which was verified as the current tip of `main` before creating this revert.