### PR TITLE
fix(console): switch agent from /chat/:agentId/:sessionId

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -124,7 +124,8 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const { message } = useAppMessage();
   const { isDark } = useTheme();
   const currentSessionId = getSessionIdFromPath(location.pathname);
-  const chatPath = buildChatPath(currentSessionId);
+  const { selectedAgent, agents } = useAgentStore();
+  const chatPath = buildChatPath(currentSessionId, selectedAgent);
   const [authEnabled, setAuthEnabled] = useState(false);
   const [accountModalOpen, setAccountModalOpen] = useState(false);
   const [accountLoading, setAccountLoading] = useState(false);
@@ -145,7 +146,6 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
 
   // Sidebar mode: "simple" (only core items) or "full" (everything)
   const { mode: sidebarMode } = useSidebarModeStore();
-  const { selectedAgent, agents } = useAgentStore();
   const currentAgent = agents.find((agent) => agent.id === selectedAgent);
   const backendCapabilities = useMemo(
     () =>
@@ -468,10 +468,10 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const handleSidebarSessionClick = useCallback(
     (sessionId: string) => {
       const effectiveId = sessionApi.getEffectiveSessionId(sessionId);
-      const targetPath = buildChatPath(effectiveId);
+      const targetPath = buildChatPath(effectiveId, selectedAgent);
       navigate(targetPath);
     },
-    [navigate],
+    [navigate, selectedAgent],
   );
 
   const handleUpdateProfile = async (values: {

--- a/console/src/os/osRouteMap.test.ts
+++ b/console/src/os/osRouteMap.test.ts
@@ -26,6 +26,7 @@ describe("osRouteMap", () => {
 
   it("routes dynamic children to their owning app", () => {
     expect(pathToRouteId("/chat/session-1", routes)).toBe("core.chat");
+    expect(pathToRouteId("/chat/sales/session-1", routes)).toBe("core.chat");
   });
 
   it("prefers a concrete PawApp over the aggregate apps route", () => {

--- a/console/src/pages/Chat/ChatPage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.test.tsx
@@ -226,6 +226,14 @@ describe("ChatPage", () => {
     expect(await screen.findByTestId("chat-ui")).toBeInTheDocument();
   });
 
+  it("switches selected agent from /chat/:agentId/:sessionId", async () => {
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/sales/sess-1"],
+    });
+    expect(await screen.findByTestId("chat-ui")).toBeInTheDocument();
+    expect(mockSetSelectedAgent).toHaveBeenCalledWith("sales");
+  });
+
   it("renders child components ModelSelector / ChatActionGroup / ChatHeaderTitle", async () => {
     renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
     await screen.findByTestId("chat-ui");

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
+import { useAgentStore } from "../../../../stores/agentStore";
+import { buildChatPath } from "../../../../utils/sessionRoute";
 import styles from "./index.module.less";
 
 interface ChatSearchPanelProps {
@@ -58,6 +60,7 @@ const formatTimestamp = (raw: string | null | undefined): string => {
 const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const selectedAgent = useAgentStore((state) => state.selectedAgent);
   const { sessions, setCurrentSessionId } = useChatAnywhereSessionsState();
   const [searchQuery, setSearchQuery] = useState("");
   const [loading, setLoading] = useState(false);
@@ -244,15 +247,15 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
         // Switch to that session
         setCurrentSessionId(session.id);
         // Navigate to the chat URL
-        navigate(`/chat/${session.id}`);
+        navigate(buildChatPath(session.id, selectedAgent));
       } else {
         // Session not in local list, navigate by chat ID directly
-        navigate(`/chat/${result.chatId}`);
+        navigate(buildChatPath(result.chatId, selectedAgent));
       }
 
       onClose();
     },
-    [sessions, setCurrentSessionId, navigate, onClose],
+    [sessions, setCurrentSessionId, navigate, onClose, selectedAgent],
   );
 
   return (

--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -252,7 +252,7 @@ describe("ChatSessionDrawer", () => {
       expect(screen.getByText("Session One")).toBeInTheDocument(),
     );
     await user.click(screen.getByText("Session One"));
-    expect(mockNavigate).toHaveBeenCalledWith("/chat/s1");
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/default/s1");
   });
 
   it("clicking the close button calls onClose", async () => {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -421,10 +421,10 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       // the "flash to new chat" issue.
       setSwitchingSessionId(sessionId);
       const effectiveId = sessionApi.getEffectiveSessionId(sessionId);
-      const targetPath = buildChatPath(effectiveId);
+      const targetPath = buildChatPath(effectiveId, selectedAgent);
       navigate(targetPath);
     },
-    [currentSessionId, navigate],
+    [currentSessionId, navigate, selectedAgent],
   );
 
   // Listen for embedded switch completion so we can clear switchingSessionId.

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -10,12 +10,13 @@ import {
   useSessionListStore,
   type ExtendedSession,
 } from "../../../../stores/sessionListStore";
+import { useAgentStore } from "../../../../stores/agentStore";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
 
 /**
  * URL chatId → context currentSessionId (one direction of bidirectional sync).
  *
- * Extracts the session ID from the canonical `/chat/<id>` URL.
+ * Extracts the session ID from `/chat/:agentId/:sessionId` or legacy `/chat/:id`.
  *
  * Only reacts to URL or session list changes. currentSessionId is read via ref
  * to avoid triggering the effect when the context changes from the other direction
@@ -156,7 +157,10 @@ const ChatSessionInitializer: React.FC = () => {
               sessionId,
               realId,
             );
-            const targetUrl = buildChatPath(effectiveId);
+            const targetUrl = buildChatPath(
+              effectiveId,
+              useAgentStore.getState().selectedAgent,
+            );
             sessionApi.trackNavigatedSession(effectiveId);
             sessionApi.preferredChatId = effectiveId;
             navigate(targetUrl, { replace: true });

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -169,7 +169,9 @@ import {
 import {
   CHAT_BASE_PATH,
   buildChatPath,
+  getAgentIdFromPath,
   getSessionIdFromPath,
+  shouldPreserveUrlSessionOnAgentSwitch,
 } from "../../utils/sessionRoute";
 import { useUploadLimitStore } from "../../stores/uploadLimitStore";
 import ChatSenderTabsPanel from "./components/ChatSenderTabsPanel";
@@ -1167,7 +1169,11 @@ export default function ChatPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { isDark } = useTheme();
-  const { selectedAgent, agents } = useAgentStore();
+  const { selectedAgent, agents, setSelectedAgent } = useAgentStore();
+  const urlAgentId = useMemo(
+    () => getAgentIdFromPath(location.pathname),
+    [location.pathname],
+  );
   const chatId = useMemo(
     () => getSessionIdFromPath(location.pathname),
     [location.pathname],
@@ -2279,7 +2285,7 @@ export default function ChatPage() {
 
   useEffect(() => {
     const buildCurrentSessionPath = (sessionId: string) =>
-      buildChatPath(sessionId);
+      buildChatPath(sessionId, selectedAgentRef.current);
 
     const buildCurrentBasePath = () => CHAT_BASE_PATH;
 
@@ -2454,6 +2460,14 @@ export default function ChatPage() {
 
   // Setup multimodal capabilities tracking via custom hook
 
+  // Deep-link `/chat/:agentId/:sessionId` must switch the selected agent
+  // before the session list is treated as source of truth.
+  useEffect(() => {
+    if (urlAgentId && urlAgentId !== selectedAgent) {
+      setSelectedAgent(urlAgentId);
+    }
+  }, [urlAgentId, selectedAgent, setSelectedAgent]);
+
   // Refresh chat when selectedAgent changes, preserving last active chat per agent
   const prevSelectedAgentRef = useRef(selectedAgent);
   useEffect(() => {
@@ -2476,41 +2490,64 @@ export default function ChatPage() {
       // and the first message of a fresh chat would carry it.
       sessionApi.resetWindowIdentity();
 
+      const urlSessionId = chatIdRef.current;
+      const keepUrlSession =
+        shouldPreserveUrlSessionOnAgentSwitch(
+          urlAgentId,
+          selectedAgent,
+          urlSessionId,
+        ) && !isLocalTimestampId(urlSessionId);
+
       // Save current chat ID for the agent we're leaving.
       // Skip temporary local timestamp ids — they are not real backend
       // sessions and should not be restored later.
-      const currentChatId =
-        chatIdRef.current || lastSessionIdRef.current || undefined;
-      if (currentChatId && prevAgent && !isLocalTimestampId(currentChatId)) {
+      // When the URL already names the destination session, attribute the
+      // previously viewed session (not the URL id) to the agent we leave.
+      const currentChatId = keepUrlSession
+        ? lastSessionIdRef.current || undefined
+        : chatIdRef.current || lastSessionIdRef.current || undefined;
+      if (
+        currentChatId &&
+        prevAgent &&
+        !isLocalTimestampId(currentChatId) &&
+        (!keepUrlSession || currentChatId !== urlSessionId)
+      ) {
         setLastChatId(prevAgent, currentChatId);
       }
 
-      // Restore last chat ID for the agent we're switching to.
-      // Ignore temporary local timestamp ids that may have been persisted
-      // before this guard was added.
-      const restored = getLastChatId(selectedAgent);
-      if (restored && !isLocalTimestampId(restored)) {
-        navigateRef.current(buildChatPath(restored), {
-          replace: true,
-        });
-        sessionApi.preferredChatId = restored;
-        sessionApi.lastActiveChatId = restored;
+      if (keepUrlSession && urlSessionId) {
+        // URL already points at this agent's session — do not restore lastChatId.
+        sessionApi.preferredChatId = urlSessionId;
+        sessionApi.lastActiveChatId = urlSessionId;
       } else {
-        navigateRef.current("/chat", { replace: true });
-        sessionApi.lastActiveChatId = null;
+        // Restore last chat ID for the agent we're switching to.
+        // Ignore temporary local timestamp ids that may have been persisted
+        // before this guard was added.
+        const restored = getLastChatId(selectedAgent);
+        if (restored && !isLocalTimestampId(restored)) {
+          navigateRef.current(buildChatPath(restored, selectedAgent), {
+            replace: true,
+          });
+          sessionApi.preferredChatId = restored;
+          sessionApi.lastActiveChatId = restored;
+        } else {
+          navigateRef.current("/chat", { replace: true });
+          sessionApi.lastActiveChatId = null;
+        }
       }
       // Mark the current session as stale so late-arriving onSessionSelected
       // callbacks from the OLD library instance are suppressed (Bug: after
       // agent switch, old library's in-flight getSession may complete and
       // trigger onSessionSelected for the wrong session).
-      staleAutoSelectedIdRef.current =
-        lastSessionIdRef.current || chatIdRef.current || null;
+      staleAutoSelectedIdRef.current = keepUrlSession
+        ? lastSessionIdRef.current || null
+        : lastSessionIdRef.current || chatIdRef.current || null;
       lastSessionIdRef.current = null;
 
       setRefreshKey((prev) => prev + 1);
     }
     prevSelectedAgentRef.current = selectedAgent;
-  }, [selectedAgent, setLastChatId, getLastChatId]);
+  }, [selectedAgent, setLastChatId, getLastChatId, urlAgentId]);
 
   const copyResponse = useCallback(
     async (response: CopyableResponse) => {

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useDeferredValue } from "react";
 import { useNavigate } from "react-router-dom";
+import { useAgentStore } from "../../../stores/agentStore";
+import { buildChatPath } from "../../../utils/sessionRoute";
 import { Card, Form, Modal, Table, Button, Tabs } from "@agentscope-ai/design";
 import { useAppMessage } from "../../../hooks/useAppMessage";
 import { useTranslation } from "react-i18next";
@@ -19,6 +21,7 @@ import styles from "./index.module.less";
 function SessionsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const selectedAgent = useAgentStore((state) => state.selectedAgent);
   const {
     sessions,
     loading,
@@ -125,7 +128,7 @@ function SessionsPage() {
   };
 
   const handleView = (session: Session) => {
-    navigate(`/chat/${encodeURIComponent(session.id)}`);
+    navigate(buildChatPath(session.id, selectedAgent));
   };
 
   const handleArchiveToggle = async (session: Session) => {

--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import type { AgentSummary } from "../api/types/agents";
 import { agentsApi } from "../api/modules/agents";
 import { menuRegistry } from "../plugins/registry/store";
+import { getAgentIdFromPath } from "../utils/sessionRoute";
 
 /**
  * Storage key used by both sessionStorage (per-tab state) and localStorage
@@ -37,15 +38,53 @@ interface AgentStore {
   getLastChatId: (agentId: string) => string | undefined;
 }
 
+function getAgentIdFromWindowPath(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return getAgentIdFromPath(window.location.pathname);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Keep persist storage in sync so X-Agent-Id matches the URL agent. */
+function patchStoredSelectedAgent(agentId: string): void {
+  try {
+    localStorage.setItem(LAST_USED_AGENT_KEY, agentId);
+  } catch {
+    /* ignore */
+  }
+  for (const storage of [sessionStorage, localStorage]) {
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw) as { state?: { selectedAgent?: string } };
+      if (parsed?.state) {
+        parsed.state.selectedAgent = agentId;
+        storage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 /**
  * Determines the initial selectedAgent for this tab.
  *
  * Priority:
- *  1. sessionStorage (returning to a tab that already picked an agent)
- *  2. localStorage lastUsedAgent (new tab inherits the most recent choice)
- *  3. "default"
+ *  1. `/chat/:agentId/:sessionId` in the current URL
+ *  2. sessionStorage (returning to a tab that already picked an agent)
+ *  3. localStorage lastUsedAgent (new tab inherits the most recent choice)
+ *  4. "default"
  */
 function getInitialSelectedAgent(): string {
+  const fromUrl = getAgentIdFromWindowPath();
+  if (fromUrl) {
+    patchStoredSelectedAgent(fromUrl);
+    return fromUrl;
+  }
+
   // 1. sessionStorage: returning to a tab that already picked an agent
   try {
     const sessionValue = sessionStorage.getItem(STORAGE_KEY);
@@ -206,6 +245,19 @@ export const useAgentStore = create<AgentStore>()(
           sessionStorage.removeItem(name);
           localStorage.removeItem(name);
         },
+      },
+      merge: (persistedState, currentState) => {
+        const raw = persistedState as
+          | ({ state?: Partial<AgentStore> } & Partial<AgentStore>)
+          | undefined;
+        const persisted = raw?.state ?? raw ?? {};
+        const fromUrl = getAgentIdFromWindowPath();
+        return {
+          ...currentState,
+          ...persisted,
+          selectedAgent:
+            fromUrl || persisted.selectedAgent || currentState.selectedAgent,
+        };
       },
     },
   ),

--- a/console/src/utils/sessionRoute.test.ts
+++ b/console/src/utils/sessionRoute.test.ts
@@ -1,13 +1,62 @@
 import { describe, expect, it } from "vitest";
 
-import { buildChatPath, getSessionIdFromPath } from "./sessionRoute";
+import {
+  buildChatPath,
+  getAgentIdFromPath,
+  getSessionIdFromPath,
+  parseChatPath,
+  shouldPreserveUrlSessionOnAgentSwitch,
+} from "./sessionRoute";
 
 describe("chat session routes", () => {
-  it("builds and parses the unified chat route", () => {
+  it("builds and parses the legacy chat route", () => {
     const path = buildChatPath("chat-123");
 
     expect(path).toBe("/chat/chat-123");
     expect(getSessionIdFromPath(path)).toBe("chat-123");
+    expect(getAgentIdFromPath(path)).toBeUndefined();
     expect(buildChatPath()).toBe("/chat");
+  });
+
+  it("builds and parses /chat/:agentId/:sessionId", () => {
+    const path = buildChatPath("chat-123", "sales");
+
+    expect(path).toBe("/chat/sales/chat-123");
+    expect(parseChatPath(path)).toEqual({
+      agentId: "sales",
+      sessionId: "chat-123",
+    });
+    expect(getAgentIdFromPath(path)).toBe("sales");
+    expect(getSessionIdFromPath(path)).toBe("chat-123");
+  });
+
+  it("encodes and decodes special characters in agent and session ids", () => {
+    const path = buildChatPath("sess/a", "agent b");
+
+    expect(path).toBe("/chat/agent%20b/sess%2Fa");
+    expect(parseChatPath(path)).toEqual({
+      agentId: "agent b",
+      sessionId: "sess/a",
+    });
+  });
+
+  it("treats /chat as empty", () => {
+    expect(parseChatPath("/chat")).toEqual({});
+    expect(parseChatPath("/chat/")).toEqual({});
+  });
+
+  it("preserves the URL session when switching to the agent named in the path", () => {
+    expect(
+      shouldPreserveUrlSessionOnAgentSwitch("sales", "sales", "sess-1"),
+    ).toBe(true);
+    expect(
+      shouldPreserveUrlSessionOnAgentSwitch("sales", "default", "sess-1"),
+    ).toBe(false);
+    expect(
+      shouldPreserveUrlSessionOnAgentSwitch(undefined, "sales", "sess-1"),
+    ).toBe(false);
+    expect(
+      shouldPreserveUrlSessionOnAgentSwitch("sales", "sales", undefined),
+    ).toBe(false);
   });
 });

--- a/console/src/utils/sessionRoute.ts
+++ b/console/src/utils/sessionRoute.ts
@@ -1,10 +1,65 @@
-export function getSessionIdFromPath(pathname: string): string | undefined {
-  const match = pathname.match(/^\/chat\/(.+)$/);
-  return match?.[1];
-}
-
 export const CHAT_BASE_PATH = "/chat";
 
-export function buildChatPath(sessionId?: string | null): string {
-  return sessionId ? `${CHAT_BASE_PATH}/${sessionId}` : CHAT_BASE_PATH;
+export interface ChatPathParts {
+  agentId?: string;
+  sessionId?: string;
+}
+
+function decodePathSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Parse `/chat`, `/chat/:sessionId` (legacy), or `/chat/:agentId/:sessionId`.
+ */
+export function parseChatPath(pathname: string): ChatPathParts {
+  const path = pathname.split(/[?#]/, 1)[0] ?? "";
+  const two = path.match(/^\/chat\/([^/]+)\/(.+)$/);
+  if (two) {
+    return {
+      agentId: decodePathSegment(two[1]),
+      sessionId: decodePathSegment(two[2]),
+    };
+  }
+  const one = path.match(/^\/chat\/(.+)$/);
+  if (one) {
+    return { sessionId: decodePathSegment(one[1]) };
+  }
+  return {};
+}
+
+export function getSessionIdFromPath(pathname: string): string | undefined {
+  return parseChatPath(pathname).sessionId;
+}
+
+export function getAgentIdFromPath(pathname: string): string | undefined {
+  return parseChatPath(pathname).agentId;
+}
+
+export function buildChatPath(
+  sessionId?: string | null,
+  agentId?: string | null,
+): string {
+  if (sessionId && agentId) {
+    return `${CHAT_BASE_PATH}/${encodeURIComponent(
+      agentId,
+    )}/${encodeURIComponent(sessionId)}`;
+  }
+  if (sessionId) {
+    return `${CHAT_BASE_PATH}/${encodeURIComponent(sessionId)}`;
+  }
+  return CHAT_BASE_PATH;
+}
+
+/** True when the URL already names this agent's session and must not be replaced. */
+export function shouldPreserveUrlSessionOnAgentSwitch(
+  urlAgentId: string | undefined,
+  selectedAgent: string,
+  urlSessionId: string | null | undefined,
+): boolean {
+  return Boolean(urlAgentId && urlAgentId === selectedAgent && urlSessionId);
 }


### PR DESCRIPTION
## Description

When multiple agents exist, opening a conversation via URL only carried a `sessionId`. The console kept the last selected agent, listed that agent's sessions, and the SDK then rewrote the URL to another conversation.

This change adds `/chat/:agentId/:sessionId` so a deep link can name both the agent and the session.

- New links are written as `/chat/<agentId>/<sessionId>` (sidebar, session drawer, search, sessions page).
- Opening that URL selects the named agent and keeps the named session.
- Agent-switch restore of `lastChatId` is skipped when the URL already names this agent's session, so it is not overwritten.
- Full-page load reads the agent from the URL and patches persist storage so the first `/chats` request sends the correct `X-Agent-Id`.
- Legacy `/chat/:sessionId` still works, but does not switch agents.

**Related Issue:** [to #85515624](https://project.aone.alibaba-inc.com/v2/project/2161835/req/85515624)

**Security Considerations:** N/A — frontend routing only; chat APIs remain agent-scoped via `X-Agent-Id`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Use two agents (for example `default` and `sales`), each with at least one session.
2. Copy a session URL from `sales` (now `/chat/sales/<sessionId>`).
3. Switch the selector to `default`.
4. Paste the `sales` URL (or open it in a new tab).
5. Confirm the selector switches to `sales` and the URL session stays selected (it should not jump to a `default` session).
6. Manually switch agents in the selector and confirm last-session restore still works.

## Evidence

Console unit tests covering the route helper, agent store, session drawer navigation, OS route map, and session ownership:

```bash
cd console && npm run test:run -- \
  src/utils/sessionRoute.test.ts \
  src/stores/agentStore.test.ts \
  src/os/osRouteMap.test.ts \
  src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx \
  src/pages/Chat/tests/agentSessionOwnership.test.ts
```

```
Test Files  5 passed (5)
     Tests  57 passed (57)
```

`npx tsc -b --noEmit` in `console/` also passed.

## Additional Notes

Old `/chat/<sessionId>` bookmarks keep working. New navigations emit `/chat/<agentId>/<sessionId>`.

Aone: https://project.aone.alibaba-inc.com/v2/project/2161835/req/85515624