### PR TITLE
feat(chats): add limit/before pagination to GET /chats/{chat_id}

### DIFF
--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -16,6 +16,7 @@ from agentscope.state import AgentState
 
 from .session import SafeJSONSession
 from .manager import ChatManager, MAX_BATCH_SIZE
+from .history_window import apply_history_window
 from .models import (
     BatchArchiveResult,
     ChatSpec,
@@ -333,6 +334,23 @@ async def clear_chat_project_dir(
 @router.get("/{chat_id}", response_model=ChatHistory)
 async def get_chat(
     chat_id: str,
+    limit: int = Query(
+        0,
+        ge=0,
+        le=10000,
+        description=(
+            "Maximum number of most-recent messages to return. "
+            "0 (default) returns the full history (backward compatible)."
+        ),
+    ),
+    before: Optional[str] = Query(
+        None,
+        description=(
+            "Return only messages older than the message whose "
+            "metadata.original_id equals this value (cursor for "
+            "'load earlier messages' pagination)."
+        ),
+    ),
     mgr: ChatManager = Depends(get_chat_manager),
     session: SafeJSONSession = Depends(get_session),
     workspace=Depends(get_workspace),
@@ -340,13 +358,17 @@ async def get_chat(
     """Get detailed information about a specific chat by UUID.
 
     Args:
-        request: FastAPI request (for agent context)
         chat_id: Chat UUID
+        limit: Maximum number of most-recent messages to return (0 = all)
+        before: Optional ``metadata.original_id`` cursor; when set, only
+            messages older than that message are returned
         mgr: Chat manager dependency
         session: SafeJSONSession dependency
 
     Returns:
-        ChatHistory with messages and status (idle/running)
+        ChatHistory with messages and status (idle/running); ``total`` and
+        ``has_more`` describe the unwindowed history so clients can offer
+        "load earlier messages" (see issues #3915 and #6635)
 
     Raises:
         HTTPException: If chat not found (404)
@@ -410,7 +432,17 @@ async def get_chat(
             memories, _summary = parse_legacy_memory_state(memory_raw)
 
     messages = agentscope_msg_to_message(memories)
-    return ChatHistory(messages=messages, status=status)
+    messages, total, has_more = apply_history_window(
+        messages,
+        limit=limit,
+        before=before,
+    )
+    return ChatHistory(
+        messages=messages,
+        status=status,
+        total=total,
+        has_more=has_more,
+    )
 
 
 @router.put("/{chat_id}", response_model=ChatSpec)

--- a/src/qwenpaw/app/chats/history_window.py
+++ b/src/qwenpaw/app/chats/history_window.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Windowing helpers for paginated chat history loading.
+
+``GET /api/chats/{chat_id}`` used to return the whole message history in a
+single response. For long-running chats (real-world workspaces reach 1 MB+
+of JSON and thousands of messages) this makes the console slow to open and
+can freeze the webview entirely (see issues #3915 and #6635). The helpers
+here implement a small windowing layer so the endpoint can serve the most
+recent messages first and older pages on demand:
+
+- ``limit=0`` (default) keeps the original behaviour (full history).
+- ``before`` is a cursor value taken from ``metadata.original_id`` — the
+  persistent AgentScope ``Msg`` id. ``Message.id`` cannot be used as a
+  cursor because ``agentscope_msg_to_message`` regenerates it on every
+  request.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+__all__ = ["apply_history_window", "message_original_id"]
+
+
+def message_original_id(message: Any) -> Optional[str]:
+    """Return ``metadata.original_id`` of a chat message, if present."""
+    metadata = getattr(message, "metadata", None) or {}
+    if isinstance(metadata, dict):
+        value = metadata.get("original_id")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def apply_history_window(
+    messages: List[Any],
+    limit: int = 0,
+    before: Optional[str] = None,
+) -> Tuple[List[Any], int, bool]:
+    """Slice a chat history into a window of the most recent messages.
+
+    Args:
+        messages: Full ordered history (oldest first), already converted to
+            ``Message`` objects.
+        limit: Maximum number of messages to return, counting from the most
+            recent one. ``0`` (default) means no slicing.
+        before: When set, only messages strictly older than the first
+            message whose ``metadata.original_id`` equals this value are
+            considered (a page of "load earlier" history). An unknown or
+            stale cursor is ignored gracefully.
+
+    Returns:
+        ``(windowed_messages, total, has_more)`` where ``total`` is the
+        message count before windowing and ``has_more`` reports whether
+        older messages exist beyond the returned window.
+    """
+    total = len(messages)
+
+    if before is not None:
+        cut = next(
+            (
+                index
+                for index, message in enumerate(messages)
+                if message_original_id(message) == before
+            ),
+            None,
+        )
+        if cut is not None:
+            messages = messages[:cut]
+
+    if limit and limit > 0 and len(messages) > limit:
+        return messages[-limit:], total, True
+
+    return messages, total, False

--- a/src/qwenpaw/app/chats/history_window.py
+++ b/src/qwenpaw/app/chats/history_window.py
@@ -68,7 +68,7 @@ def apply_history_window(
         if cut is not None:
             messages = messages[:cut]
 
-    if limit and limit > 0 and len(messages) > limit:
+    if 0 < limit < len(messages):
         return messages[-limit:], total, True
 
     return messages, total, False

--- a/src/qwenpaw/app/chats/models.py
+++ b/src/qwenpaw/app/chats/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Chat models with UUID management."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -100,6 +101,20 @@ class ChatHistory(BaseModel):
     status: str = Field(
         default="idle",
         description="Conversation status: idle or running",
+    )
+    total: int = Field(
+        default=0,
+        description=(
+            "Total number of messages in the chat before pagination "
+            "windowing was applied."
+        ),
+    )
+    has_more: bool = Field(
+        default=False,
+        description=(
+            "True when older messages exist beyond the returned window; "
+            "clients should offer a 'load earlier messages' action."
+        ),
     )
 
 

--- a/tests/unit/app/chats/test_api_history_pagination.py
+++ b/tests/unit/app/chats/test_api_history_pagination.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Route-level tests for ``GET /api/chats/{chat_id}`` pagination.
+
+Exercises the real endpoint (dependency overrides for the workspace
+only) with a session state built from genuine AgentScope messages, so
+the full path — state → ``agentscope_msg_to_message`` →
+``apply_history_window`` → ``ChatHistory`` — is covered.
+"""
+
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agentscope.message import Msg, TextBlock
+from agentscope.state import AgentState
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.chats import api as chats_api
+from qwenpaw.app.chats.models import ChatSpec
+
+CHAT_ID = "pagination-chat-1"
+SESSION_ID = "console:pagination-user"
+USER_ID = "pagination-user"
+CHANNEL = "console"
+
+
+def build_messages(count: int) -> list[Msg]:
+    """Alternating user/assistant messages with distinct ids and texts."""
+    messages = []
+    for index in range(count):
+        role = "user" if index % 2 == 0 else "assistant"
+        messages.append(
+            Msg(
+                name=USER_ID if role == "user" else "agent",
+                content=[TextBlock(type="text", text=f"message-{index}")],
+                role=role,
+                id=f"scoped-msg-{index}",
+            ),
+        )
+    return messages
+
+
+@pytest.fixture
+def chat_workspace():
+    """Workspace mock backing the chats router dependencies."""
+    chat = ChatSpec(
+        id=CHAT_ID,
+        name="Pagination chat",
+        session_id=SESSION_ID,
+        user_id=USER_ID,
+        channel=CHANNEL,
+    )
+    workspace = MagicMock(name="workspace")
+    workspace.chat_manager = MagicMock(name="ChatManager")
+    workspace.chat_manager.get_chat = AsyncMock(return_value=chat)
+    workspace.task_tracker.get_status = AsyncMock(return_value="idle")
+    workspace.config.backend = "qwenpaw"
+
+    session = MagicMock(name="SafeJSONSession")
+    session.get_session_state_dict = AsyncMock(
+        return_value={
+            "agent": {
+                "state": AgentState(context=build_messages(6)).model_dump()
+            }
+        },
+    )
+    workspace.session = session
+    return workspace
+
+
+@pytest.fixture
+def client(chat_workspace) -> TestClient:
+    """FastAPI app mounting only the chats router, deps overridden."""
+    application = FastAPI()
+    application.include_router(chats_api.router, prefix="/api")
+
+    async def _override_workspace():
+        return chat_workspace
+
+    def _override_manager():
+        return chat_workspace.chat_manager
+
+    def _override_session():
+        return chat_workspace.session
+
+    # All three must be overridden: get_chat_manager / get_session call
+    # the module-level get_workspace directly, so the FastAPI override
+    # on get_workspace alone does not reach them.
+    application.dependency_overrides[chats_api.get_workspace] = (
+        _override_workspace
+    )
+    application.dependency_overrides[chats_api.get_chat_manager] = (
+        _override_manager
+    )
+    application.dependency_overrides[chats_api.get_session] = _override_session
+    return TestClient(application)
+
+
+def text_of(message: dict) -> str:
+    return "".join(
+        block.get("text", "")
+        for block in message.get("content", [])
+        if isinstance(block, dict)
+    )
+
+
+def test_without_params_returns_full_history(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["messages"]) == 6
+    assert body["total"] == 6
+    assert body["has_more"] is False
+    assert body["status"] == "idle"
+
+
+def test_limit_returns_most_recent_window(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=2")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [text_of(m) for m in body["messages"]] == [
+        "message-4",
+        "message-5",
+    ]
+    assert body["total"] == 6
+    assert body["has_more"] is True
+
+
+def test_limit_covering_everything_disables_has_more(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=6")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["messages"]) == 6
+    assert body["has_more"] is False
+
+
+def test_before_cursor_pages_older_history(client):
+    full = client.get(f"/api/chats/{CHAT_ID}").json()
+    # Cursor on the oldest message of the first window: message-4's
+    # source Msg id is exposed via metadata.original_id.
+    oldest_in_window = full["messages"][4]
+    cursor = oldest_in_window["metadata"]["original_id"]
+    assert cursor == "scoped-msg-4"
+
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=2&before={cursor}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [text_of(m) for m in body["messages"]] == [
+        "message-2",
+        "message-3",
+    ]
+    assert body["total"] == 6
+    assert body["has_more"] is True
+
+
+def test_before_cursor_on_oldest_message_returns_empty(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=10&before=scoped-msg-0")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["messages"] == []
+    assert body["total"] == 6
+    assert body["has_more"] is False
+
+
+def test_stale_cursor_falls_back_to_limit_window(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=3&before=no-such-cursor")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [text_of(m) for m in body["messages"]] == [
+        "message-3",
+        "message-4",
+        "message-5",
+    ]
+    assert body["has_more"] is True
+
+
+def test_invalid_limit_is_rejected(client):
+    resp = client.get(f"/api/chats/{CHAT_ID}?limit=-1")
+    assert resp.status_code == 422

--- a/tests/unit/app/chats/test_history_window.py
+++ b/tests/unit/app/chats/test_history_window.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``qwenpaw.app.chats.history_window``.
+
+Covers the pagination windowing used by ``GET /api/chats/{chat_id}``
+(``limit`` + ``before`` cursor). Messages are stubbed with lightweight
+objects so the tests stay independent of the conversion pipeline.
+"""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import List, Optional
+
+from qwenpaw.app.chats.history_window import (
+    apply_history_window,
+    message_original_id,
+)
+
+
+def make_message(original_id: Optional[str]) -> SimpleNamespace:
+    metadata = {"original_id": original_id} if original_id else {}
+    return SimpleNamespace(metadata=metadata)
+
+
+def make_history(count: int, prefix: str = "msg") -> List[SimpleNamespace]:
+    return [make_message(f"{prefix}-{i}") for i in range(count)]
+
+
+def ids(messages: List[SimpleNamespace]) -> List[Optional[str]]:
+    return [message_original_id(m) for m in messages]
+
+
+class TestMessageOriginalId:
+    def test_reads_original_id(self):
+        assert message_original_id(make_message("abc")) == "abc"
+
+    def test_missing_metadata(self):
+        assert message_original_id(SimpleNamespace()) is None
+
+    def test_none_metadata(self):
+        assert message_original_id(SimpleNamespace(metadata=None)) is None
+
+    def test_non_string_value(self):
+        message = SimpleNamespace(metadata={"original_id": 123})
+        assert message_original_id(message) is None
+
+
+class TestApplyHistoryWindow:
+    def test_no_arguments_returns_everything(self):
+        history = make_history(5)
+        window, total, has_more = apply_history_window(history)
+        assert window == history
+        assert total == 5
+        assert has_more is False
+
+    def test_limit_returns_most_recent(self):
+        history = make_history(5)
+        window, total, has_more = apply_history_window(history, limit=2)
+        assert ids(window) == ["msg-3", "msg-4"]
+        assert total == 5
+        assert has_more is True
+
+    def test_limit_equal_to_length(self):
+        history = make_history(3)
+        window, total, has_more = apply_history_window(history, limit=3)
+        assert ids(window) == ["msg-0", "msg-1", "msg-2"]
+        assert total == 3
+        assert has_more is False
+
+    def test_limit_larger_than_length(self):
+        history = make_history(3)
+        window, total, has_more = apply_history_window(history, limit=10)
+        assert len(window) == 3
+        assert has_more is False
+
+    def test_empty_history(self):
+        window, total, has_more = apply_history_window([], limit=50)
+        assert window == []
+        assert total == 0
+        assert has_more is False
+
+    def test_before_keeps_strictly_older_messages(self):
+        history = make_history(5)
+        window, total, has_more = apply_history_window(history, before="msg-2")
+        assert ids(window) == ["msg-0", "msg-1"]
+        assert total == 5
+        assert has_more is False
+
+    def test_before_with_limit_pages_older_history(self):
+        history = make_history(5)
+        window, total, has_more = apply_history_window(history, limit=1, before="msg-2")
+        assert ids(window) == ["msg-1"]
+        assert total == 5
+        assert has_more is True
+
+    def test_before_oldest_message_returns_empty(self):
+        history = make_history(4)
+        window, total, has_more = apply_history_window(history, before="msg-0")
+        assert window == []
+        assert total == 4
+        assert has_more is False
+
+    def test_unknown_cursor_is_ignored(self):
+        history = make_history(5)
+        window, total, has_more = apply_history_window(
+            history, limit=3, before="no-such-cursor"
+        )
+        assert ids(window) == ["msg-2", "msg-3", "msg-4"]
+        assert total == 5
+        assert has_more is True
+
+    def test_duplicate_original_id_cuts_at_first_occurrence(self):
+        # One AgentScope Msg can expand into several Message objects that
+        # share the same metadata.original_id (text / reasoning / tool
+        # segments). The cursor must cut before the whole group.
+        history = [
+            make_message("msg-0"),
+            make_message("msg-1"),
+            make_message("msg-1"),  # second segment of msg-1
+            make_message("msg-2"),
+        ]
+        window, total, has_more = apply_history_window(history, before="msg-1")
+        assert ids(window) == ["msg-0"]
+        assert total == 4
+        assert has_more is False
+
+    def test_messages_without_original_id_are_kept(self):
+        history = [
+            make_message(None),
+            make_message("msg-1"),
+            make_message(None),
+        ]
+        window, total, has_more = apply_history_window(history, limit=2)
+        assert len(window) == 2
+        assert total == 3
+        assert has_more is True

--- a/tests/unit/app/chats/test_history_window.py
+++ b/tests/unit/app/chats/test_history_window.py
@@ -70,7 +70,7 @@ class TestApplyHistoryWindow:
 
     def test_limit_larger_than_length(self):
         history = make_history(3)
-        window, total, has_more = apply_history_window(history, limit=10)
+        window, _total, has_more = apply_history_window(history, limit=10)
         assert len(window) == 3
         assert has_more is False
 
@@ -89,7 +89,9 @@ class TestApplyHistoryWindow:
 
     def test_before_with_limit_pages_older_history(self):
         history = make_history(5)
-        window, total, has_more = apply_history_window(history, limit=1, before="msg-2")
+        window, total, has_more = apply_history_window(
+            history, limit=1, before="msg-2"
+        )
         assert ids(window) == ["msg-1"]
         assert total == 5
         assert has_more is True


### PR DESCRIPTION
## Description

Add optional pagination to `GET /api/chats/{chat_id}` so the console can load the most recent messages first and fetch older history on demand, instead of receiving the whole conversation in a single response.

- New query params: `limit` (max number of most-recent messages, default `0` = full history) and `before` (cursor for "load earlier messages").
- `ChatHistory` now also returns `total` (message count before windowing) and `has_more` (pagination hint for clients).
- **Fully backward compatible**: without query params the endpoint behaves exactly as before (response shape only gains two additive fields with safe defaults).

Design notes:

- The `before` cursor uses **`metadata.original_id`** (the persistent AgentScope `Msg` id), not `Message.id`: `agentscope_msg_to_message` regenerates `Message.id` (`uuid4().hex`) on every request, so it is not stable across calls and cannot serve as a cursor.
- One AgentScope `Msg` can expand into multiple `Message` objects (text / reasoning / tool segments) sharing the same `original_id`; the cursor cuts at the **first** occurrence so segments of the same source message are never split across pages.
- An unknown/stale cursor is ignored gracefully (the request degrades to a plain `limit` window) instead of erroring.
- Windowing runs after `agentscope_msg_to_message`, after scroll placeholders / synthetic messages are already filtered out.

**Related Issue:** Relates to #3915 (backend foundation for "lazy-load older messages when scrolling up" and eventual virtualization) and #6635 (the chat-history pagination direction; the gzip / timeout / skills-list parts there are left to the ongoing work under that issue, which already has an assignee).

**Security Considerations:** None — the endpoint only gains optional query parameters; no new data is exposed (`total`/`has_more` are counts derived from the same history the endpoint already returns). `limit` is validated (`ge=0, le=10000`).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI) *(follow-up: open chats with `?limit=50`, add a "Load earlier messages" action, then virtualize the main message list per #3915 — pagination and virtualization compose well)*
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website) — checked: `website/public/docs` only lists the endpoint name (`/api/chats/* - chat management`), no per-parameter API reference to update
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest`) and they pass
- [x] Documentation updated (if needed) — not needed, see above
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

New tests (19 total):

- `tests/unit/app/chats/test_history_window.py` — 12 unit tests for `apply_history_window`: default full-history behaviour, `limit` slicing, `before` cut, combined paging, stale cursor, oldest-message cursor, duplicate `original_id` groups, empty history, messages without metadata.
- `tests/unit/app/chats/test_api_history_pagination.py` — 7 route-level tests exercising the real endpoint via FastAPI `TestClient` (dependency overrides + genuine AgentScope `Msg` session state): full history, `limit` window + `has_more`, boundary (`limit` = length), `before`-cursor paging, cursor on oldest message, stale-cursor fallback, and `limit=-1` → 422.

Manual verification of backward compatibility: calling the endpoint without query params returns the identical message list as `main` plus the two new fields.

## Evidence

Local gate run (Python 3.13.13, Windows, `pip install -e ".[dev,test]"`):

```bash
$ black --line-length 79 <changed files>   # .pre-commit-config.yaml pins black 23.3.0, --line-length=79
All done! ✨ 🍰 ✨
5 files left unchanged.

$ flake8 --extend-ignore=E203 <changed files>
(exit 0, no findings)

$ pylint <pre-commit args> src/qwenpaw/app/chats/history_window.py tests/unit/app/chats/test_history_window.py
Your code has been rated at 10.00/10

$ mypy --ignore-missing-imports <pre-commit args> <3 changed src files>
Success: no issues found in 3 source files

$ pytest tests/unit/app/ -q
786 passed, 1 skipped in 13.77s     # includes the 19 new tests above

$ pytest tests/integration/test_chats_agent_scoped.py -q
2 passed in 19.57s                   # existing chats integration tests unaffected
```

Also verified: `check-ast`, `check-docstring-first`, `fix-encoding-pragma`, `trailing-whitespace`, `detect-private-key` clean on all changed files.

## Additional Notes

- Real-world motivation (from a long-running agent workspace): a single chat reaching a ~540k-token context produced ~277k streamed console events; the WebView renderer pegs one core at 100% and the UI freezes completely, and reopening the chat repeats the freeze because the full history is re-fetched and re-rendered each time. Serving a latest window first makes opening any chat cheap regardless of history size.
- Suggested follow-ups (separate PRs): console-side "load earlier messages" using these params; virtualized main message list (#3915).