### PR TITLE
feat(console): add media download controls

### DIFF
--- a/console/src/components/Chat/MediaDownload/index.module.less
+++ b/console/src/components/Chat/MediaDownload/index.module.less
@@ -1,0 +1,120 @@
+.mediaList {
+  display: grid;
+  gap: 8px;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.mediaDownload {
+  position: relative;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.mediaDownloadInline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mediaContent {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.audioDownloadSlot {
+  display: inline-flex;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+}
+
+.downloadButton {
+  display: inline-flex;
+  flex: 0 0 36px;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
+  background: var(--ant-color-bg-container, #fff);
+  border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+  touch-action: manipulation;
+
+  > span {
+    display: inline-flex;
+  }
+
+  &:hover:not(:disabled) {
+    color: var(--ant-color-primary, #1677ff);
+    background: var(--ant-color-primary-bg, #e6f4ff);
+    border-color: var(--ant-color-primary-border, #91caff);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ant-color-primary-border, #91caff);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.72;
+  }
+}
+
+.audioDownloadButton {
+  flex-basis: 24px;
+  width: 24px;
+  height: 24px;
+  color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
+  background: transparent;
+  border-color: transparent;
+  border-radius: 6px;
+  box-shadow: none;
+
+  &:hover:not(:disabled) {
+    color: var(--ant-color-primary, #1677ff);
+    background: var(--ant-color-primary-bg, #e6f4ff);
+    border-color: transparent;
+  }
+}
+
+.mediaDownloadOverlay .downloadButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(24, 24, 24, 0.72);
+  border-color: rgba(255, 255, 255, 0.24);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(8px);
+
+  &:hover:not(:disabled) {
+    color: #fff;
+    background: rgba(24, 24, 24, 0.9);
+    border-color: rgba(255, 255, 255, 0.48);
+  }
+}
+
+@media (max-width: 720px) {
+  .downloadButton {
+    flex-basis: 44px;
+    width: 44px;
+    height: 44px;
+  }
+
+  .audioDownloadButton {
+    flex-basis: 24px;
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/console/src/components/Chat/MediaDownload/index.module.less
+++ b/console/src/components/Chat/MediaDownload/index.module.less
@@ -11,12 +11,6 @@
   max-width: 100%;
 }
 
-.mediaDownloadInline {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .mediaContent {
   min-width: 0;
   max-width: 100%;
@@ -31,16 +25,16 @@
 
 .downloadButton {
   display: inline-flex;
-  flex: 0 0 36px;
+  flex: 0 0 24px;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
-  background: var(--ant-color-bg-container, #fff);
-  border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.12));
-  border-radius: 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
   cursor: pointer;
   transition:
     color 160ms ease,
@@ -56,7 +50,7 @@
   &:hover:not(:disabled) {
     color: var(--ant-color-primary, #1677ff);
     background: var(--ant-color-primary-bg, #e6f4ff);
-    border-color: var(--ant-color-primary-border, #91caff);
+    border-color: transparent;
   }
 
   &:focus-visible {
@@ -67,54 +61,5 @@
   &:disabled {
     cursor: wait;
     opacity: 0.72;
-  }
-}
-
-.audioDownloadButton {
-  flex-basis: 24px;
-  width: 24px;
-  height: 24px;
-  color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
-  background: transparent;
-  border-color: transparent;
-  border-radius: 6px;
-  box-shadow: none;
-
-  &:hover:not(:disabled) {
-    color: var(--ant-color-primary, #1677ff);
-    background: var(--ant-color-primary-bg, #e6f4ff);
-    border-color: transparent;
-  }
-}
-
-.mediaDownloadOverlay .downloadButton {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 2;
-  color: rgba(255, 255, 255, 0.95);
-  background: rgba(24, 24, 24, 0.72);
-  border-color: rgba(255, 255, 255, 0.24);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
-  backdrop-filter: blur(8px);
-
-  &:hover:not(:disabled) {
-    color: #fff;
-    background: rgba(24, 24, 24, 0.9);
-    border-color: rgba(255, 255, 255, 0.48);
-  }
-}
-
-@media (max-width: 720px) {
-  .downloadButton {
-    flex-basis: 44px;
-    width: 44px;
-    height: 44px;
-  }
-
-  .audioDownloadButton {
-    flex-basis: 24px;
-    width: 24px;
-    height: 24px;
   }
 }

--- a/console/src/components/Chat/MediaDownload/index.test.tsx
+++ b/console/src/components/Chat/MediaDownload/index.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { downloadFileFromUrl, messageError } = vi.hoisted(() => ({
+  downloadFileFromUrl: vi.fn(),
+  messageError: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useAppMessage", () => ({
+  useAppMessage: () => ({ message: { error: messageError } }),
+}));
+
+vi.mock("../../../api/authHeaders", () => ({
+  buildAuthHeaders: () => ({ Authorization: "Bearer token" }),
+}));
+
+vi.mock("../../../utils/downloadFileFromUrl", () => ({
+  DownloadCancelledError: class DownloadCancelledError extends Error {},
+  downloadFileFromUrl,
+}));
+
+vi.mock("@agentscope-ai/chat/lib/DefaultCards/Audios", () => ({
+  default: () => (
+    <div data-testid="audio-card">
+      <div className="spark-media-player-controller">
+        <button type="button" data-testid="play-button">
+          play
+        </button>
+        <button type="button" data-testid="volume-button">
+          volume
+        </button>
+        <span>00:00</span>
+        <div className="spark-media-progress-container" />
+        <span>00:00</span>
+      </div>
+    </div>
+  ),
+}));
+
+vi.mock("@agentscope-ai/chat/lib/DefaultCards/Images", () => ({
+  default: () => <div data-testid="image-card" />,
+}));
+
+vi.mock("@agentscope-ai/chat/lib/DefaultCards/Videos", () => ({
+  default: () => <div data-testid="video-card" />,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import {
+  DownloadableAudios,
+  DownloadableImages,
+  DownloadableVideos,
+  MediaDownload,
+} from ".";
+import { DownloadCancelledError } from "../../../utils/downloadFileFromUrl";
+import { mediaFilenameFromUrl } from "./utils";
+import styles from "./index.module.less";
+
+describe("mediaFilenameFromUrl", () => {
+  it("extracts and decodes the filename without query parameters", () => {
+    expect(
+      mediaFilenameFromUrl(
+        "/api/files/preview/recording%20one.mp3?token=test",
+        "audio",
+      ),
+    ).toBe("recording one.mp3");
+  });
+
+  it("uses the fallback for inline media URLs", () => {
+    expect(mediaFilenameFromUrl("data:audio/mp3;base64,abc", "audio.mp3")).toBe(
+      "audio.mp3",
+    );
+  });
+});
+
+describe("MediaDownload", () => {
+  beforeEach(() => {
+    downloadFileFromUrl.mockReset();
+    downloadFileFromUrl.mockResolvedValue(undefined);
+    messageError.mockReset();
+  });
+
+  it("downloads with an inferred filename and auth headers", async () => {
+    render(
+      <MediaDownload url="/api/files/preview/recording.mp3">
+        <div>audio</div>
+      </MediaDownload>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "common.download" }));
+
+    await waitFor(() => {
+      expect(downloadFileFromUrl).toHaveBeenCalledWith(
+        "/api/files/preview/recording.mp3",
+        "recording.mp3",
+        {
+          headers: { Authorization: "Bearer token" },
+          errorMessage: "files.downloadFailed",
+        },
+      );
+    });
+  });
+
+  it("does not report a cancelled native save dialog as an error", async () => {
+    downloadFileFromUrl.mockRejectedValue(new DownloadCancelledError());
+    render(
+      <MediaDownload url="/api/files/preview/recording.mp3">
+        <div>audio</div>
+      </MediaDownload>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "common.download" }));
+
+    await waitFor(() => {
+      expect(downloadFileFromUrl).toHaveBeenCalledOnce();
+    });
+    expect(messageError).not.toHaveBeenCalled();
+  });
+
+  it("does not send console auth headers to external media URLs", async () => {
+    render(
+      <MediaDownload url="https://cdn.example.com/recording.mp3">
+        <div>audio</div>
+      </MediaDownload>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "common.download" }));
+
+    await waitFor(() => {
+      expect(downloadFileFromUrl).toHaveBeenCalledWith(
+        "https://cdn.example.com/recording.mp3",
+        "recording.mp3",
+        {
+          headers: {},
+          errorMessage: "files.downloadFailed",
+        },
+      );
+    });
+  });
+
+  it("puts the audio download action inside the player controls", () => {
+    render(<DownloadableAudios data={[{ src: "/recording.mp3" }]} />);
+
+    const controller = document.querySelector(".spark-media-player-controller");
+    const downloadButton = screen.getByRole("button", {
+      name: "common.download",
+    });
+
+    expect(controller).toContainElement(downloadButton);
+    expect(downloadButton).toHaveClass(styles.audioDownloadButton);
+    expect(downloadButton.parentElement?.previousElementSibling).toBe(
+      screen.getByTestId("play-button"),
+    );
+    expect(downloadButton.parentElement?.nextElementSibling).toBe(
+      screen.getByTestId("volume-button"),
+    );
+  });
+
+  it("renders download actions for image and video cards", () => {
+    render(
+      <>
+        <DownloadableImages data={[{ url: "/photo.png" }]} />
+        <DownloadableVideos data={[{ src: "/clip.mp4" }]} />
+      </>,
+    );
+
+    expect(screen.getByTestId("image-card")).toBeInTheDocument();
+    expect(screen.getByTestId("video-card")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "common.download" }),
+    ).toHaveLength(2);
+  });
+});

--- a/console/src/components/Chat/MediaDownload/index.test.tsx
+++ b/console/src/components/Chat/MediaDownload/index.test.tsx
@@ -38,24 +38,11 @@ vi.mock("@agentscope-ai/chat/lib/DefaultCards/Audios", () => ({
   ),
 }));
 
-vi.mock("@agentscope-ai/chat/lib/DefaultCards/Images", () => ({
-  default: () => <div data-testid="image-card" />,
-}));
-
-vi.mock("@agentscope-ai/chat/lib/DefaultCards/Videos", () => ({
-  default: () => <div data-testid="video-card" />,
-}));
-
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-import {
-  DownloadableAudios,
-  DownloadableImages,
-  DownloadableVideos,
-  MediaDownload,
-} from ".";
+import { AudioDownload, DownloadableAudios } from ".";
 import { DownloadCancelledError } from "../../../utils/downloadFileFromUrl";
 import { mediaFilenameFromUrl } from "./utils";
 import styles from "./index.module.less";
@@ -77,7 +64,7 @@ describe("mediaFilenameFromUrl", () => {
   });
 });
 
-describe("MediaDownload", () => {
+describe("AudioDownload", () => {
   beforeEach(() => {
     downloadFileFromUrl.mockReset();
     downloadFileFromUrl.mockResolvedValue(undefined);
@@ -86,9 +73,9 @@ describe("MediaDownload", () => {
 
   it("downloads with an inferred filename and auth headers", async () => {
     render(
-      <MediaDownload url="/api/files/preview/recording.mp3">
+      <AudioDownload url="/api/files/preview/recording.mp3">
         <div>audio</div>
-      </MediaDownload>,
+      </AudioDownload>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "common.download" }));
@@ -108,9 +95,9 @@ describe("MediaDownload", () => {
   it("does not report a cancelled native save dialog as an error", async () => {
     downloadFileFromUrl.mockRejectedValue(new DownloadCancelledError());
     render(
-      <MediaDownload url="/api/files/preview/recording.mp3">
+      <AudioDownload url="/api/files/preview/recording.mp3">
         <div>audio</div>
-      </MediaDownload>,
+      </AudioDownload>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "common.download" }));
@@ -123,9 +110,9 @@ describe("MediaDownload", () => {
 
   it("does not send console auth headers to external media URLs", async () => {
     render(
-      <MediaDownload url="https://cdn.example.com/recording.mp3">
+      <AudioDownload url="https://cdn.example.com/recording.mp3">
         <div>audio</div>
-      </MediaDownload>,
+      </AudioDownload>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "common.download" }));
@@ -151,27 +138,12 @@ describe("MediaDownload", () => {
     });
 
     expect(controller).toContainElement(downloadButton);
-    expect(downloadButton).toHaveClass(styles.audioDownloadButton);
+    expect(downloadButton).toHaveClass(styles.downloadButton);
     expect(downloadButton.parentElement?.previousElementSibling).toBe(
       screen.getByTestId("play-button"),
     );
     expect(downloadButton.parentElement?.nextElementSibling).toBe(
       screen.getByTestId("volume-button"),
     );
-  });
-
-  it("renders download actions for image and video cards", () => {
-    render(
-      <>
-        <DownloadableImages data={[{ url: "/photo.png" }]} />
-        <DownloadableVideos data={[{ src: "/clip.mp4" }]} />
-      </>,
-    );
-
-    expect(screen.getByTestId("image-card")).toBeInTheDocument();
-    expect(screen.getByTestId("video-card")).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("button", { name: "common.download" }),
-    ).toHaveLength(2);
   });
 });

--- a/console/src/components/Chat/MediaDownload/index.tsx
+++ b/console/src/components/Chat/MediaDownload/index.tsx
@@ -11,8 +11,6 @@ import { Download, LoaderCircle } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import Audios from "@agentscope-ai/chat/lib/DefaultCards/Audios";
-import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
-import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
 import { getApiUrl } from "../../../api/config";
 import { buildAuthHeaders } from "../../../api/authHeaders";
 import { useAppMessage } from "../../../hooks/useAppMessage";
@@ -36,12 +34,9 @@ function mediaDownloadHeaders(url: string): Record<string, string> {
   }
 }
 
-type MediaDownloadPlacement = "audio" | "inline" | "overlay";
-
-interface MediaDownloadProps {
+interface AudioDownloadProps {
   children: ReactNode;
   filename?: string;
-  placement?: MediaDownloadPlacement;
   url: string;
 }
 
@@ -50,23 +45,7 @@ interface AudioData {
   src: string;
 }
 
-interface ImageData {
-  name?: string;
-  url: string;
-}
-
-interface VideoData {
-  name?: string;
-  poster?: string;
-  src: string;
-}
-
-export function MediaDownload({
-  children,
-  filename,
-  placement = "overlay",
-  url,
-}: MediaDownloadProps) {
+export function AudioDownload({ children, filename, url }: AudioDownloadProps) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
   const reduceMotion = useReducedMotion();
@@ -75,19 +54,8 @@ export function MediaDownload({
   const [audioDownloadSlot, setAudioDownloadSlot] =
     useState<HTMLSpanElement | null>(null);
   const resolvedFilename = mediaFilenameFromUrl(url, filename || "download");
-  const placementClass =
-    placement === "inline"
-      ? styles.mediaDownloadInline
-      : placement === "overlay"
-      ? styles.mediaDownloadOverlay
-      : "";
 
   useLayoutEffect(() => {
-    if (placement !== "audio") {
-      setAudioDownloadSlot(null);
-      return;
-    }
-
     const controller = mediaContentRef.current?.querySelector<HTMLElement>(
       '[class*="-media-player-controller"]',
     );
@@ -107,7 +75,7 @@ export function MediaDownload({
     return () => {
       slot.remove();
     };
-  }, [placement]);
+  }, []);
 
   const handleDownload = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -131,9 +99,7 @@ export function MediaDownload({
     <Tooltip title={t("common.download")}>
       <button
         type="button"
-        className={`${styles.downloadButton} ${
-          placement === "audio" ? styles.audioDownloadButton : ""
-        }`}
+        className={styles.downloadButton}
         aria-label={t("common.download")}
         aria-busy={downloading}
         disabled={downloading}
@@ -155,11 +121,11 @@ export function MediaDownload({
   );
 
   return (
-    <div className={`${styles.mediaDownload} ${placementClass}`}>
+    <div className={styles.mediaDownload}>
       <div ref={mediaContentRef} className={styles.mediaContent}>
         {children}
       </div>
-      {placement === "audio" && audioDownloadSlot
+      {audioDownloadSlot
         ? createPortal(downloadAction, audioDownloadSlot)
         : downloadAction}
     </div>
@@ -170,47 +136,13 @@ export function DownloadableAudios({ data }: { data: AudioData[] }) {
   return (
     <div className={styles.mediaList}>
       {data.map((audio, index) => (
-        <MediaDownload
+        <AudioDownload
           key={`${audio.src}-${index}`}
           url={audio.src}
           filename={audio.name}
-          placement="audio"
         >
           <Audios data={[audio]} />
-        </MediaDownload>
-      ))}
-    </div>
-  );
-}
-
-export function DownloadableImages({ data }: { data: ImageData[] }) {
-  return (
-    <div className={styles.mediaList}>
-      {data.map((image, index) => (
-        <MediaDownload
-          key={`${image.url}-${index}`}
-          url={image.url}
-          filename={image.name}
-          placement="inline"
-        >
-          <Images data={[image]} />
-        </MediaDownload>
-      ))}
-    </div>
-  );
-}
-
-export function DownloadableVideos({ data }: { data: VideoData[] }) {
-  return (
-    <div className={styles.mediaList}>
-      {data.map((video, index) => (
-        <MediaDownload
-          key={`${video.src}-${index}`}
-          url={video.src}
-          filename={video.name}
-        >
-          <Videos data={[video]} />
-        </MediaDownload>
+        </AudioDownload>
       ))}
     </div>
   );

--- a/console/src/components/Chat/MediaDownload/index.tsx
+++ b/console/src/components/Chat/MediaDownload/index.tsx
@@ -1,0 +1,217 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { Tooltip } from "antd";
+import { Download, LoaderCircle } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useTranslation } from "react-i18next";
+import Audios from "@agentscope-ai/chat/lib/DefaultCards/Audios";
+import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
+import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
+import { getApiUrl } from "../../../api/config";
+import { buildAuthHeaders } from "../../../api/authHeaders";
+import { useAppMessage } from "../../../hooks/useAppMessage";
+import {
+  DownloadCancelledError,
+  downloadFileFromUrl,
+} from "../../../utils/downloadFileFromUrl";
+import styles from "./index.module.less";
+import { mediaFilenameFromUrl } from "./utils";
+
+function mediaDownloadHeaders(url: string): Record<string, string> {
+  try {
+    const targetOrigin = new URL(url, window.location.origin).origin;
+    const pageOrigin = window.location.origin;
+    const apiOrigin = new URL(getApiUrl("/"), pageOrigin).origin;
+    return targetOrigin === pageOrigin || targetOrigin === apiOrigin
+      ? buildAuthHeaders()
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+type MediaDownloadPlacement = "audio" | "inline" | "overlay";
+
+interface MediaDownloadProps {
+  children: ReactNode;
+  filename?: string;
+  placement?: MediaDownloadPlacement;
+  url: string;
+}
+
+interface AudioData {
+  name?: string;
+  src: string;
+}
+
+interface ImageData {
+  name?: string;
+  url: string;
+}
+
+interface VideoData {
+  name?: string;
+  poster?: string;
+  src: string;
+}
+
+export function MediaDownload({
+  children,
+  filename,
+  placement = "overlay",
+  url,
+}: MediaDownloadProps) {
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+  const reduceMotion = useReducedMotion();
+  const [downloading, setDownloading] = useState(false);
+  const mediaContentRef = useRef<HTMLDivElement>(null);
+  const [audioDownloadSlot, setAudioDownloadSlot] =
+    useState<HTMLSpanElement | null>(null);
+  const resolvedFilename = mediaFilenameFromUrl(url, filename || "download");
+  const placementClass =
+    placement === "inline"
+      ? styles.mediaDownloadInline
+      : placement === "overlay"
+      ? styles.mediaDownloadOverlay
+      : "";
+
+  useLayoutEffect(() => {
+    if (placement !== "audio") {
+      setAudioDownloadSlot(null);
+      return;
+    }
+
+    const controller = mediaContentRef.current?.querySelector<HTMLElement>(
+      '[class*="-media-player-controller"]',
+    );
+    const playButton = Array.from(controller?.children ?? []).find(
+      (child) => child.tagName === "BUTTON",
+    );
+    if (!controller || !playButton) {
+      setAudioDownloadSlot(null);
+      return;
+    }
+
+    const slot = document.createElement("span");
+    slot.className = styles.audioDownloadSlot;
+    controller.insertBefore(slot, playButton.nextSibling);
+    setAudioDownloadSlot(slot);
+
+    return () => {
+      slot.remove();
+    };
+  }, [placement]);
+
+  const handleDownload = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDownloading(true);
+    try {
+      await downloadFileFromUrl(url, filename || resolvedFilename, {
+        headers: mediaDownloadHeaders(url),
+        errorMessage: t("files.downloadFailed"),
+      });
+    } catch (error) {
+      if (!(error instanceof DownloadCancelledError)) {
+        message.error(t("files.downloadFailed"));
+      }
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const downloadAction = (
+    <Tooltip title={t("common.download")}>
+      <button
+        type="button"
+        className={`${styles.downloadButton} ${
+          placement === "audio" ? styles.audioDownloadButton : ""
+        }`}
+        aria-label={t("common.download")}
+        aria-busy={downloading}
+        disabled={downloading}
+        onClick={(event) => void handleDownload(event)}
+      >
+        <motion.span
+          aria-hidden="true"
+          animate={{ rotate: downloading && !reduceMotion ? 360 : 0 }}
+          transition={
+            downloading && !reduceMotion
+              ? { duration: 0.8, ease: "linear", repeat: Infinity }
+              : { duration: 0 }
+          }
+        >
+          {downloading ? <LoaderCircle size={17} /> : <Download size={17} />}
+        </motion.span>
+      </button>
+    </Tooltip>
+  );
+
+  return (
+    <div className={`${styles.mediaDownload} ${placementClass}`}>
+      <div ref={mediaContentRef} className={styles.mediaContent}>
+        {children}
+      </div>
+      {placement === "audio" && audioDownloadSlot
+        ? createPortal(downloadAction, audioDownloadSlot)
+        : downloadAction}
+    </div>
+  );
+}
+
+export function DownloadableAudios({ data }: { data: AudioData[] }) {
+  return (
+    <div className={styles.mediaList}>
+      {data.map((audio, index) => (
+        <MediaDownload
+          key={`${audio.src}-${index}`}
+          url={audio.src}
+          filename={audio.name}
+          placement="audio"
+        >
+          <Audios data={[audio]} />
+        </MediaDownload>
+      ))}
+    </div>
+  );
+}
+
+export function DownloadableImages({ data }: { data: ImageData[] }) {
+  return (
+    <div className={styles.mediaList}>
+      {data.map((image, index) => (
+        <MediaDownload
+          key={`${image.url}-${index}`}
+          url={image.url}
+          filename={image.name}
+          placement="inline"
+        >
+          <Images data={[image]} />
+        </MediaDownload>
+      ))}
+    </div>
+  );
+}
+
+export function DownloadableVideos({ data }: { data: VideoData[] }) {
+  return (
+    <div className={styles.mediaList}>
+      {data.map((video, index) => (
+        <MediaDownload
+          key={`${video.src}-${index}`}
+          url={video.src}
+          filename={video.name}
+        >
+          <Videos data={[video]} />
+        </MediaDownload>
+      ))}
+    </div>
+  );
+}

--- a/console/src/components/Chat/MediaDownload/utils.ts
+++ b/console/src/components/Chat/MediaDownload/utils.ts
@@ -1,0 +1,19 @@
+function decodeFilename(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function mediaFilenameFromUrl(
+  url: string,
+  fallbackFilename: string,
+): string {
+  if (url.startsWith("data:") || url.startsWith("blob:")) {
+    return fallbackFilename;
+  }
+  const path = url.split(/[?#]/, 1)[0].replace(/\\/g, "/");
+  const filename = path.split("/").pop();
+  return filename ? decodeFilename(filename) : fallbackFilename;
+}

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
@@ -64,8 +64,24 @@ function mockFetchByUrl(responses: Record<string, number>) {
 }
 
 describe("MediaPreview error state", () => {
-  it.each(["image", "video", "audio"] as const)(
-    "shows a download action for %s previews",
+  it("shows a download action for audio previews", () => {
+    render(
+      <MediaPreview
+        media={{
+          url: "/api/files/preview/media.audio",
+          name: "media.audio",
+          type: "audio",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "common.download" }),
+    ).toBeInTheDocument();
+  });
+
+  it.each(["image", "video"] as const)(
+    "does not show a download action for %s previews",
     (type) => {
       render(
         <MediaPreview
@@ -78,8 +94,8 @@ describe("MediaPreview error state", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: "common.download" }),
-      ).toBeInTheDocument();
+        screen.queryByRole("button", { name: "common.download" }),
+      ).not.toBeInTheDocument();
     },
   );
 

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
@@ -18,7 +18,21 @@ vi.mock("@agentscope-ai/chat", () => ({
 }));
 
 vi.mock("@agentscope-ai/design", () => ({
-  Audio: () => <div data-testid="audio" />,
+  Audio: () => (
+    <div data-testid="audio">
+      <div className="spark-media-player-controller">
+        <button type="button" data-testid="play-button">
+          play
+        </button>
+        <button type="button" data-testid="volume-button">
+          volume
+        </button>
+        <span>00:00</span>
+        <div className="spark-media-progress-container" />
+        <span>00:00</span>
+      </div>
+    </div>
+  ),
   Video: () => <div data-testid="video" />,
 }));
 
@@ -50,6 +64,25 @@ function mockFetchByUrl(responses: Record<string, number>) {
 }
 
 describe("MediaPreview error state", () => {
+  it.each(["image", "video", "audio"] as const)(
+    "shows a download action for %s previews",
+    (type) => {
+      render(
+        <MediaPreview
+          media={{
+            url: `/api/files/preview/media.${type}`,
+            name: `media.${type}`,
+            type,
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "common.download" }),
+      ).toBeInTheDocument();
+    },
+  );
+
   it("shows a warning when the file preview URL 404s", async () => {
     mockFetchByUrl({ "/api/files/preview/file1.txt": 404 });
 

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
@@ -13,7 +13,7 @@ import type { Locale } from "antd/es/locale";
 import { useTranslation } from "react-i18next";
 import type { MediaInfo } from "./utils";
 import { filePathFromPreviewUrl } from "../../../../features/files-workspace/internalFileLinks";
-import { MediaDownload } from "../../MediaDownload";
+import { AudioDownload } from "../../MediaDownload";
 import styles from "./toolCards.module.less";
 
 export interface MediaPreviewProps {
@@ -99,32 +99,28 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media, onFileOpen }) => {
   return (
     <div className={styles.toolCallMediaPreview}>
       {media.type === "image" && (
-        <MediaDownload url={media.url} filename={media.name}>
-          <ConfigProvider locale={{ Image: { preview: "" } } as Locale}>
-            <div className={styles.toolCallImage}>
-              <Image
-                src={media.url}
-                style={{ width: "100%", objectFit: "contain" }}
-                preview={{ transitionName: "" }}
-                onError={handleMediaError}
-              />
-            </div>
-          </ConfigProvider>
-        </MediaDownload>
+        <ConfigProvider locale={{ Image: { preview: "" } } as Locale}>
+          <div className={styles.toolCallImage}>
+            <Image
+              src={media.url}
+              style={{ width: "100%", objectFit: "contain" }}
+              preview={{ transitionName: "" }}
+              onError={handleMediaError}
+            />
+          </div>
+        </ConfigProvider>
       )}
       {media.type === "video" && (
-        <MediaDownload url={media.url} filename={media.name}>
-          <div className={styles.bubbleVideo}>
-            <Video src={media.url} controls onError={handleMediaError} />
-          </div>
-        </MediaDownload>
+        <div className={styles.bubbleVideo}>
+          <Video src={media.url} controls onError={handleMediaError} />
+        </div>
       )}
       {media.type === "audio" && (
-        <MediaDownload url={media.url} filename={media.name} placement="audio">
+        <AudioDownload url={media.url} filename={media.name}>
           <div className={styles.bubbleAudio}>
             <Audio src={media.url} onError={handleMediaError} />
           </div>
-        </MediaDownload>
+        </AudioDownload>
       )}
       {media.type === "file" && (
         <div

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
@@ -13,6 +13,7 @@ import type { Locale } from "antd/es/locale";
 import { useTranslation } from "react-i18next";
 import type { MediaInfo } from "./utils";
 import { filePathFromPreviewUrl } from "../../../../features/files-workspace/internalFileLinks";
+import { MediaDownload } from "../../MediaDownload";
 import styles from "./toolCards.module.less";
 
 export interface MediaPreviewProps {
@@ -98,26 +99,32 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media, onFileOpen }) => {
   return (
     <div className={styles.toolCallMediaPreview}>
       {media.type === "image" && (
-        <ConfigProvider locale={{ Image: { preview: "" } } as Locale}>
-          <div className={styles.toolCallImage}>
-            <Image
-              src={media.url}
-              style={{ width: "100%", objectFit: "contain" }}
-              preview={{ transitionName: "" }}
-              onError={handleMediaError}
-            />
-          </div>
-        </ConfigProvider>
+        <MediaDownload url={media.url} filename={media.name}>
+          <ConfigProvider locale={{ Image: { preview: "" } } as Locale}>
+            <div className={styles.toolCallImage}>
+              <Image
+                src={media.url}
+                style={{ width: "100%", objectFit: "contain" }}
+                preview={{ transitionName: "" }}
+                onError={handleMediaError}
+              />
+            </div>
+          </ConfigProvider>
+        </MediaDownload>
       )}
       {media.type === "video" && (
-        <div className={styles.bubbleVideo}>
-          <Video src={media.url} controls onError={handleMediaError} />
-        </div>
+        <MediaDownload url={media.url} filename={media.name}>
+          <div className={styles.bubbleVideo}>
+            <Video src={media.url} controls onError={handleMediaError} />
+          </div>
+        </MediaDownload>
       )}
       {media.type === "audio" && (
-        <div className={styles.bubbleAudio}>
-          <Audio src={media.url} onError={handleMediaError} />
-        </div>
+        <MediaDownload url={media.url} filename={media.name} placement="audio">
+          <div className={styles.bubbleAudio}>
+            <Audio src={media.url} onError={handleMediaError} />
+          </div>
+        </MediaDownload>
       )}
       {media.type === "file" && (
         <div

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -29,10 +29,7 @@ import {
   type IAgentScopeRuntimeResponse,
 } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types";
 import { useChatAnywhereOptions } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereOptionsContext";
-import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
-import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
 import Files from "@agentscope-ai/chat/lib/DefaultCards/Files";
-import Audios from "@agentscope-ai/chat/lib/DefaultCards/Audios";
 import { Bubble, Markdown } from "@agentscope-ai/chat";
 import { Avatar, Flex } from "antd";
 import { renderableCodeComponents } from "../../components/RenderableCodeBlock";
@@ -49,6 +46,11 @@ import type {
   ChatRequestData,
   ChatResponseData,
 } from "../../plugins/registry/types";
+import {
+  DownloadableAudios,
+  DownloadableImages,
+  DownloadableVideos,
+} from "../../components/Chat/MediaDownload";
 
 function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
   return arr
@@ -88,14 +90,14 @@ function HostMessage({ data }: { data: IAgentScopeRuntimeMessage }) {
             return <Markdown key={index} content={item.refusal} raw />;
           case AgentScopeRuntimeContentType.IMAGE:
             return (
-              <Images
+              <DownloadableImages
                 key={index}
-                data={[{ url: formatMediaURL(item.image_url) }]}
+                data={[{ url: formatMediaURL(item.image_url) || "" }]}
               />
             );
           case AgentScopeRuntimeContentType.VIDEO:
             return (
-              <Videos
+              <DownloadableVideos
                 key={index}
                 data={[
                   {
@@ -121,7 +123,7 @@ function HostMessage({ data }: { data: IAgentScopeRuntimeMessage }) {
             );
           case AgentScopeRuntimeContentType.AUDIO:
             return (
-              <Audios
+              <DownloadableAudios
                 key={index}
                 data={[
                   { src: formatMediaURL(item.audio_url || item.data) || "" },

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -29,6 +29,8 @@ import {
   type IAgentScopeRuntimeResponse,
 } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types";
 import { useChatAnywhereOptions } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereOptionsContext";
+import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
+import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
 import Files from "@agentscope-ai/chat/lib/DefaultCards/Files";
 import { Bubble, Markdown } from "@agentscope-ai/chat";
 import { Avatar, Flex } from "antd";
@@ -46,11 +48,7 @@ import type {
   ChatRequestData,
   ChatResponseData,
 } from "../../plugins/registry/types";
-import {
-  DownloadableAudios,
-  DownloadableImages,
-  DownloadableVideos,
-} from "../../components/Chat/MediaDownload";
+import { DownloadableAudios } from "../../components/Chat/MediaDownload";
 
 function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
   return arr
@@ -90,14 +88,14 @@ function HostMessage({ data }: { data: IAgentScopeRuntimeMessage }) {
             return <Markdown key={index} content={item.refusal} raw />;
           case AgentScopeRuntimeContentType.IMAGE:
             return (
-              <DownloadableImages
+              <Images
                 key={index}
-                data={[{ url: formatMediaURL(item.image_url) || "" }]}
+                data={[{ url: formatMediaURL(item.image_url) }]}
               />
             );
           case AgentScopeRuntimeContentType.VIDEO:
             return (
-              <DownloadableVideos
+              <Videos
                 key={index}
                 data={[
                   {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -72,6 +72,11 @@ import {
 } from "../../plugins/registry/types";
 import { ChatScalar, ChatList } from "../../plugins/registry/slotKeys";
 import { HostRequestCard, HostResponseCard } from "./HostBubbles";
+import {
+  DownloadableAudios,
+  DownloadableImages,
+  DownloadableVideos,
+} from "../../components/Chat/MediaDownload";
 import { withGenericFallback } from "../../components/Chat/ToolCards/adapters/v1Adapter";
 import { applyApprovalLevelToRequestBody } from "./approvalPayload";
 import {
@@ -3402,6 +3407,9 @@ export default function ChatPage() {
         // compose plugin slots otherwise.
         AgentScopeRuntimeRequestCard: HostRequestCard,
         AgentScopeRuntimeResponseCard: HostResponseCard,
+        Audios: DownloadableAudios,
+        Images: DownloadableImages,
+        Videos: DownloadableVideos,
         ...pluginCards,
       },
       actions: {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -72,11 +72,7 @@ import {
 } from "../../plugins/registry/types";
 import { ChatScalar, ChatList } from "../../plugins/registry/slotKeys";
 import { HostRequestCard, HostResponseCard } from "./HostBubbles";
-import {
-  DownloadableAudios,
-  DownloadableImages,
-  DownloadableVideos,
-} from "../../components/Chat/MediaDownload";
+import { DownloadableAudios } from "../../components/Chat/MediaDownload";
 import { withGenericFallback } from "../../components/Chat/ToolCards/adapters/v1Adapter";
 import { applyApprovalLevelToRequestBody } from "./approvalPayload";
 import {
@@ -3408,8 +3404,6 @@ export default function ChatPage() {
         AgentScopeRuntimeRequestCard: HostRequestCard,
         AgentScopeRuntimeResponseCard: HostResponseCard,
         Audios: DownloadableAudios,
-        Images: DownloadableImages,
-        Videos: DownloadableVideos,
         ...pluginCards,
       },
       actions: {


### PR DESCRIPTION
Implement unified download capabilities for media attachments in chats:
Place the audio download button in the player control bar, following the sequence: "Play → Download → Volume → Time/Progress."
Use slots for audio buttons to ensure visual order aligns with keyboard focus order.
Add download buttons to images and videos while retaining existing preview interactions.
Continue using the existing file preview drawer for standard files; do not add redundant buttons.
Support automatic inference of download filenames from URLs.
Include authentication headers only for requests to the current console/API domain; do not send console authentication information for external media URLs.
Retain support for "downloading" states, download cancellation, tooltips, accessibility labels, and mobile responsiveness.

<img width="1899" height="1301" alt="image" src="https://github.com/user-attachments/assets/7bc89b57-0f77-4548-9892-a4db83f9e94e" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
