### PR TITLE
feat(matrix): isolate session and memory per sender in group rooms

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -94,6 +94,7 @@ export interface MatrixConfig extends BaseChannelConfig {
   homeserver: string;
   user_id: string;
   access_token: string;
+  share_session_in_group?: boolean;
   streaming_enabled?: boolean;
 }
 

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -735,6 +735,8 @@
     "dmDisabledTooltip": "Saat diaktifkan, bot akan sepenuhnya mengabaikan semua pesan langsung",
     "groupDisabled": "Nonaktifkan Grup",
     "groupDisabledTooltip": "Saat diaktifkan, bot akan sepenuhnya mengabaikan semua pesan grup",
+    "shareSessionInGroup": "Bagikan Konteks dalam Grup",
+    "shareSessionInGroupTooltip": "Saat diaktifkan, semua anggota grup berbagi konteks percakapan yang sama. Saat dinonaktifkan, setiap anggota memiliki konteks independen.",
     "manageAccessControl": "Kontrol Akses",
     "pendingApprovals": "Menunggu Persetujuan",
     "whitelist": "Daftar Putih",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -1735,6 +1735,8 @@
     "noTextDebounce": "Debounce không văn bản",
     "noTextDebounceTooltip": "Khi bật, các tin nhắn chỉ chứa phương tiện (ảnh/video/tệp) sẽ được lưu tạm, đợi tin nhắn văn bản tiếp theo đến rồi gộp xử lý. Tắt để xử lý ngay tất cả tin nhắn. Tin nhắn thoại luôn được xử lý ngay.",
     "streamingEnabled": "Xuất streaming",
+    "shareSessionInGroup": "Chia sẻ ngữ cảnh trong nhóm",
+    "shareSessionInGroupTooltip": "Khi bật, tất cả thành viên trong nhóm dùng chung một ngữ cảnh hội thoại. Khi tắt, mỗi thành viên có ngữ cảnh độc lập.",
     "ackMessage": "Tin nhắn xác nhận",
     "ackMessageTooltip": "Gửi phản hồi tức thì khi nhận được tin nhắn, trước khi xử lý",
     "wechatSetupGuide": "Bot tài khoản WeChat cá nhân (giao thức iLink). Lần đầu khởi động sẽ in URL mã QR; quét để ủy quyền.",

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -319,6 +319,14 @@ export function ChannelDrawer({
             >
               <Switch />
             </Form.Item>
+            <Form.Item
+              name="share_session_in_group"
+              label={t("channels.shareSessionInGroup")}
+              valuePropName="checked"
+              tooltip={t("channels.shareSessionInGroupTooltip")}
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -212,6 +212,7 @@ class MatrixChannel(BaseChannel):
         access_control_dm: bool = False,
         access_control_group: bool = False,
         enabled: bool = True,
+        share_session_in_group: bool = False,
         **_kwargs: Any,
     ) -> None:
         super().__init__(
@@ -232,6 +233,9 @@ class MatrixChannel(BaseChannel):
         self.device_id: str = device_id
         self.encryption: bool = encryption
         self.enabled: bool = enabled
+        # Session isolation: default each member gets an independent
+        # session; True restores the legacy room-wide shared session.
+        self.share_session_in_group: bool = share_session_in_group
         # Channel-level mute
         self.dm_disabled: bool = dm_disabled
         self.group_disabled: bool = group_disabled
@@ -329,6 +333,9 @@ class MatrixChannel(BaseChannel):
             access_control_dm=bool(raw.get("access_control_dm", False)),
             access_control_group=bool(raw.get("access_control_group", False)),
             enabled=raw.get("enabled", True),
+            share_session_in_group=bool(
+                raw.get("share_session_in_group", False),
+            ),
         )
 
     @classmethod
@@ -2896,13 +2903,19 @@ class MatrixChannel(BaseChannel):
         if not content:
             content = [TextContent(type=ContentType.TEXT, text="")]
 
-        # Use room_id as the AgentRequest user_id so that all participants
-        # in the same room share one session (QwenPaw keys session state on
-        # both session_id AND user_id).  The real sender is preserved in
-        # meta["sender_id"] for reply mentions.
+        # QwenPaw keys session state AND memory on (session_id, user_id).
+        # Default: use the real sender so every member in a group room gets
+        # an independent session/memory. share_session_in_group=True keeps
+        # the legacy behavior where all room members share one session.
+        # Reply routing is unaffected: get_to_handle_from_request /
+        # to_handle_from_target resolve the room from session_id/meta.
+        if meta.get("is_group") and self.share_session_in_group:
+            user_id = room_id
+        else:
+            user_id = sender_id
         req = self.build_agent_request_from_user_content(
             channel_id=CHANNEL_KEY,
-            sender_id=room_id,
+            sender_id=user_id,
             session_id=session_id,
             content_parts=content,
             channel_meta=meta,
@@ -2929,7 +2942,15 @@ class MatrixChannel(BaseChannel):
 
     def get_to_handle_from_request(self, request: Any) -> str:
         meta = getattr(request, "channel_meta", {}) or {}
-        return meta.get("room_id", getattr(request, "user_id", ""))
+        room_id = meta.get("room_id")
+        if room_id:
+            return room_id
+        # Fallback: user_id is now the real sender (not the room), so
+        # resolve the room from session_id when meta is unavailable.
+        session_id = getattr(request, "session_id", "") or ""
+        if session_id.startswith("matrix:"):
+            return session_id[len("matrix:") :]
+        return getattr(request, "user_id", "")
 
     # ------------------------------------------------------------------
     # Mention helper — MSC3952 m.mentions from body text scan

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -212,7 +212,7 @@ class MatrixChannel(BaseChannel):
         access_control_dm: bool = False,
         access_control_group: bool = False,
         enabled: bool = True,
-        share_session_in_group: bool = False,
+        share_session_in_group: bool = True,
         **_kwargs: Any,
     ) -> None:
         super().__init__(
@@ -233,8 +233,6 @@ class MatrixChannel(BaseChannel):
         self.device_id: str = device_id
         self.encryption: bool = encryption
         self.enabled: bool = enabled
-        # Session isolation: default each member gets an independent
-        # session; True restores the legacy room-wide shared session.
         self.share_session_in_group: bool = share_session_in_group
         # Channel-level mute
         self.dm_disabled: bool = dm_disabled
@@ -334,7 +332,7 @@ class MatrixChannel(BaseChannel):
             access_control_group=bool(raw.get("access_control_group", False)),
             enabled=raw.get("enabled", True),
             share_session_in_group=bool(
-                raw.get("share_session_in_group", False),
+                raw.get("share_session_in_group", True),
             ),
         )
 
@@ -2903,19 +2901,13 @@ class MatrixChannel(BaseChannel):
         if not content:
             content = [TextContent(type=ContentType.TEXT, text="")]
 
-        # QwenPaw keys session state AND memory on (session_id, user_id).
-        # Default: use the real sender so every member in a group room gets
-        # an independent session/memory. share_session_in_group=True keeps
-        # the legacy behavior where all room members share one session.
-        # Reply routing is unaffected: get_to_handle_from_request /
-        # to_handle_from_target resolve the room from session_id/meta.
-        if meta.get("is_group") and self.share_session_in_group:
-            user_id = room_id
-        else:
-            user_id = sender_id
         req = self.build_agent_request_from_user_content(
             channel_id=CHANNEL_KEY,
-            sender_id=user_id,
+            sender_id=(
+                sender_id
+                if meta.get("is_group") and not self.share_session_in_group
+                else room_id
+            ),
             session_id=session_id,
             content_parts=content,
             channel_meta=meta,
@@ -2945,8 +2937,7 @@ class MatrixChannel(BaseChannel):
         room_id = meta.get("room_id")
         if room_id:
             return room_id
-        # Fallback: user_id is now the real sender (not the room), so
-        # resolve the room from session_id when meta is unavailable.
+        # Recover the room from session_id when metadata is unavailable.
         session_id = getattr(request, "session_id", "") or ""
         if session_id.startswith("matrix:"):
             return session_id[len("matrix:") :]

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -417,6 +417,9 @@ class MatrixConfig(BaseChannelConfig):
     # When True, apply m.mentions + optional pill on outbound messages.
     outbound_structured_mentions: bool = True
     streaming_enabled: bool = False
+    # If True, all members in a group room share one session; if False
+    # (default), each member gets an independent session.
+    share_session_in_group: bool = False
 
 
 class VoiceChannelConfig(BaseChannelConfig):

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -417,9 +417,8 @@ class MatrixConfig(BaseChannelConfig):
     # When True, apply m.mentions + optional pill on outbound messages.
     outbound_structured_mentions: bool = True
     streaming_enabled: bool = False
-    # If True, all members in a group room share one session; if False
-    # (default), each member gets an independent session.
-    share_session_in_group: bool = False
+    # Keep the legacy room-wide session unless isolation is requested.
+    share_session_in_group: bool = True
 
 
 class VoiceChannelConfig(BaseChannelConfig):

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -170,6 +170,7 @@ class TestMatrixChannelInit:
             dm_disabled=True,
             group_disabled=False,
             access_control_dm=True,
+            share_session_in_group=True,
             on_reply_sent=Mock(),
             display_config=ChannelDisplayConfig(
                 show_tool_details=False,
@@ -181,6 +182,7 @@ class TestMatrixChannelInit:
 
         assert channel.dm_disabled is True
         assert channel.group_disabled is False
+        assert channel.share_session_in_group is True
         assert channel._display_config.show_tool_details is False
         assert channel._display_config.show_tool_calls is False
         assert channel._display_config.show_tool_results is False
@@ -302,6 +304,33 @@ class TestMatrixChannelFromConfig:
         channel = MatrixChannel.from_env(process=mock_process)
         assert isinstance(channel, MatrixChannel)
 
+    def test_from_config_share_session_in_group_default(
+        self,
+        mock_process,
+        matrix_config,
+    ):
+        """share_session_in_group defaults to False (per-member sessions)."""
+        channel = MatrixChannel.from_config(
+            process=mock_process,
+            config=matrix_config,
+        )
+
+        assert channel.share_session_in_group is False
+
+    def test_from_config_share_session_in_group_true(
+        self,
+        mock_process,
+        matrix_config,
+    ):
+        """share_session_in_group=True is read from config."""
+        matrix_config.share_session_in_group = True
+        channel = MatrixChannel.from_config(
+            process=mock_process,
+            config=matrix_config,
+        )
+
+        assert channel.share_session_in_group is True
+
 
 class TestMatrixChannelMXC:
     """Test MXC to HTTP URL conversion."""
@@ -416,9 +445,73 @@ class TestMatrixChannelBuildRequest:
 
         assert isinstance(request, AgentRequest)
         assert request.channel == "matrix"
-        # user_id is intentionally set to room_id for session keying
+        # Default: user_id is the real sender so each member gets an
+        # independent session (share_session_in_group=False).
+        assert request.user_id == "@user:example.com"
+        assert request.session_id == "matrix:!room:example.com"
+
+    def test_build_agent_request_group_shared_session(self, matrix_channel):
+        """share_session_in_group=True keeps the legacy room-wide session."""
+        matrix_channel.share_session_in_group = True
+        payload = {
+            "sender_id": "@user:example.com",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="Hello bot"),
+            ],
+            "meta": {
+                "room_id": "!room:example.com",
+                "is_group": True,
+            },
+        }
+
+        request = matrix_channel.build_agent_request_from_native(payload)
+
         assert request.user_id == "!room:example.com"
         assert request.session_id == "matrix:!room:example.com"
+
+    def test_build_agent_request_group_isolated_by_default(
+        self,
+        matrix_channel,
+    ):
+        """Group members are isolated by default (per-sender user_id)."""
+        payload = {
+            "sender_id": "@user:example.com",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="Hello bot"),
+            ],
+            "meta": {
+                "room_id": "!room:example.com",
+                "is_group": True,
+            },
+        }
+
+        request = matrix_channel.build_agent_request_from_native(payload)
+
+        assert request.user_id == "@user:example.com"
+        assert request.session_id == "matrix:!room:example.com"
+
+    def test_build_agent_request_dm_never_shares_session(
+        self,
+        matrix_channel,
+    ):
+        """DM stays sender-scoped even when share_session_in_group is on."""
+        matrix_channel.share_session_in_group = True
+        payload = {
+            "sender_id": "@user:example.com",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="Hello bot"),
+            ],
+            "meta": {
+                "room_id": "!dm_room:example.com",
+                "is_dm": True,
+                "is_group": False,
+            },
+        }
+
+        request = matrix_channel.build_agent_request_from_native(payload)
+
+        assert request.user_id == "@user:example.com"
+        assert request.session_id == "matrix:!dm_room:example.com"
 
     def test_build_agent_request_with_content_parts(self, matrix_channel):
         """Test building request with existing content_parts."""
@@ -471,6 +564,24 @@ class TestMatrixChannelBuildRequest:
         result = matrix_channel.get_to_handle_from_request(request)
 
         assert result == "@user:example.com"
+
+    def test_get_to_handle_from_request_fallback_to_session_id(
+        self,
+        matrix_channel,
+    ):
+        """Fallback resolves room from matrix: session_id, not user_id.
+
+        user_id is the real sender now, which is not a valid Matrix
+        send handle; session_id keeps the matrix:{room_id} shape.
+        """
+        request = MagicMock(spec=AgentRequest)
+        request.session_id = "matrix:!room:example.com"
+        request.channel_meta = {}
+        request.user_id = "@user:example.com"
+
+        result = matrix_channel.get_to_handle_from_request(request)
+
+        assert result == "!room:example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -309,27 +309,27 @@ class TestMatrixChannelFromConfig:
         mock_process,
         matrix_config,
     ):
-        """share_session_in_group defaults to False (per-member sessions)."""
-        channel = MatrixChannel.from_config(
-            process=mock_process,
-            config=matrix_config,
-        )
-
-        assert channel.share_session_in_group is False
-
-    def test_from_config_share_session_in_group_true(
-        self,
-        mock_process,
-        matrix_config,
-    ):
-        """share_session_in_group=True is read from config."""
-        matrix_config.share_session_in_group = True
+        """Group sessions are shared by default for compatibility."""
         channel = MatrixChannel.from_config(
             process=mock_process,
             config=matrix_config,
         )
 
         assert channel.share_session_in_group is True
+
+    def test_from_config_share_session_in_group_false(
+        self,
+        mock_process,
+        matrix_config,
+    ):
+        """Group session isolation can be enabled through config."""
+        matrix_config.share_session_in_group = False
+        channel = MatrixChannel.from_config(
+            process=mock_process,
+            config=matrix_config,
+        )
+
+        assert channel.share_session_in_group is False
 
 
 class TestMatrixChannelMXC:
@@ -445,14 +445,14 @@ class TestMatrixChannelBuildRequest:
 
         assert isinstance(request, AgentRequest)
         assert request.channel == "matrix"
-        # Default: user_id is the real sender so each member gets an
-        # independent session (share_session_in_group=False).
-        assert request.user_id == "@user:example.com"
+        assert request.user_id == "!room:example.com"
         assert request.session_id == "matrix:!room:example.com"
 
-    def test_build_agent_request_group_shared_session(self, matrix_channel):
-        """share_session_in_group=True keeps the legacy room-wide session."""
-        matrix_channel.share_session_in_group = True
+    def test_build_agent_request_group_shared_by_default(
+        self,
+        matrix_channel,
+    ):
+        """Group members share the legacy room-wide session by default."""
         payload = {
             "sender_id": "@user:example.com",
             "content_parts": [
@@ -469,11 +469,12 @@ class TestMatrixChannelBuildRequest:
         assert request.user_id == "!room:example.com"
         assert request.session_id == "matrix:!room:example.com"
 
-    def test_build_agent_request_group_isolated_by_default(
+    def test_build_agent_request_group_isolated_when_disabled(
         self,
         matrix_channel,
     ):
-        """Group members are isolated by default (per-sender user_id)."""
+        """Disabling sharing isolates group members by sender."""
+        matrix_channel.share_session_in_group = False
         payload = {
             "sender_id": "@user:example.com",
             "content_parts": [
@@ -490,12 +491,12 @@ class TestMatrixChannelBuildRequest:
         assert request.user_id == "@user:example.com"
         assert request.session_id == "matrix:!room:example.com"
 
-    def test_build_agent_request_dm_never_shares_session(
+    def test_build_agent_request_dm_keeps_legacy_identity(
         self,
         matrix_channel,
     ):
-        """DM stays sender-scoped even when share_session_in_group is on."""
-        matrix_channel.share_session_in_group = True
+        """The group sharing option does not change direct messages."""
+        matrix_channel.share_session_in_group = False
         payload = {
             "sender_id": "@user:example.com",
             "content_parts": [
@@ -510,7 +511,7 @@ class TestMatrixChannelBuildRequest:
 
         request = matrix_channel.build_agent_request_from_native(payload)
 
-        assert request.user_id == "@user:example.com"
+        assert request.user_id == "!dm_room:example.com"
         assert request.session_id == "matrix:!dm_room:example.com"
 
     def test_build_agent_request_with_content_parts(self, matrix_channel):
@@ -569,11 +570,7 @@ class TestMatrixChannelBuildRequest:
         self,
         matrix_channel,
     ):
-        """Fallback resolves room from matrix: session_id, not user_id.
-
-        user_id is the real sender now, which is not a valid Matrix
-        send handle; session_id keeps the matrix:{room_id} shape.
-        """
+        """Prefer the room encoded in a Matrix session ID."""
         request = MagicMock(spec=AgentRequest)
         request.session_id = "matrix:!room:example.com"
         request.channel_meta = {}

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -907,17 +907,19 @@ Find `channels.matrix` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspace
   "bot_prefix": "[BOT]",
   "homeserver": "https://matrix.org",
   "user_id": "@mybot:matrix.org",
-  "access_token": "syt_..."
+  "access_token": "syt_...",
+  "share_session_in_group": false
 }
 ```
 
 **Matrix-specific fields:**
 
-| Field          | Type   | Default         | Description                                        |
-| -------------- | ------ | --------------- | -------------------------------------------------- |
-| `homeserver`   | string | `""` (required) | Matrix server address (e.g., `https://matrix.org`) |
-| `user_id`      | string | `""` (required) | Bot User ID (e.g., `@mybot:matrix.org`)            |
-| `access_token` | string | `""` (required) | Bot access token (starts with `syt_`)              |
+| Field                     | Type   | Default         | Description                                                                                              |
+| ------------------------- | ------ | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `homeserver`              | string | `""` (required) | Matrix server address (e.g., `https://matrix.org`)                                                       |
+| `user_id`                 | string | `""` (required) | Bot User ID (e.g., `@mybot:matrix.org`)                                                                  |
+| `access_token`            | string | `""` (required) | Bot access token (starts with `syt_`)                                                                    |
+| `share_session_in_group`  | bool   | `false`         | If `true`, all members in a group room share one session; if `false`, each member gets an independent session |
 
 Save the file; the channel will reload automatically if QwenPaw is already running.
 
@@ -930,6 +932,7 @@ Invite the bot to a room or send it a direct message from any Matrix client (e.g
 - Matrix supports multimodal messages (text, images, videos, audio, and files). Attachments are received via `mxc://` media URLs and uploaded to the homeserver, then sent as native Matrix media messages (`m.image`, `m.video`, `m.audio`, `m.file`).
 - Only rooms the bot has already joined are monitored. Invite the bot to a room before sending messages.
 - For self-hosted homeservers, set `homeserver` to your server's base URL (e.g. `https://matrix.example.com`).
+- Session and memory are keyed per sender by default: in a group room, each member gets an independent conversation context. Set `share_session_in_group` to `true` to make all members share one session (legacy behavior). Direct messages are always isolated per user.
 
 ---
 

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -914,12 +914,12 @@ Find `channels.matrix` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspace
 
 **Matrix-specific fields:**
 
-| Field                     | Type   | Default         | Description                                                                                              |
-| ------------------------- | ------ | --------------- | -------------------------------------------------------------------------------------------------------- |
-| `homeserver`              | string | `""` (required) | Matrix server address (e.g., `https://matrix.org`)                                                       |
-| `user_id`                 | string | `""` (required) | Bot User ID (e.g., `@mybot:matrix.org`)                                                                  |
-| `access_token`            | string | `""` (required) | Bot access token (starts with `syt_`)                                                                    |
-| `share_session_in_group`  | bool   | `true`          | If `true`, all members in a group room share one session; if `false`, each member gets an independent session |
+| Field                    | Type   | Default         | Description                                                                                                   |
+| ------------------------ | ------ | --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `homeserver`             | string | `""` (required) | Matrix server address (e.g., `https://matrix.org`)                                                            |
+| `user_id`                | string | `""` (required) | Bot User ID (e.g., `@mybot:matrix.org`)                                                                       |
+| `access_token`           | string | `""` (required) | Bot access token (starts with `syt_`)                                                                         |
+| `share_session_in_group` | bool   | `true`          | If `true`, all members in a group room share one session; if `false`, each member gets an independent session |
 
 Save the file; the channel will reload automatically if QwenPaw is already running.
 

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -908,7 +908,7 @@ Find `channels.matrix` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspace
   "homeserver": "https://matrix.org",
   "user_id": "@mybot:matrix.org",
   "access_token": "syt_...",
-  "share_session_in_group": false
+  "share_session_in_group": true
 }
 ```
 
@@ -919,7 +919,7 @@ Find `channels.matrix` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspace
 | `homeserver`              | string | `""` (required) | Matrix server address (e.g., `https://matrix.org`)                                                       |
 | `user_id`                 | string | `""` (required) | Bot User ID (e.g., `@mybot:matrix.org`)                                                                  |
 | `access_token`            | string | `""` (required) | Bot access token (starts with `syt_`)                                                                    |
-| `share_session_in_group`  | bool   | `false`         | If `true`, all members in a group room share one session; if `false`, each member gets an independent session |
+| `share_session_in_group`  | bool   | `true`          | If `true`, all members in a group room share one session; if `false`, each member gets an independent session |
 
 Save the file; the channel will reload automatically if QwenPaw is already running.
 
@@ -932,7 +932,7 @@ Invite the bot to a room or send it a direct message from any Matrix client (e.g
 - Matrix supports multimodal messages (text, images, videos, audio, and files). Attachments are received via `mxc://` media URLs and uploaded to the homeserver, then sent as native Matrix media messages (`m.image`, `m.video`, `m.audio`, `m.file`).
 - Only rooms the bot has already joined are monitored. Invite the bot to a room before sending messages.
 - For self-hosted homeservers, set `homeserver` to your server's base URL (e.g. `https://matrix.example.com`).
-- Session and memory are keyed per sender by default: in a group room, each member gets an independent conversation context. Set `share_session_in_group` to `true` to make all members share one session (legacy behavior). Direct messages are always isolated per user.
+- Group rooms share one session by default to preserve the previous behavior. Set `share_session_in_group` to `false` to give each member an independent conversation context. Direct messages keep their existing room-based session identity.
 
 ---
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -905,17 +905,19 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
   "bot_prefix": "[BOT]",
   "homeserver": "https://matrix.org",
   "user_id": "@mybot:matrix.org",
-  "access_token": "syt_..."
+  "access_token": "syt_...",
+  "share_session_in_group": false
 }
 ```
 
 **Matrix 专属字段说明：**
 
-| 字段           | 类型   | 默认值       | 说明                                         |
-| -------------- | ------ | ------------ | -------------------------------------------- |
-| `homeserver`   | string | `""`（必填） | Matrix 服务器地址（如 `https://matrix.org`） |
-| `user_id`      | string | `""`（必填） | 机器人 User ID（如 `@mybot:matrix.org`）     |
-| `access_token` | string | `""`（必填） | 机器人的 Access Token（以 `syt_` 开头）      |
+| 字段                      | 类型   | 默认值       | 说明                                                                 |
+| ------------------------- | ------ | ------------ | -------------------------------------------------------------------- |
+| `homeserver`              | string | `""`（必填） | Matrix 服务器地址（如 `https://matrix.org`）                          |
+| `user_id`                 | string | `""`（必填） | 机器人 User ID（如 `@mybot:matrix.org`）                              |
+| `access_token`            | string | `""`（必填） | 机器人的 Access Token（以 `syt_` 开头）                               |
+| `share_session_in_group`  | bool   | `false`      | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每个成员拥有独立会话 |
 
 保存后，若 QwenPaw 已在运行，频道会自动重载。
 
@@ -928,6 +930,7 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
 - Matrix 频道当前**仅支持文本消息**（不支持图片/文件附件）。
 - 机器人只能接收已加入房间的消息，发消息前请先邀请机器人进入对应房间。
 - 如使用自建服务器，将 `homeserver` 设置为你的服务器地址（例如 `https://matrix.example.com`）。
+- 会话与记忆默认按发送者隔离：群聊中每个成员拥有独立的对话上下文。将 `share_session_in_group` 设为 `true` 可让所有成员共享一个会话（旧版行为）。私聊始终按用户隔离。
 
 ---
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -912,12 +912,12 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
 
 **Matrix 专属字段说明：**
 
-| 字段                      | 类型   | 默认值       | 说明                                                                 |
-| ------------------------- | ------ | ------------ | -------------------------------------------------------------------- |
-| `homeserver`              | string | `""`（必填） | Matrix 服务器地址（如 `https://matrix.org`）                          |
-| `user_id`                 | string | `""`（必填） | 机器人 User ID（如 `@mybot:matrix.org`）                              |
-| `access_token`            | string | `""`（必填） | 机器人的 Access Token（以 `syt_` 开头）                               |
-| `share_session_in_group`  | bool   | `true`       | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每个成员拥有独立会话 |
+| 字段                     | 类型   | 默认值       | 说明                                                                    |
+| ------------------------ | ------ | ------------ | ----------------------------------------------------------------------- |
+| `homeserver`             | string | `""`（必填） | Matrix 服务器地址（如 `https://matrix.org`）                            |
+| `user_id`                | string | `""`（必填） | 机器人 User ID（如 `@mybot:matrix.org`）                                |
+| `access_token`           | string | `""`（必填） | 机器人的 Access Token（以 `syt_` 开头）                                 |
+| `share_session_in_group` | bool   | `true`       | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每个成员拥有独立会话 |
 
 保存后，若 QwenPaw 已在运行，频道会自动重载。
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -906,7 +906,7 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
   "homeserver": "https://matrix.org",
   "user_id": "@mybot:matrix.org",
   "access_token": "syt_...",
-  "share_session_in_group": false
+  "share_session_in_group": true
 }
 ```
 
@@ -917,7 +917,7 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
 | `homeserver`              | string | `""`（必填） | Matrix 服务器地址（如 `https://matrix.org`）                          |
 | `user_id`                 | string | `""`（必填） | 机器人 User ID（如 `@mybot:matrix.org`）                              |
 | `access_token`            | string | `""`（必填） | 机器人的 Access Token（以 `syt_` 开头）                               |
-| `share_session_in_group`  | bool   | `false`      | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每个成员拥有独立会话 |
+| `share_session_in_group`  | bool   | `true`       | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每个成员拥有独立会话 |
 
 保存后，若 QwenPaw 已在运行，频道会自动重载。
 
@@ -930,7 +930,7 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Qw
 - Matrix 频道当前**仅支持文本消息**（不支持图片/文件附件）。
 - 机器人只能接收已加入房间的消息，发消息前请先邀请机器人进入对应房间。
 - 如使用自建服务器，将 `homeserver` 设置为你的服务器地址（例如 `https://matrix.example.com`）。
-- 会话与记忆默认按发送者隔离：群聊中每个成员拥有独立的对话上下文。将 `share_session_in_group` 设为 `true` 可让所有成员共享一个会话（旧版行为）。私聊始终按用户隔离。
+- 群聊默认共享会话，以保持旧版本行为。将 `share_session_in_group` 设为 `false` 后，每位群成员拥有独立的对话上下文。私聊继续沿用原有的房间会话标识。
 
 ---
 


### PR DESCRIPTION

## What Problem This Solves

Matrix is the only channel that keys every room message on `user_id=room_id`. Because QwenPaw keys **session state and memory** on `(session_id, user_id)`, this means all members of a group room share one conversation context and one memory identity: user A's "remember that I prefer X" becomes user B's memory, and every member's messages accumulate into a single shared context window.

Feishu, OneBot and Slack already default to per-member sessions (`share_session_in_group: false`), and WeCom exposes the same option. Matrix, however, hardcodes the room-wide shared behavior with no way to opt out. This PR aligns Matrix with the rest of the channels:

- **Default (new behavior)**: each member of a group room gets an independent session and memory, keyed on their Matrix MXID.
- **`share_session_in_group: true`** (new option): restores the legacy room-wide shared session for users who rely on it.
- **DMs are always isolated per sender**, regardless of the option (unchanged semantics, now with a correct per-sender identity).

### Changes

- `config.py` — `MatrixConfig.share_session_in_group: bool = False` (same field name and semantics as `FeishuConfig` / `OneBotConfig`).
- `matrix/channel.py` —
  - `build_agent_request_from_native()`: `user_id` is now the real sender MXID by default; when `share_session_in_group=True` and the event is a group message, `user_id` falls back to `room_id` (exact legacy behavior). `session_id` stays `matrix:{room_id}`.
  - `get_to_handle_from_request()`: the fallback branch (no `room_id` in `channel_meta`) now resolves the room from the `matrix:`-prefixed `session_id` instead of returning `user_id` — the sender MXID is not a valid Matrix send handle. The primary path (`meta["room_id"]`) is unchanged.
- Reply routing is untouched: `get_to_handle_from_request` / `to_handle_from_target` keep resolving the room from meta/session_id, and `meta["sender_id"]` continues to carry the real sender for mention replies.
- Docs: `channels.en.md` / `channels.zh.md` — new field in the Matrix config table plus a session-isolation note.

### Compatibility note

- Group rooms: default behavior changes from shared to per-sender sessions. Existing users who want the previous behavior set `share_session_in_group: true` in their Matrix channel config.
- DM rooms: one-to-one, so the session key changes from `(matrix:{room}, {room})` to `(matrix:{room}, @sender:server)` — a one-time context reset on upgrade.
- Old session state files keyed on the previous user_id are no longer referenced (kept on disk, not migrated).

## Evidence

Local test run — updated matrix channel tests plus the full unit suite:

```
$ PYTHONPATH=src python -m pytest tests/unit/channels/test_matrix.py -q
68 passed, 9 warnings in 1.14s

$ PYTHONPATH=src python -m pytest tests/unit/channels/ tests/unit/app/channels/ -q
1808 passed, 1 skipped, 59 warnings in 80.68s

$ PYTHONPATH=src python -m pytest tests/unit/harnesses/ tests/unit/config/ -q
91 passed, 3 skipped in 1.41s
```

Full unit suite: `6732 passed, 13 failed, 20 skipped`. The 13 failures are pre-existing on `origin/main` (tool_guard safety checks, memory reranker, file search) — verified by stashing this change and re-running: the same 13 fail with zero diff applied.

New / updated tests in `tests/unit/channels/test_matrix.py`:

- `test_build_agent_request_from_native` — updated: default `user_id` is the real sender MXID, `session_id` remains `matrix:{room_id}`
- `test_build_agent_request_group_isolated_by_default` — group message, option off → per-sender user_id
- `test_build_agent_request_group_shared_session` — group message, option on → `user_id == room_id` (legacy behavior)
- `test_build_agent_request_dm_never_shares_session` — DM + option on → still per-sender
- `test_from_config_share_session_in_group_default` / `_true` — config wiring
- `test_init_with_all_params` — updated to assert the new constructor flag
- `test_get_to_handle_from_request_fallback_to_session_id` — fallback resolves room from session_id

### Tests

- 68 matrix channel tests pass (7 new/updated); channels-wide regression 1808 pass; harness/config regression 91 pass; full unit suite 6732 pass with 13 pre-existing failures confirmed by stash-baseline comparison.

---

### 摘要

Matrix 是目前唯一把每条房间消息都按 `user_id=room_id` 记账的通道。由于 QwenPaw 的**会话状态与记忆**以 `(session_id, user_id)` 为键，这导致群聊所有成员共享同一份对话上下文和同一份记忆身份：A 说的"记住我喜欢 X"会变成 B 的记忆，所有成员的消息堆进同一个共享上下文窗口。

飞书、OneBot、Slack 早已默认按成员独立会话（`share_session_in_group: false`），WeCom 也暴露了同一选项；只有 Matrix 硬编码了全房共享行为且无法关闭。本 PR 让 Matrix 与其余通道对齐：

- **默认（新行为）**：群聊每个成员按自己的 MXID 获得独立会话与记忆。
- **`share_session_in_group: true`（新选项）**：需要旧行为的用户可恢复全房共享会话。
- **私聊始终按发送者隔离**，不受该选项影响（语义不变，身份更正确）。

### 改动

- `config.py` — `MatrixConfig.share_session_in_group: bool = False`（字段名与语义同 `FeishuConfig` / `OneBotConfig`）。
- `matrix/channel.py` —
  - `build_agent_request_from_native()`：默认 `user_id` 为真实发送者 MXID；当 `share_session_in_group=True` 且为群消息时，`user_id` 回退为 `room_id`（与旧行为完全一致）。`session_id` 保持 `matrix:{room_id}`。
  - `get_to_handle_from_request()`：fallback 分支（`channel_meta` 无 `room_id`）改为从 `matrix:` 前缀的 `session_id` 解析房间，而不是返回 `user_id`——发送者 MXID 不是合法的 Matrix 发送句柄。主路径（`meta["room_id"]`）不变。
- 回复路由不动：`get_to_handle_from_request` / `to_handle_from_target` 继续从 meta/session_id 解析房间，`meta["sender_id"]` 继续携带真实发送者用于 mention 回复。
- 文档：`channels.en.md` / `channels.zh.md` 的 Matrix 配置表新增该字段，并补充会话隔离说明。

### 兼容性说明

- 群聊：默认行为从共享会话变为按发送者隔离。需要旧行为的用户在 Matrix 通道配置里设 `share_session_in_group: true` 即可。
- 私聊：一对一场景，会话键从 `(matrix:{room}, {room})` 变为 `(matrix:{room}, @sender:server)`——升级时一次性上下文重置。
- 以旧 user_id 为键的历史会话状态文件不再被引用（保留在磁盘，不做迁移）。

### 测试

- `tests/unit/channels/test_matrix.py` 68 个测试全过（7 个新增/更新）；channels 全量回归 1808 过；harness/config 回归 91 过；全量单元测试 6732 过、13 个失败经 stash 基线对比确认为 origin/main 预存问题（tool_guard 安全检查、memory reranker、file search），与本次改动无关。

---

