### PR TITLE
feat(console): persist spawn parent-child linkage in chat meta

### DIFF
--- a/src/qwenpaw/app/chats/manager.py
+++ b/src/qwenpaw/app/chats/manager.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from collections.abc import Awaitable, Callable
-from typing import Optional
+from typing import Any, Optional
 
 from .models import (
     BatchArchiveResult,
@@ -507,6 +507,23 @@ class ChatManager:  # pylint: disable=too-many-public-methods
             merged.updated_at = datetime.now(timezone.utc)
             await self._repo.upsert_chat(merged)
             return merged
+
+    async def update_meta(
+        self,
+        chat_id: str,
+        meta: dict[str, Any],
+    ) -> Optional[ChatSpec]:
+        """Merge ``meta`` into the chat metadata, preserving other keys."""
+        async with self._lock:
+            existing = await self._repo.get_chat(chat_id)
+            if existing is None:
+                return None
+            merged_meta = dict(existing.meta)
+            merged_meta.update(meta)
+            updated = existing.model_copy(update={"meta": merged_meta})
+            updated.updated_at = datetime.now(timezone.utc)
+            await self._repo.upsert_chat(updated)
+            return updated
 
     async def delete_chats(self, chat_ids: list[str]) -> bool:
         """Delete a chat spec.

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -212,6 +212,40 @@ async def _persist_pending_project_dirs(
     return updated
 
 
+async def _apply_spawn_whitelist(
+    workspace,
+    chat,
+    native_payload: dict[str, Any],
+):
+    """Persist spawn tool/skill whitelists into chat meta.
+
+    Spawn lineage (``source = "subagent"``, ``parent_session_id``,
+    ``root_session_id``) is already persisted as first-class ``ChatSpec``
+    fields by ``_chat_registration_fields``. The tool/skill whitelists
+    only travel in the request context, where the runtime builder
+    consumes them once — so merge them into ``meta`` here, letting
+    spawn-tree consumers read back (via the chat list API) exactly what
+    each subagent was allowed to use.
+    """
+    request_context = native_payload["meta"].get("request_context")
+    if not isinstance(request_context, dict):
+        return chat
+    if request_context.get("_spawn_subagent") is not True:
+        return chat
+    whitelist_meta: dict[str, Any] = {}
+    for key in ("subagent_allowed_tools", "subagent_skills"):
+        value = request_context.get(key)
+        if isinstance(value, list) and value:
+            whitelist_meta[key] = list(value)
+    if not whitelist_meta:
+        return chat
+    updated = await workspace.chat_manager.update_meta(
+        chat.id,
+        whitelist_meta,
+    )
+    return updated or chat
+
+
 def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
     """Extract run_key (ChatSpec.id), session_id, and native payload.
 
@@ -413,6 +447,11 @@ async def post_console_chat(
             return _empty_sse_response()
     else:
         chat = await _persist_pending_project_dirs(
+            workspace,
+            chat,
+            native_payload,
+        )
+        chat = await _apply_spawn_whitelist(
             workspace,
             chat,
             native_payload,
@@ -856,6 +895,11 @@ async def post_console_chat_task(
         **_chat_registration_fields(native_payload),
     )
     chat = await _persist_pending_project_dirs(
+        workspace,
+        chat,
+        native_payload,
+    )
+    chat = await _apply_spawn_whitelist(
         workspace,
         chat,
         native_payload,

--- a/tests/unit/app/chats/test_manager.py
+++ b/tests/unit/app/chats/test_manager.py
@@ -299,6 +299,38 @@ async def test_set_project_dir_persists_and_clears_controlled_meta(
     assert "runtime_context" not in cleared.meta
 
 
+@pytest.mark.asyncio
+async def test_update_meta_merges_into_existing_meta(manager: ChatManager):
+    spec = await manager.create_chat(_make_spec(name="Spawn session"))
+    await manager.update_meta(spec.id, {"runtime_context": {"a": 1}})
+
+    updated = await manager.update_meta(
+        spec.id,
+        {"subagent_allowed_tools": ["read_file"]},
+    )
+
+    assert updated is not None
+    assert updated.meta["subagent_allowed_tools"] == ["read_file"]
+    assert updated.meta["runtime_context"] == {"a": 1}
+    persisted = await manager.get_chat(spec.id)
+    assert persisted is not None
+    assert persisted.meta["subagent_allowed_tools"] == ["read_file"]
+    assert persisted.meta["runtime_context"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_meta_returns_none_for_missing_chat(
+    manager: ChatManager,
+):
+    assert (
+        await manager.update_meta(
+            "no-such-chat",
+            {"subagent_allowed_tools": ["read_file"]},
+        )
+        is None
+    )
+
+
 # ---------------------------------------------------------------------------
 # patch_chat / patch_chat_if_name_matches
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -241,3 +241,63 @@ async def test_new_message_rejects_active_run(
         "use a different session_id."
     )
     assert console_workspace.console_channel.stream_calls == []
+
+
+def test_spawn_chat_persists_tool_skill_whitelists(
+    client,
+    console_workspace,
+):
+    """Foreground spawn (POST /console/chat) persists whitelists in meta.
+
+    The spawn lineage itself (``source = "subagent"``,
+    ``parent_session_id``, ``root_session_id``) is persisted as
+    first-class ``ChatSpec`` fields by ``_chat_registration_fields``;
+    this pins the meta merge that records the tool/skill whitelists.
+    The background task endpoint is covered in
+    ``test_console_chat_task.py``.
+    """
+
+    async def _safe_stream(payload):
+        yield 'data: {"type": "message", "output": []}\n\n'
+
+    console_workspace.console_channel.stream_one = _safe_stream
+    chat = MagicMock(name="ChatSpec")
+    chat.id = "chat-spawn"
+    chat.name = "New Chat"
+    chat.meta = {}
+    console_workspace.chat_manager.get_or_create_chat = AsyncMock(
+        return_value=chat,
+    )
+    update_meta = AsyncMock(return_value=chat)
+    console_workspace.chat_manager.update_meta = update_meta
+
+    response = client.post(
+        "/api/console/chat",
+        json={
+            "session_id": "sub-ab12cd34",
+            "user_id": "default",
+            "channel": "console",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "run"}],
+                },
+            ],
+            "request_context": {
+                "_spawn_subagent": True,
+                "root_session_id": "session:root",
+                "parent_session_id": "session:root",
+                "subagent_allowed_tools": ["read_file"],
+                "subagent_skills": ["docx"],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    update_meta.assert_awaited_once_with(
+        "chat-spawn",
+        {
+            "subagent_allowed_tools": ["read_file"],
+            "subagent_skills": ["docx"],
+        },
+    )

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -87,12 +87,25 @@ def _install_hook(fork: _Fork, tmp_path: Path, body: str) -> None:
 
 
 class _ChatManager:
+    def __init__(self) -> None:
+        self.created_chats: list[dict[str, Any]] = []
+        self.meta_updates: list[tuple[str, dict[str, Any]]] = []
+
     async def get_or_create_chat(
         self,
         *args: Any,
         **kwargs: Any,
     ) -> SimpleNamespace:
+        self.created_chats.append(kwargs)
         return SimpleNamespace(id="test-chat", meta={})
+
+    async def update_meta(
+        self,
+        chat_id: str,
+        meta: dict[str, Any],
+    ) -> SimpleNamespace:
+        self.meta_updates.append((chat_id, dict(meta)))
+        return SimpleNamespace(id=chat_id, meta=dict(meta))
 
     async def mark_chat_finished(self, chat_id: str, finish_time: Any) -> None:
         """Match the production completion callback used by TaskTracker."""
@@ -431,3 +444,150 @@ async def test_forked_task_stays_running_until_worktree_is_finalized(
     finally:
         (fork.worktree / ".hook-release").touch(exist_ok=True)
         await asyncio.gather(background_task, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# spawn tool/skill whitelists persisted into chat meta
+# ---------------------------------------------------------------------------
+
+
+async def _submit_spawn_task(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    request_context: dict[str, Any],
+) -> tuple[_Workspace, asyncio.Task]:
+    workspace = _Workspace(tmp_path)
+
+    async def _get_workspace(_request):
+        return workspace
+
+    monkeypatch.setattr(console, "get_agent_for_request", _get_workspace)
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda _agent_id: SimpleNamespace(project_dir=None),
+    )
+    payload: dict[str, Any] = {
+        "channel": "console",
+        "user_id": "test-user",
+        "session_id": "sub-abc12345",
+        "input": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": [{"type": "text", "text": "run"}],
+            },
+        ],
+        "request_context": request_context,
+    }
+    submitted = await console.post_console_chat_task(payload, None)
+    task_id = submitted["task_id"]
+    background_task = console._bg_tasks[task_id].asyncio_task
+    assert background_task is not None
+    return workspace, background_task
+
+
+@pytest.mark.asyncio
+async def test_spawn_task_persists_tool_and_skill_whitelists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tool/skill whitelists are recorded in meta when the spawn set them."""
+    workspace, background_task = await _submit_spawn_task(
+        monkeypatch,
+        tmp_path,
+        request_context={
+            "_spawn_subagent": True,
+            "root_session_id": "session:parent",
+            "parent_session_id": "session:parent",
+            "subagent_allowed_tools": ["read_file", "execute_shell_command"],
+            "subagent_skills": ["docx"],
+        },
+    )
+    try:
+        await asyncio.wait_for(background_task, timeout=10)
+    finally:
+        await asyncio.gather(background_task, return_exceptions=True)
+
+    chat_manager = workspace.chat_manager
+    assert chat_manager.meta_updates == [
+        (
+            "test-chat",
+            {
+                "subagent_allowed_tools": [
+                    "read_file",
+                    "execute_shell_command",
+                ],
+                "subagent_skills": ["docx"],
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_plain_task_leaves_chat_meta_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-spawn requests must not write whitelist metadata."""
+    workspace, background_task = await _submit_spawn_task(
+        monkeypatch,
+        tmp_path,
+        request_context={"approval_level": "normal"},
+    )
+    try:
+        await asyncio.wait_for(background_task, timeout=10)
+    finally:
+        await asyncio.gather(background_task, return_exceptions=True)
+
+    chat_manager = workspace.chat_manager
+    assert chat_manager.meta_updates == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_task_without_whitelists_skips_meta(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spawn that restricted nothing does not write meta."""
+    workspace, background_task = await _submit_spawn_task(
+        monkeypatch,
+        tmp_path,
+        request_context={
+            "_spawn_subagent": True,
+            "root_session_id": "session:parent",
+            "parent_session_id": "session:parent",
+        },
+    )
+    try:
+        await asyncio.wait_for(background_task, timeout=10)
+    finally:
+        await asyncio.gather(background_task, return_exceptions=True)
+
+    chat_manager = workspace.chat_manager
+    assert chat_manager.meta_updates == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_task_skips_empty_tool_whitelists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty whitelist values are not persisted into meta."""
+    workspace, background_task = await _submit_spawn_task(
+        monkeypatch,
+        tmp_path,
+        request_context={
+            "_spawn_subagent": True,
+            "root_session_id": "session:parent",
+            "subagent_allowed_tools": [],
+            "subagent_skills": None,
+        },
+    )
+    try:
+        await asyncio.wait_for(background_task, timeout=10)
+    finally:
+        await asyncio.gather(background_task, return_exceptions=True)
+
+    chat_manager = workspace.chat_manager
+    assert chat_manager.meta_updates == []

--- a/website/public/docs/multi-agent.en.md
+++ b/website/public/docs/multi-agent.en.md
@@ -717,6 +717,24 @@ QwenPaw also supports spawning ephemeral sub-tasks **within the current project*
 - **Same Agent**: The subagent runs as the same agent (same config, persona, tools), just in a separate session.
 - **Always available**: `fork=True` works regardless of whether Coding Mode is enabled.
 
+### Spawn Sessions in the Chat List
+
+Every subagent runs as its own console chat with a `sub-*` session id, so it
+shows up in the chat list, in `GET /agents/{agentId}/chats`, and in the
+built-in "Subagents" group. Each spawn chat records its lineage:
+
+- `source = "subagent"` — the chat's `SessionSource` (filters spawn chats)
+- `parent_session_id` — the session id of the **direct parent**
+  (the session that issued this spawn)
+- `root_session_id` — the session id of the **root** conversation
+  (nested spawns still point at the original root)
+- `meta.subagent_allowed_tools` / `meta.subagent_skills` — the tool/skill
+  whitelist passed to the spawn, recorded in `meta` when one was set
+
+This lets downstream tools rebuild the spawn tree by grouping chats on
+`root_session_id` and linking children to `parent_session_id`, and inspect
+the whitelists in `meta` to see what each subagent was allowed to use.
+
 ### fork=True Behavior by Environment
 
 | Environment                              | Behavior                                                                                                         |

--- a/website/public/docs/multi-agent.zh.md
+++ b/website/public/docs/multi-agent.zh.md
@@ -716,6 +716,17 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 - **同一 Agent**：子 Agent 使用相同的 Agent 配置（persona、tools），只是在独立 session 中运行。
 - **无需额外配置**：`fork=True` 始终可用，无论是否开启 Coding Mode。
 
+### 会话列表中的子 Agent 会话
+
+每个子 Agent 都会以独立的 console chat（`sub-*` session id）运行，因此会出现在会话列表、`GET /agents/{agentId}/chats` 以及内置的「Subagents」分组中。每个 spawn 会话都会记录其血缘关系：
+
+- `source = "subagent"` —— 会话的 `SessionSource` 来源标记（用于筛选所有子 Agent 会话）
+- `parent_session_id` —— **直接父**会话的 session id（发起本次派发的会话）
+- `root_session_id` —— **根**会话的 session id（嵌套 spawn 仍指向最初的根会话）
+- `meta.subagent_allowed_tools` / `meta.subagent_skills` —— 派发时指定的工具/技能白名单（设置过才会记录在 `meta` 中）
+
+下游工具可以按 `root_session_id` 分组、按 `parent_session_id` 链接父子来精确重建 spawn 树，并通过 `meta` 中的白名单查看每个子 Agent 被允许使用的工具/技能。
+
 ### fork=True 在不同环境下的行为
 
 | 环境                                       | 行为                                                                                                |


### PR DESCRIPTION

## What's Changed

### What Problem This Solves

When a `spawn_subagent` call restricts the subagent via `allowed_tools` / `skills`, that whitelist only travels in the spawn request context, where the runtime builder consumes it once. Nothing is ever persisted: after the subagent finishes, no API can answer "what was this subagent allowed to use?" Spawn-tree consumers (dashboard, workbench) can reconstruct the hierarchy — upstream now persists `source = "subagent"` plus first-class `parent_session_id` / `root_session_id` on both console endpoints — but each node's sandbox scope is lost. This PR records the restriction so the tree can show exactly what each subagent was allowed to use.

### Summary

Persist the spawn **tool/skill whitelists** into `ChatSpec.meta`.

Spawn lineage itself (`source = "subagent"`, `parent_session_id`, `root_session_id`) is already persisted as first-class `ChatSpec` fields by `_chat_registration_fields` on both `/console/chat` and `/console/chat/task`. The one piece that never reaches the chat record is the restriction: when a `spawn_subagent` call limits the subagent via `allowed_tools` / `skills`, that whitelist only travels in the request context, where the runtime builder consumes it once. Nothing downstream can later answer "what was this subagent allowed to use?" — so a spawn-tree view can show the hierarchy but not the sandbox each node ran under.

This PR closes that gap:

- **`ChatManager.update_meta(chat_id, meta)`** — new generic, key-preserving meta merge (lock-guarded, `updated_at` bump). Reusable by any future consumer that needs to merge metadata without clobbering existing keys.
- **`_apply_spawn_whitelist()`** in the console router — when the request context carries `_spawn_subagent` plus non-empty `subagent_allowed_tools` / `subagent_skills`, they are merged into `meta` on both the foreground (`/console/chat`) and background (`/console/chat/task`) endpoints. No whitelist → no write (plain chats and unrestricted spawns stay untouched).
- Docs: `multi-agent.en.md` / `multi-agent.zh.md` — "Spawn Sessions in the Chat List" section documenting the combined contract (first-class lineage fields + `meta` whitelists + the built-in "Subagents" group).

### Why the scope changed (8/27 rework)

This PR's original scope persisted the full lineage (`spawn` flag, root/parent session ids, whitelists) into `meta` under a new `SessionSource.spawn`. While waiting for review, main moved forward: spawn chats are now tagged `source = "subagent"` and their lineage is persisted as first-class `ChatSpec` fields on both endpoints, and subagent chats get a built-in "Subagents" group. Keeping the old design would have introduced a second, competing lineage mechanism. The PR was rebased onto the latest main and reduced to the part upstream does not cover: the whitelist persistence above.

### Behavior

| Scenario | Chat record |
|---|---|
| Plain chat / cron / non-spawn | unchanged (no meta write) |
| Spawn without restrictions | lineage fields only (upstream); no `meta` write |
| Spawn with `allowed_tools` / `skills` | lineage fields (upstream) + `meta.subagent_allowed_tools` / `meta.subagent_skills` |
| Reconnect to a running spawn chat | unchanged (registration fields are idempotent; whitelist is written on the original send) |

### Testing

- New unit tests (7): `update_meta` merge + missing-chat; foreground spawn whitelist persistence via `POST /console/chat`; background task — whitelist persisted / plain task untouched / unrestricted spawn no write / empty whitelists skipped.
- Local verification (rebased onto latest main `2de79c1b`):
  - touched test files: **44/44 passed**
  - full unit suite: **9836 passed**, 3 failures in `tests/unit/cli/test_hub_cmd.py` are **pre-existing on clean main** (missing optional `docker`/hub deps in the local env; identical failure set without this PR's changes)
  - pre-commit: black (79) / mypy / pylint / flake8 / trailing-comma / ast all passed on changed files

### Evidence

- `subagent_allowed_tools` / `subagent_skills` are set into the spawn request context by `agent_management.py` (`rc["subagent_allowed_tools"] = ...`) and consumed once at run time by `runtime/builder.py`; before this PR they were the only spawn inputs with no persisted trace.
- `_chat_registration_fields` (upstream) already reads the same request context for lineage on both endpoints — this PR's helper follows the same read-only pattern (does not pop/mutate the context) and is placed right after `_persist_pending_project_dirs` at both call sites, matching the existing post-registration persistence flow.

---


### 解决什么问题

`spawn_subagent` 通过 `allowed_tools` / `skills` 收窄子 Agent 时，白名单只存在于派发请求上下文里、由 runtime builder 消费一次，之后没有任何 API 能回答「这个子 Agent 当时被允许用什么」。spawn 树消费方（dashboard / 工作台）能重建层级（上游已持久化 `source = "subagent"` + 一等字段 `parent_session_id` / `root_session_id`），但每个节点的沙箱范围丢失。本 PR 把限制记录下来，让 spawn 树能显示每个子 Agent 当时的权限范围。

### 改动摘要

把 spawn 的**工具/技能白名单**持久化进 `ChatSpec.meta`。

spawn 的血缘本身（`source = "subagent"`、`parent_session_id`、`root_session_id`）上游已经在 `/console/chat` 和 `/console/chat/task` 两个端点通过 `_chat_registration_fields` 持久化为一等字段。唯一落不了地的是「限制」本身：`spawn_subagent` 通过 `allowed_tools` / `skills` 收窄子 Agent 时，白名单只存在于请求上下文里、由 runtime builder 消费一次——之后没有任何下游能回答「这个子 Agent 当时被允许用什么」。spawn 树视图因此只能画层级、看不到每个节点当时的沙箱范围。

本 PR 补上这个缺口：

- **`ChatManager.update_meta(chat_id, meta)`**——新的通用 meta 合并方法（加锁、保留已有键、刷新 `updated_at`），后续任何需要合并元数据的场景可复用。
- **console 路由 `_apply_spawn_whitelist()`**——请求上下文带 `_spawn_subagent` 且 `subagent_allowed_tools` / `subagent_skills` 非空时，在前台（`/console/chat`）和后台（`/console/chat/task`）两个端点把它们合并进 `meta`；没有限制就不写（普通会话与无限制 spawn 零扰动）。
- 文档：`multi-agent.en.md` / `multi-agent.zh.md` 新增「会话列表中的子 Agent 会话」一节，完整描述合并后的契约（一等 lineage 字段 + `meta` 白名单 + 内置 Subagents 分组）。

### 为什么 8/27 缩小了范围

本 PR 最初的范围是把完整血缘（`spawn` 标记、root/parent session id、白名单）以 `meta` 五键形式持久化，并新增 `SessionSource.spawn`。等待 review 期间上游 main 前进了：spawn 会话现在被标记为 `source = "subagent"`、lineage 以一等字段在双端点持久化、并有了内置「Subagents」分组。若沿用原设计，会引入第二套互相竞争的血缘机制。因此本 PR rebase 到最新 main 后，收敛为上游未覆盖的部分：白名单持久化。

### 测试

- 新增 7 个单测：`update_meta` 合并/缺失 chat；前台 spawn 白名单持久化；后台任务——白名单持久化/普通任务不写/无限制 spawn 不写/空白名单跳过。
- 本地验证（已 rebase 到最新 main `2de79c1b`）：改动测试文件 **44/44 通过**；全量单测 **9836 通过**，`test_hub_cmd.py` 3 个失败为**干净 main 上预存**（本地环境缺可选 `docker`/hub 依赖，无本 PR 改动时失败集合完全一致）；pre-commit（black 79 / mypy / pylint / flake8 / trailing-comma / ast）改动文件全部通过。