### PR TITLE
fix(config): return HTTP 422 on invalid single-channel config (#6910)

### DIFF
--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -13,7 +13,7 @@ from fastapi import (
     Query,
     Request,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ...agents.acp.core import ACPAgentConfig, ACPConfig
 from ...agents.acp.node_runtime import (
@@ -495,7 +495,16 @@ async def put_channel(
 
     config_class = _channel_config_class(channel_name)
     if config_class is not None:
-        channel_config = config_class(**single_channel_config)
+        try:
+            channel_config = config_class(**single_channel_config)
+        except ValidationError as exc:
+            # An invalid single-channel payload must surface as a 422
+            # (client error) instead of leaking an unhandled exception
+            # as a 500 Internal Server Error.
+            raise HTTPException(
+                status_code=422,
+                detail=exc.errors(),
+            ) from exc
     else:
         # For custom channels, just use the dict
         channel_config = single_channel_config

--- a/tests/unit/app/routers/test_config_router.py
+++ b/tests/unit/app/routers/test_config_router.py
@@ -266,10 +266,9 @@ def test_put_onebot_channel_rejects_invalid_value(
 ):
     """An invalid value is refused instead of reaching the disk.
 
-    The rejection currently surfaces as a 500 because the model error
-    propagates; 422 is accepted too so that turning it into a proper
-    validation response stays a green change.  A 404 would mean the
-    route never ran, which must not pass for this guard.
+    The single-channel PUT must map a Pydantic validation failure to a
+    422 client error (not leak it as a 500), and must not persist the
+    malformed config.
     """
     lenient_client = TestClient(app, raise_server_exceptions=False)
 
@@ -279,7 +278,7 @@ def test_put_onebot_channel_rejects_invalid_value(
             json={"enabled": True, "ws_port": "not-a-port"},
         )
 
-    assert response.status_code in (422, 500)
+    assert response.status_code == 422, response.text
     save_mock.assert_not_called()
     assert isinstance(
         fake_agent_workspace.config.channels.onebot,


### PR DESCRIPTION
## What Problem This Solves

Fixes #6910

`PUT /api/config/channels/{channel_name}` with an invalid single-channel payload (e.g. `PUT /api/config/channels/onebot` with `{"enabled": true, "ws_port": "not-a-port"}`) currently surfaces as an **HTTP 500 Internal Server Error**. The `ValidationError` raised by Pydantic inside the handler propagates unhandled instead of being mapped to a client error, so an operator/Console input mistake looks like a server failure and hides the actual validation problem.

This PR wraps the per-channel model instantiation in `put_channel` (`src/qwenpaw/app/routers/config.py`) with a `try/except ValidationError` that re-raises as `HTTPException(status_code=422, detail=exc.errors())` — consistent with how the multi-channel `PUT /api/config/channels` endpoint already reports validation failures — and tightens `test_put_onebot_channel_rejects_invalid_value` to assert exactly `422`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran the relevant focused verification locally and it passes (see Evidence)
- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) — N/A
- [x] Ready for review

**Security Considerations:** None — this is a pure error-handling path in the shared config router; no auth, env, or channel-secret handling is touched.

## Evidence

Standalone proof of the exact code path in `put_channel()` (pydantic 2.13.4 + fastapi TestClient, no full QwenPaw import required):

```text
OK: pydantic raises ValidationError on malformed payload
HTTP status on bad payload: 422
HTTP status on valid payload: 200

ALL CHECKS PASSED: invalid single-channel payload now returns 422, valid still 200
```

Test change: `test_put_onebot_channel_rejects_invalid_value` now asserts `response.status_code == 422` (was `in (422, 500)`), and still asserts `save_mock.assert_not_called()` so a malformed config never reaches disk. The full QwenPaw suite requires a fully-provisioned environment (heavy dependency install) that this offline sandbox could not complete; the exact mechanism is verified in isolation above. To run once provisioned:

```bash
pytest tests/unit/app/routers/test_config_router.py -k put_onebot_channel_rejects_invalid_value
```

## Additional Notes

PR diff is minimal: `src/qwenpaw/app/routers/config.py` (+ValidationError import, try/except → 422) and `tests/unit/app/routers/test_config_router.py` (tightened assertion + docstring), 15 additions / 7 deletions across 2 files.
