### PR TITLE
fix(console): reuse mobile state in loop selector

### DIFF
--- a/console/src/components/LoopInput/LoopModeSelector.test.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.test.tsx
@@ -64,7 +64,7 @@ describe("LoopModeSelector", () => {
 
   it("shows localized built-ins and verbatim custom modes", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<LoopModeSelector />);
+    renderWithProviders(<LoopModeSelector isMobile={false} />);
 
     await user.click(screen.getByRole("button", { name: "loop.selectorAria" }));
 
@@ -92,7 +92,7 @@ describe("LoopModeSelector", () => {
 
   it("selects a custom mode from the compact menu", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<LoopModeSelector />);
+    renderWithProviders(<LoopModeSelector isMobile={false} />);
 
     await user.click(screen.getByRole("button", { name: "loop.selectorAria" }));
     await user.click(screen.getByText("Quality Review"));
@@ -100,10 +100,24 @@ describe("LoopModeSelector", () => {
     expect(useLoopStore.getState().selectedModeId).toBe("custom:quality");
   });
 
+  it("centers the menu above the trigger in a narrow window", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LoopModeSelector isMobile={true} />);
+
+    await user.click(screen.getByRole("button", { name: "loop.selectorAria" }));
+
+    expect(
+      document.querySelector(".ant-popover-placement-top"),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(".ant-popover-placement-topLeft"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows starting before the first response event", () => {
     useLoopStore.getState().setStartingMode(custom);
 
-    renderWithProviders(<LoopModeSelector />);
+    renderWithProviders(<LoopModeSelector isMobile={false} />);
 
     expect(screen.getByText("Quality Review")).toBeInTheDocument();
     expect(screen.getByText("loop.starting")).toBeInTheDocument();
@@ -115,7 +129,7 @@ describe("LoopModeSelector", () => {
   it("shows running after the first response event", () => {
     useLoopStore.getState().setSessionMode(custom, "running");
 
-    renderWithProviders(<LoopModeSelector />);
+    renderWithProviders(<LoopModeSelector isMobile={false} />);
 
     expect(screen.getByText("loop.running")).toBeInTheDocument();
   });
@@ -123,7 +137,7 @@ describe("LoopModeSelector", () => {
   it("shows that an active mode is waiting for the user", () => {
     useLoopStore.getState().setSessionMode(custom, "awaiting_user");
 
-    renderWithProviders(<LoopModeSelector />);
+    renderWithProviders(<LoopModeSelector isMobile={false} />);
 
     expect(screen.getByText("loop.awaiting_user")).toBeInTheDocument();
   });

--- a/console/src/components/LoopInput/LoopModeSelector.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.tsx
@@ -35,7 +35,7 @@ function ModeIcon({ mode, size = 14 }: { mode: LoopModeInfo; size?: number }) {
   return <CircleDot size={size} />;
 }
 
-export function LoopModeSelector() {
+export function LoopModeSelector({ isMobile }: { isMobile: boolean }) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language || "en";
   const navigate = useNavigate();
@@ -170,8 +170,10 @@ export function LoopModeSelector() {
       content={content}
       onOpenChange={setOpen}
       open={open}
-      overlayClassName={styles.modePopover}
-      placement="topLeft"
+      overlayClassName={`${styles.modePopover} ${
+        isMobile ? styles.modePopoverMobile : ""
+      }`}
+      placement={isMobile ? "top" : "topLeft"}
       trigger="click"
     >
       <button

--- a/console/src/components/LoopInput/index.module.less
+++ b/console/src/components/LoopInput/index.module.less
@@ -91,10 +91,33 @@
   overflow: hidden;
 }
 
+.modePopover {
+  width: min(360px, calc(100% - 24px));
+}
+
 .modeMenu {
-  width: min(360px, calc(100vw - 24px));
+  width: 100%;
   padding: 10px;
   background: var(--ant-color-bg-elevated);
+}
+
+.modePopoverMobile {
+  right: 12px !important;
+  left: 12px !important;
+  width: auto;
+
+  .modeMenu {
+    max-height: min(480px, calc(100dvh - 32px));
+    padding-bottom: max(10px, env(safe-area-inset-bottom));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .settingsButton {
+    width: 44px;
+    height: 44px;
+    touch-action: manipulation;
+  }
 }
 
 .menuHeader {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -3196,7 +3196,7 @@ export default function ChatPage() {
                 onTranscription={handleWhisperTranscription}
               />
             ) : null}
-            {usesQwenPawBackend && <LoopModeSelector />}
+            {usesQwenPawBackend && <LoopModeSelector isMobile={isMobile} />}
             {pluginSenderPrefix}
           </>
         ),
@@ -3506,6 +3506,7 @@ export default function ChatPage() {
     handleQueueRetry,
     handleQueueSkip,
     effectiveIsFullMode,
+    isMobile,
     historyPanelOpen,
     toggleHistoryPanel,
     handleCompactCommand,


### PR DESCRIPTION
Removed the redundant `useIsMobile()` call within `LoopModeSelector`.
Leveraged the existing `isMobile` state from `ChatPage` and passed it to the selector via a prop.
Retained and refined the mobile overlay behavior: it now centers above the trigger button on mobile devices.
Limited the overlay's maximum height and enabled scrolling.
Added support for the bottom safe area.
Increased the touch target area for the settings button.

Added a test for mobile overlay positioning and updated existing tests for the selector.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
