### PR TITLE
chore: bump the version to v2.1.1b1

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "2.1.0"
+__version__ = "2.1.1b1"


### PR DESCRIPTION
## Description

Bump the QwenPaw package version from `2.1.0` to `2.1.1b1` for the first 2.1.1 beta release.

## Type of Change

- [x] CI/CD / release maintenance

## Testing

- `uv run --extra test pytest tests/integration/test_version.py tests/unit/cli/test_cli_version.py -q`
- `pre-commit run --files src/qwenpaw/__version__.py`

## Evidence

```text
5 passed in 0.95s
All pre-commit hooks passed for src/qwenpaw/__version__.py
```

## Checklist

- [x] Version-related tests pass
- [x] Pre-commit checks pass
- [x] Ready for review