### PR TITLE
fix(cli): sync top-level text on cron update --text for agent jobs

### DIFF
--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -716,6 +716,10 @@ def _resolve_update_spec(
                         "content": [{"type": "text", "text": text.strip()}],
                     },
                 ]
+            # Keep the top-level "text" field in sync with the request-side
+            # prompt so cron get/list surface the updated value (agent jobs
+            # may carry both copies; they must be updated together).
+            payload["text"] = text.strip()
         else:
             payload["text"] = text.strip()
 

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -278,3 +278,24 @@ def test_update_agent_text_with_malformed_input_rebuilds():
 
     content2 = result2["request"]["input"][0]["content"][0]
     assert content2["text"] == "fresh prompt"
+
+
+def test_update_agent_text_syncs_top_level_text():
+    """--text on an agent job must sync the top-level text field too.
+
+    Agent jobs can carry the prompt in two places: the top-level ``text``
+    field and ``request.input[0].content[0].text``.  A single-field update
+    must update both copies so ``cron get``/``cron list`` surface the new
+    prompt (regression test for issue #7048).
+    """
+    spec = _agent_job_spec()
+    spec["text"] = "OLD-TOPLEVEL"
+
+    result = _update(spec, text="new prompt")
+
+    assert result["text"] == "new prompt"
+    content = result["request"]["input"][0]["content"][0]
+    assert content["text"] == "new prompt"
+    # untouched fields preserved
+    assert result["request"]["model"] == "custom-model"
+    assert result["name"] == "agent-job"


### PR DESCRIPTION
## Summary

Fixes #7048.

When `qwenpaw cron update <id> --text "<prompt>"` is run on an **agent-type** cron job, only `request.input[0].content[0].text` was updated while the top-level `text` field kept its old value. `cron get` / `cron list` display the top-level `text`, so the update appeared to succeed (rc=0, JSON returned) but the prompt never changed.

## Root cause

`_resolve_update_spec` in `src/qwenpaw/cli/cron_cmd.py` patches the request-side prompt for agent jobs but leaves the top-level `text` field untouched. Agent jobs can carry the prompt in both places; they must be updated together. The reporter confirmed the same requirement when using `-f` with a full spec (both copies must be kept in sync).

## Change

- `src/qwenpaw/cli/cron_cmd.py`: sync `payload["text"]` alongside `request.input[0].content[0].text` when `--text` is provided for agent jobs.
- `tests/unit/cli/test_cron_cmd.py`: regression test `test_update_agent_text_syncs_top_level_text` asserting both copies update and untouched fields survive.

## Test

`python -m pytest tests/unit/cli/test_cron_cmd.py` → 13 passed.