### PR TITLE
fix(openrouter): limit app attribution categories

### DIFF
--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -36,7 +36,7 @@ class OpenRouterProvider(Provider):
         ),
     )
 
-    _OPENROUTER_CATEGORIES = "personal-agent,programming-app"
+    _OPENROUTER_CATEGORIES = "personal-agent,cli-agent"
 
     _DEFAULT_HEADERS = {
         "HTTP-Referer": "https://qwenpaw.agentscope.io/",

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -36,11 +36,7 @@ class OpenRouterProvider(Provider):
         ),
     )
 
-    _OPENROUTER_CATEGORIES = (
-        "cli-agent,cloud-agent,programming-app,"
-        "creative-writing,writing-assistant,"
-        "general-chat,personal-agent"
-    )
+    _OPENROUTER_CATEGORIES = "personal-agent,programming-app"
 
     _DEFAULT_HEADERS = {
         "HTTP-Referer": "https://qwenpaw.agentscope.io/",


### PR DESCRIPTION
## Summary

- limit `X-OpenRouter-Categories` to the documented maximum of two categories per request
- classify QwenPaw as `personal-agent` and `cli-agent`, consistent with Hermes Agent
- allow OpenRouter to associate QwenPaw with both the Productivity and Coding marketplace groups

## Context

OpenRouter currently reports an empty `categories` array for QwenPaw. The existing header sends seven categories in one request, while OpenRouter accepts at most two categories per request.

## Testing

Not run, per request; this change only updates the static attribution header value.