### PR TITLE
feat(console): compact background task list and add scroll hint

### DIFF
--- a/console/src/hooks/useBackgroundTaskWatcher.ts
+++ b/console/src/hooks/useBackgroundTaskWatcher.ts
@@ -92,7 +92,6 @@ async function finalizeFromOutput(
   store.updateTask(toolCallId, {
     status,
     result: resultText || null,
-    hintVisible: true,
   });
 
   if (alreadyTerminal) return;
@@ -335,7 +334,6 @@ export async function cancelBackgroundTask(
   useBackgroundTasksStore.getState().updateTask(toolCallId, {
     status: "cancelled",
     result: live || null,
-    hintVisible: true,
   });
 }
 

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3759,14 +3759,18 @@
         "title": "Background tasks",
         "running": "Running",
         "done": "Done",
+        "doneLabel": "Task completed",
         "cancelled": "Cancelled",
         "totalDuration": "Total",
         "cancel": "Cancel",
         "remove": "Remove",
         "cancelAll": "Cancel all",
-        "clearAll": "Clear all",
+        "clearAll": "Clear completed",
         "cancelAllDone": "Cancelled all running tasks",
-        "clearAllDone": "Cleared background task list",
+        "clearAllDone": "Cleared completed tasks",
+        "showFinished": "Show completed",
+        "emptyRunning": "No running tasks",
+        "scrollMore": "Scroll to view more",
         "noOutput": "No output yet"
       }
     }

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3770,6 +3770,7 @@
         "clearAllDone": "Cleared completed tasks",
         "showFinished": "Show completed",
         "emptyRunning": "No running tasks",
+        "emptyHiddenFinished": "{{count}} completed (hidden)",
         "scrollMore": "Scroll to view more",
         "noOutput": "No output yet"
       }

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3788,6 +3788,7 @@
         "clearAllDone": "已清除已完成任务",
         "showFinished": "显示已完成",
         "emptyRunning": "暂无运行中任务",
+        "emptyHiddenFinished": "{{count}} 个已完成（已隐藏）",
         "scrollMore": "可滑动查看",
         "noOutput": "暂无输出"
       }

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3777,14 +3777,18 @@
         "title": "后台任务",
         "running": "运行中",
         "done": "已完成",
+        "doneLabel": "任务已完成",
         "cancelled": "已取消",
         "totalDuration": "总耗时",
         "cancel": "取消",
         "remove": "移除",
         "cancelAll": "全部取消",
-        "clearAll": "全部清除",
+        "clearAll": "清除已完成",
         "cancelAllDone": "已取消全部运行中任务",
-        "clearAllDone": "已清除后台任务列表",
+        "clearAllDone": "已清除已完成任务",
+        "showFinished": "显示已完成",
+        "emptyRunning": "暂无运行中任务",
+        "scrollMore": "可滑动查看",
         "noOutput": "暂无输出"
       }
     }

--- a/console/src/pages/Chat/components/BackgroundTaskPanel.tsx
+++ b/console/src/pages/Chat/components/BackgroundTaskPanel.tsx
@@ -21,8 +21,8 @@ import {
 } from "../../../hooks/useBackgroundTaskWatcher";
 import { message } from "antd";
 
-/** ~3 collapsed rows (32px row + 6px gaps) so the list cannot grow the chat. */
-const LIST_MAX_HEIGHT_PX = 108;
+/** ~3 collapsed rows (bordered ~36px + 6px gaps) so 1–3 items do not overflow. */
+const LIST_MAX_HEIGHT_PX = 120;
 const SCROLL_EDGE_PX = 1;
 
 function measureListOverflow(el: HTMLElement): {
@@ -113,6 +113,13 @@ export default function BackgroundTaskPanel({
     [sessionTasks],
   );
   const visibleTasks = showFinished ? sessionTasks : runningTasks;
+  const expandedTask = visibleTasks.find(
+    (task) => task.toolCallId === expandedId,
+  );
+
+  useEffect(() => {
+    if (expandedId && !expandedTask) setExpandedId(null);
+  }, [expandedId, expandedTask]);
 
   useLayoutEffect(() => {
     if (!showBody) return;
@@ -125,7 +132,7 @@ export default function BackgroundTaskPanel({
       observer.observe(child);
     }
     return () => observer.disconnect();
-  }, [showBody, visibleTasks, expandedId, showFinished, syncListOverflow]);
+  }, [showBody, visibleTasks, showFinished, syncListOverflow]);
 
   const handleClose = useCallback(
     async (task: BackgroundTask) => {
@@ -189,7 +196,11 @@ export default function BackgroundTaskPanel({
     ? "rgba(114,46,209,0.25)"
     : "rgba(114,46,209,0.12)";
   const badgeColor = hasRunning ? "#d48806" : "#722ed1";
-  const badgeCount = hasRunning ? runningTasks.length : finishedTasks.length;
+  const badgeCount = hasRunning
+    ? runningTasks.length
+    : showFinished
+    ? finishedTasks.length
+    : 0;
   const listMask =
     listOverflow.canScrollUp && listOverflow.canScrollDown
       ? "linear-gradient(to bottom, transparent, #000 20px, #000 calc(100% - 28px), transparent)"
@@ -317,17 +328,19 @@ export default function BackgroundTaskPanel({
             }}
           >
             <span>{t("tool.control.bgQueue.title", "Background tasks")}</span>
-            <span
-              style={{
-                fontSize: 11,
-                padding: "0 6px",
-                borderRadius: 10,
-                background: badgeBg,
-                color: badgeColor,
-              }}
-            >
-              {badgeCount}
-            </span>
+            {badgeCount > 0 && (
+              <span
+                style={{
+                  fontSize: 11,
+                  padding: "0 6px",
+                  borderRadius: 10,
+                  background: badgeBg,
+                  color: badgeColor,
+                }}
+              >
+                {badgeCount}
+              </span>
+            )}
             <span
               style={{
                 marginLeft: "auto",
@@ -348,56 +361,64 @@ export default function BackgroundTaskPanel({
       )}
 
       {showBody && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <div
-            ref={listRef}
-            onScroll={syncListOverflow}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-              maxHeight: LIST_MAX_HEIGHT_PX,
-              overflowY: "auto",
-              WebkitMaskImage: listMask,
-              maskImage: listMask,
-            }}
-          >
-            {visibleTasks.length === 0 && (
-              <div
-                style={{
-                  fontSize: 12,
-                  color: isDark ? "#888" : "#999",
-                  padding: "6px 8px",
-                }}
-              >
-                {t("tool.control.bgQueue.emptyRunning", "No running tasks")}
-              </div>
-            )}
-            {visibleTasks.map((task) => {
-              const body =
-                task.status === "running"
-                  ? task.liveOutput
-                  : task.result || task.liveOutput;
-              const isExpanded = expandedId === task.toolCallId;
-              const isRunning = task.status === "running";
-              const duration = formatDuration(task.startTime, task.endTime);
-              const statusText = isRunning
-                ? `${t("tool.control.bgQueue.running", "Running")} ${duration}`
-                : task.status === "cancelled"
-                ? `${t("tool.control.bgQueue.cancelled", "Cancelled")} · ${t(
-                    "tool.control.bgQueue.totalDuration",
-                    "Total",
-                  )} ${duration}`
-                : `${t(
-                    "tool.control.bgQueue.doneLabel",
-                    "Task completed",
-                  )} · ${t(
-                    "tool.control.bgQueue.totalDuration",
-                    "Total",
-                  )} ${duration}`;
-              return (
-                <div key={task.toolCallId}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <div style={{ position: "relative" }}>
+            <div
+              ref={listRef}
+              onScroll={syncListOverflow}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+                maxHeight: LIST_MAX_HEIGHT_PX,
+                overflowY: "auto",
+                WebkitMaskImage: listMask,
+                maskImage: listMask,
+              }}
+            >
+              {visibleTasks.length === 0 && (
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: isDark ? "#888" : "#999",
+                    padding: "6px 8px",
+                  }}
+                >
+                  {!showFinished && finishedTasks.length > 0
+                    ? t("tool.control.bgQueue.emptyHiddenFinished", {
+                        count: finishedTasks.length,
+                        defaultValue: "{{count}} completed (hidden)",
+                      })
+                    : t(
+                        "tool.control.bgQueue.emptyRunning",
+                        "No running tasks",
+                      )}
+                </div>
+              )}
+              {visibleTasks.map((task) => {
+                const isExpanded = expandedId === task.toolCallId;
+                const isRunning = task.status === "running";
+                const duration = formatDuration(task.startTime, task.endTime);
+                const statusText = isRunning
+                  ? `${t(
+                      "tool.control.bgQueue.running",
+                      "Running",
+                    )} ${duration}`
+                  : task.status === "cancelled"
+                  ? `${t("tool.control.bgQueue.cancelled", "Cancelled")} · ${t(
+                      "tool.control.bgQueue.totalDuration",
+                      "Total",
+                    )} ${duration}`
+                  : `${t(
+                      "tool.control.bgQueue.doneLabel",
+                      "Task completed",
+                    )} · ${t(
+                      "tool.control.bgQueue.totalDuration",
+                      "Total",
+                    )} ${duration}`;
+                return (
                   <div
+                    key={task.toolCallId}
                     role="button"
                     tabIndex={0}
                     onClick={() =>
@@ -419,7 +440,18 @@ export default function BackgroundTaskPanel({
                       gap: 8,
                       padding: "6px 8px",
                       borderRadius: 6,
-                      background: isDark
+                      border: `2px solid ${
+                        isExpanded
+                          ? isDark
+                            ? "rgba(179,127,235,0.7)"
+                            : "rgba(179,127,235,0.85)"
+                          : "transparent"
+                      }`,
+                      background: isExpanded
+                        ? isDark
+                          ? "rgba(114,46,209,0.16)"
+                          : "rgba(114,46,209,0.06)"
+                        : isDark
                         ? "rgba(255,255,255,0.04)"
                         : "rgba(0,0,0,0.02)",
                       cursor: "pointer",
@@ -494,47 +526,56 @@ export default function BackgroundTaskPanel({
                         : t("tool.control.bgQueue.remove", "Remove")}
                     </button>
                   </div>
-                  {isExpanded && (
-                    <pre
-                      style={{
-                        margin: "4px 0 0",
-                        padding: 8,
-                        maxHeight: 160,
-                        overflow: "auto",
-                        fontSize: 11,
-                        fontFamily:
-                          "ui-monospace, SFMono-Regular, Menlo, monospace",
-                        whiteSpace: "pre-wrap",
-                        wordBreak: "break-word",
-                        background: isDark ? "#141414" : "#fafafa",
-                        border: `1px solid ${borderColor}`,
-                        borderRadius: 6,
-                        color: isDark ? "#ccc" : "#333",
-                      }}
-                    >
-                      {body ||
-                        t("tool.control.bgQueue.noOutput", "No output yet")}
-                    </pre>
-                  )}
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
+            {listOverflow.canScrollDown && (
+              <div
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 4,
+                  height: 28,
+                  fontSize: 11,
+                  color: isDark ? "#bbb" : "#666",
+                  pointerEvents: "none",
+                  background: isDark
+                    ? "linear-gradient(to top, rgba(20,20,20,0.92), rgba(20,20,20,0.45), transparent)"
+                    : "linear-gradient(to top, rgba(255,255,255,0.96), rgba(255,255,255,0.55), transparent)",
+                }}
+              >
+                <ChevronDown size={12} aria-hidden />
+                {t("tool.control.bgQueue.scrollMore", "Scroll to view more")}
+              </div>
+            )}
           </div>
-          {listOverflow.canScrollDown && (
-            <div
+          {expandedTask && (
+            <pre
               style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: 4,
+                margin: 0,
+                padding: 8,
+                maxHeight: 160,
+                overflow: "auto",
                 fontSize: 11,
-                color: isDark ? "#888" : "#999",
-                padding: "0 8px 2px",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                background: isDark ? "#141414" : "#fafafa",
+                border: `1px solid ${borderColor}`,
+                borderRadius: 6,
+                color: isDark ? "#ccc" : "#333",
               }}
             >
-              <ChevronDown size={12} aria-hidden />
-              {t("tool.control.bgQueue.scrollMore", "Scroll to view more")}
-            </div>
+              {(expandedTask.status === "running"
+                ? expandedTask.liveOutput
+                : expandedTask.result || expandedTask.liveOutput) ||
+                t("tool.control.bgQueue.noOutput", "No output yet")}
+            </pre>
           )}
         </div>
       )}

--- a/console/src/pages/Chat/components/BackgroundTaskPanel.tsx
+++ b/console/src/pages/Chat/components/BackgroundTaskPanel.tsx
@@ -1,12 +1,14 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useTheme } from "../../../contexts/ThemeContext";
 import {
   selectTasksForSession,
@@ -19,10 +21,31 @@ import {
 } from "../../../hooks/useBackgroundTaskWatcher";
 import { message } from "antd";
 
+/** ~3 collapsed rows (32px row + 6px gaps) so the list cannot grow the chat. */
+const LIST_MAX_HEIGHT_PX = 108;
+const SCROLL_EDGE_PX = 1;
+
+function measureListOverflow(el: HTMLElement): {
+  canScrollUp: boolean;
+  canScrollDown: boolean;
+} {
+  const { scrollTop, clientHeight, scrollHeight } = el;
+  return {
+    canScrollUp: scrollTop > SCROLL_EDGE_PX,
+    canScrollDown: scrollTop + clientHeight < scrollHeight - SCROLL_EDGE_PX,
+  };
+}
+
 interface BackgroundTaskPanelProps {
   sessionId: string;
   /** When true, omit outer chrome/title (used inside ChatSenderTabsPanel). */
   embedded?: boolean;
+  /** When set (embedded), parent owns the finished-task filter. */
+  showFinished?: boolean;
+}
+
+function isFinished(task: BackgroundTask): boolean {
+  return task.status === "done" || task.status === "cancelled";
 }
 
 function formatDuration(startTime: number, endTime: number | null): string {
@@ -37,13 +60,13 @@ function formatDuration(startTime: number, endTime: number | null): string {
 export default function BackgroundTaskPanel({
   sessionId,
   embedded = false,
+  showFinished: showFinishedProp,
 }: BackgroundTaskPanelProps) {
   const { t } = useTranslation();
   const { isDark } = useTheme();
   const tasks = useBackgroundTasksStore((s) => s.tasks);
   const removeTask = useBackgroundTasksStore((s) => s.removeTask);
   const removeTasks = useBackgroundTasksStore((s) => s.removeTasks);
-  const dismissHint = useBackgroundTasksStore((s) => s.dismissHint);
 
   const sessionTasks = useMemo(
     () => selectTasksForSession(tasks, sessionId),
@@ -53,8 +76,27 @@ export default function BackgroundTaskPanel({
   const [collapsed, setCollapsed] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [batchBusy, setBatchBusy] = useState(false);
+  const [localShowFinished, setLocalShowFinished] = useState(false);
+  const [listOverflow, setListOverflow] = useState({
+    canScrollUp: false,
+    canScrollDown: false,
+  });
+  const listRef = useRef<HTMLDivElement>(null);
   const [, setTick] = useState(0);
   const showBody = embedded || !collapsed;
+  const showFinished = showFinishedProp ?? localShowFinished;
+
+  const syncListOverflow = useCallback(() => {
+    const el = listRef.current;
+    if (!el) {
+      setListOverflow({
+        canScrollUp: false,
+        canScrollDown: false,
+      });
+      return;
+    }
+    setListOverflow(measureListOverflow(el));
+  }, []);
 
   useEffect(() => {
     if (!sessionTasks.some((t) => t.status === "running")) return;
@@ -66,6 +108,24 @@ export default function BackgroundTaskPanel({
     () => sessionTasks.filter((t) => t.status === "running"),
     [sessionTasks],
   );
+  const finishedTasks = useMemo(
+    () => sessionTasks.filter(isFinished),
+    [sessionTasks],
+  );
+  const visibleTasks = showFinished ? sessionTasks : runningTasks;
+
+  useLayoutEffect(() => {
+    if (!showBody) return;
+    syncListOverflow();
+    const el = listRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => syncListOverflow());
+    observer.observe(el);
+    for (const child of Array.from(el.children)) {
+      observer.observe(child);
+    }
+    return () => observer.disconnect();
+  }, [showBody, visibleTasks, expandedId, showFinished, syncListOverflow]);
 
   const handleClose = useCallback(
     async (task: BackgroundTask) => {
@@ -106,27 +166,16 @@ export default function BackgroundTaskPanel({
     }
   }, [runningTasks, batchBusy, t]);
 
-  const handleClearAll = useCallback(async () => {
-    if (sessionTasks.length === 0 || batchBusy) return;
-    setBatchBusy(true);
-    try {
-      // Cancel running tools first, then remove every entry in this session.
-      await Promise.allSettled(
-        runningTasks.map((task) =>
-          cancelBackgroundTask(task.sessionId, task.toolCallId),
-        ),
-      );
-      for (const task of sessionTasks) {
-        stopBackgroundTaskWatcher(task.toolCallId);
-      }
-      removeTasks(sessionTasks.map((task) => task.toolCallId));
-      message.info(
-        t("tool.control.bgQueue.clearAllDone", "Cleared background task list"),
-      );
-    } finally {
-      setBatchBusy(false);
+  const handleClearFinished = useCallback(() => {
+    if (finishedTasks.length === 0 || batchBusy) return;
+    for (const task of finishedTasks) {
+      stopBackgroundTaskWatcher(task.toolCallId);
     }
-  }, [sessionTasks, runningTasks, batchBusy, removeTasks, t]);
+    removeTasks(finishedTasks.map((task) => task.toolCallId));
+    message.info(
+      t("tool.control.bgQueue.clearAllDone", "Cleared completed tasks"),
+    );
+  }, [finishedTasks, batchBusy, removeTasks, t]);
 
   if (sessionTasks.length === 0) return null;
 
@@ -140,6 +189,15 @@ export default function BackgroundTaskPanel({
     ? "rgba(114,46,209,0.25)"
     : "rgba(114,46,209,0.12)";
   const badgeColor = hasRunning ? "#d48806" : "#722ed1";
+  const badgeCount = hasRunning ? runningTasks.length : finishedTasks.length;
+  const listMask =
+    listOverflow.canScrollUp && listOverflow.canScrollDown
+      ? "linear-gradient(to bottom, transparent, #000 20px, #000 calc(100% - 28px), transparent)"
+      : listOverflow.canScrollDown
+      ? "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent)"
+      : listOverflow.canScrollUp
+      ? "linear-gradient(to bottom, transparent, #000 20px, #000 100%)"
+      : undefined;
   const actionBtnStyle: CSSProperties = {
     border: `1px solid ${borderColor}`,
     background: isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)",
@@ -152,8 +210,34 @@ export default function BackgroundTaskPanel({
     opacity: batchBusy ? 0.5 : 1,
   };
 
+  const showFinishedToggle = (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        fontSize: 11,
+        color: isDark ? "#bbb" : "#555",
+        cursor: "pointer",
+        userSelect: "none",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={showFinished}
+        onChange={(e) => setLocalShowFinished(e.target.checked)}
+        onClick={(e) => e.stopPropagation()}
+      />
+      {t("tool.control.bgQueue.showFinished", "Show completed")}
+    </label>
+  );
+
   const batchActions = (
-    <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+    <div
+      style={{ display: "flex", gap: 6, flexShrink: 0, alignItems: "center" }}
+    >
+      {showFinishedToggle}
       <button
         type="button"
         disabled={batchBusy || runningTasks.length === 0}
@@ -172,14 +256,19 @@ export default function BackgroundTaskPanel({
       </button>
       <button
         type="button"
-        disabled={batchBusy || sessionTasks.length === 0}
+        disabled={batchBusy || finishedTasks.length === 0}
         onClick={(e) => {
           e.stopPropagation();
-          void handleClearAll();
+          handleClearFinished();
         }}
-        style={actionBtnStyle}
+        style={{
+          ...actionBtnStyle,
+          opacity: batchBusy || finishedTasks.length === 0 ? 0.4 : 1,
+          cursor:
+            batchBusy || finishedTasks.length === 0 ? "not-allowed" : "pointer",
+        }}
       >
-        {t("tool.control.bgQueue.clearAll", "Clear all")}
+        {t("tool.control.bgQueue.clearAll", "Clear completed")}
       </button>
     </div>
   );
@@ -237,7 +326,7 @@ export default function BackgroundTaskPanel({
                 color: badgeColor,
               }}
             >
-              {sessionTasks.length}
+              {badgeCount}
             </span>
             <span
               style={{
@@ -258,199 +347,197 @@ export default function BackgroundTaskPanel({
         </div>
       )}
 
-      {showBody &&
-        sessionTasks.map((task) => {
-          const body =
-            task.status === "running"
-              ? task.liveOutput
-              : task.result || task.liveOutput;
-          const isExpanded = expandedId === task.toolCallId;
-          const isRunning = task.status === "running";
-          return (
-            <div key={task.toolCallId}>
-              {task.hintVisible && (
-                <div
-                  style={{
-                    borderLeft: "3px solid #722ed1",
-                    padding: "6px 10px",
-                    marginBottom: 4,
-                    fontSize: 12,
-                    background: isDark
-                      ? "rgba(114,46,209,0.12)"
-                      : "rgba(114,46,209,0.06)",
-                    color: isDark ? "#d3adf7" : "#531dab",
-                    display: "flex",
-                    justifyContent: "space-between",
-                    gap: 8,
-                  }}
-                >
-                  <span>
-                    {task.status === "cancelled"
-                      ? t("tool.control.hint.cancelled", {
-                          tool: task.toolName,
-                          defaultValue: `Tool ${task.toolName} cancelled`,
-                        })
-                      : t("tool.control.hint.completed", {
-                          tool: task.toolName,
-                          defaultValue: `Tool ${task.toolName} completed in background`,
-                        })}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => dismissHint(task.toolCallId)}
-                    style={{
-                      border: "none",
-                      background: "transparent",
-                      cursor: "pointer",
-                      color: "inherit",
-                      opacity: 0.7,
-                      display: "inline-flex",
-                      alignItems: "center",
-                      padding: 0,
-                    }}
-                    aria-label={t("common.close", "Close")}
-                  >
-                    <X size={14} aria-hidden />
-                  </button>
-                </div>
-              )}
+      {showBody && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <div
+            ref={listRef}
+            onScroll={syncListOverflow}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              maxHeight: LIST_MAX_HEIGHT_PX,
+              overflowY: "auto",
+              WebkitMaskImage: listMask,
+              maskImage: listMask,
+            }}
+          >
+            {visibleTasks.length === 0 && (
               <div
-                role="button"
-                tabIndex={0}
-                onClick={() =>
-                  setExpandedId((id) =>
-                    id === task.toolCallId ? null : task.toolCallId,
-                  )
-                }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setExpandedId((id) =>
-                      id === task.toolCallId ? null : task.toolCallId,
-                    );
-                  }
-                }}
                 style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  padding: "6px 8px",
-                  borderRadius: 6,
-                  background: isDark
-                    ? "rgba(255,255,255,0.04)"
-                    : "rgba(0,0,0,0.02)",
-                  cursor: "pointer",
                   fontSize: 12,
+                  color: isDark ? "#888" : "#999",
+                  padding: "6px 8px",
                 }}
               >
-                <span
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: "50%",
-                    background: isRunning
-                      ? "#722ed1"
-                      : task.status === "cancelled"
-                      ? "#8c8c8c"
-                      : "#52c41a",
-                    flexShrink: 0,
-                  }}
-                />
-                <span
-                  style={{
-                    flex: 1,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    color: isDark ? "#ddd" : "#333",
-                  }}
-                  title={task.toolName}
-                >
-                  {task.toolName}
-                </span>
-                <span
-                  style={{
-                    color: isDark ? "#888" : "#999",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {isRunning
-                    ? `${t(
-                        "tool.control.bgQueue.running",
-                        "Running",
-                      )} ${formatDuration(task.startTime, null)}`
-                    : task.status === "cancelled"
-                    ? `${t(
-                        "tool.control.bgQueue.cancelled",
-                        "Cancelled",
-                      )} · ${t(
-                        "tool.control.bgQueue.totalDuration",
-                        "Total",
-                      )} ${formatDuration(task.startTime, task.endTime)}`
-                    : `${t(
-                        "tool.control.bgQueue.totalDuration",
-                        "Total",
-                      )} ${formatDuration(task.startTime, task.endTime)}`}
-                </span>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleClose(task);
-                  }}
-                  style={{
-                    border: `1px solid ${
-                      isRunning
-                        ? isDark
-                          ? "rgba(255,77,79,0.45)"
-                          : "rgba(255,77,79,0.35)"
-                        : borderColor
-                    }`,
-                    background: "transparent",
-                    cursor: "pointer",
-                    color: isRunning
-                      ? isDark
-                        ? "#ff7875"
-                        : "#cf1322"
-                      : isDark
-                      ? "#aaa"
-                      : "#666",
-                    fontSize: 11,
-                    padding: "1px 8px",
-                    borderRadius: 4,
-                    flexShrink: 0,
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {isRunning
-                    ? t("tool.control.bgQueue.cancel", "Cancel")
-                    : t("tool.control.bgQueue.remove", "Remove")}
-                </button>
+                {t("tool.control.bgQueue.emptyRunning", "No running tasks")}
               </div>
-              {isExpanded && (
-                <pre
-                  style={{
-                    margin: "4px 0 0",
-                    padding: 8,
-                    maxHeight: 160,
-                    overflow: "auto",
-                    fontSize: 11,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, Menlo, monospace",
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                    background: isDark ? "#141414" : "#fafafa",
-                    border: `1px solid ${borderColor}`,
-                    borderRadius: 6,
-                    color: isDark ? "#ccc" : "#333",
-                  }}
-                >
-                  {body || t("tool.control.bgQueue.noOutput", "No output yet")}
-                </pre>
-              )}
+            )}
+            {visibleTasks.map((task) => {
+              const body =
+                task.status === "running"
+                  ? task.liveOutput
+                  : task.result || task.liveOutput;
+              const isExpanded = expandedId === task.toolCallId;
+              const isRunning = task.status === "running";
+              const duration = formatDuration(task.startTime, task.endTime);
+              const statusText = isRunning
+                ? `${t("tool.control.bgQueue.running", "Running")} ${duration}`
+                : task.status === "cancelled"
+                ? `${t("tool.control.bgQueue.cancelled", "Cancelled")} · ${t(
+                    "tool.control.bgQueue.totalDuration",
+                    "Total",
+                  )} ${duration}`
+                : `${t(
+                    "tool.control.bgQueue.doneLabel",
+                    "Task completed",
+                  )} · ${t(
+                    "tool.control.bgQueue.totalDuration",
+                    "Total",
+                  )} ${duration}`;
+              return (
+                <div key={task.toolCallId}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() =>
+                      setExpandedId((id) =>
+                        id === task.toolCallId ? null : task.toolCallId,
+                      )
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setExpandedId((id) =>
+                          id === task.toolCallId ? null : task.toolCallId,
+                        );
+                      }
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "6px 8px",
+                      borderRadius: 6,
+                      background: isDark
+                        ? "rgba(255,255,255,0.04)"
+                        : "rgba(0,0,0,0.02)",
+                      cursor: "pointer",
+                      fontSize: 12,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: isRunning
+                          ? "#722ed1"
+                          : task.status === "cancelled"
+                          ? "#8c8c8c"
+                          : "#52c41a",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      style={{
+                        flex: 1,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        color: isDark ? "#ddd" : "#333",
+                      }}
+                      title={task.toolName}
+                    >
+                      {task.toolName}
+                    </span>
+                    <span
+                      style={{
+                        color: isDark ? "#888" : "#999",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {statusText}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleClose(task);
+                      }}
+                      style={{
+                        border: `1px solid ${
+                          isRunning
+                            ? isDark
+                              ? "rgba(255,77,79,0.45)"
+                              : "rgba(255,77,79,0.35)"
+                            : borderColor
+                        }`,
+                        background: "transparent",
+                        cursor: "pointer",
+                        color: isRunning
+                          ? isDark
+                            ? "#ff7875"
+                            : "#cf1322"
+                          : isDark
+                          ? "#aaa"
+                          : "#666",
+                        fontSize: 11,
+                        padding: "1px 8px",
+                        borderRadius: 4,
+                        flexShrink: 0,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {isRunning
+                        ? t("tool.control.bgQueue.cancel", "Cancel")
+                        : t("tool.control.bgQueue.remove", "Remove")}
+                    </button>
+                  </div>
+                  {isExpanded && (
+                    <pre
+                      style={{
+                        margin: "4px 0 0",
+                        padding: 8,
+                        maxHeight: 160,
+                        overflow: "auto",
+                        fontSize: 11,
+                        fontFamily:
+                          "ui-monospace, SFMono-Regular, Menlo, monospace",
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                        background: isDark ? "#141414" : "#fafafa",
+                        border: `1px solid ${borderColor}`,
+                        borderRadius: 6,
+                        color: isDark ? "#ccc" : "#333",
+                      }}
+                    >
+                      {body ||
+                        t("tool.control.bgQueue.noOutput", "No output yet")}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {listOverflow.canScrollDown && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 4,
+                fontSize: 11,
+                color: isDark ? "#888" : "#999",
+                padding: "0 8px 2px",
+              }}
+            >
+              <ChevronDown size={12} aria-hidden />
+              {t("tool.control.bgQueue.scrollMore", "Scroll to view more")}
             </div>
-          );
-        })}
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/console/src/pages/Chat/components/ChatSenderTabsPanel.tsx
+++ b/console/src/pages/Chat/components/ChatSenderTabsPanel.tsx
@@ -65,6 +65,7 @@ export default function ChatSenderTabsPanel({
     (s) => s.runStates[queueSessionId] ?? "idle",
   );
   const [batchBusy, setBatchBusy] = useState(false);
+  const [showFinished, setShowFinished] = useState(false);
 
   const sessionTasks = useMemo(
     () => selectTasksForSession(tasks, bgSessionId),
@@ -72,6 +73,13 @@ export default function ChatSenderTabsPanel({
   );
   const runningTasks = useMemo(
     () => sessionTasks.filter((task) => task.status === "running"),
+    [sessionTasks],
+  );
+  const finishedTasks = useMemo(
+    () =>
+      sessionTasks.filter(
+        (task) => task.status === "done" || task.status === "cancelled",
+      ),
     [sessionTasks],
   );
 
@@ -115,26 +123,16 @@ export default function ChatSenderTabsPanel({
     }
   }, [runningTasks, batchBusy, t]);
 
-  const handleClearAll = useCallback(async () => {
-    if (sessionTasks.length === 0 || batchBusy) return;
-    setBatchBusy(true);
-    try {
-      await Promise.allSettled(
-        runningTasks.map((task) =>
-          cancelBackgroundTask(task.sessionId, task.toolCallId),
-        ),
-      );
-      for (const task of sessionTasks) {
-        stopBackgroundTaskWatcher(task.toolCallId);
-      }
-      removeTasks(sessionTasks.map((task) => task.toolCallId));
-      message.info(
-        t("tool.control.bgQueue.clearAllDone", "Cleared background task list"),
-      );
-    } finally {
-      setBatchBusy(false);
+  const handleClearFinished = useCallback(() => {
+    if (finishedTasks.length === 0 || batchBusy) return;
+    for (const task of finishedTasks) {
+      stopBackgroundTaskWatcher(task.toolCallId);
     }
-  }, [sessionTasks, runningTasks, batchBusy, removeTasks, t]);
+    removeTasks(finishedTasks.map((task) => task.toolCallId));
+    message.info(
+      t("tool.control.bgQueue.clearAllDone", "Cleared completed tasks"),
+    );
+  }, [finishedTasks, batchBusy, removeTasks, t]);
 
   if (!hasBg && !hasQueue) return null;
 
@@ -237,6 +235,25 @@ export default function ChatSenderTabsPanel({
   const tabActions =
     activeTab === "bg" && hasBg ? (
       <div style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            fontSize: 11,
+            color: textColor,
+            cursor: "pointer",
+            userSelect: "none",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showFinished}
+            onChange={(e) => setShowFinished(e.target.checked)}
+          />
+          {t("tool.control.bgQueue.showFinished", "Show completed")}
+        </label>
         <button
           type="button"
           disabled={batchBusy || !hasRunningBg}
@@ -254,20 +271,20 @@ export default function ChatSenderTabsPanel({
         </button>
         <button
           type="button"
-          disabled={batchBusy || sessionTasks.length === 0}
-          onClick={() => void handleClearAll()}
+          disabled={batchBusy || finishedTasks.length === 0}
+          onClick={handleClearFinished}
           style={{
             ...chipBtnStyle,
-            opacity: batchBusy || sessionTasks.length === 0 ? 0.45 : 1,
+            opacity: batchBusy || finishedTasks.length === 0 ? 0.45 : 1,
             cursor:
-              batchBusy || sessionTasks.length === 0
+              batchBusy || finishedTasks.length === 0
                 ? "not-allowed"
                 : "pointer",
           }}
         >
           <SparkClearLine style={{ ...chipIconStyle, color: mutedColor }} />
           <span style={chipLabelStyle}>
-            {t("tool.control.bgQueue.clearAll", "Clear all")}
+            {t("tool.control.bgQueue.clearAll", "Clear completed")}
           </span>
         </button>
       </div>
@@ -376,7 +393,7 @@ export default function ChatSenderTabsPanel({
             renderTab(
               "bg",
               t("tool.control.bgQueue.title", "Background tasks"),
-              sessionTasks.length,
+              hasRunningBg ? runningTasks.length : finishedTasks.length,
               bgBadgeBg,
               bgBadgeColor,
             )}
@@ -397,7 +414,11 @@ export default function ChatSenderTabsPanel({
 
       <div style={{ padding: "8px 12px" }}>
         {activeTab === "bg" && hasBg && (
-          <BackgroundTaskPanel sessionId={bgSessionId} embedded />
+          <BackgroundTaskPanel
+            sessionId={bgSessionId}
+            embedded
+            showFinished={showFinished}
+          />
         )}
         {activeTab === "queue" && hasQueue && (
           <MessageQueuePanel

--- a/console/src/pages/Chat/components/ChatSenderTabsPanel.tsx
+++ b/console/src/pages/Chat/components/ChatSenderTabsPanel.tsx
@@ -181,10 +181,16 @@ export default function ChatSenderTabsPanel({
     alignItems: "center" as const,
   };
 
+  const bgBadgeCount = hasRunningBg
+    ? runningTasks.length
+    : showFinished && finishedTasks.length > 0
+    ? finishedTasks.length
+    : null;
+
   const renderTab = (
     key: TabKey,
     label: string,
-    count: number,
+    count: number | null,
     badgeBg: string,
     badgeColor: string,
   ) => {
@@ -216,18 +222,20 @@ export default function ChatSenderTabsPanel({
         }}
       >
         <span>{label}</span>
-        <span
-          style={{
-            fontSize: 11,
-            padding: "0 6px",
-            borderRadius: 10,
-            background: badgeBg,
-            color: badgeColor,
-            lineHeight: "16px",
-          }}
-        >
-          {count}
-        </span>
+        {count != null && (
+          <span
+            style={{
+              fontSize: 11,
+              padding: "0 6px",
+              borderRadius: 10,
+              background: badgeBg,
+              color: badgeColor,
+              lineHeight: "16px",
+            }}
+          >
+            {count}
+          </span>
+        )}
       </button>
     );
   };
@@ -393,7 +401,7 @@ export default function ChatSenderTabsPanel({
             renderTab(
               "bg",
               t("tool.control.bgQueue.title", "Background tasks"),
-              hasRunningBg ? runningTasks.length : finishedTasks.length,
+              bgBadgeCount,
               bgBadgeBg,
               bgBadgeColor,
             )}


### PR DESCRIPTION
## Description

Tighten the Console background-task panel so a long running list no longer pushes the chat input down, and make overflow obvious without a misleading leftover count.

- Cap the visible list at about 3 rows (`120px`, enough for the 2px selected border) and scroll the rest
- Hide completed tasks by default; add a "Show completed" toggle in the tab toolbar
- Replace "Clear all" with "Clear completed" (does not cancel running tasks)
- Remove per-task "already finished in background" hint banners; show completion and total duration on the row
- When the list overflows, fade the bottom edge and overlay "Scroll to view more" (no remaining-count, does not take layout height). The overlay hides at the bottom; the list height stays the same
- Expanded task output renders **below** the 3-row scroller (not inside it), so viewing output is not clipped
- When every task has finished and "Show completed" is off: do not show a finished-count badge on an empty list; show "N completed (hidden)" instead
- Selected row uses a light continuous purple border (not an outside outline)

**Related Issue:** N/A

**Security Considerations:** N/A (Console-only list/filter/scroll UX; no auth, env, or tool-execution changes)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run` locally on the staged files and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Start Console, offload several `execute_shell_command` tasks (4+ running).
2. Confirm the background-task tab shows about 3 rows, the bottom fades, and "Scroll to view more" is overlaid on the last visible row.
3. Scroll to the bottom: remaining rows are reachable; the overlay disappears and the panel height does **not** jump.
4. Click a row: output appears below the list (full 160px pane), not squeezed into the 3-row scroller. The selected row has a light purple border.
5. Leave "Show completed" unchecked: finished tasks are hidden. Check it to see them.
6. When all tasks finish and the toggle is still off: empty copy is "N completed (hidden)"; the tab badge is not a finished count on a blank list.
7. "Clear completed" removes only done/cancelled rows and does not cancel running tasks.
8. "Cancel all" still cancels running tasks.
9. With 1–3 running tasks, there is no scroll hint and no empty reserved row.