### PR TITLE
feat(console): add background chat task list API

### DIFF
--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -922,3 +922,34 @@ async def get_console_chat_task(task_id: str) -> dict:
     if bg.status == "finished" and bg.result is not None:
         response["result"] = bg.result
     return response
+
+
+@router.get(
+    "/chat/tasks",
+    status_code=200,
+    summary="List all background chat task statuses",
+)
+async def list_console_chat_tasks() -> dict:
+    """Return status summaries for all background chat tasks.
+
+    Lets callers query the whole task set in one request instead of
+    polling each task id individually (issue #7056). Each entry mirrors
+    the single-task response shape; finished tasks include their result.
+    """
+    async with _bg_lock:
+        task_ids = list(_bg_tasks.keys())
+    tasks: Dict[str, Any] = {}
+    for task_id in task_ids:
+        async with _bg_lock:
+            bg = _bg_tasks.get(task_id)
+        if bg is None:
+            continue
+        entry: Dict[str, Any] = {"status": bg.status}
+        if bg.started_at is not None:
+            entry["started_at"] = bg.started_at
+        if bg.finished_at is not None:
+            entry["finished_at"] = bg.finished_at
+        if bg.status == "finished" and bg.result is not None:
+            entry["result"] = bg.result
+        tasks[task_id] = entry
+    return {"tasks": tasks}

--- a/tests/unit/app/routers/test_console_task_list.py
+++ b/tests/unit/app/routers/test_console_task_list.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the background task list API (issue #7056).
+
+``GET /console/chat/tasks`` returns status summaries for every in-flight
+background chat task in one request, so callers no longer need to poll
+each task id individually.
+"""
+
+# pylint: disable=protected-access
+import pytest
+
+from qwenpaw.app.routers import console
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_empty() -> None:
+    """An empty task store yields an empty mapping."""
+    console._bg_tasks.clear()
+    result = await console.list_console_chat_tasks()
+    assert result == {"tasks": {}}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_mixed_statuses() -> None:
+    """Running and finished tasks both appear with their own fields."""
+    console._bg_tasks.clear()
+    console._bg_tasks["task-running"] = console._BackgroundTask(
+        status="running",
+        started_at=100.0,
+    )
+    console._bg_tasks["task-done"] = console._BackgroundTask(
+        status="finished",
+        started_at=50.0,
+        finished_at=60.0,
+        result={"status": "completed", "output": ["ok"]},
+    )
+    try:
+        result = await console.list_console_chat_tasks()
+    finally:
+        console._bg_tasks.clear()
+
+    tasks = result["tasks"]
+    assert set(tasks.keys()) == {"task-running", "task-done"}
+
+    running = tasks["task-running"]
+    assert running["status"] == "running"
+    assert running["started_at"] == 100.0
+    assert "finished_at" not in running
+    assert "result" not in running
+
+    done = tasks["task-done"]
+    assert done["status"] == "finished"
+    assert done["finished_at"] == 60.0
+    assert done["result"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_matches_single_task_shape() -> None:
+    """Each list entry mirrors the single-task endpoint response shape."""
+    console._bg_tasks.clear()
+    console._bg_tasks["task-x"] = console._BackgroundTask(
+        status="finished",
+        started_at=1.0,
+        finished_at=2.0,
+        result={"status": "completed"},
+    )
+    try:
+        listed = await console.list_console_chat_tasks()
+        single = await console.get_console_chat_task("task-x")
+    finally:
+        console._bg_tasks.clear()
+
+    entry = listed["tasks"]["task-x"]
+    assert entry["status"] == single["status"]
+    assert entry["started_at"] == single["started_at"]
+    assert entry["result"] == single["result"]


### PR DESCRIPTION
## Summary

Implements the minimal part of issue #7056's proposal: a task status **list API**.

Background tasks submitted via `submit_to_agent` (POST `/console/chat/task`) could only be inspected one-by-one by polling `GET /console/chat/task/{id}`. For multi-agent coordination there was no way to query all in-flight tasks at once.

## Change

- `src/qwenpaw/app/routers/console.py`: new `GET /console/chat/tasks` endpoint returning a `{"tasks": {task_id: {...}}}` mapping with status summaries for every background chat task. Each entry mirrors the single-task response shape (status / started_at / finished_at / result for finished tasks), so callers can check the whole set in one request.
- `tests/unit/app/routers/test_console_task_list.py`: 3 tests — empty store, mixed running/finished tasks, and shape parity with the single-task endpoint.

## Test

`python -m pytest tests/unit/app/routers/test_console_task_list.py` (3 tests) — locally validated via direct function-level checks because the full `qwenpaw.app.routers` import chain requires heavy optional deps (playwright etc.); CI runs the file with the full environment.

Note: WebSocket push (the issue's first proposal) is a larger feature and intentionally left out of this small PR.