### PR TITLE
fix(providers): lower rate limiter init log level

### DIFF
--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -343,7 +343,7 @@ async def get_rate_limiter(
             jitter_range=resolved_jitter,
         )
         _limiters[limiter_key] = limiter
-        logger.info(
+        logger.debug(
             "LLM rate limiter initialized: key=%r max_concurrent=%d "
             "max_qpm=%d default_pause=%.1fs jitter=%.1fs",
             limiter_key,

--- a/tests/unit/providers/test_rate_limiter.py
+++ b/tests/unit/providers/test_rate_limiter.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
-import logging
 import time
 
 import pytest
@@ -144,21 +143,3 @@ async def test_get_rate_limiter_different_keys() -> None:
     limiter_a = await get_rate_limiter(limiter_key="provider_a:model")
     limiter_b = await get_rate_limiter(limiter_key="provider_b:model")
     assert limiter_a is not limiter_b
-
-
-async def test_get_rate_limiter_logs_initialization_at_debug(caplog) -> None:
-    from qwenpaw.providers.rate_limiter import get_rate_limiter
-
-    with caplog.at_level(
-        logging.DEBUG,
-        logger="qwenpaw.providers.rate_limiter",
-    ):
-        await get_rate_limiter(limiter_key="test:debug")
-
-    records = [
-        record
-        for record in caplog.records
-        if record.getMessage().startswith("LLM rate limiter initialized")
-    ]
-    assert len(records) == 1
-    assert records[0].levelno == logging.DEBUG

--- a/tests/unit/providers/test_rate_limiter.py
+++ b/tests/unit/providers/test_rate_limiter.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+import logging
 import time
 
 import pytest
@@ -143,3 +144,21 @@ async def test_get_rate_limiter_different_keys() -> None:
     limiter_a = await get_rate_limiter(limiter_key="provider_a:model")
     limiter_b = await get_rate_limiter(limiter_key="provider_b:model")
     assert limiter_a is not limiter_b
+
+
+async def test_get_rate_limiter_logs_initialization_at_debug(caplog) -> None:
+    from qwenpaw.providers.rate_limiter import get_rate_limiter
+
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="qwenpaw.providers.rate_limiter",
+    ):
+        await get_rate_limiter(limiter_key="test:debug")
+
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("LLM rate limiter initialized")
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG


### PR DESCRIPTION
## Description

Lower the one-time LLM rate limiter initialization message from INFO to DEBUG.

The message is routine diagnostic state rather than an operational event. Keeping it at INFO also exposes both `rate limiter` in the message and `rate_limiter.py` in pathname-based log formats, which can cause downstream text-based error classifiers to mistake unrelated agent failures for rate-limit failures.

This keeps the diagnostic available when DEBUG logging is enabled while removing it from normal production logs.

## Testing

- `pytest tests/unit/providers/test_rate_limiter.py -q`: 13 passed
- pre-commit on both changed files: all hooks passed

A regression test verifies that the initialization record is emitted at DEBUG.