### PR TITLE
fix(skill): Reduce file io for system files & skills files via file cache [READY TO MERGE]

### DIFF
--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from ...exceptions import SkillsError
+from ...utils.io_utils import write_text_atomic
 from ..utils.file_handling import read_text_file_with_encoding_fallback
 from .models import SkillInfo
 from .registry import (
@@ -581,9 +582,11 @@ class SkillPoolService:
                     encoding="utf-8",
                 )
                 scan_skill_dir_or_raise(staged_dir, skill_name)
-            (skill_dir / "SKILL.md").write_text(
+            write_text_atomic(
+                skill_dir / "SKILL.md",
                 content,
                 encoding="utf-8",
+                new_file_mode=0o644,
             )
 
         source = (

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -3,18 +3,24 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
 import os
 import re
+import stat
 import threading
+import weakref
+from collections import OrderedDict
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from ...exceptions import SkillsError
+from ...utils.file_snapshot_cache import FileSignature
 from ..utils.file_handling import read_text_file_with_encoding_fallback
 from .models import (
     BuiltinSkillIdentity,
@@ -57,6 +63,24 @@ _ENV_LOCK = threading.Lock()
 
 _builtin_cache: dict[str, Any] = {}
 _BUILTIN_CACHE_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _WorkspaceInventory:
+    manifest: FileSignature | None
+    skills: tuple[
+        tuple[str, FileSignature, FileSignature],
+        ...,
+    ]
+
+
+_MAX_WORKSPACE_INVENTORIES = 256
+_WORKSPACE_INVENTORIES: OrderedDict[str, _WorkspaceInventory] = OrderedDict()
+_WORKSPACE_INVENTORY_LOCKS: weakref.WeakValueDictionary[
+    str,
+    threading.Lock,
+] = weakref.WeakValueDictionary()
+_WORKSPACE_INVENTORY_GUARD = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -1074,7 +1098,11 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
     if not manifest_path.exists():
         write_json_atomic(manifest_path, default_workspace_manifest())
 
-    def _update(payload: dict[str, Any]) -> dict[str, Any]:
+    reconciled: dict[str, Any] | None = None
+
+    def _update(payload: dict[str, Any]) -> dict[str, Any] | bool:
+        nonlocal reconciled
+        original = copy.deepcopy(payload)
         payload.setdefault("skills", {})
         skills = payload["skills"]
 
@@ -1149,13 +1177,19 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
             if skill_name not in discovered:
                 skills.pop(skill_name, None)
 
-        return payload
+        reconciled = payload
+        return payload if payload != original else False
 
-    return mutate_json(
+    result = mutate_json(
         manifest_path,
         default_workspace_manifest(),
         _update,
     )
+    assert reconciled is not None
+    if result is False:
+        return reconciled
+    assert isinstance(result, dict)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1216,9 +1250,76 @@ def resolve_effective_skills(
     return resolved
 
 
+def _path_signature(path: Path) -> FileSignature | None:
+    try:
+        return FileSignature.from_stat(path.stat())
+    except OSError:
+        return None
+
+
+def _workspace_skill_inventory(workspace_dir: Path) -> _WorkspaceInventory:
+    """Return a metadata-only fingerprint of runtime Skill inputs."""
+    manifest = get_workspace_skill_manifest_path(workspace_dir)
+    skill_root = get_workspace_skills_dir(workspace_dir)
+    skills: list[tuple[str, FileSignature, FileSignature]] = []
+    try:
+        children = sorted(skill_root.iterdir(), key=lambda item: item.name)
+    except OSError:
+        children = []
+    for child in children:
+        if is_ignored_skill_entry(child.name):
+            continue
+        try:
+            child_stat = child.stat()
+        except OSError:
+            continue
+        if not stat.S_ISDIR(child_stat.st_mode):
+            continue
+        child_signature = FileSignature.from_stat(child_stat)
+        skill_md = child / "SKILL.md"
+        signature = _path_signature(skill_md)
+        if signature is not None:
+            skills.append((child.name, child_signature, signature))
+    return _WorkspaceInventory(_path_signature(manifest), tuple(skills))
+
+
+def _cached_workspace_inventory(key: str) -> _WorkspaceInventory | None:
+    with _WORKSPACE_INVENTORY_GUARD:
+        inventory = _WORKSPACE_INVENTORIES.get(key)
+        if inventory is not None:
+            _WORKSPACE_INVENTORIES.move_to_end(key)
+        return inventory
+
+
+def _remember_workspace_inventory(
+    key: str,
+    inventory: _WorkspaceInventory,
+) -> None:
+    with _WORKSPACE_INVENTORY_GUARD:
+        _WORKSPACE_INVENTORIES[key] = inventory
+        _WORKSPACE_INVENTORIES.move_to_end(key)
+        while len(_WORKSPACE_INVENTORIES) > _MAX_WORKSPACE_INVENTORIES:
+            _WORKSPACE_INVENTORIES.popitem(last=False)
+
+
 def ensure_skills_initialized(workspace_dir: Path) -> None:
-    """Ensure workspace manifests exist before runtime use."""
-    reconcile_workspace_manifest(workspace_dir)
+    """Reconcile only when the manifest or on-disk Skill inventory changed."""
+    workspace_dir = Path(workspace_dir).expanduser().resolve(strict=False)
+    key = os.path.normcase(str(workspace_dir))
+    with _WORKSPACE_INVENTORY_GUARD:
+        lock = _WORKSPACE_INVENTORY_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _WORKSPACE_INVENTORY_LOCKS[key] = lock
+    with lock:
+        current = _workspace_skill_inventory(workspace_dir)
+        if _cached_workspace_inventory(key) == current:
+            return
+        reconcile_workspace_manifest(workspace_dir)
+        reconciled = _workspace_skill_inventory(workspace_dir)
+        # A concurrent Skill edit may make the just-written manifest stale.
+        if reconciled.skills == current.skills:
+            _remember_workspace_inventory(key, reconciled)
 
 
 # ---------------------------------------------------------------------------

--- a/src/qwenpaw/agents/skill_system/runtime_cache.py
+++ b/src/qwenpaw/agents/skill_system/runtime_cache.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""Runtime cache for parsed AgentScope skills."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import frontmatter
+from agentscope.skill import Skill
+
+from ...utils.file_snapshot_cache import FileSignature, get_file_snapshot_cache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _SkillRecord:
+    name: str
+    description: str
+    markdown: str
+    updated_at: float
+
+    def to_agentscope(self, directory: Path) -> Skill:
+        return Skill(
+            name=self.name,
+            description=self.description,
+            dir=os.path.abspath(os.fspath(directory)),
+            markdown=self.markdown,
+            updated_at=self.updated_at,
+        )
+
+
+@dataclass(frozen=True)
+class _ParsedEntry:
+    signature: FileSignature
+    record: _SkillRecord | None
+    byte_size: int
+
+
+class RuntimeSkillCache:
+    """Cache frontmatter and body parsed from runtime ``SKILL.md`` files."""
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = 256,
+        max_bytes: int = 32 * 1024 * 1024,
+    ) -> None:
+        if max_entries <= 0 or max_bytes <= 0:
+            raise ValueError("cache limits must be positive")
+        self.max_entries = max_entries
+        self.max_bytes = max_bytes
+        self._entries: OrderedDict[str, _ParsedEntry] = OrderedDict()
+        self._bytes = 0
+        self._lock = threading.RLock()
+
+    def _parse(self, skill_dir: Path) -> _SkillRecord | None:
+        skill_md = skill_dir / "SKILL.md"
+        cache = get_file_snapshot_cache()
+        snapshot = cache.get_bytes(skill_md)
+        key = os.path.normcase(os.fspath(snapshot.path))
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and entry.signature == snapshot.signature:
+                self._entries.move_to_end(key)
+                return entry.record
+
+            try:
+                # Keep AgentScope LocalSkillLoader's strict UTF-8 contract.
+                content = snapshot.data.decode("utf-8")
+                content = content.replace("\r\n", "\n").replace("\r", "\n")
+                post = frontmatter.loads(content)
+                name = post.get("name")
+                description = post.get("description")
+                if not name or not description:
+                    logger.warning(
+                        "SKILL.md in %s is missing required fields "
+                        "(name or description). Skipping.",
+                        skill_dir,
+                    )
+                    record = None
+                else:
+                    record = _SkillRecord(
+                        name=str(name),
+                        description=str(description),
+                        markdown=post.content,
+                        updated_at=snapshot.signature.mtime_ns / 1_000_000_000,
+                    )
+            except Exception as exc:  # match upstream graceful behavior
+                logger.warning(
+                    "Failed to load skill from %s: %s",
+                    skill_dir,
+                    exc,
+                )
+                record = None
+
+            previous = self._entries.pop(key, None)
+            if previous is not None:
+                self._bytes -= previous.byte_size
+            parsed = _ParsedEntry(
+                signature=snapshot.signature,
+                record=record,
+                byte_size=snapshot.byte_size,
+            )
+            if parsed.byte_size <= self.max_bytes:
+                self._entries[key] = parsed
+                self._bytes += parsed.byte_size
+                while (
+                    len(self._entries) > self.max_entries
+                    or self._bytes > self.max_bytes
+                ):
+                    _, evicted = self._entries.popitem(last=False)
+                    self._bytes -= evicted.byte_size
+            return record
+
+    def load(self, skill_dirs: Iterable[str | Path]) -> list[Skill]:
+        """Return fresh AgentScope values backed by cached parsed records."""
+        skills: list[Skill] = []
+        for raw_dir in skill_dirs:
+            skill_dir = Path(raw_dir)
+            try:
+                record = self._parse(skill_dir)
+            except Exception as exc:  # match AgentScope's per-Skill isolation
+                logger.warning(
+                    "Failed to load skill from %s: %s",
+                    skill_dir,
+                    exc,
+                )
+                continue
+            if record is not None:
+                skills.append(record.to_agentscope(skill_dir))
+        return skills
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._bytes = 0
+
+
+_RUNTIME_SKILL_CACHE = RuntimeSkillCache()
+
+
+def load_runtime_skills(skill_dirs: Iterable[str | Path]) -> list[Skill]:
+    return _RUNTIME_SKILL_CACHE.load(skill_dirs)
+
+
+__all__ = [
+    "RuntimeSkillCache",
+    "load_runtime_skills",
+]

--- a/src/qwenpaw/agents/skill_system/runtime_cache.py
+++ b/src/qwenpaw/agents/skill_system/runtime_cache.py
@@ -67,7 +67,11 @@ class RuntimeSkillCache:
         key = os.path.normcase(os.fspath(snapshot.path))
         with self._lock:
             entry = self._entries.get(key)
-            if entry is not None and entry.signature == snapshot.signature:
+            if (
+                snapshot.stable
+                and entry is not None
+                and entry.signature == snapshot.signature
+            ):
                 self._entries.move_to_end(key)
                 return entry.record
 
@@ -99,6 +103,11 @@ class RuntimeSkillCache:
                     exc,
                 )
                 record = None
+
+            # An unstable snapshot is safe for this call, but its signature
+            # may describe different bytes. Do not reuse its parsed result.
+            if not snapshot.stable:
+                return record
 
             previous = self._entries.pop(key, None)
             if previous is not None:

--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -7,7 +7,6 @@ import hashlib
 import io
 import json
 import logging
-import os
 import re
 import shutil
 import tempfile
@@ -16,7 +15,6 @@ import zipfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -906,26 +904,18 @@ def build_import_conflict(
 # ---------------------------------------------------------------------------
 
 
-@lru_cache(maxsize=256)
-def _read_file_text_cached(  # pylint: disable=unused-argument
-    path_str: str,
-    mtime_ns: int,
-) -> str:
-    """Return file text cached by *path + mtime*."""
-    return Path(path_str).read_text(encoding="utf-8")
-
-
-def _read_json_mtime_cached(
+def _read_json_snapshot_cached(
     path: Path,
     default: dict[str, Any],
 ) -> dict[str, Any]:
-    """``_read_json_unlocked`` variant with mtime cache."""
+    """Read JSON from the shared strong-signature file snapshot cache."""
     if not path.exists():
         return json.loads(json.dumps(default))
     try:
-        mtime_ns = os.stat(path).st_mtime_ns
-        text = _read_file_text_cached(str(path), mtime_ns)
-        return json.loads(text)
+        from ...utils.file_snapshot_cache import get_file_snapshot_cache
+
+        snapshot = get_file_snapshot_cache().get_bytes(path)
+        return json.loads(snapshot.data.decode("utf-8"))
     except json.JSONDecodeError:
         logger.warning("Malformed JSON in %s, resetting to default", path)
         return json.loads(json.dumps(default))
@@ -936,15 +926,15 @@ def _read_json_mtime_cached(
 def read_skill_manifest(
     workspace_dir: Path,
 ) -> dict[str, Any]:
-    """Return the workspace skill manifest, cached by file mtime."""
+    """Return the workspace skill manifest from a cached file snapshot."""
     path = get_workspace_skill_manifest_path(workspace_dir)
-    return _read_json_mtime_cached(path, default_workspace_manifest())
+    return _read_json_snapshot_cached(path, default_workspace_manifest())
 
 
 def read_skill_pool_manifest() -> dict[str, Any]:
-    """Return the pool skill manifest, cached by file mtime."""
+    """Return the pool skill manifest from a cached file snapshot."""
     path = get_pool_skill_manifest_path()
-    return _read_json_mtime_cached(path, default_pool_manifest())
+    return _read_json_snapshot_cached(path, default_pool_manifest())
 
 
 # ---------------------------------------------------------------------------

--- a/src/qwenpaw/agents/skill_system/workspace_service.py
+++ b/src/qwenpaw/agents/skill_system/workspace_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from ...exceptions import SkillsError
+from ...utils.io_utils import write_text_atomic
 from ..utils.file_handling import read_text_file_with_encoding_fallback
 from .models import SkillInfo
 from .registry import (
@@ -322,9 +323,11 @@ class SkillService:
                     encoding="utf-8",
                 )
                 scan_skill_dir_or_raise(staged_dir, skill_name)
-            (skill_dir / "SKILL.md").write_text(
+            write_text_atomic(
+                skill_dir / "SKILL.md",
                 content,
                 encoding="utf-8",
+                new_file_mode=0o644,
             )
         source = (
             "customized"

--- a/src/qwenpaw/agents/utils/file_handling.py
+++ b/src/qwenpaw/agents/utils/file_handling.py
@@ -39,6 +39,43 @@ def single_line_log_value(value: object) -> str:
     return str(value).replace("\r", "\\r").replace("\n", "\\n")
 
 
+def decode_text_bytes_with_encoding_fallback(
+    data: bytes,
+    *,
+    file_name: object = "<bytes>",
+) -> str:
+    """Decode bytes with the historical fallback and newline behavior."""
+    encodings_to_try = [
+        "utf-8-sig",
+        "utf-8",
+        "gbk",
+        "cp936",
+        "cp1252",
+        "latin-1",
+    ]
+    for encoding in encodings_to_try:
+        try:
+            content = data.decode(encoding)
+            if encoding not in ("utf-8", "utf-8-sig"):
+                logger.debug(
+                    "File %s read with encoding: %s",
+                    single_line_log_value(file_name),
+                    encoding,
+                )
+            return content.replace("\r\n", "\n").replace("\r", "\n")
+        except (UnicodeDecodeError, LookupError):
+            continue
+
+    # latin-1 can decode every byte sequence, so this is defensive only.
+    content = data.decode("utf-8", errors="replace")
+    logger.warning(
+        "File %s read with UTF-8 errors='replace' fallback, "
+        "some characters may be corrupted",
+        single_line_log_value(file_name),
+    )
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def read_text_file_with_encoding_fallback(file_path: Path | str) -> str:
     """Read text file with multiple encoding attempts for cross-platform
     compatibility.
@@ -69,48 +106,10 @@ def read_text_file_with_encoding_fallback(file_path: Path | str) -> str:
     if not file_path.exists():
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    encodings_to_try = [
-        "utf-8-sig",  # UTF-8 with BOM - try first
-        "utf-8",
-        "gbk",  # Windows Chinese default
-        "cp936",  # Alias for GBK
-        "cp1252",  # Windows Western default
-        "latin-1",  # Fallback for Western text
-    ]
-
-    for encoding in encodings_to_try:
-        try:
-            with open(file_path, "r", encoding=encoding) as f:
-                content = f.read()
-                if encoding not in ("utf-8", "utf-8-sig"):
-                    logger.debug(
-                        "File %s read with encoding: %s",
-                        single_line_log_value(file_path.name),
-                        encoding,
-                    )
-                return content
-        except (UnicodeDecodeError, LookupError):
-            continue
-
-    # Final fallback: UTF-8 with error replacement
-    try:
-        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
-            content = f.read()
-            logger.warning(
-                "File %s read with UTF-8 errors='replace' fallback, "
-                "some characters may be corrupted",
-                single_line_log_value(file_path.name),
-            )
-            return content
-    except Exception as e:
-        logger.error(
-            "File %s cannot be read even with fallback: %s",
-            single_line_log_value(file_path.name),
-            single_line_log_value(e),
-        )
-        raise IOError(
-            f"File {file_path.name} cannot be read even with fallback: {e}",
-        ) from e
+    return decode_text_bytes_with_encoding_fallback(
+        file_path.read_bytes(),
+        file_name=file_path.name,
+    )
 
 
 def _default_download_dir() -> str:

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -151,7 +151,10 @@ class AgentBuilder:
             if extra not in skill_dirs:
                 skill_dirs.append(extra)
 
-        return Toolkit(tools=tools, skills_or_loaders=skill_dirs)
+        from ..agents.skill_system.runtime_cache import load_runtime_skills
+
+        skills = await run_sync_io(load_runtime_skills, skill_dirs)
+        return Toolkit(tools=tools, skills_or_loaders=skills)
 
     @staticmethod
     def _tool_name(tool: Any) -> str:

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -143,17 +143,12 @@ class AgentBuilder:
         # Final pass: cover workspace + extras + memory in one filter.
         tools = self.apply_subagent_tool_whitelist(tools, request_context)
 
-        skill_dirs = self._resolve_skill_loader_dirs(
+        skills = await run_sync_io(
+            self._load_runtime_skills,
             effective_skills,
             workspace_dir,
+            tools,
         )
-        for extra in _bound_skill_loader_dirs(tools):
-            if extra not in skill_dirs:
-                skill_dirs.append(extra)
-
-        from ..agents.skill_system.runtime_cache import load_runtime_skills
-
-        skills = await run_sync_io(load_runtime_skills, skill_dirs)
         return Toolkit(tools=tools, skills_or_loaders=skills)
 
     @staticmethod
@@ -226,6 +221,25 @@ class AgentBuilder:
                     skill_dir,
                 )
         return dirs
+
+    @classmethod
+    def _load_runtime_skills(
+        cls,
+        effective_skills: Iterable[str] | None,
+        workspace_dir: str | None,
+        tools: Iterable[Any],
+    ) -> list[Any]:
+        """Resolve and load runtime Skills in one synchronous I/O job."""
+        from ..agents.skill_system.runtime_cache import load_runtime_skills
+
+        skill_dirs = cls._resolve_skill_loader_dirs(
+            effective_skills,
+            workspace_dir,
+        )
+        for extra in _bound_skill_loader_dirs(tools):
+            if extra not in skill_dirs:
+                skill_dirs.append(extra)
+        return load_runtime_skills(skill_dirs)
 
     # ----------------------------------------------------------------- build
 

--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -67,10 +67,15 @@ def _read_prompt_file(workspace_dir: Path, filename: str) -> str | None:
             return None
 
         from ..agents.utils.file_handling import (
-            read_text_file_with_encoding_fallback,
+            decode_text_bytes_with_encoding_fallback,
         )
+        from ..utils.file_snapshot_cache import get_file_snapshot_cache
 
-        content = read_text_file_with_encoding_fallback(path).strip()
+        snapshot = get_file_snapshot_cache().get_bytes(path)
+        content = decode_text_bytes_with_encoding_fallback(
+            snapshot.data,
+            file_name=path.name,
+        ).strip()
         if content.startswith("---"):
             parts = content.split("---", 2)
             if len(parts) >= 3:

--- a/src/qwenpaw/utils/file_snapshot_cache.py
+++ b/src/qwenpaw/utils/file_snapshot_cache.py
@@ -38,6 +38,7 @@ class FileSnapshot:
     path: Path
     signature: FileSignature
     data: bytes
+    stable: bool = True
 
     @property
     def byte_size(self) -> int:
@@ -142,8 +143,14 @@ class FileSnapshotCache:
             before = self._signature(path)
             data = path.read_bytes()
             after = self._signature(path)
-            last = FileSnapshot(path=path, signature=after, data=data)
-            if before == after and len(data) == after.size:
+            stable = before == after and len(data) == after.size
+            last = FileSnapshot(
+                path=path,
+                signature=after,
+                data=data,
+                stable=stable,
+            )
+            if stable:
                 return last, True
             if attempt == 0:
                 with self._lock:

--- a/src/qwenpaw/utils/file_snapshot_cache.py
+++ b/src/qwenpaw/utils/file_snapshot_cache.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+"""Bounded process-local cache for immutable file byte snapshots."""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class FileSignature:
+    """Metadata used to cheaply detect ordinary file changes."""
+
+    mtime_ns: int
+    ctime_ns: int
+    size: int
+    device: int
+    inode: int
+
+    @classmethod
+    def from_stat(cls, value: os.stat_result) -> "FileSignature":
+        return cls(
+            mtime_ns=value.st_mtime_ns,
+            ctime_ns=value.st_ctime_ns,
+            size=value.st_size,
+            device=getattr(value, "st_dev", 0) or 0,
+            inode=getattr(value, "st_ino", 0) or 0,
+        )
+
+
+@dataclass(frozen=True)
+class FileSnapshot:
+    """One immutable view of a file."""
+
+    path: Path
+    signature: FileSignature
+    data: bytes
+
+    @property
+    def byte_size(self) -> int:
+        return len(self.data)
+
+
+@dataclass(frozen=True)
+class FileSnapshotCacheStats:
+    hits: int
+    misses: int
+    reloads: int
+    evictions: int
+    load_errors: int
+    unstable_read_retries: int
+    singleflight_waits: int
+    entries: int
+    bytes: int
+
+
+@dataclass
+class _Flight:
+    lock: threading.Lock
+    users: int = 0
+
+
+class FileSnapshotCache:
+    """Thread-safe LRU cache which validates entries with ``stat``."""
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = 512,
+        max_bytes: int = 64 * 1024 * 1024,
+    ) -> None:
+        if max_entries <= 0 or max_bytes <= 0:
+            raise ValueError("cache limits must be positive")
+        self.max_entries = max_entries
+        self.max_bytes = max_bytes
+        self._entries: OrderedDict[str, FileSnapshot] = OrderedDict()
+        self._flights: dict[str, _Flight] = {}
+        self._lock = threading.RLock()
+        self._total_bytes = 0
+        self._hits = 0
+        self._misses = 0
+        self._reloads = 0
+        self._evictions = 0
+        self._load_errors = 0
+        self._unstable_read_retries = 0
+        self._singleflight_waits = 0
+        self._publication_epoch = 0
+
+    @staticmethod
+    def normalize(path: Path | str) -> tuple[str, Path]:
+        resolved = Path(path).expanduser().resolve(strict=False)
+        return os.path.normcase(os.fspath(resolved)), resolved
+
+    @staticmethod
+    def _signature(path: Path) -> FileSignature:
+        return FileSignature.from_stat(path.stat())
+
+    def _cached(
+        self,
+        key: str,
+        signature: FileSignature,
+    ) -> FileSnapshot | None:
+        with self._lock:
+            snapshot = self._entries.get(key)
+            if snapshot is None or snapshot.signature != signature:
+                return None
+            self._entries.move_to_end(key)
+            self._hits += 1
+            return snapshot
+
+    def _remove_locked(self, key: str) -> FileSnapshot | None:
+        snapshot = self._entries.pop(key, None)
+        if snapshot is not None:
+            self._total_bytes -= snapshot.byte_size
+        return snapshot
+
+    def _acquire_flight(self, key: str) -> _Flight:
+        with self._lock:
+            flight = self._flights.get(key)
+            if flight is None:
+                flight = _Flight(threading.Lock())
+                self._flights[key] = flight
+            elif flight.users:
+                self._singleflight_waits += 1
+            flight.users += 1
+        flight.lock.acquire()
+        return flight
+
+    def _release_flight(self, key: str, flight: _Flight) -> None:
+        flight.lock.release()
+        with self._lock:
+            flight.users -= 1
+            if flight.users == 0 and self._flights.get(key) is flight:
+                self._flights.pop(key, None)
+
+    def _load_stable(self, path: Path) -> tuple[FileSnapshot, bool]:
+        last: FileSnapshot | None = None
+        for attempt in range(2):
+            before = self._signature(path)
+            data = path.read_bytes()
+            after = self._signature(path)
+            last = FileSnapshot(path=path, signature=after, data=data)
+            if before == after and len(data) == after.size:
+                return last, True
+            if attempt == 0:
+                with self._lock:
+                    self._unstable_read_retries += 1
+        # A continuously-changing file is safe to return to this caller, but
+        # must not become a reusable cache entry.
+        assert last is not None
+        return last, False
+
+    def _publish(
+        self,
+        key: str,
+        snapshot: FileSnapshot,
+        publication_epoch: int,
+    ) -> None:
+        with self._lock:
+            if publication_epoch != self._publication_epoch:
+                return
+            self._remove_locked(key)
+            if snapshot.byte_size > self.max_bytes:
+                return
+            self._entries[key] = snapshot
+            self._total_bytes += snapshot.byte_size
+            while (
+                len(self._entries) > self.max_entries
+                or self._total_bytes > self.max_bytes
+            ):
+                old_key = next(iter(self._entries))
+                self._remove_locked(old_key)
+                self._evictions += 1
+
+    def get_bytes(self, path: Path | str) -> FileSnapshot:
+        """Return a current snapshot, coalescing concurrent cold reads."""
+        key, resolved = self.normalize(path)
+        try:
+            signature = self._signature(resolved)
+        except OSError:
+            with self._lock:
+                self._remove_locked(key)
+                self._load_errors += 1
+            raise
+
+        cached = self._cached(key, signature)
+        if cached is not None:
+            return cached
+
+        with self._lock:
+            previous = self._entries.get(key)
+            self._remove_locked(key)
+            self._misses += 1
+            publication_epoch = self._publication_epoch
+        flight = self._acquire_flight(key)
+        try:
+            # Another caller may have populated the entry while we waited.
+            signature = self._signature(resolved)
+            cached = self._cached(key, signature)
+            if cached is not None:
+                return cached
+            snapshot, stable = self._load_stable(resolved)
+            # Only publish a stable snapshot. Re-checking its signature also
+            # prevents a change immediately after the second stat.
+            if stable and self._signature(resolved) == snapshot.signature:
+                self._publish(key, snapshot, publication_epoch)
+            with self._lock:
+                if previous is not None:
+                    self._reloads += 1
+            return snapshot
+        except OSError:
+            with self._lock:
+                self._remove_locked(key)
+                self._load_errors += 1
+            raise
+        finally:
+            self._release_flight(key, flight)
+
+    def invalidate(self, path: Path | str) -> bool:
+        key, _ = self.normalize(path)
+        with self._lock:
+            self._publication_epoch += 1
+            return self._remove_locked(key) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._publication_epoch += 1
+            self._entries.clear()
+            self._total_bytes = 0
+
+    def stats(self) -> FileSnapshotCacheStats:
+        with self._lock:
+            return FileSnapshotCacheStats(
+                hits=self._hits,
+                misses=self._misses,
+                reloads=self._reloads,
+                evictions=self._evictions,
+                load_errors=self._load_errors,
+                unstable_read_retries=self._unstable_read_retries,
+                singleflight_waits=self._singleflight_waits,
+                entries=len(self._entries),
+                bytes=self._total_bytes,
+            )
+
+
+_PROCESS_CACHE = FileSnapshotCache()
+
+
+def get_file_snapshot_cache() -> FileSnapshotCache:
+    """Return the process-wide snapshot cache."""
+    return _PROCESS_CACHE
+
+
+__all__ = [
+    "FileSignature",
+    "FileSnapshot",
+    "FileSnapshotCache",
+    "FileSnapshotCacheStats",
+    "get_file_snapshot_cache",
+]


### PR DESCRIPTION
## Description

Adds a process-level cache for stable Markdown files used by system prompts and runtime Skills.

This reduces repeated file reads and Skill frontmatter parsing across queries while preserving file-change detection. It also avoids unnecessary Skill manifest reconciliation and uses atomic writes for in-place SKILL.md updates.

The cache is bounded, thread-safe, and shared across channels. Dynamic prompt content is still rebuilt for every query.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review