### PR TITLE
feat(computer-use): observe related window surfaces

### DIFF
--- a/console/src-tauri/src/computer_use_protocol.rs
+++ b/console/src-tauri/src/computer_use_protocol.rs
@@ -1,4 +1,4 @@
 //! Versioned contract shared by the desktop runtime and native helper.
 
 /// Request/response contract spoken by the Computer Use plugin and helper.
-pub(crate) const VERSION: u64 = 1;
+pub(crate) const VERSION: u64 = 2;

--- a/console/src-tauri/src/computer_use_runtime.rs
+++ b/console/src-tauri/src/computer_use_runtime.rs
@@ -1235,10 +1235,9 @@ mod tests {
 
     #[test]
     fn parses_matching_helper_ready_line() {
-        assert_eq!(
-            parse_helper_ready_line("QWENPAW_COMPUTER_USE_READY {\"protocol_version\":1}"),
-            Ok(Some(()))
-        );
+        let line =
+            format!("QWENPAW_COMPUTER_USE_READY {{\"protocol_version\":{PROTOCOL_VERSION}}}");
+        assert_eq!(parse_helper_ready_line(&line), Ok(Some(())));
     }
 
     #[test]
@@ -1248,8 +1247,12 @@ mod tests {
 
     #[test]
     fn rejects_incompatible_helper_ready_line() {
-        let error = parse_helper_ready_line("QWENPAW_COMPUTER_USE_READY {\"protocol_version\":2}")
-            .expect_err("protocol mismatch must fail startup");
+        let line = format!(
+            "QWENPAW_COMPUTER_USE_READY {{\"protocol_version\":{}}}",
+            PROTOCOL_VERSION + 1
+        );
+        let error =
+            parse_helper_ready_line(&line).expect_err("protocol mismatch must fail startup");
 
         assert!(error.contains("incompatible"));
     }

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -277,7 +277,7 @@ pub(super) fn dispatch_request(
     let mut result = match method {
         "observe_window" => {
             state.settle_before_observe(window.hwnd);
-            observe_window(state, &window)
+            observe_window(state, &window, true)
         }
         "close_window" => close_window(&window),
         "click" => click(observation(state, observation_id)?, &params),
@@ -434,7 +434,10 @@ fn refresh_after_action(state: &mut ServerState, previous: &WindowInfo) -> Optio
         return None;
     }
     state.settle_before_observe(current.hwnd);
-    observe_window(state, &current).ok()
+    // Replacement observations keep semantic state current without paying to
+    // encode images that the action response does not attach. A later
+    // coordinate action starts with an explicit visual observation.
+    observe_window(state, &current, false).ok()
 }
 
 fn parse_input_steps(
@@ -739,7 +742,7 @@ fn requires_user_idle_on_mac(method: &str, target_is_frontmost: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::super::state::WindowInfo;
+    use super::super::state::{ScreenshotTarget, WindowInfo};
     use super::*;
     use std::io::Cursor;
 
@@ -754,9 +757,18 @@ mod tests {
                 title: String::new(),
                 class_name: String::new(),
             },
-            bounds: [0, 0, 100, 100],
-            display_width: 100,
-            display_height: 100,
+            window_bounds: [0, 0, 100, 100],
+            screenshots: std::collections::HashMap::from([(
+                "screenshot-1".to_string(),
+                ScreenshotTarget {
+                    hwnd,
+                    bounds: [0, 0, 100, 100],
+                    display_width: 100,
+                    display_height: 100,
+                },
+            )]),
+            #[cfg(windows)]
+            input_hwnd: hwnd,
             accessibility_revision: None,
             #[cfg(target_os = "macos")]
             transient_text_ready: false,

--- a/console/src-tauri/src/computer_use_server/dispatch.rs
+++ b/console/src-tauri/src/computer_use_server/dispatch.rs
@@ -366,6 +366,7 @@ pub(super) fn dispatch_request(
             needs_user_idle,
         )
     }) {
+        state.note_action(active_after);
         return Ok(action_handoff(result, active_after));
     }
     // Keep the safety boundary -- the input observation has already been

--- a/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/capture.rs
@@ -12,12 +12,13 @@ use objc2_screen_capture_kit::{
     SCContentFilter, SCScreenshotManager, SCShareableContent, SCStreamConfiguration,
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::mpsc;
 use std::time::Duration;
 
 use super::super::state::{
-    accessibility_revision, next_id, Observation, ServerState, WindowInfo, SCREENSHOT_JPEG_QUALITY,
-    SCREENSHOT_MAX_EDGE,
+    accessibility_revision, next_id, Observation, ScreenshotTarget, ServerState, WindowInfo,
+    SCREENSHOT_JPEG_QUALITY, SCREENSHOT_MAX_EDGE,
 };
 use super::accessibility_tree::collect_accessibility;
 use super::window_bounds;
@@ -25,6 +26,7 @@ use super::window_bounds;
 pub(crate) fn observe_window(
     state: &mut ServerState,
     window: &WindowInfo,
+    include_screenshot: bool,
 ) -> Result<Value, (&'static str, String)> {
     let window_id = u32::try_from(window.hwnd).map_err(|_| {
         (
@@ -45,15 +47,32 @@ pub(crate) fn observe_window(
     let has_transient_surface = accessibility
         .as_ref()
         .is_ok_and(|(_, _, transient)| *transient);
-    let capture = if has_transient_surface {
-        Err(
+    let capture = if !include_screenshot {
+        None
+    } else if has_transient_surface {
+        Some(Err(
             "The active transient surface is available through accessibility but is not part of the selected window capture."
                 .to_string(),
-        )
+        ))
     } else {
-        capture_window_image(window_id, capture_width, capture_height)
+        Some(capture_window_image(
+            window_id,
+            capture_width,
+            capture_height,
+        ))
     };
-    if let (Err(capture_error), Err(accessibility_error)) = (&capture, &accessibility) {
+    if include_screenshot && !capture.as_ref().is_some_and(Result::is_ok) && accessibility.is_err()
+    {
+        let capture_error = capture
+            .as_ref()
+            .and_then(|result| result.as_ref().err())
+            .cloned()
+            .unwrap_or_else(|| "Screenshot capture was not requested.".to_string());
+        let accessibility_error = accessibility
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or_else(|| "Accessibility text was unavailable.".to_string());
         return Err((
             "capture_failed",
             format!("{capture_error} Accessibility was also unavailable: {accessibility_error}",),
@@ -69,8 +88,9 @@ pub(crate) fn observe_window(
     };
     let point_bounds = point_bounds.unwrap_or([0, 0, capture_width as i32, capture_height as i32]);
     let accessibility_revision = accessibility_revision(&accessibility);
+    let mut screenshot_targets = HashMap::new();
     let (display_width, display_height, visual, screenshots) = match capture {
-        Ok(capture) => {
+        Some(Ok(capture)) => {
             let width = capture.width;
             let height = capture.height;
             // Bound the longest edge to keep payload and image-token cost
@@ -104,22 +124,45 @@ pub(crate) fn observe_window(
                     ColorType::Rgb,
                 )
                 .map_err(|error| ("capture_failed", format!("JPEG encoding failed: {error}")))?;
+            let screenshot_id = next_id("screenshot");
+            screenshot_targets.insert(
+                screenshot_id.clone(),
+                ScreenshotTarget {
+                    hwnd: window.hwnd,
+                    bounds: point_bounds,
+                    display_width: display_width as u32,
+                    display_height: display_height as u32,
+                },
+            );
             (
                 display_width as u32,
                 display_height as u32,
                 json!({"available": true}),
                 json!([{
+                    "id": screenshot_id,
                     "url": format!(
                         "data:image/jpeg;base64,{}",
                         base64::engine::general_purpose::STANDARD.encode(&jpeg),
                     ),
+                    "origin_x": point_bounds[0],
+                    "origin_y": point_bounds[1],
+                    "width": display_width,
+                    "height": display_height,
+                    "z_index": 0,
+                    "kind": "main",
                 }]),
             )
         }
-        Err(reason) => (
+        Some(Err(reason)) => (
             0,
             0,
             json!({"available": false, "reason": reason}),
+            json!([]),
+        ),
+        None => (
+            0,
+            0,
+            json!({"available": false, "requested": false}),
             json!([]),
         ),
     };
@@ -129,9 +172,8 @@ pub(crate) fn observe_window(
         observation_id.clone(),
         Observation {
             window: window.clone(),
-            bounds: point_bounds,
-            display_width,
-            display_height,
+            window_bounds: point_bounds,
+            screenshots: screenshot_targets,
             accessibility_revision,
             transient_text_ready: false,
             elements,

--- a/console/src-tauri/src/computer_use_server/platform_macos/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_macos/input.rs
@@ -25,7 +25,7 @@ use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
 use serde_json::{json, Map, Value};
 
 use super::super::state::{
-    map_point, Observation, PendingAction, WindowInfo, INPUT_GUARD_GRACE_MS,
+    map_point, screenshot_target, Observation, PendingAction, WindowInfo, INPUT_GUARD_GRACE_MS,
 };
 use super::super::InputStep;
 use super::accessibility_tree::{
@@ -831,7 +831,7 @@ fn ensure_observed_geometry(observation: &Observation) -> Result<(), (&'static s
         current.2 as i32,
         current.3 as i32,
     ];
-    if current_bounds != observation.bounds {
+    if current_bounds != observation.window_bounds {
         return Err((
             "stale_observation",
             "Window geometry changed; observe it again.".to_string(),
@@ -847,8 +847,9 @@ fn resolve_target_point(
     y_key: &str,
 ) -> Result<CGPoint, (&'static str, String)> {
     let point = resolve_point(observation, params, x_key, y_key)?;
+    let screenshot = screenshot_target(observation, params)?;
     match frontmost_window_at_point(point) {
-        Some(window_id) if window_id == observation.window.hwnd as i64 => Ok(point),
+        Some(window_id) if window_id == screenshot.hwnd as i64 => Ok(point),
         Some(window_id) => Err((
             "target_not_at_point",
             format!("Target point is covered by window {window_id}."),
@@ -869,12 +870,13 @@ fn resolve_point(
     // The window must still be where it was when the observation was taken,
     // or the mapping below would aim at whatever now occupies those pixels.
     ensure_observed_geometry(observation)?;
+    let screenshot = screenshot_target(observation, params)?;
     let x = integer_param(params, x_key)?;
     let y = integer_param(params, y_key)?;
-    let (x_offset, y_offset) = map_point(observation, x, y)?;
+    let (x_offset, y_offset) = map_point(screenshot, x, y)?;
     Ok(CGPoint {
-        x: f64::from(observation.bounds[0]) + x_offset,
-        y: f64::from(observation.bounds[1]) + y_offset,
+        x: f64::from(screenshot.bounds[0]) + x_offset,
+        y: f64::from(screenshot.bounds[1]) + y_offset,
     })
 }
 

--- a/console/src-tauri/src/computer_use_server/platform_windows/capture.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/capture.rs
@@ -2,6 +2,7 @@
 
 use base64::Engine;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::time::Duration;
 use windows::core::HSTRING;
 use windows::Foundation::{PropertyType, PropertyValue};
@@ -13,24 +14,59 @@ use windows::Storage::Streams::{DataReader, InMemoryRandomAccessStream};
 use windows::Win32::Foundation::HWND;
 
 use super::super::state::{
-    accessibility_revision, next_id, Observation, ServerState, WindowInfo, BMP_HEADER_BYTES,
-    SCREENSHOT_JPEG_QUALITY, SCREENSHOT_MAX_EDGE,
+    accessibility_revision, next_id, Observation, ScreenshotTarget, ServerState, WindowInfo,
+    BMP_HEADER_BYTES, SCREENSHOT_JPEG_QUALITY, SCREENSHOT_MAX_EDGE,
 };
 use super::uia::collect_accessibility;
 use super::wgc::{capture_window, CaptureArgs, CaptureInfo};
-use super::window::get_visible_window_rect;
+use super::window::{get_visible_window_rect, observation_windows};
+
+struct WindowCapture {
+    hwnd: isize,
+    kind: &'static str,
+    z_index: i32,
+    result: Result<CaptureInfo, String>,
+}
+
+struct CaptureParts {
+    visual: Value,
+    screenshots: Value,
+    targets: HashMap<String, ScreenshotTarget>,
+    viewport: (u32, u32),
+}
 
 pub(crate) fn observe_window(
     state: &mut ServerState,
     window: &WindowInfo,
+    include_screenshot: bool,
 ) -> Result<Value, (&'static str, String)> {
+    let windows = observation_windows(window);
     let observation_id = next_id("observation");
-    let capture = capture_window(CaptureArgs {
-        hwnd: window.hwnd,
-        timeout: Duration::from_millis(2500),
-    });
-    let accessibility = collect_accessibility(window);
-    require_observation_source(&capture, &accessibility)?;
+    let mut captures = Vec::new();
+    if include_screenshot {
+        captures.push(WindowCapture {
+            hwnd: window.hwnd,
+            kind: "main",
+            z_index: 0,
+            result: capture_window(CaptureArgs {
+                hwnd: window.hwnd,
+                timeout: Duration::from_millis(2500),
+            }),
+        });
+        for (index, hwnd) in windows.related.iter().enumerate() {
+            captures.push(WindowCapture {
+                hwnd: *hwnd,
+                kind: "transient",
+                z_index: (index + 1) as i32,
+                result: capture_window(CaptureArgs {
+                    hwnd: *hwnd,
+                    timeout: Duration::from_millis(1200),
+                }),
+            });
+        }
+    }
+    let accessibility = collect_accessibility(windows.input_hwnd);
+    require_observation_source(include_screenshot, &captures, &accessibility)?;
     let (accessibility, elements) = match accessibility {
         Ok(result) => result,
         Err(message) => (
@@ -39,15 +75,17 @@ pub(crate) fn observe_window(
         ),
     };
     let accessibility_revision = accessibility_revision(&accessibility);
-    let (bounds, display_width, display_height, visual, screenshots) =
-        capture_parts(capture, window);
+    let window_bounds = get_visible_window_rect(HWND(window.hwnd as _))
+        .map(rect_bounds)
+        .unwrap_or_default();
+    let capture = capture_parts(include_screenshot, captures, windows.related.len());
     state.observations.insert(
         observation_id.clone(),
         Observation {
             window: window.clone(),
-            bounds,
-            display_width,
-            display_height,
+            window_bounds,
+            screenshots: capture.targets,
+            input_hwnd: windows.input_hwnd,
             accessibility_revision,
             elements,
         },
@@ -55,54 +93,95 @@ pub(crate) fn observe_window(
     Ok(json!({
         "observation_id": observation_id,
         "window": window.to_json(),
-        "viewport": {"width": display_width, "height": display_height},
-        "visual": visual,
+        "viewport": {"width": capture.viewport.0, "height": capture.viewport.1},
+        "visual": capture.visual,
         "accessibility": accessibility,
-        "screenshots": screenshots,
+        "screenshots": capture.screenshots,
     }))
 }
 
-fn require_observation_source<C, A>(
-    capture: &Result<C, String>,
+fn require_observation_source<A>(
+    include_screenshot: bool,
+    captures: &[WindowCapture],
     accessibility: &Result<A, String>,
 ) -> Result<(), (&'static str, String)> {
-    if let (Err(capture_error), Err(accessibility_error)) = (capture, accessibility) {
-        return Err((
-            "capture_failed",
-            format!("{capture_error} Accessibility was also unavailable: {accessibility_error}"),
-        ));
+    if !include_screenshot
+        || captures.iter().any(|capture| capture.result.is_ok())
+        || accessibility.is_ok()
+    {
+        return Ok(());
     }
-    Ok(())
+    let capture_error = captures
+        .iter()
+        .filter_map(|capture| capture.result.as_ref().err())
+        .next()
+        .cloned()
+        .unwrap_or_else(|| "Screenshot capture was not requested.".to_string());
+    let accessibility_error = accessibility
+        .as_ref()
+        .err()
+        .cloned()
+        .unwrap_or_else(|| "Accessibility text was unavailable.".to_string());
+    Err((
+        "capture_failed",
+        format!("{capture_error} Accessibility was also unavailable: {accessibility_error}"),
+    ))
 }
 
-type CaptureParts = ([i32; 4], u32, u32, Value, Value);
-
-fn capture_parts(capture: Result<CaptureInfo, String>, window: &WindowInfo) -> CaptureParts {
-    match capture {
-        Ok(capture) => captured_parts(capture),
-        Err(reason) => {
-            let bounds = get_visible_window_rect(HWND(window.hwnd as _))
-                .map(|rect| {
-                    [
-                        rect.left,
-                        rect.top,
-                        rect.right - rect.left,
-                        rect.bottom - rect.top,
-                    ]
-                })
-                .unwrap_or_default();
-            (
-                bounds,
-                0,
-                0,
-                json!({"available": false, "reason": reason}),
-                json!([]),
-            )
+fn capture_parts(
+    requested: bool,
+    captures: Vec<WindowCapture>,
+    related_surface_count: usize,
+) -> CaptureParts {
+    let failure = captures
+        .iter()
+        .find_map(|capture| capture.result.as_ref().err())
+        .cloned();
+    let mut screenshots = Vec::new();
+    let mut targets = HashMap::new();
+    let mut viewport = (0, 0);
+    for capture in captures {
+        let Ok(result) = capture.result else { continue };
+        let screenshot_id = next_id("screenshot");
+        let (target, screenshot) = captured_parts(
+            result,
+            capture.hwnd,
+            &screenshot_id,
+            capture.kind,
+            capture.z_index,
+        );
+        if capture.kind == "main" {
+            viewport = (target.display_width, target.display_height);
         }
+        targets.insert(screenshot_id, target);
+        screenshots.push(screenshot);
+    }
+    let visual = if !requested {
+        json!({
+            "available": false,
+            "requested": false,
+            "related_surface_count": related_surface_count,
+        })
+    } else if screenshots.is_empty() {
+        json!({"available": false, "reason": failure.unwrap_or_else(|| "No window image was captured.".to_string())})
+    } else {
+        json!({"available": true})
+    };
+    CaptureParts {
+        visual,
+        screenshots: Value::Array(screenshots),
+        targets,
+        viewport,
     }
 }
 
-fn captured_parts(capture: CaptureInfo) -> CaptureParts {
+fn captured_parts(
+    capture: CaptureInfo,
+    hwnd: isize,
+    screenshot_id: &str,
+    kind: &str,
+    z_index: i32,
+) -> (ScreenshotTarget, Value) {
     let [left, top, right, bottom] = capture.window_rect;
     let bounds = [left, top, right - left, bottom - top];
     let (display_width, display_height) = bounded_dimensions(capture.width, capture.height);
@@ -122,24 +201,35 @@ fn captured_parts(capture: CaptureInfo) -> CaptureParts {
             ("image/bmp", bytes)
         }
     };
-    (
+    let target = ScreenshotTarget {
+        hwnd,
         bounds,
         display_width,
         display_height,
-        json!({"available": true}),
-        json!([{
-            "url": format!(
-                "data:{media_type};base64,{}",
-                base64::engine::general_purpose::STANDARD.encode(image_bytes),
-            ),
-            "origin_x": bounds[0],
-            "origin_y": bounds[1],
-            "width": display_width,
-            "height": display_height,
-            "z_index": 0,
-            "kind": "main",
-        }]),
-    )
+    };
+    let screenshot = json!({
+        "id": screenshot_id,
+        "url": format!(
+            "data:{media_type};base64,{}",
+            base64::engine::general_purpose::STANDARD.encode(image_bytes),
+        ),
+        "origin_x": bounds[0],
+        "origin_y": bounds[1],
+        "width": display_width,
+        "height": display_height,
+        "z_index": z_index,
+        "kind": kind,
+    });
+    (target, screenshot)
+}
+
+fn rect_bounds(rect: windows::Win32::Foundation::RECT) -> [i32; 4] {
+    [
+        rect.left,
+        rect.top,
+        rect.right - rect.left,
+        rect.bottom - rect.top,
+    ]
 }
 
 /// Compute the delivered screenshot size, downscaling proportionally when
@@ -245,26 +335,54 @@ fn encode_screenshot_jpeg(
 
 #[cfg(test)]
 mod tests {
-    use super::require_observation_source;
+    use super::{capture_parts, require_observation_source};
 
     #[test]
     fn accessibility_keeps_an_observation_alive_when_capture_fails() {
-        let capture: Result<(), String> = Err("capture unavailable".to_string());
+        let captures = vec![super::WindowCapture {
+            hwnd: 1,
+            kind: "main",
+            z_index: 0,
+            result: Err("capture unavailable".to_string()),
+        }];
         let accessibility: Result<(), String> = Ok(());
 
-        require_observation_source(&capture, &accessibility)
+        require_observation_source(true, &captures, &accessibility)
             .expect("accessibility-only observations must remain usable");
     }
 
     #[test]
     fn observation_fails_when_both_sources_fail() {
-        let capture: Result<(), String> = Err("capture unavailable".to_string());
+        let captures = vec![super::WindowCapture {
+            hwnd: 1,
+            kind: "main",
+            z_index: 0,
+            result: Err("capture unavailable".to_string()),
+        }];
         let accessibility: Result<(), String> = Err("UIA unavailable".to_string());
 
-        let error = require_observation_source(&capture, &accessibility)
+        let error = require_observation_source(true, &captures, &accessibility)
             .expect_err("an observation needs at least one source");
         assert_eq!(error.0, "capture_failed");
         assert!(error.1.contains("capture unavailable"));
         assert!(error.1.contains("UIA unavailable"));
+    }
+
+    #[test]
+    fn lightweight_refresh_does_not_require_an_image() {
+        let accessibility: Result<(), String> = Err("UIA unavailable".to_string());
+
+        require_observation_source(false, &[], &accessibility)
+            .expect("the caller can request a full observation next");
+    }
+
+    #[test]
+    fn lightweight_refresh_reports_related_surfaces_without_images() {
+        let parts = capture_parts(false, Vec::new(), 2);
+
+        assert_eq!(parts.visual["requested"], false);
+        assert_eq!(parts.visual["related_surface_count"], 2);
+        assert!(parts.screenshots.as_array().unwrap().is_empty());
+        assert!(parts.targets.is_empty());
     }
 }

--- a/console/src-tauri/src/computer_use_server/platform_windows/input.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/input.rs
@@ -17,15 +17,18 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     MOUSEEVENTF_WHEEL, VIRTUAL_KEY,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    BringWindowToTop, GetAncestor, GetForegroundWindow, GetWindowThreadProcessId, IsWindow,
-    SetCursorPos, SetForegroundWindow, ShowWindow, WindowFromPoint, GA_ROOT, GA_ROOTOWNER,
-    SW_RESTORE,
+    BringWindowToTop, GetForegroundWindow, GetWindowThreadProcessId, IsWindow, SetCursorPos,
+    SetForegroundWindow, ShowWindow, WindowFromPoint, SW_RESTORE,
 };
 
-use super::super::state::{map_point, Observation, WindowInfo};
+use super::super::state::{
+    map_point, screenshot_target, Observation, ScreenshotTarget, WindowInfo,
+};
 use super::super::InputStep;
 use super::uia::{element_point, element_point_by_id, focused_text_input};
-use super::window::get_visible_window_rect;
+#[cfg(test)]
+use super::window::window_relation_matches;
+use super::window::{get_visible_window_rect, matches_observed_surface, matches_target_window};
 
 pub(crate) fn click(
     observation: &Observation,
@@ -111,8 +114,14 @@ fn drag_points(
             set_focus(&observation.window)?;
             ensure_observed_geometry(observation)?;
             Ok((
-                validate_target_point(observation, element_point_by_id(observation, source_id)?)?,
-                validate_target_point(observation, element_point_by_id(observation, target_id)?)?,
+                validate_target_point(
+                    observation.input_hwnd,
+                    element_point_by_id(observation, source_id)?,
+                )?,
+                validate_target_point(
+                    observation.input_hwnd,
+                    element_point_by_id(observation, target_id)?,
+                )?,
             ))
         }
         (None, None) => Ok((
@@ -382,7 +391,7 @@ fn verify_element_point(
     ensure_observed_geometry(observation)?;
     set_focus(&observation.window)?;
     ensure_observed_geometry(observation)?;
-    validate_target_point(observation, element_point(observation, params)?)
+    validate_target_point(observation.input_hwnd, element_point(observation, params)?)
 }
 
 fn verify_point_with_prefix(
@@ -390,16 +399,18 @@ fn verify_point_with_prefix(
     params: &Map<String, Value>,
     prefix: &str,
 ) -> Result<POINT, (&'static str, String)> {
-    ensure_observed_geometry(observation)?;
+    let screenshot = screenshot_target(observation, params)?;
+    ensure_screenshot_geometry(screenshot)?;
     set_focus(&observation.window)?;
+    ensure_screenshot_geometry(screenshot)?;
     let x = integer_param(params, &format!("{prefix}x"))?;
     let y = integer_param(params, &format!("{prefix}y"))?;
-    let (x_offset, y_offset) = map_point(observation, i64::from(x), i64::from(y))?;
+    let (x_offset, y_offset) = map_point(screenshot, i64::from(x), i64::from(y))?;
     let point = POINT {
-        x: observation.bounds[0] + x_offset as i32,
-        y: observation.bounds[1] + y_offset as i32,
+        x: screenshot.bounds[0] + x_offset as i32,
+        y: screenshot.bounds[1] + y_offset as i32,
     };
-    validate_target_point(observation, point)
+    validate_target_point(screenshot.hwnd, point)
 }
 
 fn ensure_observed_geometry(observation: &Observation) -> Result<(), (&'static str, String)> {
@@ -411,7 +422,7 @@ fn ensure_observed_geometry(observation: &Observation) -> Result<(), (&'static s
         current.right - current.left,
         current.bottom - current.top,
     ];
-    if current_bounds != observation.bounds {
+    if current_bounds != observation.window_bounds {
         return Err((
             "stale_observation",
             "Window geometry changed; observe it again.".to_string(),
@@ -420,15 +431,30 @@ fn ensure_observed_geometry(observation: &Observation) -> Result<(), (&'static s
     Ok(())
 }
 
-fn validate_target_point(
-    observation: &Observation,
-    point: POINT,
-) -> Result<POINT, (&'static str, String)> {
+fn ensure_screenshot_geometry(screenshot: &ScreenshotTarget) -> Result<(), (&'static str, String)> {
+    let current = get_visible_window_rect(HWND(screenshot.hwnd as _))
+        .map_err(|error| ("stale_window", error))?;
+    let current_bounds = [
+        current.left,
+        current.top,
+        current.right - current.left,
+        current.bottom - current.top,
+    ];
+    if current_bounds != screenshot.bounds {
+        return Err((
+            "stale_observation",
+            "Screenshot geometry changed; observe the window again.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target_point(surface: isize, point: POINT) -> Result<POINT, (&'static str, String)> {
     let hit = unsafe { WindowFromPoint(point) };
-    if !matches_target_window(HWND(observation.window.hwnd as _), hit) {
+    if !matches_observed_surface(HWND(surface as _), hit) {
         return Err((
             "target_not_at_point",
-            "Target window is no longer at this point.".to_string(),
+            "The observed surface is no longer at this point.".to_string(),
         ));
     }
     Ok(point)
@@ -476,33 +502,10 @@ fn try_set_foreground(hwnd: HWND) -> bool {
     }
 }
 
-/// Accept activation when the target, one of its child popups, or an owned
-/// top-level window currently holds the foreground.
+/// Accept activation when the target or one of its related surfaces currently
+/// holds the foreground.
 fn foreground_matches(hwnd: HWND) -> bool {
     matches_target_window(hwnd, unsafe { GetForegroundWindow() })
-}
-
-fn matches_target_window(target: HWND, candidate: HWND) -> bool {
-    if candidate.0.is_null() {
-        return false;
-    }
-    unsafe {
-        window_relation_matches(
-            target,
-            GetAncestor(candidate, GA_ROOT),
-            GetAncestor(target, GA_ROOTOWNER),
-            GetAncestor(candidate, GA_ROOTOWNER),
-        )
-    }
-}
-
-fn window_relation_matches(
-    target: HWND,
-    candidate_root: HWND,
-    target_root_owner: HWND,
-    candidate_root_owner: HWND,
-) -> bool {
-    candidate_root == target || (target_root_owner == target && candidate_root_owner == target)
 }
 
 /// The foreground lock rejects background processes, so temporarily join

--- a/console/src-tauri/src/computer_use_server/platform_windows/uia.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/uia.rs
@@ -15,8 +15,9 @@ use windows::Win32::UI::WindowsAndMessaging::IsWindow;
 
 use super::super::state::{
     accessibility_revision, element_line, truncate_document_text, Observation, PendingAction,
-    WindowInfo, ACCESSIBILITY_MAX_ELEMENTS, DOC_TEXT_MAX,
+    ACCESSIBILITY_MAX_ELEMENTS, DOC_TEXT_MAX,
 };
+use super::window::observation_windows;
 
 const ACCESSIBILITY_MAX_DEPTH: usize = 40;
 
@@ -140,7 +141,7 @@ pub(crate) fn focused_text_input(
             "The observed window has no focused text input.".to_string(),
         )
     })?;
-    if !element_belongs_to_window(&element, observation.window.hwnd) {
+    if !element_belongs_to_window(&element, observation.input_hwnd) {
         return Err((
             "stale_observation",
             "Keyboard focus no longer belongs to the observed window.".to_string(),
@@ -194,13 +195,13 @@ fn text_replacement_observed(before: &str, after: &str, text: &str) -> bool {
 }
 
 pub(crate) fn collect_accessibility(
-    window: &WindowInfo,
+    input_hwnd: isize,
 ) -> Result<(Value, HashMap<String, IUIAutomationElement>), String> {
     let automation: IUIAutomation = unsafe {
         CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
             .map_err(|error| format!("UI Automation is unavailable: {error}"))?
     };
-    let root = unsafe { automation.ElementFromHandle(HWND(window.hwnd as _)) }
+    let root = unsafe { automation.ElementFromHandle(HWND(input_hwnd as _)) }
         .map_err(|error| format!("UI Automation could not inspect the window: {error}"))?;
     let walker = unsafe { automation.ControlViewWalker() }
         .map_err(|error| format!("UI Automation tree is unavailable: {error}"))?;
@@ -208,12 +209,12 @@ pub(crate) fn collect_accessibility(
         .map_err(|error| format!("UI Automation raw tree is unavailable: {error}"))?;
     let focused_target = unsafe { automation.GetFocusedElement() }
         .ok()
-        .filter(|element| element_belongs_to_window_with(&raw_walker, element, window.hwnd));
+        .filter(|element| element_belongs_to_window_with(&raw_walker, element, input_hwnd));
     let mut collector = AccessibilityCollector::new(&automation, &walker, focused_target.clone());
     collector.collect(root, 0);
     if collector.focused.is_none() {
         if let Some(element) = focused_target {
-            let depth = element_depth_with(&raw_walker, &element, window.hwnd);
+            let depth = element_depth_with(&raw_walker, &element, input_hwnd);
             collector.publish(element, depth, true);
         }
     }
@@ -526,7 +527,7 @@ fn accessibility_element<'a>(
         "element_not_found",
         "Element is not available in this observation.".to_string(),
     ))?;
-    if !element_belongs_to_window(element, observation.window.hwnd) {
+    if !element_belongs_to_window(element, observation.input_hwnd) {
         return Err((
             "stale_observation",
             "The element is no longer part of the observed window; observe it again.".to_string(),
@@ -552,7 +553,14 @@ pub(crate) fn validate_observation(
         "stale_observation",
         "The observation had no accessibility revision; observe the window again.".to_string(),
     ))?;
-    let (current, _) = collect_accessibility(&observation.window).map_err(|error| {
+    let current_input = observation_windows(&observation.window).input_hwnd;
+    if current_input != observation.input_hwnd {
+        return Err((
+            "stale_observation",
+            "The active interface surface changed; observe the window again.".to_string(),
+        ));
+    }
+    let (current, _) = collect_accessibility(current_input).map_err(|error| {
         (
             "stale_observation",
             format!("The observed accessibility surface is unavailable: {error}"),

--- a/console/src-tauri/src/computer_use_server/platform_windows/window.rs
+++ b/console/src-tauri/src/computer_use_server/platform_windows/window.rs
@@ -11,8 +11,9 @@ use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumWindows, GetClassNameW, GetForegroundWindow, GetWindowRect, GetWindowTextW,
-    GetWindowThreadProcessId, IsWindow, IsWindowVisible, PostMessageW, WM_CLOSE,
+    EnumWindows, GetAncestor, GetClassNameW, GetForegroundWindow, GetWindowLongPtrW, GetWindowRect,
+    GetWindowTextW, GetWindowThreadProcessId, IsWindow, IsWindowVisible, PostMessageW, GA_ROOT,
+    GA_ROOTOWNER, GWL_STYLE, WM_CLOSE, WS_POPUP,
 };
 
 use super::super::app_identity::app_id_from_path;
@@ -23,6 +24,108 @@ use super::super::state::WindowInfo;
 // before reporting that it is still open (usually a save prompt).
 const CLOSE_POLL_ATTEMPTS: u32 = 40;
 const CLOSE_POLL_INTERVAL_MS: u64 = 50;
+const MAX_RELATED_WINDOWS: usize = 3;
+
+/// Visible top-level surfaces that belong to one stable target window.
+/// Related windows are ordered back to front for monotonically increasing
+/// screenshot z-index values; `input_hwnd` identifies the frontmost surface.
+pub(super) struct ObservationWindows {
+    pub(super) input_hwnd: isize,
+    pub(super) related: Vec<isize>,
+}
+
+pub(super) fn observation_windows(window: &WindowInfo) -> ObservationWindows {
+    let target = HWND(window.hwnd as _);
+    let target_thread = unsafe { GetWindowThreadProcessId(target, None) };
+    struct EnumData {
+        target: HWND,
+        target_thread: u32,
+        related: Vec<isize>,
+    }
+
+    unsafe extern "system" fn callback(hwnd: HWND, data: LPARAM) -> BOOL {
+        let data = unsafe { &mut *(data.0 as *mut EnumData) };
+        if hwnd == data.target {
+            return BOOL(0);
+        }
+        if data.related.len() >= MAX_RELATED_WINDOWS {
+            return BOOL(0);
+        }
+        if unsafe { IsWindowVisible(hwnd).as_bool() }
+            && matches_target_window_with_thread(data.target, hwnd, data.target_thread)
+            && get_visible_window_rect(hwnd).is_ok()
+        {
+            data.related.push(hwnd.0 as isize);
+        }
+        BOOL(1)
+    }
+
+    let mut data = EnumData {
+        target,
+        target_thread,
+        related: Vec::new(),
+    };
+    unsafe {
+        let _ = EnumWindows(Some(callback), LPARAM(&mut data as *mut EnumData as isize));
+    }
+    let input_hwnd = data.related.first().copied().unwrap_or(window.hwnd);
+    data.related.reverse();
+    ObservationWindows {
+        input_hwnd,
+        related: data.related,
+    }
+}
+
+/// Accept the selected window, its children/owned windows, and visible popup
+/// surfaces created by the same UI thread. The latter covers native menus and
+/// drop-downs that intentionally have no owner HWND.
+pub(super) fn matches_target_window(target: HWND, candidate: HWND) -> bool {
+    let target_thread = unsafe { GetWindowThreadProcessId(target, None) };
+    matches_target_window_with_thread(target, candidate, target_thread)
+}
+
+/// Return whether `candidate` is the surface itself or one of its child HWNDs.
+/// Coordinate input is bound to a captured surface, not merely to any popup
+/// created by the same application thread.
+pub(super) fn matches_observed_surface(surface: HWND, candidate: HWND) -> bool {
+    !candidate.0.is_null() && unsafe { GetAncestor(candidate, GA_ROOT) == surface }
+}
+
+fn matches_target_window_with_thread(target: HWND, candidate: HWND, target_thread: u32) -> bool {
+    if candidate.0.is_null() {
+        return false;
+    }
+    unsafe {
+        let candidate_root = GetAncestor(candidate, GA_ROOT);
+        window_relation_matches(
+            target,
+            candidate_root,
+            GetAncestor(target, GA_ROOTOWNER),
+            GetAncestor(candidate, GA_ROOTOWNER),
+        ) || same_thread_popup(candidate_root, target_thread)
+    }
+}
+
+fn same_thread_popup(candidate: HWND, target_thread: u32) -> bool {
+    popup_relation_matches(
+        target_thread,
+        unsafe { GetWindowThreadProcessId(candidate, None) },
+        unsafe { GetWindowLongPtrW(candidate, GWL_STYLE) } as u32,
+    )
+}
+
+fn popup_relation_matches(target_thread: u32, candidate_thread: u32, style: u32) -> bool {
+    target_thread != 0 && candidate_thread == target_thread && style & WS_POPUP.0 != 0
+}
+
+pub(super) fn window_relation_matches(
+    target: HWND,
+    candidate_root: HWND,
+    target_root_owner: HWND,
+    candidate_root_owner: HWND,
+) -> bool {
+    candidate_root == target || (target_root_owner == target && candidate_root_owner == target)
+}
 
 pub(crate) fn list_windows(app: Option<&str>) -> Vec<Value> {
     enumerate_windows()
@@ -222,5 +325,13 @@ mod tests {
             "notepad",
             "Notepad"
         )));
+    }
+
+    #[test]
+    fn only_same_thread_popup_styles_extend_the_target_surface() {
+        assert!(popup_relation_matches(7, 7, WS_POPUP.0));
+        assert!(!popup_relation_matches(7, 8, WS_POPUP.0));
+        assert!(!popup_relation_matches(7, 7, 0));
+        assert!(!popup_relation_matches(0, 0, WS_POPUP.0));
     }
 }

--- a/console/src-tauri/src/computer_use_server/state.rs
+++ b/console/src-tauri/src/computer_use_server/state.rs
@@ -118,23 +118,27 @@ impl WindowInfo {
     }
 }
 
-/// Everything an action needs from one observed window.
-///
-/// The identifier for this object is the only native context exposed to the
-/// model. Window handles, screenshot identifiers, and accessibility handles
-/// remain local so callers cannot accidentally combine state from separate
-/// observations.
-pub(super) struct Observation {
-    pub(super) window: WindowInfo,
-    /// The window's on-screen rectangle as `[left, top, width, height]`.
-    /// Origin plus size is used on both platforms so the meaning of each slot
-    /// is unambiguous wherever an observation is read.
+/// Native geometry for one screenshot delivered with an observation.
+#[derive(Debug)]
+pub(super) struct ScreenshotTarget {
+    pub(super) hwnd: isize,
     pub(super) bounds: [i32; 4],
-    // Pixel size of the delivered (possibly downscaled) screenshot. Model
-    // coordinates are expressed in this space and mapped back to physical
-    // window pixels before input is injected.
     pub(super) display_width: u32,
     pub(super) display_height: u32,
+}
+
+/// Everything an action needs from one observed window.
+///
+/// Observation and screenshot IDs are the only native context exposed to the
+/// model. Window and accessibility handles remain local, while screenshot IDs
+/// are opaque keys into this observation.
+pub(super) struct Observation {
+    pub(super) window: WindowInfo,
+    /// Stable target geometry, retained even for accessibility-only reads.
+    pub(super) window_bounds: [i32; 4],
+    pub(super) screenshots: HashMap<String, ScreenshotTarget>,
+    #[cfg(windows)]
+    pub(super) input_hwnd: isize,
     /// Digest of the normalized accessibility surface the model observed.
     /// Kept native-side so callers cannot copy or forge a revision token.
     pub(super) accessibility_revision: Option<[u8; 32]>,
@@ -317,25 +321,46 @@ pub(super) fn merge_app_list(installed: Vec<InstalledApp>, windows: Vec<WindowIn
         .collect()
 }
 
-/// Map a coordinate expressed in screenshot space onto the window.
+/// Resolve one screenshot capability from the current observation.
+pub(super) fn screenshot_target<'a>(
+    observation: &'a Observation,
+    params: &serde_json::Map<String, Value>,
+) -> Result<&'a ScreenshotTarget, (&'static str, String)> {
+    let screenshot_id = params
+        .get("screenshot_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or((
+            "invalid_request",
+            "screenshot_id from the current observation is required for coordinate input."
+                .to_string(),
+        ))?;
+    observation.screenshots.get(screenshot_id).ok_or((
+        "unknown_screenshot",
+        "Screenshot is not available in the current observation; observe the window again."
+            .to_string(),
+    ))
+}
+
+/// Map a coordinate expressed in screenshot space onto its native surface.
 ///
-/// Returns the offset from the window's origin in physical pixels. Both
+/// Returns the offset from the screenshot's origin in physical pixels. Both
 /// platforms share the bounds check so a coordinate outside the delivered
-/// screenshot can never be extrapolated onto another application's window.
+/// image can never be extrapolated onto another application's window.
 pub(super) fn map_point(
-    observation: &Observation,
+    screenshot: &ScreenshotTarget,
     x: i64,
     y: i64,
 ) -> Result<(f64, f64), (&'static str, String)> {
-    if observation.display_width == 0 || observation.display_height == 0 {
+    if screenshot.display_width == 0 || screenshot.display_height == 0 {
         return Err((
             "visual_unavailable",
             "Coordinate input requires a window screenshot; use an accessibility element instead."
                 .to_string(),
         ));
     }
-    let display_width = i64::from(observation.display_width.max(1));
-    let display_height = i64::from(observation.display_height.max(1));
+    let display_width = i64::from(screenshot.display_width.max(1));
+    let display_height = i64::from(screenshot.display_height.max(1));
     if x < 0 || y < 0 || x >= display_width || y >= display_height {
         return Err((
             "point_outside_viewport",
@@ -344,8 +369,8 @@ pub(super) fn map_point(
     }
     // The screenshot may have been downscaled, so scale back to the window's
     // own pixels. With no downscaling these ratios are 1:1.
-    let width = f64::from(observation.bounds[2]);
-    let height = f64::from(observation.bounds[3]);
+    let width = f64::from(screenshot.bounds[2]);
+    let height = f64::from(screenshot.bounds[3]);
     Ok((
         x as f64 * width / display_width as f64,
         y as f64 * height / display_height as f64,
@@ -361,6 +386,15 @@ mod tests {
     use super::*;
 
     fn observation(bounds: [i32; 4], display: (u32, u32)) -> Observation {
+        let screenshots = HashMap::from([(
+            "screenshot-1".to_string(),
+            ScreenshotTarget {
+                hwnd: 1,
+                bounds,
+                display_width: display.0,
+                display_height: display.1,
+            },
+        )]);
         Observation {
             window: WindowInfo {
                 hwnd: 1,
@@ -371,9 +405,10 @@ mod tests {
                 title: String::new(),
                 class_name: String::new(),
             },
-            bounds,
-            display_width: display.0,
-            display_height: display.1,
+            window_bounds: bounds,
+            screenshots,
+            #[cfg(windows)]
+            input_hwnd: 1,
             accessibility_revision: None,
             #[cfg(target_os = "macos")]
             transient_text_ready: false,
@@ -436,22 +471,36 @@ mod tests {
     fn a_point_inside_the_viewport_maps_by_proportion() {
         // A 200x100 window delivered as a 100x50 screenshot is a 2:1 scale.
         let snap = observation([10, 20, 200, 100], (100, 50));
-        let (x, y) = map_point(&snap, 50, 25).unwrap();
+        let (x, y) = map_point(&snap.screenshots["screenshot-1"], 50, 25).unwrap();
         assert_eq!((x as i32, y as i32), (100, 50));
     }
 
     #[test]
     fn an_unscaled_screenshot_maps_one_to_one() {
         let snap = observation([0, 0, 100, 100], (100, 100));
-        let (x, y) = map_point(&snap, 30, 40).unwrap();
+        let (x, y) = map_point(&snap.screenshots["screenshot-1"], 30, 40).unwrap();
         assert_eq!((x as i32, y as i32), (30, 40));
+    }
+
+    #[test]
+    fn screenshot_ids_are_bound_to_one_observation() {
+        let snap = observation([0, 0, 100, 100], (100, 100));
+        let current = serde_json::json!({"screenshot_id": "screenshot-1"});
+        let current = current.as_object().unwrap();
+        assert_eq!(screenshot_target(&snap, current).unwrap().hwnd, 1);
+
+        let unknown = serde_json::json!({"screenshot_id": "screenshot-old"});
+        let error = screenshot_target(&snap, unknown.as_object().unwrap())
+            .expect_err("an ID from another observation must be refused");
+        assert_eq!(error.0, "unknown_screenshot");
     }
 
     #[test]
     fn points_outside_the_viewport_are_refused() {
         let snap = observation([0, 0, 100, 100], (100, 100));
         for (x, y) in [(-1, 0), (0, -1), (100, 0), (0, 100)] {
-            let error = map_point(&snap, x, y).expect_err("must be refused");
+            let error =
+                map_point(&snap.screenshots["screenshot-1"], x, y).expect_err("must be refused");
             assert_eq!(error.0, "point_outside_viewport");
         }
     }

--- a/plugins/bundle/computer-use/computer_use/dispatch.py
+++ b/plugins/bundle/computer-use/computer_use/dispatch.py
@@ -14,7 +14,13 @@ import threading
 import time
 from typing import Any, Literal, Mapping
 
-from agentscope.message import DataBlock, TextBlock, ToolResultState, URLSource
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+    ToolResultState,
+    URLSource,
+)
 from agentscope.tool import ToolChunk
 
 from qwenpaw.runtime.tool_registry import tool_descriptor
@@ -212,6 +218,18 @@ def _with_compact_elements(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return {**payload, "accessibility": compact}
 
 
+def _screenshot_source(url: str) -> Base64Source | URLSource:
+    header, separator, data = url.partition(",")
+    if (
+        separator
+        and header.casefold().startswith("data:")
+        and ";base64" in header.casefold()
+    ):
+        media_type = header[5:].split(";", 1)[0] or "image/*"
+        return Base64Source(data=data, media_type=media_type)
+    return URLSource(url=url, media_type="image/*")
+
+
 def _response(
     payload: Mapping[str, Any],
     *,
@@ -227,10 +245,7 @@ def _response(
             ):
                 content.append(
                     DataBlock(
-                        source=URLSource(
-                            url=screenshot["url"],
-                            media_type="image/*",
-                        ),
+                        source=_screenshot_source(screenshot["url"]),
                     ),
                 )
     content.append(

--- a/plugins/bundle/computer-use/computer_use/dispatch.py
+++ b/plugins/bundle/computer-use/computer_use/dispatch.py
@@ -125,9 +125,8 @@ def _without_screenshot_urls(
 
     Screenshots are attached as image blocks; repeating the base64 data
     URL inside the JSON text block would double a multi-megabyte payload
-    and pollute the model's text context. Post-action observations remain
-    available natively but omit their image metadata until an explicit visual
-    observation requests the attachment.
+    and pollute the model's text context. Post-action refreshes are semantic
+    and do not capture images; a visual target starts with a fresh observation.
     """
     screenshots = payload.get("screenshots")
     if not isinstance(screenshots, list):
@@ -261,6 +260,7 @@ def _error(code: str, message: str) -> ToolChunk:
         "observation_required",
         "stale_observation",
         "target_not_at_point",
+        "unknown_screenshot",
         "user_intervention",
     }:
         payload["requires_observe"] = True
@@ -289,6 +289,7 @@ async def computer_use(
     action: ComputerUseAction,
     app: str = "",
     window_id: str = "",
+    screenshot_id: str = "",
     element_id: str = "",
     x: int = 0,
     y: int = 0,
@@ -315,6 +316,9 @@ async def computer_use(
     observation after every successful action; native rejects stale state.
     ``launch_app`` accepts an App ID returned by ``list_apps`` or an absolute
     platform-native application path.
+    ``observe_window`` returns screenshots and accessibility text.
+    Coordinate actions require the ``id`` of an attached screenshot as
+    ``screenshot_id``; coordinates are local to that image.
     Inspect the replacement observation after an action changes selection,
     focus, menus, editors, dialogs, or windows. Confirm editable focus before
     typing, and observe again after committing an edit.
@@ -349,6 +353,7 @@ async def computer_use(
             action,
             app=app,
             window_id=window_id,
+            screenshot_id=screenshot_id,
             element_id=element_id,
             x=x,
             y=y,
@@ -437,6 +442,7 @@ def _native_request(
         if element_id:
             params["element_id"] = element_id
         else:
+            params["screenshot_id"] = _screenshot_id(values)
             params["x"] = values["x"]
             params["y"] = values["y"]
         params["button"] = (
@@ -445,7 +451,11 @@ def _native_request(
         params["count"] = 2 if action == "double_click" else values["count"]
         return "click", params, False
     if action == "scroll":
-        params = {"x": values["x"], "y": values["y"]}
+        params = {
+            "screenshot_id": _screenshot_id(values),
+            "x": values["x"],
+            "y": values["y"],
+        }
         params["delta_y"] = values["delta_y"]
         return action, params, False
     if action == "drag":
@@ -468,6 +478,7 @@ def _native_request(
             )
         else:
             params.update(
+                screenshot_id=_screenshot_id(values),
                 start_x=values["start_x"],
                 start_y=values["start_y"],
                 end_x=values["end_x"],
@@ -516,3 +527,12 @@ def _native_request(
         "double_click, right_click, scroll, drag, type, press_key, invoke, "
         "begin_text_edit, set_value, sequence, wait, stop.",
     )
+
+
+def _screenshot_id(values: Mapping[str, Any]) -> str:
+    screenshot_id = str(values.get("screenshot_id") or "").strip()
+    if not screenshot_id:
+        raise ValueError(
+            "Coordinate input requires screenshot_id from observe_window.",
+        )
+    return screenshot_id

--- a/plugins/bundle/computer-use/computer_use/protocol.py
+++ b/plugins/bundle/computer-use/computer_use/protocol.py
@@ -7,9 +7,10 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from qwenpaw.app.computer_use import COMPUTER_USE_PROTOCOL_VERSION
+# The plugin can be updated independently of the desktop host. Keep its
+# expected version local so mismatched installations fail at the handshake.
+PROTOCOL_VERSION = 2
 
-PROTOCOL_VERSION = COMPUTER_USE_PROTOCOL_VERSION
 
 # Every method name this adapter may put on the wire. The helper matches on
 # these, so the two sides have to agree exactly -- a name only one of them

--- a/plugins/bundle/computer-use/dist/index.js
+++ b/plugins/bundle/computer-use/dist/index.js
@@ -72,7 +72,7 @@ function a(t, n) {
   }
   return I[t][n];
 }
-const B = "1.0.0", D = {
+const B = "1.0.1", D = {
   version: B
 }, o = window.QwenPaw.host, e = o.React, {
   Badge: J,

--- a/plugins/bundle/computer-use/plugin.json
+++ b/plugins/bundle/computer-use/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "computer-use",
   "name": "Computer Use",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Control approved desktop applications through the native runtime (Windows and macOS)",
   "description_i18n": {
     "zh-CN": "通过原生运行时操作已授权的桌面应用（Windows 与 macOS）",
@@ -14,7 +14,7 @@
   },
   "dependencies": [],
   "qwenpaw_version": {
-    "min": "2.1.0",
+    "min": "2.1.1",
     "max": "2.2.0"
   },
   "meta": {

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -104,15 +104,21 @@ Interpret result fields conservatively:
   it does not rule out a visual-only change.
 - `effect: observed` verifies the edited buffer; `effect: unverified` requires
   confirmation from replacement state or a fresh observation.
-- Follow an explicit `next_action` before choosing another action; treat it as
-  bound to the returned state.
-- `requires_observe` invalidates the old target. Use its returned window or
-  rediscover the replacement window before more input.
+- Follow an explicit `next_action` before choosing another action. Use a
+  returned replacement observation or window when present.
+- `requires_observe` invalidates the current observation, not necessarily the
+  window. Reobserve the current or returned window for `observe_window`; use
+  `list_windows` to rediscover a target only when instructed.
 - `confirmation_required` or `pending_action` means the edit is not complete.
 
-When a visual result appears before its accessibility element, wait and observe
-again until it becomes actionable or the operation times out or stops making
-progress. Do not click or type into a screenshot-only control.
+When a visual transition is expected to expose an accessibility element, wait
+and observe again until it becomes actionable or the operation times out or
+stops making progress. For a stable control with no accessibility
+representation, use current screenshot coordinates as described below and
+observe again after acting.
+
+`wait` only delays execution; it does not observe or verify application state.
+Call `observe_window` afterward when current state is needed.
 
 ## Choose an Action
 
@@ -198,13 +204,15 @@ include `ENTER`, `TAB`, `ESC`, `SPACE`, `BACKSPACE`, `DELETE`, `HOME`, `END`,
 
 - Express Command as `WIN` and Option as `ALT`; for example,
   `WIN+SHIFT+N` is Command-Shift-N.
-- Use `begin_text_edit` only for an observed menu command whose semantics
-  require immediate text input; otherwise use `invoke`.
+- `begin_text_edit` is macOS-only. Use it only for an observed menu command
+  whose semantics require immediate text input; otherwise use `invoke`.
 
 ## Recover From Changes
 
-When an action opens another application, window, sheet, or dialog, follow the
-returned handoff instead of continuing against the old observation.
+When an action returns a window handoff, observe the returned window before
+continuing. Without a handoff, follow any `next_action` or inspect the
+replacement observation of the current target; menus, sheets, and dialogs may
+remain related or transient surfaces rather than new targets.
 
 `user_intervention` cancels only the current action and invalidates its
 observation. Never replay that action. Observe or rediscover, then decide from

--- a/plugins/bundle/computer-use/skills/computer_use/SKILL.md
+++ b/plugins/bundle/computer-use/skills/computer_use/SKILL.md
@@ -52,7 +52,8 @@ grant it. Do not retry until the user confirms the permission was granted.
 
 ## Read an Observation
 
-`observe_window` returns a point-in-time window observation. Start with:
+`observe_window` returns a point-in-time window observation with screenshots
+and accessibility text. Start with:
 
 - `accessibility.focused_element`: the control that owns keyboard focus.
 - `accessibility.document_text`: a capped view of the focused document; never
@@ -65,6 +66,13 @@ infer behavior from an opaque identifier alone.
 
 Indentation preserves the native accessibility hierarchy. Use parent and
 container context to distinguish controls with duplicate names.
+
+Each attached image has a `screenshots[].id`, image-local dimensions, screen
+origin, kind, and z-index. On Windows, one observation may include the selected
+window plus related menus, drop-downs, or dialogs. Treat the highest z-index
+related image as the frontmost visual surface, while keeping the original
+`window_id` as the stable target. Attached images and `screenshots` entries
+use the same order.
 
 Common markers:
 
@@ -85,6 +93,10 @@ valid for that observation.
 Every successful desktop mutation invalidates its input observation. The
 response normally installs and returns a settled replacement observation.
 Inspect it before the next action and derive fresh element IDs from it.
+Post-action replacements do not attach images. On Windows,
+`visual.related_surface_count` reports related menus, drop-downs, or dialogs
+seen during that lightweight refresh. Call `observe_window` before choosing a
+visual target or using coordinates.
 
 Interpret result fields conservatively:
 
@@ -129,14 +141,17 @@ claim that one of these actions used `CTRL`, `ALT`, `SHIFT`, or `WIN`. Use
 another supported action only when it preserves the requested semantics;
 otherwise report the limitation.
 
-Use coordinates only with the current observation. The runtime revalidates
-window geometry and the hit window before input. If it rejects a changed,
-covered, or interrupted target, observe again; never bypass the failure by
-reusing the same coordinates.
+Use coordinates only with an attached image from the current observation and
+pass that image's `screenshots[].id` as `screenshot_id`. Coordinates are
+local to that image. The runtime revalidates its geometry and the hit window
+before input. If it rejects an unknown, changed, covered, or interrupted
+target, observe again; never bypass the failure by reusing the same
+coordinates.
 
 For drag and drop, use `source_element_id` and `target_element_id` whenever
-both endpoints are observed. Use coordinates only for an endpoint without an
-accessibility element, and verify the requested state change afterward.
+both endpoints are observed. A coordinate drag uses one `screenshot_id`, so
+both endpoints must belong to that attached image. Verify the requested state
+change afterward.
 
 ### Text and Resource Editing
 

--- a/src/qwenpaw/app/computer_use/runtime.py
+++ b/src/qwenpaw/app/computer_use/runtime.py
@@ -24,7 +24,7 @@ _CONTROL_HOST_ENV = "QWENPAW_COMPUTER_USE_CONTROL_HOST"
 _CONTROL_PORT_ENV = "QWENPAW_COMPUTER_USE_CONTROL_PORT"
 _CONTROL_TOKEN_ENV = "QWENPAW_COMPUTER_USE_CONTROL_TOKEN"
 # Request/response contract shared by the plugin and native helper.
-COMPUTER_USE_PROTOCOL_VERSION = 1
+COMPUTER_USE_PROTOCOL_VERSION = 2
 _CONTROL_MAX_MESSAGE_BYTES = 4096
 # The desktop host answers acquire only after it has spawned the helper
 # process; the first spawn after an install or update can be slowed by

--- a/tests/unit/plugins/computer_use/test_capability_recovery.py
+++ b/tests/unit/plugins/computer_use/test_capability_recovery.py
@@ -23,7 +23,7 @@ def _capability(pipe: str) -> RuntimeCapability:
     return RuntimeCapability(
         _pipe_name=pipe,
         _secret="secret",
-        protocol_version=1,
+        protocol_version=runtime_module.COMPUTER_USE_PROTOCOL_VERSION,
     )
 
 
@@ -105,7 +105,10 @@ def test_a_spent_environment_capability_stops_being_returned(
     """
     monkeypatch.setenv("QWENPAW_COMPUTER_USE_PIPE", "pipe-from-env")
     monkeypatch.setenv("QWENPAW_COMPUTER_USE_CAPABILITY", "secret")
-    monkeypatch.setenv("QWENPAW_COMPUTER_USE_PROTOCOL", "1")
+    monkeypatch.setenv(
+        "QWENPAW_COMPUTER_USE_PROTOCOL",
+        str(runtime_module.COMPUTER_USE_PROTOCOL_VERSION),
+    )
 
     injected = HostRuntimeProvider.get_capability()
     assert injected is not None
@@ -132,7 +135,10 @@ def test_an_incompatible_desktop_capability_is_not_exposed(
 ) -> None:
     monkeypatch.setenv("QWENPAW_COMPUTER_USE_PIPE", "pipe-old")
     monkeypatch.setenv("QWENPAW_COMPUTER_USE_CAPABILITY", "secret")
-    monkeypatch.setenv("QWENPAW_COMPUTER_USE_PROTOCOL", "2")
+    monkeypatch.setenv(
+        "QWENPAW_COMPUTER_USE_PROTOCOL",
+        str(runtime_module.COMPUTER_USE_PROTOCOL_VERSION + 1),
+    )
 
     assert HostRuntimeProvider.get_capability() is None
 

--- a/tests/unit/plugins/computer_use/test_computer_use_protocol.py
+++ b/tests/unit/plugins/computer_use/test_computer_use_protocol.py
@@ -241,8 +241,8 @@ def test_client_rejects_action_before_observe() -> None:
     assert refusal.value.code == "observation_required"
 
 
-def test_screenshot_data_stays_out_of_the_text_block() -> None:
-    """Inline screenshot data must not be duplicated into the JSON text."""
+def test_screenshot_data_uses_base64_source_and_stays_out_of_text() -> None:
+    """Inline screenshots use the standard media representation once."""
     data_url = "data:image/jpeg;base64," + "A" * 4096
     payload = {
         "ok": True,
@@ -263,7 +263,9 @@ def test_screenshot_data_stays_out_of_the_text_block() -> None:
     ]
     text_blocks = [block for block in response.content if block.type == "text"]
     assert len(image_blocks) == 1
-    assert str(image_blocks[0].source.url) == data_url
+    assert image_blocks[0].source.type == "base64"
+    assert image_blocks[0].source.media_type == "image/jpeg"
+    assert image_blocks[0].source.data == "A" * 4096
     assert len(text_blocks) == 1
     assert data_url not in text_blocks[0].text
     assert "screenshot-1" in text_blocks[0].text

--- a/tests/unit/plugins/computer_use/test_computer_use_protocol.py
+++ b/tests/unit/plugins/computer_use/test_computer_use_protocol.py
@@ -93,7 +93,7 @@ def test_host_runtime_requests_a_capability_only_when_needed(
     assert capability == runtime_module.RuntimeCapability(
         "pipe-1",
         "secret-1",
-        1,
+        runtime_module.COMPUTER_USE_PROTOCOL_VERSION,
     )
     assert received == {
         "token": token,
@@ -104,6 +104,7 @@ def test_host_runtime_requests_a_capability_only_when_needed(
 def test_coordinate_input_leaves_observation_context_to_client() -> None:
     method, params, include_images = _native_request(
         "click",
+        screenshot_id="screenshot-7",
         x=40,
         y=60,
         button="left",
@@ -113,11 +114,28 @@ def test_coordinate_input_leaves_observation_context_to_client() -> None:
     assert method == "click"
     assert include_images is False
     assert params == {
+        "screenshot_id": "screenshot-7",
         "x": 40,
         "y": 60,
         "button": "left",
         "count": 1,
     }
+
+
+def test_observe_window_requests_current_visual_and_semantic_state() -> None:
+    method, params, include_images = _native_request(
+        "observe_window",
+        window_id="42",
+    )
+
+    assert method == "observe_window"
+    assert params == {"window_id": "42"}
+    assert include_images is True
+
+
+def test_coordinate_input_requires_a_current_screenshot() -> None:
+    with pytest.raises(ValueError):
+        _native_request("click", x=40, y=60, button="left", count=1)
 
 
 def test_close_window_maps_to_the_native_method() -> None:
@@ -391,10 +409,13 @@ class _FakeTransport(ComputerUseTransport):
         payload = dict(message)
         self.messages.append(payload)
         if payload["method"] == "hello":
+            protocol_version = runtime_module.COMPUTER_USE_PROTOCOL_VERSION
             return {
                 "request_id": payload["request_id"],
                 "ok": True,
-                "result": {"protocol_version": 1},
+                "result": {
+                    "protocol_version": protocol_version,
+                },
             }
         result = {}
         if payload["method"] in client_module._OBSERVED_METHODS:
@@ -467,7 +488,11 @@ async def test_acquire_capability_retries_cold_start_misses(
 ) -> None:
     """A transient acquire miss must be retried before giving up."""
     attempts: list[int] = []
-    capability = runtime_module.RuntimeCapability("pipe-1", "secret-1", 1)
+    capability = runtime_module.RuntimeCapability(
+        "pipe-1",
+        "secret-1",
+        runtime_module.COMPUTER_USE_PROTOCOL_VERSION,
+    )
 
     def _flaky_acquire():
         attempts.append(len(attempts))
@@ -493,7 +518,11 @@ async def test_acquire_capability_rejects_an_incompatible_desktop(
     monkeypatch.setattr(
         client_module.HostRuntimeProvider,
         "acquire_capability",
-        lambda: runtime_module.RuntimeCapability("pipe-1", "secret-1", 2),
+        lambda: runtime_module.RuntimeCapability(
+            "pipe-1",
+            "secret-1",
+            runtime_module.COMPUTER_USE_PROTOCOL_VERSION + 1,
+        ),
     )
 
     with pytest.raises(ComputerUseProtocolError) as refusal:

--- a/tests/unit/plugins/computer_use/test_protocol_contract.py
+++ b/tests/unit/plugins/computer_use/test_protocol_contract.py
@@ -28,6 +28,7 @@ from computer_use.protocol import (
     ComputerUseProtocolError,
     NativeRequest,
 )
+from qwenpaw.app.computer_use import COMPUTER_USE_PROTOCOL_VERSION
 
 _SERVER = (
     Path(__file__).resolve().parents[4]
@@ -38,6 +39,14 @@ _SERVER = (
 )
 _DISPATCH = _SERVER / "dispatch.rs"
 _PROTOCOL = _SERVER.parent / "computer_use_protocol.rs"
+_PLUGIN_PROTOCOL = (
+    Path(__file__).resolve().parents[4]
+    / "plugins"
+    / "bundle"
+    / "computer-use"
+    / "computer_use"
+    / "protocol.py"
+)
 
 # A method the helper answers but the adapter never sends. Listed rather than
 # ignored, so unused protocol surface stays visible instead of accumulating.
@@ -103,8 +112,8 @@ def test_the_guarded_set_is_a_subset_of_the_vocabulary() -> None:
     assert guarded <= NATIVE_METHODS, sorted(guarded - NATIVE_METHODS)
 
 
-def test_both_sides_speak_the_same_protocol_version() -> None:
-    """The version is declared once per language, with nothing tying them.
+def test_all_components_speak_the_same_protocol_version() -> None:
+    """The independently installed components must reject contract drift.
 
     A mismatch is caught at run time as a refused handshake, so it cannot go
     unnoticed -- but it would be noticed by whoever is holding the machine,
@@ -113,7 +122,18 @@ def test_both_sides_speak_the_same_protocol_version() -> None:
     source = _PROTOCOL.read_text(encoding="utf-8")
     match = re.search(r"const VERSION: u64 = (\d+);", source)
     assert match, "the helper should declare its protocol version"
-    assert int(match.group(1)) == PROTOCOL_VERSION
+    plugin_source = _PLUGIN_PROTOCOL.read_text(encoding="utf-8")
+    plugin_match = re.search(
+        r"^PROTOCOL_VERSION = (\d+)$",
+        plugin_source,
+        re.M,
+    )
+    assert plugin_match, "the plugin should own its expected protocol version"
+    assert {
+        int(match.group(1)),
+        int(plugin_match.group(1)),
+        COMPUTER_USE_PROTOCOL_VERSION,
+    } == {PROTOCOL_VERSION}
 
 
 def test_a_method_outside_the_vocabulary_never_reaches_the_wire() -> None:

--- a/tests/unit/plugins/computer_use/test_windows_pipe.py
+++ b/tests/unit/plugins/computer_use/test_windows_pipe.py
@@ -30,7 +30,10 @@ from computer_use.transport.windows_pipe import (
     WindowsPipeTransport,
     _kernel32,
 )
-from qwenpaw.app.computer_use.runtime import RuntimeCapability
+from qwenpaw.app.computer_use.runtime import (
+    COMPUTER_USE_PROTOCOL_VERSION,
+    RuntimeCapability,
+)
 
 pytestmark = pytest.mark.skipif(
     os.name != "nt",
@@ -112,7 +115,7 @@ class _MockHelper:
             request_id = message.get("request_id")
             result: dict[str, Any]
             if method == "hello":
-                result = {"protocol_version": 1}
+                result = {"protocol_version": COMPUTER_USE_PROTOCOL_VERSION}
             elif method == "list_apps":
                 result = {"apps": []}
             elif method == "delayed":
@@ -132,7 +135,7 @@ class _MockHelper:
                         "warning": "",
                     },
                     "meta": message.get("meta"),
-                    "protocol_version": 1,
+                    "protocol_version": COMPUTER_USE_PROTOCOL_VERSION,
                 }
                 self._write_frame(kernel32, hpipe, reverse)
                 reply = self._read_message(kernel32, hpipe)
@@ -220,12 +223,16 @@ def _request(
             "turn_id": "test",
             "deadline_ms": deadline,
         },
-        "protocol_version": 1,
+        "protocol_version": COMPUTER_USE_PROTOCOL_VERSION,
     }
 
 
 def _transport(helper: _MockHelper) -> WindowsPipeTransport:
-    capability = RuntimeCapability(helper.pipe_name, helper.secret, 1)
+    capability = RuntimeCapability(
+        helper.pipe_name,
+        helper.secret,
+        COMPUTER_USE_PROTOCOL_VERSION,
+    )
     return WindowsPipeTransport(capability)
 
 


### PR DESCRIPTION
## Description

Computer Use observed only the selected top-level window, so native menus,
drop-downs, and owned dialogs could become the active interface without being
available as a visual target.

This change keeps the selected window as the stable target while:

- observing up to three related Windows surfaces and rooting UI Automation at
  the frontmost surface;
- assigning every attached screenshot an observation-scoped ID and requiring
  that ID for coordinate input;
- binding coordinate hit validation to the exact captured surface;
- using accessibility-only post-action refreshes, with a bounded related-
  surface count, instead of encoding screenshots that are not attached;
- applying the same screenshot-ID mapping and lightweight refresh contract on
  macOS;
- advancing the unpublished native contract from v1 to v2 and releasing the
  Computer Use plugin as 1.0.1.

The Skill now explains multi-surface observations and when a fresh visual
observation is required.

**Related Issue:** N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

## Testing

```text
cargo test --manifest-path console/src-tauri/Cargo.toml computer_use_server -- --nocapture
# Native helper: 55 passed

cargo check --manifest-path console/src-tauri/Cargo.toml --bin qwenpaw-computer-use-helper
# Passed

python -m pytest -q --confcutdir=tests/unit/plugins/computer_use \
  tests/unit/plugins/computer_use/test_capability_recovery.py \
  tests/unit/plugins/computer_use/test_computer_use_protocol.py \
  tests/unit/plugins/computer_use/test_protocol_contract.py \
  tests/unit/plugins/computer_use/test_windows_pipe.py
# 58 passed

python -m pre_commit run --files <20 changed files>
# All applicable hooks passed
```

## Additional Notes

- The desktop host/helper and plugin must agree on protocol v2; mismatched
  installations fail during capability negotiation.
- macOS implements the shared contract but was not compiled or exercised on a
  macOS host in this environment.
