### PR TITLE
fix(providers): prevent semaphore leaks from unconsumed LLM streams

### DIFF
--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -12,11 +12,12 @@ Concurrency and rate-limit control (LLMRateLimiter):
   thundering-herd problem where multiple callers retry at the same instant.
 
 Semaphore ownership rules:
-- Non-streaming: __call__'s finally block always releases the slot
+- Non-streaming: _call_with_slot's finally block always releases the slot
   (owns_semaphore stays True throughout).
-- Streaming: ownership transfers to _consume_stream_with_slot the moment
-  __call__ returns the generator.  owns_semaphore is set to False before
-  the return so __call__'s finally skips the release.
+- Streaming: acquisition is deferred until the returned generator is first
+  consumed.  Ownership then transfers to _consume_stream_with_slot.
+  owns_semaphore is set to False before the return so the call helper's
+  finally block skips the release.
   _consume_stream_with_slot releases after the first chunk arrives.
 - Cancellation safety: the boolean flag `acquired` tracks whether the
   semaphore slot has actually been taken; the final block only releases
@@ -478,6 +479,36 @@ class RetryChatModel(ChatModelBase):
         *args: Any,
         **kwargs: Any,
     ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        if self.stream:
+            return self._deferred_stream_call(*args, **kwargs)
+        return await self._call_with_slot(*args, **kwargs)
+
+    async def _deferred_stream_call(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Start a streaming call only when its result is first consumed.
+
+        An async generator does not execute until ``__anext__`` is awaited.
+        Deferring the existing call path to this point prevents a semaphore
+        slot from being acquired when a caller abandons or closes an
+        unstarted stream.  Consequently, call and acquire errors surface on
+        the first iteration rather than from ``await model(...)``.
+        """
+        result = await self._call_with_slot(*args, **kwargs)
+        if isinstance(result, AsyncGenerator):
+            async for chunk in result:
+                yield chunk
+            return
+        yield result
+
+    async def _call_with_slot(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        """Execute the existing rate-limited call and retry lifecycle."""
         cache = get_capability_cache()
         key = self.model_key
 

--- a/tests/unit/runtime/test_llm_acquire_timeout.py
+++ b/tests/unit/runtime/test_llm_acquire_timeout.py
@@ -16,17 +16,22 @@ the agent until the 300s default ``acquire_timeout`` elapsed.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from dataclasses import replace
+from typing import Any, AsyncGenerator, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from agentscope.model._model_response import ChatResponse
 
+from qwenpaw.providers.rate_limiter import LLMRateLimiter
 from qwenpaw.providers.retry_chat_model import (
     RateLimitConfig,
     RetryChatModel,
     RetryConfig,
     _AcquireTimeoutError,
 )
+
+_TEST_ACQUIRE_TIMEOUT = 0.01
 
 
 class _HungInnerModel:
@@ -48,6 +53,77 @@ class _HungInnerModel:
         raise AssertionError("inner model __call__ should not be reached")
 
 
+async def _successful_stream() -> AsyncGenerator[Any, None]:
+    yield _OKResponse()
+
+
+class _StreamingInnerModel:
+    """Streaming model used to verify lazy semaphore ownership."""
+
+    model = "acquire-timeout-stream-test"
+    stream = True
+    context_size = 32768
+    parameters = None
+    _provider_id = "unit"
+    credential = None
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        self.calls += 1
+        return _successful_stream()
+
+
+class _BlockingStreamingInnerModel(_StreamingInnerModel):
+    """Streaming model that never produces its first chunk.
+
+    ``release`` intentionally remains unset.  Cancelling the consumer task
+    must terminate the wait and close the stream.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def _blocking_stream(self) -> AsyncGenerator[Any, None]:
+        self.started.set()
+        await self.release.wait()
+        yield _OKResponse()
+
+    async def __call__(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        self.calls += 1
+        return self._blocking_stream()
+
+
+class _CompletedStreamingInnerModel(_StreamingInnerModel):
+    """Streaming model that returns a completed response directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.response = ChatResponse(
+            content=[],
+            is_last=True,
+        )
+
+    async def __call__(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> ChatResponse:
+        self.calls += 1
+        return self.response
+
+
 def _build_model() -> RetryChatModel:
     return RetryChatModel(
         _HungInnerModel(),  # type: ignore[arg-type]
@@ -60,6 +136,161 @@ def _build_model() -> RetryChatModel:
             acquire_timeout=10.0,
         ),
     )
+
+
+def _build_streaming_model(
+    inner: _StreamingInnerModel,
+) -> RetryChatModel:
+    return RetryChatModel(
+        inner,
+        retry_config=RetryConfig(enabled=False),
+        rate_limit_config=RateLimitConfig(
+            max_concurrent=1,
+            max_qpm=0,
+            pause_seconds=1.0,
+            jitter_range=0.0,
+            acquire_timeout=10.0,
+        ),
+    )
+
+
+def _use_fast_acquire_timeout(model: RetryChatModel) -> None:
+    """Shorten real timeout-path tests without changing production bounds."""
+    model._rate_limit_config = replace(
+        model._rate_limit_config,
+        acquire_timeout=_TEST_ACQUIRE_TIMEOUT,
+    )
+
+
+async def _consume_streaming_model(
+    model: RetryChatModel,
+) -> list[Any]:
+    result = await model(messages=[])
+    return [chunk async for chunk in cast(AsyncGenerator[Any, None], result)]
+
+
+@pytest.mark.asyncio
+async def test_unconsumed_stream_does_not_acquire_semaphore() -> None:
+    """Returning or closing an unconsumed stream must not take a slot."""
+    inner = _StreamingInnerModel()
+    model = _build_streaming_model(inner)
+    limiter = LLMRateLimiter(
+        max_concurrent=1,
+        max_qpm=0,
+        default_pause_seconds=1.0,
+        jitter_range=0.0,
+    )
+
+    with patch(
+        "qwenpaw.providers.retry_chat_model.get_rate_limiter",
+        return_value=limiter,
+    ):
+        result = await model(messages=[])
+        stream = cast(AsyncGenerator[Any, None], result)
+
+        assert inner.calls == 0
+        assert limiter.stats()["current_in_flight"] == 0
+
+        await stream.aclose()
+
+        assert limiter.stats()["current_in_flight"] == 0
+
+        chunks = await asyncio.wait_for(
+            _consume_streaming_model(model),
+            timeout=0.1,
+        )
+
+    assert len(chunks) == 1
+    assert inner.calls == 1
+    assert limiter.stats()["current_in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_cancelled_before_first_iteration_does_not_leak() -> None:
+    """Cancellation before the lazy stream starts must leave no slot held."""
+    inner = _StreamingInnerModel()
+    model = _build_streaming_model(inner)
+    limiter = LLMRateLimiter(
+        max_concurrent=1,
+        max_qpm=0,
+        default_pause_seconds=1.0,
+        jitter_range=0.0,
+    )
+
+    with patch(
+        "qwenpaw.providers.retry_chat_model.get_rate_limiter",
+        return_value=limiter,
+    ):
+        result = await model(messages=[])
+        stream = cast(AsyncGenerator[Any, None], result)
+        pending = asyncio.ensure_future(stream.__anext__())
+        pending.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        await stream.aclose()
+
+    assert inner.calls == 0
+    assert limiter.stats()["current_in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_cancelled_before_first_chunk_releases() -> None:
+    """Cancellation after acquire but before the first chunk releases once."""
+    inner = _BlockingStreamingInnerModel()
+    model = _build_streaming_model(inner)
+    limiter = LLMRateLimiter(
+        max_concurrent=1,
+        max_qpm=0,
+        default_pause_seconds=1.0,
+        jitter_range=0.0,
+    )
+
+    with patch(
+        "qwenpaw.providers.retry_chat_model.get_rate_limiter",
+        return_value=limiter,
+    ):
+        result = await model(messages=[])
+        stream = cast(AsyncGenerator[Any, None], result)
+        pending = asyncio.ensure_future(stream.__anext__())
+        try:
+            await asyncio.wait_for(inner.started.wait(), timeout=1.0)
+
+            assert inner.calls == 1
+            assert limiter.stats()["current_in_flight"] == 1
+        finally:
+            pending.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await pending
+            await stream.aclose()
+
+    assert limiter.stats()["current_in_flight"] == 0
+    assert limiter.stats()["current_available"] == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_model_wraps_final_response() -> None:
+    """A direct final response remains complete when exposed as a stream."""
+    inner = _CompletedStreamingInnerModel()
+    model = _build_streaming_model(inner)
+    limiter = LLMRateLimiter(
+        max_concurrent=1,
+        max_qpm=0,
+        default_pause_seconds=1.0,
+        jitter_range=0.0,
+    )
+
+    with patch(
+        "qwenpaw.providers.retry_chat_model.get_rate_limiter",
+        return_value=limiter,
+    ):
+        chunks = await _consume_streaming_model(model)
+
+    assert chunks == [inner.response]
+    assert chunks[0].is_last is True
+    assert inner.calls == 1
+    assert limiter.stats()["current_in_flight"] == 0
 
 
 @pytest.mark.asyncio
@@ -113,11 +344,10 @@ async def test_acquire_timeout_leaves_no_pending_tasks() -> None:
     ``limiter.acquire()`` coroutine should remain pending — the agent must be
     fully released and ready for the next run."""
     model = _build_model()
+    _use_fast_acquire_timeout(model)
 
     # A real limiter whose acquire sleeps longer than the timeout. This
     # exercises the real ``asyncio.wait_for`` cancellation path.
-    from qwenpaw.providers.rate_limiter import LLMRateLimiter
-
     real_limiter = LLMRateLimiter(
         max_concurrent=1,
         max_qpm=0,
@@ -155,6 +385,7 @@ async def test_normal_call_after_timeout_succeeds() -> None:
     must not be hung by leaked limiter state — the agent is released and can
     serve again immediately."""
     model = _build_model()
+    _use_fast_acquire_timeout(model)
 
     calls = {"n": 0}
 
@@ -182,8 +413,6 @@ async def test_normal_call_after_timeout_succeeds() -> None:
             acquire_timeout=10.0,
         ),
     )
-
-    from qwenpaw.providers.rate_limiter import LLMRateLimiter
 
     limiter = LLMRateLimiter(
         max_concurrent=1,


### PR DESCRIPTION
## Summary

Fixes #5411 by preventing streaming LLM calls from leaking rate-limiter semaphore permits when the returned stream is abandoned or cancelled before consumption.

This change keeps the existing acquire timeout unchanged and fixes the underlying stream lifecycle issue instead of merely reducing the time spent waiting for a leaked permit.

## Root Cause

Previously, `RetryChatModel.__call__` acquired a semaphore permit and invoked the inner streaming model before returning an async generator to the caller.

Ownership of the permit was then transferred to the returned generator. If that generator was never consumed, closed before its first iteration, or cancelled before producing its first chunk, its cleanup path might never run. The permit would remain occupied.

After enough leaked permits accumulated, later LLM calls could wait until the acquire timeout expired, making the application appear to hang.

## Changes

- Defer streaming model execution until the returned async generator is first consumed.
- Avoid acquiring a semaphore permit for streams that are never consumed.
- Ensure cancellation before the first streamed chunk releases the acquired permit.
- Preserve the existing retry, rate-limiting, and streaming cleanup behavior.
- Wrap a direct `ChatResponse` returned by a streaming inner model as one final stream chunk.
- Document the exception-timing change introduced by deferred stream execution.
- Improve timeout tests so they fail quickly while still exercising the real semaphore-acquisition timeout path.

## Behavioral Note

For streaming calls, provider errors, authentication errors, exhausted retries, and acquire-timeout errors now surface during the first async iteration instead of at:

```python
await model(...)
```

Callers should therefore keep exception handling around both obtaining and consuming the stream:

```python
try:
    response = await model(messages=messages)
    async for chunk in response:
        ...
except Exception:
    ...
```

The existing AgentScope consumers were reviewed and already handle exceptions across both operations.

## Compatibility

The change is compatible with the existing consumers in this repository.

There are two observable contract details:

1. Streaming-call errors are raised on the first iteration rather than when awaiting the model call.
2. If a model configured with `stream=True` returns a complete `ChatResponse` instead of an async generator, it is exposed as a single final stream chunk.

The fallback response is verified to retain `is_last=True`, allowing consumers to construct the completed response correctly.

## Performance

No material performance regression is expected.

Normal streaming calls add only one lightweight async-generator delegation layer. This overhead is negligible compared with model and network latency.

Streams that are never consumed are now cheaper because they no longer invoke the inner model or acquire a rate-limiter permit.

## Tests

Added regression coverage for:

- Abandoning a stream without consuming it.
- Closing a stream before its first iteration.
- Cancelling a stream before its first chunk.
- Releasing the semaphore permit after cancellation.
- Handling `stream=True` when the inner model returns a complete response.
- Detecting leaked permits with a short timeout around the complete stream-consumption path.
- Exercising the actual acquire-timeout and cancellation behavior without waiting for the production timeout.
