### PR TITLE
fix(cli): sync top-level text on agent cron --text update (#7048)

### DIFF
--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -716,6 +716,9 @@ def _resolve_update_spec(
                         "content": [{"type": "text", "text": text.strip()}],
                     },
                 ]
+            # Keep the top-level 'text' summary in sync with the request
+            # payload so cron list/get show the updated prompt (issue #7048).
+            payload["text"] = text.strip()
         else:
             payload["text"] = text.strip()
 

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -259,6 +259,18 @@ def test_update_agent_text_replaces_prompt_keeps_extensions():
     assert result["request"]["request_context"] == {"source_tag": "ops"}
 
 
+def test_update_agent_text_syncs_top_level_text():
+    """--text on an agent job must keep top-level text in sync with the
+    request payload so cron list/get display the updated prompt (issue #7048).
+    """
+    result = _update(_agent_job_spec(), text="new prompt")
+
+    # Both copies of the prompt must reflect the new value.
+    assert result["text"] == "new prompt"
+    content = result["request"]["input"][0]["content"][0]
+    assert content["text"] == "new prompt"
+
+
 def test_update_agent_text_with_malformed_input_rebuilds():
     """--text on an agent job with empty/malformed input rebuilds it."""
     spec = _agent_job_spec()


### PR DESCRIPTION
Fixes #7048.

## What Problem This Solves

`qwenpaw cron update <id> --text "<new prompt>"` on an **agent-type** cron
job silently failed: the command returned rc=0 and a task JSON (looking
successful), but the prompt (`text`) never actually changed on subsequent
`cron list` / `cron get`.  The single-field update path updated only one
copy of the prompt, leaving the other stale.  `--name` and the
`-f <full spec.json>` workaround were unaffected.

QwenPaw cron jobs store the agent prompt in two places:

- top-level `spec.text`  — the human-readable summary shown by
  `cron list` / `cron get`
- nested `request.input[0].content[0].text` — the execution payload sent
  to the agent

The CLI's `_resolve_update_spec` for `task_type=="agent"` only patched the
nested copy, so the top-level summary drifted and `cron list/get` kept
displaying the old prompt.  This was a silent config-drift bug: callers
had no way to tell the update had not fully taken effect.

## Evidence

- Isolated verification (`verify_7048.py`) re-runs the real
  `_resolve_update_spec` against an agent-type spec and asserts:
  1. normal `--text` update syncs **both** the top-level `text` and the
     nested `request.input[0].content[0].text` to the new value;
  2. request extensions (`model`, `request_context`) are preserved;
  3. the malformed-input fallback branch also syncs both copies;
  4. the input spec dict is not mutated in place;
  5. `text`-type jobs still set only the top-level `text` (unchanged).

  All 5 checks pass.
- New regression unit test
  `test_update_agent_text_syncs_top_level_text` in
  `tests/unit/cli/test_cron_cmd.py` locks in the dual-copy sync.
- Lint pre-check with the repo-pinned toolchain (black 23.3.0
  `--line-length 79`, add-trailing-comma v3.1.0, flake8 6.1.0) — both
  touched files are left unchanged (idempotent).

## Compatibility

- Scope is limited to the `task_type=="agent"` branch of the
  single-field `--text` update path.  `--name`, `-f <spec>`, and
  `text`-type jobs are untouched.
- No CLI flag or API contract changes; the top-level `text` field for
  agent jobs simply mirrors the execution payload, matching what the
  `-f <full spec>` path and the server-side validator already expect.
- Backward compatible: existing jobs keep working; only the previously
  silent no-op on `--text` is corrected to behave as documented.
