### PR TITLE
fix(console): render data-URL images in historical messages on session reload

### DIFF
--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -339,4 +339,15 @@ describe("toDisplayUrl", () => {
       "http://localhost:8000/uploads/img.png",
     );
   });
+
+  it("passes data URLs through untouched (issue #7051)", () => {
+    const dataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB";
+    expect(toDisplayUrl(dataUrl)).toBe(dataUrl);
+  });
+
+  it("passes data URLs through without filePreviewUrl fallback", () => {
+    const dataUrl = "data:image/png;base64,AAA=";
+    expect(toDisplayUrl(dataUrl)).toBe(dataUrl);
+    expect(toDisplayUrl(dataUrl)).not.toContain("/files/preview");
+  });
 });

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -184,6 +184,10 @@ export function normalizeContentUrls(part: any): any {
 export function toDisplayUrl(url: string | undefined): string {
   if (!url) return "";
   if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  // Data URLs (base64 images etc.) must pass through untouched — routing
+  // them through filePreviewUrl would corrupt the URL and break rendering
+  // of historical messages on session reload.
+  if (url.startsWith("data:")) return url;
   if (url.startsWith("file://")) url = url.replace("file://", "");
   return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
 }


### PR DESCRIPTION
## Summary

Fixes #7051.

Images attached to Console chat messages render fine when first sent, but after closing and re-opening the chat the history view shows a broken/empty thumbnail. The backend correctly serves the image as a `data:` URL (`data:image/png;base64,...`) on history load, but the frontend failed to render it for historical messages.

## Root cause

`toDisplayUrl` in `console/src/pages/Chat/utils.ts` only recognized `http(s)://` and `file://` prefixes. A `data:` URL (base64 image) fell through to `chatApi.filePreviewUrl`, which wrapped it as a file-preview path — corrupting the URL so the image could not render. The live-render path renders `data:` URLs fine, which is why only history hydration broke.

## Change

- `console/src/pages/Chat/utils.ts`: `toDisplayUrl` now passes `data:` URLs through untouched, matching the live-render path.
- `console/src/pages/Chat/utils.test.ts`: two regression tests — a `data:` URL round-trips unchanged and never falls back to `/files/preview`.

## Test

`npx vitest run src/pages/Chat/utils.test.ts` → 37 passed (incl. 2 new).