### PR TITLE
fix(scroll): keep expand pagination snapshots stable

### DIFF
--- a/src/qwenpaw/agents/context/scroll/memoryspace.py
+++ b/src/qwenpaw/agents/context/scroll/memoryspace.py
@@ -457,6 +457,11 @@ class MemorySpace:
         ``seq`` is globally unique, but rows from concurrent conversations can
         interleave inside a range. The eviction index belongs to this
         MemorySpace's conversation, so retain its session and agent lineage.
+
+        The current active turn is deliberately excluded. Besides already
+        being present in the live context, its assistant row grows in place as
+        later tool calls are appended. Returning that mutable row on page one
+        would invalidate the result-bound cursor before page two can run.
         """
         where = ["seq BETWEEN ? AND ?"]
         params: list = [int(lo), int(hi)]
@@ -469,6 +474,10 @@ class MemorySpace:
             # until startup reconciliation can claim the canonical session.
             where.append("(agent_id = ? OR agent_id IS NULL)")
             params.append(self._agent_id)
+        active_exclusion = self._active_turn_exclusion()
+        if active_exclusion:
+            where.append(active_exclusion[0])
+            params.extend(active_exclusion[1])
         return self._select(
             "SELECT seq, kind, role, name, content, headline, blocks, "
             "metadata, created_at "

--- a/src/qwenpaw/agents/context/scroll/recall_tool.py
+++ b/src/qwenpaw/agents/context/scroll/recall_tool.py
@@ -272,8 +272,10 @@ scrolled out of context (seq spans come from the [context compressed] map)
 plus your earlier sessions. Pick an op:
 
   • op="expand", lo=180, hi=184 — turns in the seq span [lo, hi], oldest
-    first. Results are explicit pages that never silently truncate; pass the
-    returned cursor unchanged to continue.
+    first. The current in-progress turn is excluded because it is already in
+    the live context and is not a stable historical snapshot. Results are
+    explicit pages that never silently truncate; pass the returned cursor
+    unchanged to continue.
   • op="search", query="flight number", k=10 — full-text search over your
     whole history (across your past sessions). Whether the keyword matches a
     user, assistant, or tool-result row, each result includes that row's full

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -1495,6 +1495,40 @@ def test_expand_returns_full_turns_in_span(ms: MemorySpace):
     assert [r["content"] for r in rows] == ["tanks rolled in"]
 
 
+def test_expand_excludes_the_active_turn(tmp_path: Path):
+    """Mutable live rows must not enter a result-bound pagination snapshot."""
+    history = HistoryStore(tmp_path / "active-expand.db")
+    entries = [
+        ("old", "model_turn", "assistant", "stable historical row"),
+        ("cur-u", "context_msg", "user", "current request"),
+        ("cur-a", "model_turn", "assistant", "in-progress reply"),
+    ]
+    for key, kind, role, content in entries:
+        history.append(
+            session_id="s1",
+            agent_id="ag1",
+            dedup_key=key,
+            entry=LogEntry(
+                kind=kind,
+                role=role,
+                content=content,
+            ),
+        )
+    history.close()
+    space = MemorySpace(
+        history_db_path=str(tmp_path / "active-expand.db"),
+        session_id="s1",
+        agent_id="ag1",
+    )
+
+    try:
+        rows = space.expand(1, 3)
+    finally:
+        space.close()
+
+    assert [row["content"] for row in rows] == ["stable historical row"]
+
+
 def test_expand_includes_legacy_unowned_rows(history_db: Path):
     history = HistoryStore(history_db)
     legacy_seq = history.append(

--- a/tests/unit/agents/context/test_recall_tool.py
+++ b/tests/unit/agents/context/test_recall_tool.py
@@ -822,6 +822,89 @@ async def test_large_recall_is_cursor_paginated(
     assert "[recall page complete]" in _text(chunk)
 
 
+async def test_expand_cursor_survives_active_assistant_row_growth(
+    tmp_path: Path,
+):
+    """A continuation must not fingerprint the self-mutating live turn."""
+    db_path = tmp_path / "active-growth-history.db"
+    history = HistoryStore(db_path)
+    history.append(
+        session_id="s1",
+        agent_id="ag1",
+        dedup_key="old-large-row",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="stable historical payload\n" * 500,
+        ),
+    )
+    history.append(
+        session_id="s1",
+        agent_id="ag1",
+        dedup_key="current-user",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="current request",
+        ),
+    )
+    active_seq = history.append(
+        session_id="s1",
+        agent_id="ag1",
+        dedup_key="current-assistant",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            name="recall_history",
+            content="first recall call",
+            blocks=[{"type": "tool_call", "id": "call-1"}],
+        ),
+    )
+    bounded_tool = make_recall_history(
+        history_db_path=str(db_path),
+        session_id="s1",
+        agent_id="ag1",
+        page_max_bytes=1024,
+    )
+
+    first = await bounded_tool(op="expand", lo=1, hi=active_seq)
+    page = first.metadata[RECALL_PAGE_METADATA_KEY]
+    assert first.state == ToolResultState.SUCCESS
+    assert page["next_cursor"]
+    assert page["total_rows"] == 1
+
+    # AgentScope grows the same assistant Msg before the continuation executes.
+    history.update_entry(
+        active_seq,
+        content="first recall call\ncontinue recall",
+        headline=None,
+        blocks=[
+            {"type": "tool_call", "id": "call-1"},
+            {"type": "tool_call", "id": "call-2"},
+        ],
+        tool_call_id="call-2",
+        name="recall_history",
+        tool_state=None,
+        tool_input={"op": "expand", "lo": 1, "hi": active_seq},
+    )
+
+    pages = 1
+    while page["next_cursor"]:
+        chunk = await bounded_tool(
+            op="expand",
+            lo=1,
+            hi=active_seq,
+            cursor=page["next_cursor"],
+        )
+        pages += 1
+        assert chunk.state == ToolResultState.SUCCESS
+        page = chunk.metadata[RECALL_PAGE_METADATA_KEY]
+        assert pages < 100
+
+    history.close()
+    assert page["complete"] is True
+
+
 def test_render_page_with_long_utf8_label_always_advances():
     rows = [
         {


### PR DESCRIPTION
## Description

Fix Scroll `expand` pagination failing with `RecallSnapshotChangedError` when the requested sequence range includes the active assistant turn.

The active assistant row grows in place as subsequent tool calls are persisted. Because recall cursors are bound to a fingerprint of the full result set, that self-mutation invalidated the cursor before the next page could be read.

This change:

- excludes the current active turn from `MemorySpace.expand()`
- preserves result snapshot validation for genuinely changing historical data
- documents that active turns are already available in the live context
- adds regression coverage for pagination while the active assistant row grows

**Related Issue:** N/A

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] Commit-time pre-commit checks pass
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated
- [x] Ready for review

## Testing

```bash
pytest -q tests/unit/agents/context