### PR TITLE
fix: fix DashScope audio formatting and fallback retry

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -176,6 +176,9 @@ def _normalize_messages_for_formatter(
     supports_multimodal = _supports_multimodal_for_current_model()
     if getattr(formatter_instance, "_qwenpaw_force_strip_media", False):
         supports_multimodal = False
+    strip_audio = bool(
+        getattr(formatter_instance, "_qwenpaw_force_strip_audio", False),
+    )
 
     if is_anthropic_formatter:
         target_family = "anthropic"
@@ -188,6 +191,7 @@ def _normalize_messages_for_formatter(
         msgs,
         supports_multimodal=supports_multimodal,
         target_family=target_family,
+        strip_audio=strip_audio,
     )
 
     return (
@@ -237,6 +241,7 @@ _WIRE_MEDIA_BLOCK_TYPES = frozenset(
     },
 )
 _WIRE_MEDIA_CONTAINER_KEYS = frozenset({"file_data", "inline_data"})
+_WIRE_AUDIO_BLOCK_TYPES = frozenset({"audio", "input_audio"})
 
 
 def _count_wire_media_blocks(value: Any) -> int:
@@ -251,6 +256,21 @@ def _count_wire_media_blocks(value: Any) -> int:
     if any(key in value for key in _WIRE_MEDIA_CONTAINER_KEYS):
         return 1
     return sum(_count_wire_media_blocks(item) for item in value.values())
+
+
+def _count_wire_audio_blocks(value: Any) -> int:
+    """Count provider-formatted audio blocks in a nested payload."""
+    if isinstance(value, list):
+        return sum(_count_wire_audio_blocks(item) for item in value)
+    if not isinstance(value, dict):
+        return 0
+
+    if value.get("type") in _WIRE_AUDIO_BLOCK_TYPES:
+        return 1
+    media_type = value.get("mime_type") or value.get("media_type")
+    if isinstance(media_type, str) and media_type.startswith("audio/"):
+        return 1
+    return sum(_count_wire_audio_blocks(item) for item in value.values())
 
 
 def _video_oversize_placeholder(
@@ -1098,6 +1118,7 @@ def _create_file_block_support_formatter(
             # A formatter failure must not leave media evidence from a
             # previous request behind for the capability fallback layer.
             self._qwenpaw_last_wire_media_count = 0
+            self._qwenpaw_last_wire_audio_count = 0
 
             # Per-wire-request dedup scope — second occurrence of the
             # same media source becomes a text placeholder.  Reset on
@@ -1292,6 +1313,9 @@ def _create_file_block_support_formatter(
 
             wire_messages = _strip_top_level_message_name(messages)
             self._qwenpaw_last_wire_media_count = _count_wire_media_blocks(
+                wire_messages,
+            )
+            self._qwenpaw_last_wire_audio_count = _count_wire_audio_blocks(
                 wire_messages,
             )
             return wire_messages

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -543,6 +543,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
             return
         setattr(formatter, "_qwenpaw_force_strip_media", enabled)
 
+    def _set_formatter_audio_strip(self, enabled: bool) -> None:
+        """Toggle request-time audio stripping on the active formatter."""
+        formatter = self._get_active_formatter()
+        if formatter is None:
+            return
+        setattr(formatter, "_qwenpaw_force_strip_audio", enabled)
+
     def _last_wire_request_had_media(self) -> bool:
         """Return whether the last completed formatting emitted media."""
         formatter = self._get_active_formatter()
@@ -553,6 +560,41 @@ class QwenPawAgent(CodingModeMixin, Agent):
             isinstance(count, int)
             and not isinstance(count, bool)
             and (count > 0)
+        )
+
+    def _last_wire_request_had_audio(self) -> bool:
+        """Return whether the last completed formatting emitted audio."""
+        formatter = self._get_active_formatter()
+        if formatter is None:
+            return False
+        count = getattr(formatter, "_qwenpaw_last_wire_audio_count", 0)
+        return (
+            isinstance(count, int)
+            and not isinstance(count, bool)
+            and (count > 0)
+        )
+
+    @staticmethod
+    def _is_audio_fallback_error(exc: Exception) -> bool:
+        """Return whether DashScope rejected the current audio payload."""
+        error_str = " ".join(str(exc).lower().split())
+        status = extract_status_code(exc)
+        has_bad_request_status = status == 400 or "<400>" in error_str
+        invalid_url = "provided url does not appear to be valid" in error_str
+        invalid_modal = all(
+            marker in error_str
+            for marker in (
+                "incorrect modal",
+                "audio",
+                "was entered",
+                "may not be supported by the model",
+                "wrong position",
+            )
+        )
+        return (
+            has_bad_request_status
+            and "internalerror.algo.invalidparameter" in error_str
+            and (invalid_url or invalid_modal)
         )
 
     async def _prepare_model_input(self) -> dict[str, Any]:
@@ -762,24 +804,40 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 else:
                     yield evt
         except Exception as e:
-            if not (
+            audio_fallback_retry = (
+                self._last_wire_request_had_audio()
+                and self._is_audio_fallback_error(e)
+            )
+            media_capability_retry = (
                 self._last_wire_request_had_media()
                 and self._is_explicit_media_capability_error(e)
-            ):
+            )
+            if not (audio_fallback_retry or media_capability_retry):
                 raise
 
             model_key = self._get_model_key()
-            learn_global_rejection = self._is_global_media_capability_error(e)
-            logger.warning(
-                "_reasoning failed because the provider explicitly rejected "
-                "the model's media capability (%s); "
-                "stripping media and retrying.",
-                e,
+            learn_global_rejection = (
+                media_capability_retry
+                and self._is_global_media_capability_error(e)
             )
-            if self._uses_request_time_media_normalization():
-                self._set_formatter_media_strip(True)
+            if audio_fallback_retry:
+                logger.warning(
+                    "_reasoning failed because the provider rejected an "
+                    "audio payload (%s); stripping audio and retrying.",
+                    e,
+                )
+                self._set_formatter_audio_strip(True)
             else:
-                self._strip_media_blocks_from_memory()
+                logger.warning(
+                    "_reasoning failed because the provider explicitly "
+                    "rejected the model's media capability (%s); stripping "
+                    "media and retrying.",
+                    e,
+                )
+                if self._uses_request_time_media_normalization():
+                    self._set_formatter_media_strip(True)
+                else:
+                    self._strip_media_blocks_from_memory()
 
             try:
                 async for evt in super()._reasoning(
@@ -798,7 +856,10 @@ class QwenPawAgent(CodingModeMixin, Agent):
                     )
             finally:
                 if self._uses_request_time_media_normalization():
-                    self._set_formatter_media_strip(False)
+                    if audio_fallback_retry:
+                        self._set_formatter_audio_strip(False)
+                    else:
+                        self._set_formatter_media_strip(False)
         else:
             if should_strip and self._uses_request_time_media_normalization():
                 self._set_formatter_media_strip(False)

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -504,6 +504,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
             return False
         return get_capability_cache().get(key, "rejects_media", False)
 
+    def _model_rejects_audio(self) -> bool:
+        """Check the capability cache for a learned audio rejection."""
+        key = self._get_model_key()
+        if key is None:
+            return False
+        return get_capability_cache().get(key, "rejects_audio", False)
+
     def _proactive_strip_media_blocks(self) -> int:
         """Proactively strip media blocks from memory before model call.
 
@@ -580,7 +587,6 @@ class QwenPawAgent(CodingModeMixin, Agent):
         error_str = " ".join(str(exc).lower().split())
         status = extract_status_code(exc)
         has_bad_request_status = status == 400 or "<400>" in error_str
-        invalid_url = "provided url does not appear to be valid" in error_str
         invalid_modal = all(
             marker in error_str
             for marker in (
@@ -594,7 +600,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
         return (
             has_bad_request_status
             and "internalerror.algo.invalidparameter" in error_str
-            and (invalid_url or invalid_modal)
+            and invalid_modal
         )
 
     async def _prepare_model_input(self) -> dict[str, Any]:
@@ -753,11 +759,14 @@ class QwenPawAgent(CodingModeMixin, Agent):
         # ── Proactive media stripping ──
         from .model_factory import _supports_multimodal_for_current_model
 
-        should_strip = (
+        should_strip_media = (
             not _supports_multimodal_for_current_model()
             or self._model_rejects_media()
         )
-        if should_strip:
+        should_strip_audio = (
+            not should_strip_media and self._model_rejects_audio()
+        )
+        if should_strip_media:
             if self._uses_request_time_media_normalization():
                 self._set_formatter_media_strip(True)
             else:
@@ -768,6 +777,11 @@ class QwenPawAgent(CodingModeMixin, Agent):
                         "_reasoning (model lacks multimodal support).",
                         n,
                     )
+        elif (
+            should_strip_audio
+            and self._uses_request_time_media_normalization()
+        ):
+            self._set_formatter_audio_strip(True)
 
         # ── Model call with passive retry on media error ──
         final_msg: Msg | None = None
@@ -813,6 +827,11 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 and self._is_explicit_media_capability_error(e)
             )
             if not (audio_fallback_retry or media_capability_retry):
+                if self._uses_request_time_media_normalization():
+                    if should_strip_media:
+                        self._set_formatter_media_strip(False)
+                    if should_strip_audio:
+                        self._set_formatter_audio_strip(False)
                 raise
 
             model_key = self._get_model_key()
@@ -854,15 +873,22 @@ class QwenPawAgent(CodingModeMixin, Agent):
                         "rejects_media",
                         True,
                     )
+                if model_key and audio_fallback_retry:
+                    get_capability_cache().learn(
+                        model_key,
+                        "rejects_audio",
+                        True,
+                    )
             finally:
                 if self._uses_request_time_media_normalization():
-                    if audio_fallback_retry:
-                        self._set_formatter_audio_strip(False)
-                    else:
-                        self._set_formatter_media_strip(False)
+                    self._set_formatter_audio_strip(False)
+                    self._set_formatter_media_strip(False)
         else:
-            if should_strip and self._uses_request_time_media_normalization():
-                self._set_formatter_media_strip(False)
+            if self._uses_request_time_media_normalization():
+                if should_strip_media:
+                    self._set_formatter_media_strip(False)
+                if should_strip_audio:
+                    self._set_formatter_audio_strip(False)
 
         # ── Stop Hook: run every iteration ──
         stop_result = await self._run_stop_handlers(final_msg)

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -136,12 +136,44 @@ def _is_media_block(block: Any) -> bool:
     return False
 
 
-def _strip_media_blocks_in_place(msgs: list[Msg]) -> int:
+def _is_audio_block(block: Any) -> bool:
+    """Check if a block carries audio content."""
+    if isinstance(block, dict):
+        block_type = block.get("type")
+        if block_type == "audio":
+            return True
+        if block_type == "data":
+            source = block.get("source")
+            media_type = (
+                source.get("media_type", "")
+                if isinstance(source, dict)
+                else ""
+            )
+            return media_type.startswith("audio/")
+        return False
+
+    block_type = getattr(block, "type", None)
+    if block_type == "audio":
+        return True
+    if block_type == "data":
+        source = getattr(block, "source", None)
+        media_type = getattr(source, "media_type", "") or ""
+        return media_type.startswith("audio/")
+    return False
+
+
+def _strip_media_blocks_in_place(
+    msgs: list[Msg],
+    *,
+    audio_only: bool = False,
+) -> int:
     """Strip media blocks from copied messages only.
 
-    Handles both 1.x dict blocks and 2.0 Pydantic block objects.
+    Handles both 1.x dict blocks and 2.0 Pydantic block objects. When
+    ``audio_only`` is true, image, video, and file blocks are preserved.
     """
     total_stripped = 0
+    should_strip = _is_audio_block if audio_only else _is_media_block
 
     for msg in msgs:
         if not isinstance(msg.content, list):
@@ -150,7 +182,7 @@ def _strip_media_blocks_in_place(msgs: list[Msg]) -> int:
         new_content = []
         stripped_this_message = 0
         for block in msg.content:
-            if _is_media_block(block):
+            if should_strip(block):
                 total_stripped += 1
                 stripped_this_message += 1
                 continue
@@ -168,9 +200,7 @@ def _strip_media_blocks_in_place(msgs: list[Msg]) -> int:
             )
             if btype == "tool_result" and isinstance(output, list):
                 original_len = len(output)
-                filtered = [
-                    item for item in output if not _is_media_block(item)
-                ]
+                filtered = [item for item in output if not should_strip(item)]
                 stripped_count = original_len - len(filtered)
                 total_stripped += stripped_count
                 stripped_this_message += stripped_count
@@ -242,6 +272,7 @@ def normalize_messages_for_model_request(
     *,
     supports_multimodal: bool,
     target_family: str = "openai",
+    strip_audio: bool = False,
 ) -> list[Msg]:
     """Return a normalized copy for provider request formatting.
 
@@ -251,6 +282,7 @@ def normalize_messages_for_model_request(
         target_family: Provider family of the *current* model
             (``"openai"`` | ``"anthropic"`` | ``"gemini"``).
             Used to strip fields that belong to other providers.
+        strip_audio: Whether to remove only audio blocks from the request copy.
     """
     normalized = _clone_messages(msgs)
     # Sanitize first: _repair_empty_tool_inputs needs raw_input to fix
@@ -264,6 +296,8 @@ def normalize_messages_for_model_request(
         _strip_unsigned_thinking_for_anthropic(normalized)
     if not supports_multimodal:
         _strip_media_blocks_in_place(normalized)
+    elif strip_audio:
+        _strip_media_blocks_in_place(normalized, audio_only=True)
     return normalized
 
 

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -53,6 +53,13 @@ from pydantic import Field
 # rationale.
 MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
 
+_DASHSCOPE_AUDIO_FORMAT_BY_MIME = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+}
+
 
 def _resolve_local_path(url: str) -> str | None:
     """Resolve a URL or bare path to a local filesystem path.
@@ -270,13 +277,18 @@ class _CappingDashScopeFormatter(
         # Base64Source audio data as a data URL.
         if isinstance(normalized_source, Base64Source):
             media_type = normalized_source.media_type
+            provider_format = _DASHSCOPE_AUDIO_FORMAT_BY_MIME.get(media_type)
+            if provider_format is None:
+                raise ValueError(
+                    f"Unsupported DashScope audio MIME type: {media_type}",
+                )
             return {
                 "type": "input_audio",
                 "input_audio": {
                     "data": (
                         f"data:{media_type};base64,{normalized_source.data}"
                     ),
-                    "format": media_type.split("/")[-1],
+                    "format": provider_format,
                 },
             }
         return super()._format_audio_source(normalized_source)

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -265,9 +265,21 @@ class _CappingDashScopeFormatter(
         capped = self._maybe_cap(source, "audio")
         if capped is not None:
             return capped
-        return super()._format_audio_source(
-            self._local_source_to_base64(source),
-        )
+        normalized_source = self._local_source_to_base64(source)
+        # TODO: Remove this workaround after AgentScope formats DashScope
+        # Base64Source audio data as a data URL.
+        if isinstance(normalized_source, Base64Source):
+            media_type = normalized_source.media_type
+            return {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": (
+                        f"data:{media_type};base64,{normalized_source.data}"
+                    ),
+                    "format": media_type.split("/")[-1],
+                },
+            }
+        return super()._format_audio_source(normalized_source)
 
 
 class _CappingOpenAIResponseFormatter(

--- a/src/qwenpaw/providers/model_capability_cache.py
+++ b/src/qwenpaw/providers/model_capability_cache.py
@@ -51,6 +51,9 @@ class ModelCapabilityCache:
         ``rejects_media`` (bool):
             The model rejects multimodal (image/audio/video) input
             despite being marked as supporting it.
+        ``rejects_audio`` (bool):
+            The model rejects audio input while other media can remain
+            supported.
     """
 
     _instance: ModelCapabilityCache | None = None

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -2,6 +2,7 @@
 """Tests for message_request_normalizer module."""
 
 # pylint: disable=redefined-outer-name,protected-access
+from copy import deepcopy
 import json
 
 import pytest
@@ -264,6 +265,46 @@ def test_normalize_preserves_original_messages(mixed_content_message):
         supports_multimodal=False,
     )
     assert mixed_content_message.to_dict() == original_dict
+
+
+def test_normalize_strip_audio_handles_nested_tool_result():
+    msgs = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ToolCallBlock(
+                    type="tool_call",
+                    id="call_1",
+                    name="media_tool",
+                    input="{}",
+                ),
+                ToolResultBlock(
+                    type="tool_result",
+                    id="call_1",
+                    name="media_tool",
+                    output=[
+                        TextBlock(text="Tool output"),
+                        _data_block("image/png", "file:///tmp/image.png"),
+                        _data_block("audio/mpeg", "file:///tmp/audio.mp3"),
+                        _data_block("video/mp4", "file:///tmp/video.mp4"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    original = [msg.model_dump(mode="json") for msg in msgs]
+    expected = deepcopy(original)
+    del expected[0]["content"][1]["output"][2]
+
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+        strip_audio=True,
+    )
+
+    assert [msg.model_dump(mode="json") for msg in msgs] == original
+    assert [msg.model_dump(mode="json") for msg in normalized] == expected
 
 
 def test_normalize_returns_new_message_instances(text_message):

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -35,6 +35,7 @@ from qwenpaw.agents import model_factory
 from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
 from qwenpaw.providers.capping_formatter import (
     _CappingAnthropicFormatter,
+    _CappingDashScopeFormatter,
     _CappingOpenAIFormatter,
 )
 from qwenpaw.utils.tool_call_extra import persist_tool_call_extras
@@ -282,6 +283,63 @@ async def test_formatter_resets_wire_media_count_before_failure(
         await formatter.format([valid])
 
     assert formatter._qwenpaw_last_wire_media_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dashscope_audio_strip_flag_preserves_other_media(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingDashScopeFormatter,
+    )
+    formatter = formatter_class()
+    audio_block = _base64_data_block("audio/mpeg", b"audio")
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[
+            TextBlock(text="Mixed media"),
+            _base64_data_block("image/png", b"image"),
+            audio_block,
+            _base64_data_block("video/mp4", b"video"),
+        ],
+    )
+    original = msg.model_dump(mode="json")
+
+    first_request = await formatter.format([msg])
+
+    assert [block["type"] for block in first_request[0]["content"]] == [
+        "text",
+        "image_url",
+        "input_audio",
+        "video_url",
+    ]
+    assert first_request[0]["content"][2] == {
+        "type": "input_audio",
+        "input_audio": {
+            "data": (f"data:audio/mpeg;base64,{audio_block.source.data}"),
+            "format": "mpeg",
+        },
+    }
+    assert formatter._qwenpaw_last_wire_media_count == 3
+    assert formatter._qwenpaw_last_wire_audio_count == 1
+
+    formatter._qwenpaw_force_strip_audio = True
+    retry_request = await formatter.format([msg])
+
+    assert [block["type"] for block in retry_request[0]["content"]] == [
+        "text",
+        "image_url",
+        "video_url",
+    ]
+    assert formatter._qwenpaw_last_wire_media_count == 2
+    assert formatter._qwenpaw_last_wire_audio_count == 0
+    assert msg.model_dump(mode="json") == original
 
 
 def test_formatter_flags_returned_correctly() -> None:

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -323,7 +323,7 @@ async def test_dashscope_audio_strip_flag_preserves_other_media(
         "type": "input_audio",
         "input_audio": {
             "data": (f"data:audio/mpeg;base64,{audio_block.source.data}"),
-            "format": "mpeg",
+            "format": "mp3",
         },
     }
     assert formatter._qwenpaw_last_wire_media_count == 3

--- a/tests/unit/agents/test_react_agent_scroll_seen.py
+++ b/tests/unit/agents/test_react_agent_scroll_seen.py
@@ -11,6 +11,7 @@ from agentscope.model import FinishedReason
 
 from qwenpaw.agents.react_agent import QwenPawAgent
 from qwenpaw.loop.gates import StopAction, StopHandlerResult
+from qwenpaw.providers.model_capability_cache import get_capability_cache
 
 
 _AUDIO_MODAL_ERROR = (
@@ -161,7 +162,10 @@ async def test_audio_modal_error_strips_audio_and_retries_once(
     monkeypatch,
 ) -> None:
     _skip_media_strip(monkeypatch)
+    cache = get_capability_cache()
+    cache.clear()
     agent = make_agent(SeenTracker())
+    agent.model = SimpleNamespace(model_key="dashscope:qwen3.7-plus")
     agent._uses_request_time_media_normalization = lambda: True
     agent.formatter = SimpleNamespace(
         _qwenpaw_last_wire_media_count=1,
@@ -186,9 +190,22 @@ async def test_audio_modal_error_strips_audio_and_retries_once(
 
     monkeypatch.setattr(Agent, "_reasoning", provider_reasoning)
 
-    events = [event async for event in agent._reasoning()]
+    try:
+        events = [event async for event in agent._reasoning()]
+        next_events = [event async for event in agent._reasoning()]
 
-    assert calls == 2
-    assert isinstance(events[-1], Msg)
-    assert agent.formatter._qwenpaw_force_strip_audio is False
-    assert agent.formatter._qwenpaw_force_strip_media is False
+        assert calls == 3
+        assert isinstance(events[-1], Msg)
+        assert isinstance(next_events[-1], Msg)
+        assert (
+            cache.get(
+                "dashscope:qwen3.7-plus",
+                "rejects_audio",
+                False,
+            )
+            is True
+        )
+        assert agent.formatter._qwenpaw_force_strip_audio is False
+        assert agent.formatter._qwenpaw_force_strip_media is False
+    finally:
+        cache.clear()

--- a/tests/unit/agents/test_react_agent_scroll_seen.py
+++ b/tests/unit/agents/test_react_agent_scroll_seen.py
@@ -13,6 +13,15 @@ from qwenpaw.agents.react_agent import QwenPawAgent
 from qwenpaw.loop.gates import StopAction, StopHandlerResult
 
 
+_AUDIO_MODAL_ERROR = (
+    "Error code: 400 - {'error': {'message': '<400> "
+    "InternalError.Algo.InvalidParameter: An incorrect modal `audio` was "
+    "entered, which may not be supported by the model or was placed in the "
+    "wrong position (e.g., in system/assistant).', "
+    "'type': 'invalid_request_error'}}"
+)
+
+
 class SeenTracker:
     """Minimal Scroll manager surface used by ``QwenPawAgent._reasoning``."""
 
@@ -145,3 +154,41 @@ async def test_compress_context_forwards_one_shot_instructions():
     await agent.compress_context(config, instructions=instructions)
 
     assert tracker.calls == [(agent, config, instructions)]
+
+
+@pytest.mark.asyncio
+async def test_audio_modal_error_strips_audio_and_retries_once(
+    monkeypatch,
+) -> None:
+    _skip_media_strip(monkeypatch)
+    agent = make_agent(SeenTracker())
+    agent._uses_request_time_media_normalization = lambda: True
+    agent.formatter = SimpleNamespace(
+        _qwenpaw_last_wire_media_count=1,
+        _qwenpaw_last_wire_audio_count=1,
+        _qwenpaw_force_strip_media=False,
+        _qwenpaw_force_strip_audio=False,
+    )
+    calls = 0
+
+    async def provider_reasoning(self, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError(_AUDIO_MODAL_ERROR)
+        assert agent.formatter._qwenpaw_force_strip_audio is True
+        assert agent.formatter._qwenpaw_force_strip_media is False
+        yield Msg(
+            name="agent",
+            role="assistant",
+            content=[TextBlock(type="text", text="done")],
+        )
+
+    monkeypatch.setattr(Agent, "_reasoning", provider_reasoning)
+
+    events = [event async for event in agent._reasoning()]
+
+    assert calls == 2
+    assert isinstance(events[-1], Msg)
+    assert agent.formatter._qwenpaw_force_strip_audio is False
+    assert agent.formatter._qwenpaw_force_strip_media is False


### PR DESCRIPTION
## Description

Format DashScope Base64 audio as data URLs and retry once without audio when the provider rejects an audio URL or unsupported audio modality. The fallback preserves other media and does not mutate conversation history. Includes focused regression tests.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
