### PR TITLE
feat(chrome): support remote bridge endpoint for LAN/network browsers

### DIFF
--- a/plugins/bundle/chrome/api/routes.py
+++ b/plugins/bundle/chrome/api/routes.py
@@ -22,7 +22,10 @@ from qwenpaw.browser.control_link.chrome.bridge import (
 from ..extension_setup import (
     CHROME_EXTENSIONS_URL,
     atomic_write_json_0600,
+    bridge_endpoint_source,
+    endpoint_is_loopback,
     extension_install_status,
+    BridgeEndpointError,
     BridgeEndpointUnavailable,
     InstallModeError,
     open_extension_folder,
@@ -90,13 +93,33 @@ def configure_nm_bridge(
 async def get_extension_status() -> dict[str, Any]:
     """Return install state plus the core endpoint the host will contact."""
     status = extension_install_status()
-    bridge_endpoint = require_bridge_endpoint()
+    endpoint_error = None
+    try:
+        bridge_endpoint: str | None = require_bridge_endpoint()
+    except BridgeEndpointError as exc:
+        bridge_endpoint = None
+        endpoint_error = str(exc)
     configured_endpoint = status.pop("ws_url", None)
     return {
         **status,
         "bridge_endpoint": bridge_endpoint,
         "configured_endpoint": configured_endpoint,
-        "bridge_endpoint_stale": configured_endpoint != bridge_endpoint,
+        "bridge_endpoint_stale": (
+            bridge_endpoint is not None
+            and configured_endpoint != bridge_endpoint
+        ),
+        "endpoint_source": bridge_endpoint_source(),
+        "endpoint_error": endpoint_error,
+        "remote": (
+            not endpoint_is_loopback(bridge_endpoint)
+            if bridge_endpoint is not None
+            else False
+        ),
+        "secure_transport": (
+            bridge_endpoint.startswith("wss://")
+            if bridge_endpoint is not None
+            else False
+        ),
     }
 
 

--- a/plugins/bundle/chrome/dist/index.js
+++ b/plugins/bundle/chrome/dist/index.js
@@ -1,4 +1,4 @@
-const F = {
+const U = {
   en: {
     routeLabel: "Chrome",
     pageTitle: "Chrome",
@@ -65,6 +65,14 @@ const F = {
     nativeHost: "Local connection helper",
     config: "Local settings file",
     bridgeEndpoint: "Connection endpoint",
+    endpointLocal: "Local",
+    endpointRemote: "Remote",
+    endpointInsecureWarning: "The endpoint uses ws:// on a non-loopback address; the bridge token crosses the network in plaintext. Prefer wss:// or a trusted LAN.",
+    endpointInvalid: "Invalid endpoint override: {error}",
+    remoteSetupTitle: "Connect a browser on another machine",
+    remoteSetupDescription: "Copy the plugin's chrome folder to the browser machine, then run its setup CLI there with this endpoint and the server token (see ~/.qwenpaw/nm-bridge.json on the server).",
+    remoteSetupCommandLabel: "Setup command",
+    copyCommand: "Copy command",
     checksTitle: "Connection checks",
     checkExtensionBridge: "Extension bridge",
     checkNmHost: "Native Messaging host",
@@ -164,6 +172,14 @@ const F = {
     nativeHost: "本机连接助手",
     config: "本地设置文件",
     bridgeEndpoint: "连接端点",
+    endpointLocal: "本机",
+    endpointRemote: "远程",
+    endpointInsecureWarning: "当前端点在非回环地址上使用 ws://，桥接 token 会以明文经过网络。建议改用 wss:// 或仅在可信局域网内使用。",
+    endpointInvalid: "端点覆盖配置无效：{error}",
+    remoteSetupTitle: "连接其他机器上的浏览器",
+    remoteSetupDescription: "把插件的 chrome 目录拷到浏览器所在机器，在该机器上运行其自带 setup CLI，并填入此端点与服务端 token（见服务端 ~/.qwenpaw/nm-bridge.json）。",
+    remoteSetupCommandLabel: "安装命令",
+    copyCommand: "复制命令",
     checksTitle: "连接检查",
     checkExtensionBridge: "扩展桥接",
     checkNmHost: "Native Messaging 宿主",
@@ -206,23 +222,23 @@ function J() {
     return null;
   }
 }
-function j(t = J()) {
+function $(t = J()) {
   return String(t || "").trim().split("-")[0].toLowerCase() === "zh" ? "zh" : "en";
 }
 function o(t, n, r) {
-  let l = F[t][n] ?? F.en[n];
+  let l = U[t][n] ?? U.en[n];
   if (r)
-    for (const [i, h] of Object.entries(r))
-      l = l.split(`{${i}}`).join(String(h));
+    for (const [a, m] of Object.entries(r))
+      l = l.split(`{${a}}`).join(String(m));
   return l;
 }
-const f = window.QwenPaw.host, e = f.React, Z = f.antd, X = f.getApiUrl, R = f.getApiToken, { Alert: U, Button: u, Collapse: ee, Space: be, Spin: te, Typography: ne, message: S } = Z, { Text: d, Title: N } = ne, re = {
+const E = window.QwenPaw.host, e = E.React, Z = E.antd, X = E.getApiUrl, I = E.getApiToken, { Alert: B, Button: u, Collapse: ee, Space: be, Spin: te, Tag: ne, Typography: re, message: S } = Z, { Text: d, Title: N } = re, oe = {
   extension_bridge: "checkExtensionBridge",
   nm_host: "checkNmHost",
   extension_assets: "checkExtensionAssets",
   bridge_lifecycle: "checkBridgeLifecycle",
   contract_drift: "checkContractDrift"
-}, oe = {
+}, ie = {
   reinstall_nm_host: "repairReinstallNmHost",
   reload_unpacked_extension: "repairReloadUnpackedExtension",
   wait_or_restart_chrome: "repairWaitOrRestartChrome",
@@ -656,10 +672,10 @@ function ae(t) {
   };
 }
 function v() {
-  const { token: t } = f.antd.theme.useToken();
+  const { token: t } = E.antd.theme.useToken();
   return e.useMemo(() => ae(t), [t]);
 }
-function ie() {
+function le() {
   return /* @__PURE__ */ e.createElement(
     "svg",
     {
@@ -682,8 +698,8 @@ function ie() {
     /* @__PURE__ */ e.createElement("line", { x1: 14.925, y1: 13.688, x2: 10.753, y2: 20.916 })
   );
 }
-function le() {
-  const t = {}, n = R == null ? void 0 : R();
+function se() {
+  const t = {}, n = I == null ? void 0 : I();
   return n && (t.Authorization = `Bearer ${n}`), t;
 }
 async function T(t, n) {
@@ -691,26 +707,26 @@ async function T(t, n) {
     ...n,
     headers: {
       ...(n == null ? void 0 : n.headers) || {},
-      ...le()
+      ...se()
     }
-  }), l = await r.text(), i = l ? JSON.parse(l) : null;
+  }), l = await r.text(), a = l ? JSON.parse(l) : null;
   if (!r.ok)
     throw new Error(
-      typeof (i == null ? void 0 : i.detail) == "string" ? i.detail : r.statusText
+      typeof (a == null ? void 0 : a.detail) == "string" ? a.detail : r.statusText
     );
-  return i;
+  return a;
 }
-function se() {
+function ce() {
   return T("/chrome/install-status");
 }
-async function ce() {
+async function de() {
   try {
     return await T("/browser/chrome/status");
   } catch {
     return null;
   }
 }
-async function de() {
+async function pe() {
   try {
     return await T("/browser/chrome/self-test", {
       method: "POST"
@@ -719,7 +735,7 @@ async function de() {
     return null;
   }
 }
-function pe(t) {
+function me(t) {
   return T("/chrome/setup", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -734,7 +750,7 @@ function he() {
     }
   );
 }
-function me(t, n) {
+function ue(t, n) {
   if (!t)
     return o(n, "justNow");
   const r = new Date(t).getTime();
@@ -743,19 +759,19 @@ function me(t, n) {
   const l = Math.max(0, Math.floor((Date.now() - r) / 6e4));
   return l < 1 ? o(n, "justNow") : l < 60 ? o(n, "minutesAgo", { count: l }) : o(n, "hoursAgo", { count: Math.floor(l / 60) });
 }
-function ue(t, n) {
-  const r = oe[n];
+function ye(t, n) {
+  const r = ie[n];
   return r ? o(t, r) : "";
 }
-function ye(t, n) {
-  const r = re[n];
+function ge(t, n) {
+  const r = oe[n];
   return r ? o(t, r) : o(t, "checkUnknown", { name: n });
 }
-function ge(t) {
+function xe(t) {
   return !t.passed || t.severity === "warn" || t.severity === "error";
 }
 function O({ ready: t }) {
-  const { token: n } = f.antd.theme.useToken(), r = v();
+  const { token: n } = E.antd.theme.useToken(), r = v();
   return /* @__PURE__ */ e.createElement(
     "span",
     {
@@ -774,7 +790,7 @@ function z({ name: t, size: n }) {
     strokeWidth: 2,
     strokeLinecap: "round",
     strokeLinejoin: "round"
-  }, i = {
+  }, a = {
     chromeExtensions: /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("path", { d: "M8 6h12v12H8z" }), /* @__PURE__ */ e.createElement("path", { d: "M4 10h4M4 14h4" })),
     copy: /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("rect", { x: "9", y: "9", width: "11", height: "11", rx: "2" }), /* @__PURE__ */ e.createElement("path", { d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" })),
     folderPlus: /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("path", { d: "M12 5v14" }), /* @__PURE__ */ e.createElement("path", { d: "M5 12h14" }), /* @__PURE__ */ e.createElement("path", { d: "M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" })),
@@ -792,7 +808,7 @@ function z({ name: t, size: n }) {
       } : r.inlineIcon,
       ...l
     },
-    i[t]
+    a[t]
   );
 }
 function _({
@@ -800,44 +816,44 @@ function _({
   label: n,
   loading: r,
   onClick: l,
-  tone: i = "default",
-  iconOnly: h = !1
+  tone: a = "default",
+  iconOnly: m = !1
 }) {
-  const p = v(), g = i === "primary" ? p.stepControlPrimary : i === "blue" ? p.stepControlBlue : i === "placeholder" ? p.stepControlPlaceholder : null;
+  const p = v(), y = a === "primary" ? p.stepControlPrimary : a === "blue" ? p.stepControlBlue : a === "placeholder" ? p.stepControlPlaceholder : null;
   return /* @__PURE__ */ e.createElement(
     u,
     {
-      "aria-label": h ? n : void 0,
+      "aria-label": m ? n : void 0,
       loading: r,
       onClick: l,
       style: {
         ...p.stepControl,
-        ...g,
-        ...h ? p.stepControlIconOnly : null
+        ...y,
+        ...m ? p.stepControlIconOnly : null
       },
-      title: h ? n : void 0,
+      title: m ? n : void 0,
       type: "text"
     },
-    /* @__PURE__ */ e.createElement(z, { name: t, size: h ? 16 : void 0 }),
-    h ? null : n
+    /* @__PURE__ */ e.createElement(z, { name: t, size: m ? 16 : void 0 }),
+    m ? null : n
   );
 }
-function xe() {
-  var l, i;
-  const t = ((l = window.navigator) == null ? void 0 : l.platform) || "", n = ((i = window.navigator) == null ? void 0 : i.userAgent) || "", r = `${t} ${n}`.toLowerCase();
+function fe() {
+  var l, a;
+  const t = ((l = window.navigator) == null ? void 0 : l.platform) || "", n = ((a = window.navigator) == null ? void 0 : a.userAgent) || "", r = `${t} ${n}`.toLowerCase();
   return r.includes("mac") ? "mac" : r.includes("win") ? "windows" : "linux";
 }
-function fe({
+function Ee({
   locale: t,
   onCopy: n,
   status: r
 }) {
-  const l = v(), i = [
+  const l = v(), a = [
     { key: "extension_dir", label: "extensionDir" },
     { key: "native_manifest_path", label: "nativeManifest" },
     { key: "native_host_path", label: "nativeHost" },
     { key: "config_path", label: "config" }
-  ], h = (r == null ? void 0 : r.bridge_endpoint) || "not ready";
+  ], m = (r == null ? void 0 : r.bridge_endpoint) || "not ready", p = r != null && r.bridge_endpoint ? `python3 extension_setup.py --ws-url ${r.bridge_endpoint} --token <server-token>` : "";
   return /* @__PURE__ */ e.createElement(
     ee,
     {
@@ -846,56 +862,82 @@ function fe({
         {
           key: "advanced",
           label: o(t, "advancedInfo"),
-          children: /* @__PURE__ */ e.createElement("div", { style: l.advancedRows }, i.map((p) => {
-            const g = (r == null ? void 0 : r[p.key]) || "-";
-            return /* @__PURE__ */ e.createElement("div", { key: p.key, style: l.advancedRow }, /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, p.label)), /* @__PURE__ */ e.createElement("code", { style: l.advancedValue }, g), /* @__PURE__ */ e.createElement(
+          children: /* @__PURE__ */ e.createElement("div", { style: l.advancedRows }, a.map((y) => {
+            const g = (r == null ? void 0 : r[y.key]) || "-";
+            return /* @__PURE__ */ e.createElement("div", { key: y.key, style: l.advancedRow }, /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, y.label)), /* @__PURE__ */ e.createElement("code", { style: l.advancedValue }, g), /* @__PURE__ */ e.createElement(
               u,
               {
-                disabled: !(r != null && r[p.key]),
+                disabled: !(r != null && r[y.key]),
                 onClick: () => n(g)
               },
               o(t, "copyPath")
             ));
-          }), /* @__PURE__ */ e.createElement("div", { style: l.advancedRow }, /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, "bridgeEndpoint")), /* @__PURE__ */ e.createElement("code", { style: l.advancedValue }, h), /* @__PURE__ */ e.createElement(u, { onClick: () => n(h) }, o(t, "copyPath"))))
+          }), /* @__PURE__ */ e.createElement("div", { style: l.advancedRow }, /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, "bridgeEndpoint")), /* @__PURE__ */ e.createElement("code", { style: l.advancedValue }, m), /* @__PURE__ */ e.createElement(
+            ne,
+            {
+              color: r != null && r.remote ? "geekblue" : "default",
+              style: { marginInlineEnd: 0 }
+            },
+            o(
+              t,
+              r != null && r.remote ? "endpointRemote" : "endpointLocal"
+            )
+          ), /* @__PURE__ */ e.createElement(u, { onClick: () => n(m) }, o(t, "copyPath"))), r != null && r.endpoint_error ? /* @__PURE__ */ e.createElement(
+            B,
+            {
+              type: "error",
+              showIcon: !0,
+              message: o(t, "endpointInvalid", {
+                error: r.endpoint_error
+              })
+            }
+          ) : null, r != null && r.remote && !(r != null && r.secure_transport) ? /* @__PURE__ */ e.createElement(
+            B,
+            {
+              type: "warning",
+              showIcon: !0,
+              message: o(t, "endpointInsecureWarning")
+            }
+          ) : null, r != null && r.remote ? /* @__PURE__ */ e.createElement("div", { style: l.advancedRows }, /* @__PURE__ */ e.createElement(d, { strong: !0 }, o(t, "remoteSetupTitle")), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, "remoteSetupDescription")), /* @__PURE__ */ e.createElement("div", { style: l.advancedRow }, /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(t, "remoteSetupCommandLabel")), /* @__PURE__ */ e.createElement("code", { style: l.advancedValue }, p), /* @__PURE__ */ e.createElement(u, { onClick: () => n(p) }, o(t, "copyCommand")))) : null)
         }
       ]
     }
   );
 }
-function Ee() {
-  var H;
-  const t = v(), n = j(), [r, l] = e.useState(null), [i, h] = e.useState(null), [p, g] = e.useState(null), [E, I] = e.useState(!0), [M, L] = e.useState(!1), [D, k] = e.useState(null), [W, G] = e.useState(!1), [A, V] = e.useState(() => xe()), x = e.useCallback(
-    async (a) => {
-      a != null && a.silent || I(!0), k(null);
+function we() {
+  var F;
+  const t = v(), n = $(), [r, l] = e.useState(null), [a, m] = e.useState(null), [p, y] = e.useState(null), [g, L] = e.useState(!0), [M, D] = e.useState(!1), [W, k] = e.useState(null), [A, G] = e.useState(!1), [H, V] = e.useState(() => fe()), f = e.useCallback(
+    async (i) => {
+      i != null && i.silent || L(!0), k(null);
       try {
-        const [s, y] = await Promise.all([
-          se(),
-          ce()
+        const [s, x] = await Promise.all([
+          ce(),
+          de()
         ]);
-        return l(s), h(y), s;
+        return l(s), m(x), s;
       } catch (s) {
-        const y = s instanceof Error ? s.message : String(s);
-        return k(y), null;
+        const x = s instanceof Error ? s.message : String(s);
+        return k(x), null;
       } finally {
-        a != null && a.silent || I(!1);
+        i != null && i.silent || L(!1);
       }
     },
     []
   );
   e.useEffect(() => {
-    x();
-  }, [x]);
-  const b = e.useCallback(
-    async (a) => {
-      if (r != null && r.extension_dir && r.installed && !(a != null && a.refresh))
+    f();
+  }, [f]);
+  const w = e.useCallback(
+    async (i) => {
+      if (r != null && r.extension_dir && r.installed && !(i != null && i.refresh))
         return r;
-      L(!0), k(null);
+      D(!0), k(null);
       try {
-        const s = await pe({
+        const s = await me({
           install_mode: "unpacked",
           reset: !1
         });
-        return l(s), a != null && a.silent || (s.native_host_repair_required ? S.error(
+        return l(s), i != null && i.silent || (s.native_host_repair_required ? S.error(
           s.native_host_repair_instruction || o(n, "installFailed")
         ) : S.success(
           o(
@@ -904,34 +946,34 @@ function Ee() {
           )
         )), s;
       } catch (s) {
-        const y = s instanceof Error ? s.message : String(s);
-        return k(y), a != null && a.silent || S.error(o(n, "installFailed")), null;
+        const x = s instanceof Error ? s.message : String(s);
+        return k(x), i != null && i.silent || S.error(o(n, "installFailed")), null;
       } finally {
-        L(!1);
+        D(!1);
       }
     },
     [n, r]
-  ), w = e.useCallback(
-    async (a, s = "copied") => {
-      var y;
+  ), b = e.useCallback(
+    async (i, s = "copied") => {
+      var x;
       try {
-        if (!((y = navigator.clipboard) != null && y.writeText))
+        if (!((x = navigator.clipboard) != null && x.writeText))
           throw new Error("clipboard API is unavailable");
-        return await navigator.clipboard.writeText(a), S.success(o(n, s)), !0;
+        return await navigator.clipboard.writeText(i), S.success(o(n, s)), !0;
       } catch {
         return S.error(o(n, "copyFailed")), !1;
       }
     },
     [n]
   ), q = e.useCallback(async () => {
-    const a = await b({ refresh: !0 });
-    a != null && a.extension_dir && await w(a.extension_dir);
-  }, [w, b]), P = e.useCallback(
-    async (a = !1) => w(
+    const i = await w({ refresh: !0 });
+    i != null && i.extension_dir && await b(i.extension_dir);
+  }, [b, w]), P = e.useCallback(
+    async (i = !1) => b(
       (r == null ? void 0 : r.chrome_extensions_url) ?? "chrome://extensions",
-      a ? "chromeExtensionsCopiedFallback" : "chromeExtensionsCopied"
+      i ? "chromeExtensionsCopiedFallback" : "chromeExtensionsCopied"
     ),
-    [w, r == null ? void 0 : r.chrome_extensions_url]
+    [b, r == null ? void 0 : r.chrome_extensions_url]
   ), K = e.useCallback(async () => {
     try {
       if ((await he()).opened)
@@ -945,43 +987,43 @@ function Ee() {
     linux: ["shortcutLinuxStep1", "shortcutLinuxStep2"]
   };
   e.useEffect(() => {
-    E || W || r != null && r.extension_dir || (G(!0), b({ silent: !0 }));
-  }, [E, b, W, r == null ? void 0 : r.extension_dir]);
-  const m = !!(r != null && r.installed && (i != null && i.connected)), C = !!(r != null && r.native_host_repair_required && !(i != null && i.connected)), B = !!(r != null && r.installed && !C && !(i != null && i.connected));
+    g || A || r != null && r.extension_dir || (G(!0), w({ silent: !0 }));
+  }, [g, w, A, r == null ? void 0 : r.extension_dir]);
+  const h = !!(r != null && r.installed && (a != null && a.connected)), C = !!(r != null && r.native_host_repair_required && !(a != null && a.connected)), R = !!(r != null && r.installed && !C && !(a != null && a.connected));
   return e.useEffect(() => {
-    if (!m) {
-      g(null);
+    if (!h) {
+      y(null);
       return;
     }
-    let a = !1;
-    return de().then((s) => {
-      a || g(s ?? (i == null ? void 0 : i.last_self_test) ?? null);
+    let i = !1;
+    return pe().then((s) => {
+      i || y(s ?? (a == null ? void 0 : a.last_self_test) ?? null);
     }), () => {
-      a = !0;
+      i = !0;
     };
-  }, [m, i == null ? void 0 : i.last_self_test]), e.useEffect(() => {
-    if (m)
+  }, [h, a == null ? void 0 : a.last_self_test]), e.useEffect(() => {
+    if (h)
       return;
-    const a = window.setInterval(() => {
-      x({ silent: !0 });
+    const i = window.setInterval(() => {
+      f({ silent: !0 });
     }, 5e3);
     return () => {
-      window.clearInterval(a);
+      window.clearInterval(i);
     };
-  }, [m, x]), /* @__PURE__ */ e.createElement("div", { style: t.page }, /* @__PURE__ */ e.createElement("div", { style: t.shell }, /* @__PURE__ */ e.createElement("div", { style: t.panel }, /* @__PURE__ */ e.createElement("div", { style: t.statusBlock }, /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement("div", { style: t.header }, /* @__PURE__ */ e.createElement("div", { style: t.titleRow }, /* @__PURE__ */ e.createElement("span", { style: t.chromeIcon }), /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement(N, { level: 3, style: { margin: 0 } }, o(n, "pageTitle")), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(n, "pageSubtitle"))))), /* @__PURE__ */ e.createElement("div", { style: { marginTop: 22 } }, /* @__PURE__ */ e.createElement("div", { style: t.statusTitleRow }, m || B ? /* @__PURE__ */ e.createElement(O, { ready: m }) : null, /* @__PURE__ */ e.createElement(N, { level: 4, style: { margin: 0 } }, o(
+  }, [h, f]), /* @__PURE__ */ e.createElement("div", { style: t.page }, /* @__PURE__ */ e.createElement("div", { style: t.shell }, /* @__PURE__ */ e.createElement("div", { style: t.panel }, /* @__PURE__ */ e.createElement("div", { style: t.statusBlock }, /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement("div", { style: t.header }, /* @__PURE__ */ e.createElement("div", { style: t.titleRow }, /* @__PURE__ */ e.createElement("span", { style: t.chromeIcon }), /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement(N, { level: 3, style: { margin: 0 } }, o(n, "pageTitle")), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(n, "pageSubtitle"))))), /* @__PURE__ */ e.createElement("div", { style: { marginTop: 22 } }, /* @__PURE__ */ e.createElement("div", { style: t.statusTitleRow }, h || R ? /* @__PURE__ */ e.createElement(O, { ready: h }) : null, /* @__PURE__ */ e.createElement(N, { level: 4, style: { margin: 0 } }, o(
     n,
-    m ? "readyTitle" : C ? "repairTitle" : B ? "awaitingTitle" : "installTitle"
-  ))), /* @__PURE__ */ e.createElement("div", { style: t.statusCopy }, C ? o(n, "repairDescription") : m ? o(n, "readyDescription", {
-    version: (i == null ? void 0 : i.extension_version) || o(n, "versionUnknown"),
-    connectedSince: me(
-      i == null ? void 0 : i.connected_since,
+    h ? "readyTitle" : C ? "repairTitle" : R ? "awaitingTitle" : "installTitle"
+  ))), /* @__PURE__ */ e.createElement("div", { style: t.statusCopy }, C ? o(n, "repairDescription") : h ? o(n, "readyDescription", {
+    version: (a == null ? void 0 : a.extension_version) || o(n, "versionUnknown"),
+    connectedSince: ue(
+      a == null ? void 0 : a.connected_since,
       n
     )
-  }) : B ? o(n, "awaitingDescription") : (r == null ? void 0 : r.recovery_copy) || o(n, "installDescription")))), /* @__PURE__ */ e.createElement("div", { style: t.actions }, m ? /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement(
+  }) : R ? o(n, "awaitingDescription") : (r == null ? void 0 : r.recovery_copy) || o(n, "installDescription")))), /* @__PURE__ */ e.createElement("div", { style: t.actions }, h ? /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement(
     u,
     {
-      loading: E,
-      onClick: () => void x()
+      loading: g,
+      onClick: () => void f()
     },
     o(n, "refreshStatus")
   ), /* @__PURE__ */ e.createElement(
@@ -996,38 +1038,38 @@ function Ee() {
     {
       type: "primary",
       loading: M,
-      onClick: () => void b({ refresh: !0 })
+      onClick: () => void w({ refresh: !0 })
     },
     o(n, "repairBrowserConnector")
   ) : /* @__PURE__ */ e.createElement(
     u,
     {
       type: "primary",
-      loading: E,
-      onClick: () => void x()
+      loading: g,
+      onClick: () => void f()
     },
     o(n, "installedRefresh")
-  ))), D ? /* @__PURE__ */ e.createElement(
-    U,
+  ))), W ? /* @__PURE__ */ e.createElement(
+    B,
     {
       showIcon: !0,
       type: "error",
-      message: D,
+      message: W,
       style: { marginTop: 16 }
     }
   ) : null, C && (r != null && r.native_host_repair_instruction) ? /* @__PURE__ */ e.createElement(
-    U,
+    B,
     {
       showIcon: !0,
       type: "error",
       message: r == null ? void 0 : r.native_host_repair_instruction,
       style: { marginTop: 16 }
     }
-  ) : null, m ? /* @__PURE__ */ e.createElement("div", { style: t.section }, /* @__PURE__ */ e.createElement(d, { strong: !0 }, o(n, "checksTitle")), (H = p == null ? void 0 : p.checks) != null && H.length ? /* @__PURE__ */ e.createElement("div", { style: t.checkGrid }, p.checks.filter((a) => a.name !== "semantic_control").map((a) => {
-    const s = ge(a);
-    return /* @__PURE__ */ e.createElement("div", { key: a.name, style: t.checkTile }, /* @__PURE__ */ e.createElement("div", { style: t.checkTitle }, /* @__PURE__ */ e.createElement(O, { ready: !s }), /* @__PURE__ */ e.createElement(d, { strong: !0 }, ye(n, a.name))), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, s ? `${a.message} ${ue(
+  ) : null, h ? /* @__PURE__ */ e.createElement("div", { style: t.section }, /* @__PURE__ */ e.createElement(d, { strong: !0 }, o(n, "checksTitle")), (F = p == null ? void 0 : p.checks) != null && F.length ? /* @__PURE__ */ e.createElement("div", { style: t.checkGrid }, p.checks.filter((i) => i.name !== "semantic_control").map((i) => {
+    const s = xe(i);
+    return /* @__PURE__ */ e.createElement("div", { key: i.name, style: t.checkTile }, /* @__PURE__ */ e.createElement("div", { style: t.checkTitle }, /* @__PURE__ */ e.createElement(O, { ready: !s }), /* @__PURE__ */ e.createElement(d, { strong: !0 }, ge(n, i.name))), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, s ? `${i.message} ${ye(
       n,
-      a.repair_action
+      i.repair_action
     )}`.trim() : o(n, "checkReady")));
   })) : /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(n, "checksPending"))) : /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("div", { style: t.section }, /* @__PURE__ */ e.createElement(d, { strong: !0 }, o(n, "installMethodsTitle")), /* @__PURE__ */ e.createElement("div", { style: t.methodGrid }, /* @__PURE__ */ e.createElement("div", { style: t.methodTile }, /* @__PURE__ */ e.createElement("div", { style: t.methodHeader }, /* @__PURE__ */ e.createElement(d, { strong: !0 }, o(n, "localMethodTitle")), /* @__PURE__ */ e.createElement("span", { style: t.badge }, o(n, "recommendedBadge"))), /* @__PURE__ */ e.createElement(d, { type: "secondary" }, o(n, "localMethodDescription")), /* @__PURE__ */ e.createElement(
     u,
@@ -1070,14 +1112,14 @@ function Ee() {
       ["mac", "macOS"],
       ["windows", "Windows"],
       ["linux", "Linux"]
-    ].map(([a, s]) => /* @__PURE__ */ e.createElement(
+    ].map(([i, s]) => /* @__PURE__ */ e.createElement(
       "button",
       {
-        key: a,
-        onClick: () => V(a),
+        key: i,
+        onClick: () => V(i),
         style: {
           ...t.osTab,
-          ...A === a ? t.osTabActive : null
+          ...H === i ? t.osTabActive : null
         },
         type: "button"
       },
@@ -1092,25 +1134,25 @@ function Ee() {
         tone: "blue",
         iconOnly: !0
       }
-    ), /* @__PURE__ */ e.createElement("span", null, o(n, "shortcutCopyPathSuffix")))), Y[A].map(
-      (a, s) => /* @__PURE__ */ e.createElement("li", { key: a, style: t.shortcutStep }, /* @__PURE__ */ e.createElement("span", { style: t.tipDot }, s + 2), /* @__PURE__ */ e.createElement("span", null, o(n, a)))
+    ), /* @__PURE__ */ e.createElement("span", null, o(n, "shortcutCopyPathSuffix")))), Y[H].map(
+      (i, s) => /* @__PURE__ */ e.createElement("li", { key: i, style: t.shortcutStep }, /* @__PURE__ */ e.createElement("span", { style: t.tipDot }, s + 2), /* @__PURE__ */ e.createElement("span", null, o(n, i)))
     )))
   )))), /* @__PURE__ */ e.createElement(
-    fe,
+    Ee,
     {
       locale: n,
-      onCopy: (a) => void w(a),
+      onCopy: (i) => void b(i),
       status: r
     }
-  )), E && !r ? /* @__PURE__ */ e.createElement(te, null) : null));
+  )), g && !r ? /* @__PURE__ */ e.createElement(te, null) : null));
 }
-var Q, $;
-($ = (Q = window.QwenPaw).registerRoutes) == null || $.call(Q, "chrome", [
+var Q, j;
+(j = (Q = window.QwenPaw).registerRoutes) == null || j.call(Q, "chrome", [
   {
     path: "/plugin/chrome",
-    component: Ee,
-    label: o(j(), "routeLabel"),
-    icon: /* @__PURE__ */ e.createElement(ie, null),
+    component: we,
+    label: o($(), "routeLabel"),
+    icon: /* @__PURE__ */ e.createElement(le, null),
     priority: 40
   }
 ]);

--- a/plugins/bundle/chrome/extension_setup.py
+++ b/plugins/bundle/chrome/extension_setup.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import secrets
@@ -14,6 +15,7 @@ import sys
 import webbrowser
 from ipaddress import ip_address
 from pathlib import Path
+from urllib.parse import urlparse
 
 from qwenpaw.config.utils import read_last_api
 from qwenpaw.utils.io_utils import write_json_atomic
@@ -54,6 +56,11 @@ CWS_COMING_SOON_MESSAGE = (
     "Developer Preview"
 )
 DEFAULT_WS_URL = "ws://127.0.0.1:8088/api/ws/chrome"
+# Environment variable that overrides the bridge WebSocket endpoint. Set this
+# when the browser (extension + Native Messaging host) runs on a different
+# machine than the QwenPaw server, e.g. QwenPaw in Docker or a LAN browser:
+#   QWENPAW_CHROME_BRIDGE_WS_URL=ws://192.168.31.4:8088/api/ws/chrome
+BRIDGE_WS_URL_ENV = "QWENPAW_CHROME_BRIDGE_WS_URL"
 CHROME_EXTENSIONS_URL = "chrome://extensions"
 LOCAL_BRIDGE_CONFIG_JS = "bridge_config.js"
 LOCAL_INITIAL_RECONNECT_BACKOFF_SECONDS = 5
@@ -273,16 +280,81 @@ class BridgeEndpointUnavailable(RuntimeError):
     """Raised when the local API bind cannot safely host the bridge token."""
 
 
+class BridgeEndpointError(ValueError):
+    """Raised when a configured bridge endpoint override is invalid."""
+
+
 class InstallModeError(ValueError):
     """Raised when the requested extension install mode cannot be used."""
 
 
-def require_bridge_endpoint() -> str:
-    """Derive a loopback-only bridge endpoint from the running server bind."""
+def validate_bridge_ws_url(url: str) -> str:
+    """Validate and normalize an explicit bridge WebSocket endpoint."""
+    candidate = url.strip()
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"ws", "wss"}:
+        raise BridgeEndpointError(
+            "Chrome bridge endpoint must use ws:// or wss:// "
+            f"(got {candidate!r}).",
+        )
+    if not parsed.hostname:
+        raise BridgeEndpointError(
+            f"Chrome bridge endpoint must include a host (got {candidate!r}).",
+        )
+    if parsed.username or parsed.password:
+        raise BridgeEndpointError(
+            "Chrome bridge endpoint must not embed credentials; "
+            "the bridge token is sent separately.",
+        )
+    return candidate
+
+
+def bridge_endpoint_override() -> str | None:
+    """Return the env-configured bridge endpoint override, when present."""
+    raw = os.environ.get(BRIDGE_WS_URL_ENV, "").strip()
+    if not raw:
+        return None
+    return validate_bridge_ws_url(raw)
+
+
+def endpoint_is_loopback(url: str) -> bool:
+    """Return whether the endpoint host is a loopback address or localhost."""
+    hostname = (urlparse(url.strip()).hostname or "").strip()
+    if hostname == "localhost":
+        return True
     try:
-        api_info = read_last_api()
-    except Exception:
-        api_info = None
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _safe_read_last_api() -> tuple[str, int] | None:
+    """Read the running server bind, tolerating a missing/unreadable state."""
+    try:
+        return read_last_api()
+    except Exception:  # noqa: BLE001 - state file shape is not guaranteed
+        return None
+
+
+def bridge_endpoint_source() -> str:
+    """Classify where the effective bridge endpoint comes from."""
+    if os.environ.get(BRIDGE_WS_URL_ENV, "").strip():
+        return "override"
+    return "server-bind" if _safe_read_last_api() else "default"
+
+
+def require_bridge_endpoint() -> str:
+    """Resolve the bridge endpoint the Native Messaging host should dial.
+
+    An explicit override (env var) wins so browsers on other machines can
+    reach the bridge; otherwise derive a loopback-only endpoint from the
+    running server bind.
+    """
+    override = bridge_endpoint_override()
+    if override is not None:
+        return override
+
+    api_info = _safe_read_last_api()
 
     if not api_info:
         return DEFAULT_WS_URL
@@ -318,16 +390,18 @@ def _copy_extension(qwenpaw_home: Path) -> Path:
 def _write_local_extension_config(
     extension_dir: Path,
     build: dict[str, str | None] | None = None,
+    ws_url: str | None = None,
 ) -> Path:
     config_path = extension_dir / LOCAL_BRIDGE_CONFIG_JS
+    effective_url = ws_url or resolve_default_ws_url()
+    parsed = urlparse(effective_url)
+    default_port = 443 if parsed.scheme == "wss" else 80
     config = {
         "initialReconnectBackoffSeconds": (
             LOCAL_INITIAL_RECONNECT_BACKOFF_SECONDS
         ),
         "maxReconnectBackoffSeconds": LOCAL_MAX_RECONNECT_BACKOFF_SECONDS,
-        "localPort": int(
-            resolve_default_ws_url().rsplit(":", 1)[1].split("/")[0],
-        ),
+        "localPort": parsed.port or default_port,
         "build": build or _build_fingerprint(),
     }
     config_path.write_text(
@@ -516,7 +590,7 @@ def _write_host(
         )
     else:
         host.write_text(
-            "#!/usr/bin/env sh\n" f'exec "{interpreter}" "{host_impl}" "$@"\n',
+            f'#!/usr/bin/env sh\nexec "{interpreter}" "{host_impl}" "$@"\n',
             encoding="utf-8",
         )
         host.chmod(
@@ -578,8 +652,15 @@ def setup_extension_files(
     home: Path | None = None,
     platform: str | None = None,
     registry: object | None = None,
+    ws_url: str | None = None,
+    token: str | None = None,
 ) -> dict[str, str | bool]:
-    """Install extension files and Native Messaging registration."""
+    """Install extension files and Native Messaging registration.
+
+    ``ws_url``/``token`` override the resolved bridge endpoint and the
+    generated token; both are primarily used by the standalone CLI when
+    setting up a browser machine that is remote from the QwenPaw server.
+    """
     if install_mode == "cws":
         raise InstallModeError(CWS_COMING_SOON_MESSAGE)
     if install_mode != "unpacked":
@@ -588,7 +669,11 @@ def setup_extension_files(
     home = home or Path.home()
     platform = platform or sys.platform
     native_host_registry = _native_host_registry(platform, registry)
-    ws_url = require_bridge_endpoint()
+    ws_url = (
+        validate_bridge_ws_url(ws_url)
+        if ws_url is not None
+        else require_bridge_endpoint()
+    )
     qwenpaw_home = _qwenpaw_home(home)
     if reset:
         _uninstall(
@@ -598,13 +683,16 @@ def setup_extension_files(
             registry=native_host_registry,
         )
 
-    token = None if reset else _read_existing_nm_token(qwenpaw_home)
+    if token is not None and not token.strip():
+        raise ValueError("Native Messaging bridge token must not be empty")
+    if token is None and not reset:
+        token = _read_existing_nm_token(qwenpaw_home)
     token = token or secrets.token_urlsafe(32)
     build = _build_fingerprint()
     extension_dir = None
     if install_mode == "unpacked":
         extension_dir = _copy_extension(qwenpaw_home)
-        _write_local_extension_config(extension_dir, build)
+        _write_local_extension_config(extension_dir, build, ws_url=ws_url)
     config_path = _write_nm_config(qwenpaw_home, token, ws_url)
     host_path = _write_host(qwenpaw_home, platform=platform, build=build)
     manifest_path = _write_native_manifest(
@@ -889,3 +977,82 @@ def open_chrome_extensions_page(
             "error": str(exc),
         }
     return {"opened": bool(opened), "url": CHROME_EXTENSIONS_URL}
+
+
+def _build_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="qwenpaw-chrome-setup",
+        description=(
+            "Install the QwenPaw Chrome extension files and Native Messaging "
+            "host on this machine. Run directly on the machine that hosts the "
+            "browser; for a browser remote from the QwenPaw server, pass the "
+            "server-side bridge endpoint and token explicitly."
+        ),
+    )
+    parser.add_argument(
+        "--ws-url",
+        default=None,
+        help=(
+            "Bridge WebSocket endpoint the Native Messaging host dials, e.g. "
+            "ws://192.168.1.10:8088/api/ws/chrome. Defaults to the "
+            f"{BRIDGE_WS_URL_ENV} override or the local server bind."
+        ),
+    )
+    parser.add_argument(
+        "--token",
+        default=None,
+        help=(
+            "Bridge bearer token. Must match the token configured on the "
+            "QwenPaw server (see ~/.qwenpaw/nm-bridge.json there). Defaults "
+            "to the existing local token, or a freshly generated one."
+        ),
+    )
+    parser.add_argument(
+        "--install-mode",
+        default="unpacked",
+        choices=["unpacked"],
+        help="Extension install mode (only unpacked is supported).",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Remove the existing installation before reinstalling.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone setup CLI for the machine that runs the browser."""
+    args = _build_cli_parser().parse_args(argv)
+    try:
+        result = setup_extension_files(
+            install_mode=args.install_mode,
+            reset=args.reset,
+            ws_url=args.ws_url,
+            token=args.token,
+        )
+    except (
+        InstallModeError,
+        BridgeEndpointError,
+        BridgeEndpointUnavailable,
+        ValueError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    if not endpoint_is_loopback(str(result["ws_url"])):
+        print(
+            "note: the bridge endpoint is remote; the token here must match "
+            "the QwenPaw server token (~/.qwenpaw/nm-bridge.json there).",
+            file=sys.stderr,
+        )
+    print(
+        "next: open chrome://extensions, enable Developer mode, then "
+        f"'Load unpacked' from {result['extension_dir']}",
+        file=sys.stderr,
+    )
+    return 0 if result["installed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/bundle/chrome/frontend/src/index.tsx
+++ b/plugins/bundle/chrome/frontend/src/index.tsx
@@ -14,7 +14,7 @@ const antd = host.antd;
 const getApiUrl = host.getApiUrl;
 const getApiToken = host.getApiToken;
 
-const { Alert, Button, Collapse, Space, Spin, Typography, message } = antd;
+const { Alert, Button, Collapse, Space, Spin, Tag, Typography, message } = antd;
 const { Text, Title } = Typography;
 
 type InstallMode = "unpacked" | "cws";
@@ -41,6 +41,10 @@ interface ExtensionStatus {
   bridge_endpoint?: string;
   configured_endpoint?: string | null;
   bridge_endpoint_stale?: boolean;
+  endpoint_source?: string;
+  endpoint_error?: string | null;
+  remote?: boolean;
+  secure_transport?: boolean;
   chrome_extensions_url?: string;
   native_host_repair_required?: boolean;
   native_host_repair_instruction?: string;
@@ -837,6 +841,9 @@ function AdvancedInfo({
     { key: "config_path", label: "config" },
   ];
   const wsUrl = status?.bridge_endpoint || "not ready";
+  const remoteSetupCommand = status?.bridge_endpoint
+    ? `python3 extension_setup.py --ws-url ${status.bridge_endpoint} --token <server-token>`
+    : "";
 
   return (
     <Collapse
@@ -867,10 +874,54 @@ function AdvancedInfo({
                   {translate(locale, "bridgeEndpoint")}
                 </Text>
                 <code style={styles.advancedValue}>{wsUrl}</code>
+                <Tag
+                  color={status?.remote ? "geekblue" : "default"}
+                  style={{ marginInlineEnd: 0 }}
+                >
+                  {translate(
+                    locale,
+                    status?.remote ? "endpointRemote" : "endpointLocal",
+                  )}
+                </Tag>
                 <Button onClick={() => onCopy(wsUrl)}>
                   {translate(locale, "copyPath")}
                 </Button>
               </div>
+              {status?.endpoint_error ? (
+                <Alert
+                  type="error"
+                  showIcon
+                  message={translate(locale, "endpointInvalid", {
+                    error: status.endpoint_error,
+                  })}
+                />
+              ) : null}
+              {status?.remote && !status?.secure_transport ? (
+                <Alert
+                  type="warning"
+                  showIcon
+                  message={translate(locale, "endpointInsecureWarning")}
+                />
+              ) : null}
+              {status?.remote ? (
+                <div style={styles.advancedRows}>
+                  <Text strong>{translate(locale, "remoteSetupTitle")}</Text>
+                  <Text type="secondary">
+                    {translate(locale, "remoteSetupDescription")}
+                  </Text>
+                  <div style={styles.advancedRow}>
+                    <Text type="secondary">
+                      {translate(locale, "remoteSetupCommandLabel")}
+                    </Text>
+                    <code style={styles.advancedValue}>
+                      {remoteSetupCommand}
+                    </code>
+                    <Button onClick={() => onCopy(remoteSetupCommand)}>
+                      {translate(locale, "copyCommand")}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
             </div>
           ),
         },

--- a/plugins/bundle/chrome/frontend/src/locale.ts
+++ b/plugins/bundle/chrome/frontend/src/locale.ts
@@ -77,6 +77,16 @@ const messages = {
     nativeHost: "Local connection helper",
     config: "Local settings file",
     bridgeEndpoint: "Connection endpoint",
+    endpointLocal: "Local",
+    endpointRemote: "Remote",
+    endpointInsecureWarning:
+      "The endpoint uses ws:// on a non-loopback address; the bridge token crosses the network in plaintext. Prefer wss:// or a trusted LAN.",
+    endpointInvalid: "Invalid endpoint override: {error}",
+    remoteSetupTitle: "Connect a browser on another machine",
+    remoteSetupDescription:
+      "Copy the plugin's chrome folder to the browser machine, then run its setup CLI there with this endpoint and the server token (see ~/.qwenpaw/nm-bridge.json on the server).",
+    remoteSetupCommandLabel: "Setup command",
+    copyCommand: "Copy command",
     checksTitle: "Connection checks",
     checkExtensionBridge: "Extension bridge",
     checkNmHost: "Native Messaging host",
@@ -186,6 +196,16 @@ const messages = {
     nativeHost: "本机连接助手",
     config: "本地设置文件",
     bridgeEndpoint: "连接端点",
+    endpointLocal: "本机",
+    endpointRemote: "远程",
+    endpointInsecureWarning:
+      "当前端点在非回环地址上使用 ws://，桥接 token 会以明文经过网络。建议改用 wss:// 或仅在可信局域网内使用。",
+    endpointInvalid: "端点覆盖配置无效：{error}",
+    remoteSetupTitle: "连接其他机器上的浏览器",
+    remoteSetupDescription:
+      "把插件的 chrome 目录拷到浏览器所在机器，在该机器上运行其自带 setup CLI，并填入此端点与服务端 token（见服务端 ~/.qwenpaw/nm-bridge.json）。",
+    remoteSetupCommandLabel: "安装命令",
+    copyCommand: "复制命令",
     checksTitle: "连接检查",
     checkExtensionBridge: "扩展桥接",
     checkNmHost: "Native Messaging 宿主",

--- a/tests/integration/test_chrome_extension_setup.py
+++ b/tests/integration/test_chrome_extension_setup.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sys
 import threading
 from pathlib import Path
 
@@ -11,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from plugins.bundle.chrome import extension_setup
 from plugins.bundle.chrome.api import routes
 from plugins.bundle.chrome.api.routes import api_router
 from plugins.bundle.chrome.extension_setup import (
@@ -134,3 +137,160 @@ def test_uninstall_removes_config_and_extension_dir(
 
 
 # test_chrome_setup_repair.py
+
+
+# test_chrome_remote_bridge_endpoint.py
+
+REMOTE_WS_URL = "ws://192.168.31.4:8088/api/ws/chrome"
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_require_bridge_endpoint_prefers_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(extension_setup.BRIDGE_WS_URL_ENV, REMOTE_WS_URL)
+
+    assert extension_setup.require_bridge_endpoint() == REMOTE_WS_URL
+    assert extension_setup.bridge_endpoint_source() == "override"
+    assert extension_setup.endpoint_is_loopback(REMOTE_WS_URL) is False
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://192.168.31.4:8088/api/ws/chrome",
+        "ws:///no-host",
+        "ws://user:pass@192.168.31.4:8088/api/ws/chrome",
+        "not-a-url",
+    ],
+)
+def test_validate_bridge_ws_url_rejects_invalid(bad_url: str) -> None:
+    with pytest.raises(extension_setup.BridgeEndpointError):
+        extension_setup.validate_bridge_ws_url(bad_url)
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_endpoint_is_loopback_classification() -> None:
+    assert extension_setup.endpoint_is_loopback(
+        "ws://127.0.0.1:8088/api/ws/chrome",
+    )
+    assert extension_setup.endpoint_is_loopback(
+        "ws://localhost:8088/api/ws/chrome",
+    )
+    assert extension_setup.endpoint_is_loopback(
+        "ws://[::1]:8088/api/ws/chrome",
+    )
+    assert not extension_setup.endpoint_is_loopback(REMOTE_WS_URL)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_setup_writes_explicit_remote_endpoint_and_token(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DESKTOP_PY_RUNTIME", sys.executable)
+
+    result = extension_setup.setup_extension_files(
+        home=isolated_home,
+        ws_url=REMOTE_WS_URL,
+        token="shared-token",
+    )
+
+    assert result["installed"] is True
+    assert result["ws_url"] == REMOTE_WS_URL
+    config = json.loads(
+        (isolated_home / ".qwenpaw" / "nm-bridge.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+    assert config == {"ws_url": REMOTE_WS_URL, "token": "shared-token"}
+    bridge_config = (
+        isolated_home
+        / ".qwenpaw"
+        / "chrome-extension"
+        / "qwenpaw-chrome"
+        / "bridge_config.js"
+    ).read_text(encoding="utf-8")
+    assert '"localPort":8088' in bridge_config
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_setup_rejects_blank_explicit_token(isolated_home: Path) -> None:
+    with pytest.raises(ValueError, match="token"):
+        extension_setup.setup_extension_files(
+            home=isolated_home,
+            ws_url=REMOTE_WS_URL,
+            token="   ",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_cli_main_sets_up_remote_machine(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DESKTOP_PY_RUNTIME", sys.executable)
+
+    rc = extension_setup.main(
+        ["--ws-url", REMOTE_WS_URL, "--token", "cli-token"],
+    )
+
+    assert rc == 0
+    config = json.loads(
+        (isolated_home / ".qwenpaw" / "nm-bridge.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+    assert config == {"ws_url": REMOTE_WS_URL, "token": "cli-token"}
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_cli_main_rejects_invalid_ws_url(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    rc = extension_setup.main(["--ws-url", "http://example.com/ws"])
+
+    assert rc == 2
+    assert "ws://" in capsys.readouterr().err
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_install_status_marks_remote_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(extension_setup.BRIDGE_WS_URL_ENV, REMOTE_WS_URL)
+    app = FastAPI()
+    app.include_router(api_router)
+
+    body = TestClient(app).get("/install-status").json()
+
+    assert body["bridge_endpoint"] == REMOTE_WS_URL
+    assert body["endpoint_source"] == "override"
+    assert body["remote"] is True
+    assert body["secure_transport"] is False
+    assert body["endpoint_error"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_install_status_surfaces_invalid_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(extension_setup.BRIDGE_WS_URL_ENV, "not-a-url")
+    app = FastAPI()
+    app.include_router(api_router)
+
+    body = TestClient(app).get("/install-status").json()
+
+    assert body["bridge_endpoint"] is None
+    assert body["endpoint_error"]
+    assert body["remote"] is False


### PR DESCRIPTION
## Description

The Chrome plugin currently derives a **loopback-only** Native Messaging bridge endpoint (`require_bridge_endpoint()` raises `BridgeEndpointUnavailable` when the server binds a non-loopback address), so the extension can only bind a browser running on the **same host** as the QwenPaw server. This also breaks Docker deployments, where container loopback is not the host machine's browser.

The core WS handler (`/api/ws/chrome`) already authenticates purely by bearer token and imposes **no IP restriction** — the loopback constraint lives entirely in the plugin's setup/config layer. This PR adds an explicit, opt-in configuration surface for pointing the bridge at a LAN / network-reachable endpoint, plus a one-command standalone setup CLI for the remote browser machine:

- **`extension_setup.py`**
  - New `QWENPAW_CHROME_BRIDGE_WS_URL` env override, validated (`ws://`/`wss://` only, host required, no embedded credentials). When set, it wins over the loopback-derived endpoint; default behavior is unchanged.
  - New helpers: `validate_bridge_ws_url()`, `endpoint_is_loopback()`, `bridge_endpoint_source()` (`override` / `server-bind` / `default`), and a shared `_safe_read_last_api()`.
  - `setup_extension_files()` now accepts explicit `ws_url` / `token` (used by the CLI); the extension's `bridge_config.js` port is parsed via `urllib.parse` instead of `rsplit(":", 1)` (which broke on URLs without an explicit port).
  - New standalone CLI (`python3 extension_setup.py --ws-url ws://<server>:8088/api/ws/chrome --token <token>`) that installs the extension files, NM manifest and `nm-bridge.json` on the browser machine in one step.
- **`api/routes.py`** — `/install-status` additionally reports `endpoint_source`, `remote`, `secure_transport`, and surfaces an invalid override as `endpoint_error` instead of a 500.
- **Frontend** — the advanced panel tags the endpoint `Local`/`Remote`, warns when a remote endpoint uses plaintext `ws://`, and shows a copy-able setup command for the remote machine (en + zh locales).
- **Tests** — 8 new integration tests: override resolution, URL validation, loopback classification, explicit `ws_url`/`token` setup, blank-token rejection, the standalone CLI (success + invalid URL), and the new status fields.

**Related Issue:** N/A (no open issue found; searched upstream PRs/issues for "chrome remote / bridge endpoint / native messaging remote" — only the merged docs PR #6742 is related)

**Security Considerations:**

- Remote mode is **opt-in** via env var; without it the endpoint resolution is byte-for-byte the previous loopback-only behavior.
- The bridge remains bearer-token authenticated; this PR does not relax the core WS handler in any way.
- A remote `ws://` endpoint sends the token over the network in plaintext — the status API exposes `secure_transport` and the UI shows an explicit warning advising `wss://` or a trusted LAN.
- Endpoint overrides reject URLs with embedded credentials (`user:pass@host`) since the token is transmitted separately.
- The token itself is **not** exposed via any API; the remote setup command shown in the UI contains a `<server-token>` placeholder and points the operator at the server-side `~/.qwenpaw/nm-bridge.json`.

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] Core / Backend (plugins/bundle/chrome)
- [x] Console (plugin frontend)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest`) and they pass
- [x] Documentation updated (UI copy + CLI `--help`; no website docs exist for this yet)
- [x] Ready for review

## Testing

```bash
# unit/integration
pytest tests/integration/test_chrome_extension_setup.py \
       tests/integration/test_chrome_native_host_install.py \
       tests/integration/test_chrome_plugin_bundle.py

# frontend
cd plugins/bundle/chrome/frontend
npx tsc --noEmit && npm run build
```

Manual remote-binding flow this enables:

```bash
# on the QwenPaw server (e.g. Docker/NAS deployment)
export QWENPAW_CHROME_BRIDGE_WS_URL=ws://192.168.31.4:8088/api/ws/chrome

# on the browser machine (LAN-reachable from the server)
python3 extension_setup.py --ws-url ws://192.168.31.4:8088/api/ws/chrome --token <server-token>
# then load the unpacked extension from the printed extension_dir
```

## Evidence

Test run (this branch):

```
$ python3 -m pytest tests/integration/test_chrome_extension_setup.py tests/integration/test_chrome_native_host_install.py tests/integration/test_chrome_plugin_bundle.py -q
...............................                                   [100%]
31 passed, 1 warning in 1.53s
```

pre-commit:

```
$ pre-commit run --all-files
check python ast..........................Passed
check yaml................................Passed
check xml.................................Passed
check toml................................Passed
check docstring is first..................Passed
check json................................Passed
fix python encoding pragma................Passed
detect private key........................Passed
trim trailing whitespace..................Passed
Add trailing commas.......................Passed
mypy......................................Passed
black.....................................Passed
flake8....................................Passed
pylint....................................Passed
prettier..................................Passed
Lint GitHub Actions workflow files........Passed
```

Frontend:

```
$ npx tsc --noEmit && npm run build
../dist/index.js  42.35 kB │ gzip: 10.99 kB
✓ built in 83ms
```

New behavior spot-checks (from the test suite):

```
test_require_bridge_endpoint_prefers_env_override PASSED
test_validate_bridge_ws_url_rejects_invalid[http://192.168.31.4:8088/api/ws/chrome] PASSED
test_validate_bridge_ws_url_rejects_invalid[ws:///no-host] PASSED
test_validate_bridge_ws_url_rejects_invalid[ws://user:pass@192.168.31.4:8088/api/ws/chrome] PASSED
test_endpoint_is_loopback_classification PASSED
test_setup_writes_explicit_remote_endpoint_and_token PASSED
test_setup_rejects_blank_explicit_token PASSED
test_cli_main_sets_up_remote_machine PASSED
test_cli_main_rejects_invalid_ws_url PASSED
test_install_status_marks_remote_endpoint PASSED
test_install_status_surfaces_invalid_override PASSED
```
