### PR TITLE
fix(plugins): restore workspace state before reload swap

### DIFF
--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -193,29 +193,12 @@ class MultiAgentManager:
             event.set()
 
     @staticmethod
-    async def _fire_workspace_created_hooks(workspace_info: dict) -> None:
-        """Invoke all registered workspace_created hooks.
-
-        Supports both sync and async callbacks:
-        - Async callbacks are awaited directly.
-        - Sync callbacks are offloaded to a thread via
-          ``asyncio.to_thread`` so they never block the event loop.
-
-        Errors in individual hooks are logged but do not prevent
-        subsequent hooks from running.
-
-        Args:
-            workspace_info: Dict with at least ``agent_id`` and
-                ``workspace_dir`` keys.
-        """
-        try:
-            from ..plugins.registry import PluginRegistry
-
-            hooks = PluginRegistry().get_workspace_created_hooks()
-        except Exception:
-            # Plugin system not initialised yet — nothing to do.
-            return
-
+    async def _run_workspace_hooks(
+        hooks: list,
+        workspace_info: dict,
+        hook_type: str,
+    ) -> None:
+        """Run sync or async workspace hooks with error isolation."""
         for hook in hooks:
             try:
                 callback = hook.callback
@@ -230,11 +213,53 @@ class MultiAgentManager:
                         await result
             except Exception as exc:
                 logger.error(
-                    f"Error in workspace_created hook "
+                    f"Error in {hook_type} hook "
                     f"'{hook.hook_name}' for plugin "
                     f"'{hook.plugin_id}': {exc}",
                     exc_info=True,
                 )
+
+    @classmethod
+    async def _fire_workspace_created_hooks(cls, workspace_info: dict) -> None:
+        """Invoke hooks registered for newly created workspaces."""
+        try:
+            from ..plugins.registry import PluginRegistry
+
+            hooks = PluginRegistry().get_workspace_created_hooks()
+        except Exception:
+            # Plugin system not initialised yet — nothing to do.
+            return
+
+        await cls._run_workspace_hooks(
+            hooks,
+            workspace_info,
+            "workspace_created",
+        )
+
+    @classmethod
+    async def _setup_workspace_plugins(
+        cls,
+        workspace: Workspace,
+        workspace_dir: str,
+    ) -> None:
+        """Install plugin-contributed in-memory state into a workspace."""
+        try:
+            from ..plugins.registry import PluginRegistry
+
+            hooks = PluginRegistry().get_workspace_setup_hooks()
+        except Exception:
+            return
+
+        workspace_info = {
+            "agent_id": workspace.agent_id,
+            "workspace_dir": workspace_dir,
+            "workspace": workspace,
+        }
+        await cls._run_workspace_hooks(
+            hooks,
+            workspace_info,
+            "workspace setup",
+        )
 
     async def _graceful_stop_old_instance(
         self,
@@ -498,6 +523,10 @@ class MultiAgentManager:
         try:
             await new_instance.start()
             new_instance.set_manager(self)  # Set manager reference
+            await self._setup_workspace_plugins(
+                new_instance,
+                str(agent_ref.workspace_dir),
+            )
             logger.info(f"New workspace instance started: {agent_id}")
         except Exception as e:
             logger.exception(

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -502,6 +502,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         hook_name: str,
         callback: Callable,
         priority: int = 100,
+        reload_safe: bool = False,
     ):
         """Register a hook that fires when a new workspace is created.
 
@@ -513,6 +514,10 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             callback: Sync or async function to call on workspace creation.
                 Signature: ``(workspace_info: dict) -> None``
             priority: Execution priority (lower = earlier, default=100)
+            reload_safe: Also use this callback to restore in-memory state
+                before publishing a reloaded workspace. Reload-safe callbacks
+                must not perform workspace filesystem provisioning. During
+                reload, ``workspace_info`` also contains ``workspace``.
 
         Example:
             >>> api.register_workspace_created_hook(
@@ -526,6 +531,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
                 hook_name=hook_name,
                 callback=callback,
                 priority=priority,
+                reload_safe=reload_safe,
             )
             logger.info(
                 f"Plugin '{self.plugin_id}' registered "
@@ -949,6 +955,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             hook_name=(f"slash_cmd_ws_{self.plugin_id}_{name}"),
             callback=_on_workspace_created,
             priority=60,
+            reload_safe=True,
         )
         logger.info(
             f"Plugin '{self.plugin_id}' scheduled slash command "
@@ -991,6 +998,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             hook_name=(f"mode_ws_{self.plugin_id}_{mode_name}"),
             callback=_on_workspace_created,
             priority=70,
+            reload_safe=True,
         )
         logger.info(
             f"Plugin '{self.plugin_id}' scheduled mode "
@@ -1030,6 +1038,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             hook_name=(f"rt_hook_ws_{self.plugin_id}_{hook.name}"),
             callback=_on_workspace_created,
             priority=65,
+            reload_safe=True,
         )
         logger.info(
             f"Plugin '{self.plugin_id}' scheduled runtime hook "
@@ -1083,6 +1092,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             hook_name=(f"stop_ws_{self.plugin_id}_{reg.name}"),
             callback=_on_workspace_created,
             priority=55,
+            reload_safe=True,
         )
         logger.info(
             f"Plugin '{self.plugin_id}' scheduled stop handler "
@@ -1174,6 +1184,9 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         workspace_info: dict,
     ):
         """Get workspace instance from workspace_info dict."""
+        workspace = workspace_info.get("workspace")
+        if workspace is not None:
+            return workspace
         try:
             from .registry import PluginRegistry
 

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -72,6 +72,7 @@ class HookRegistration:
     hook_name: str
     callback: Callable
     priority: int = 100
+    reload_safe: bool = False
 
 
 @dataclass
@@ -593,6 +594,7 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         hook_name: str,
         callback: Callable,
         priority: int = 100,
+        reload_safe: bool = False,
     ):
         """Register a hook that fires when a new workspace is created.
 
@@ -605,12 +607,16 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
             callback: Sync or async callback function.
                 Signature: ``(workspace_info: dict) -> None``
             priority: Priority (lower = earlier execution)
+            reload_safe: Whether the callback only restores in-memory state
+                and may run for a replacement workspace during reload. Such
+                callbacks must not perform workspace filesystem provisioning.
         """
         hook = HookRegistration(
             plugin_id=plugin_id,
             hook_name=hook_name,
             callback=callback,
             priority=priority,
+            reload_safe=reload_safe,
         )
         self._workspace_created_hooks.append(hook)
         self._workspace_created_hooks.sort(key=lambda h: h.priority)
@@ -626,6 +632,12 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
             List of HookRegistration
         """
         return self._workspace_created_hooks.copy()
+
+    def get_workspace_setup_hooks(self) -> List[HookRegistration]:
+        """Get in-memory workspace setup hooks sorted by priority."""
+        return [
+            hook for hook in self._workspace_created_hooks if hook.reload_safe
+        ]
 
     def remove_hooks_by_name(
         self,


### PR DESCRIPTION
## Summary

- mark per-workspace in-memory plugin registrations as reload-safe
- restore slash commands, modes, runtime hooks, and stop handlers on the replacement workspace before the atomic swap
- keep `workspace_created` provisioning hooks, including skill directory copies, out of the reload path

## Problem

`reload_agent()` creates a fresh `WorkspacePlugins` instance. Built-in registrations are bootstrapped, but plugin-contributed per-workspace state was not restored, so it disappeared after reloads such as `PUT /api/models/active`.

## Zero-downtime and filesystem safety

Reload-safe setup runs after the replacement workspace starts, before it is published, and outside the manager lock. The old workspace continues serving requests during setup. Filesystem provisioning hooks are not replayed, avoiding destructive skill directory replacement while in-flight work may still use the shared workspace path.

## Tests

- `pytest -q tests/unit/app/test_multi_agent_manager_startup.py tests/unit/plugins/test_plugin_api_extensions.py tests/unit/plugins/test_plugin_load_isolation.py` (54 passed)
- pre-commit checks for all changed files