### PR TITLE
fix(agents): localize remote media URLs client-side before model requests

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -45,6 +45,7 @@ from agentscope.formatter import OpenAIResponseFormatter
 from .utils.message_request_normalizer import (
     normalize_messages_for_model_request,
 )
+from .remote_media_cache import localize_remote_url, remote_media_cache_enabled
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
@@ -1272,6 +1273,33 @@ def _fixup_media_list(items: list) -> None:
                         f" — file deleted from disk]"
                     ),
                 )
+            elif (
+                url.startswith(("http://", "https://"))
+                and remote_media_cache_enabled()
+            ):
+                # Remote media URLs are fetched client-side and swapped
+                # for a cached local path.  Some backends (e.g. vLLM)
+                # fetch URLs server-side and reject the *whole request*
+                # when the fetch fails (hotlink-protected hosts, 403,
+                # firewalled networks) — one dead URL would poison
+                # every subsequent turn of the session.
+                local_path, err = localize_remote_url(url)
+                if local_path:
+                    source["url"] = local_path
+                else:
+                    logger.warning(
+                        "Failed to localize remote media %s (%s), "
+                        "replacing with placeholder",
+                        url,
+                        err,
+                    )
+                    items[i] = TextBlock(
+                        type="text",
+                        text=(
+                            f"[{btype.title()} unavailable"
+                            f" — remote fetch failed: {err}]"
+                        ),
+                    )
         elif btype == "data":
             # 2.0 DataBlock — decode percent-encoded file:// URLs and
             # check if local file still exists.  Pydantic's AnyUrl
@@ -1298,6 +1326,33 @@ def _fixup_media_list(items: list) -> None:
                     )
                 elif source is not None:
                     source.url = local_path
+            elif (
+                url_str.startswith(("http://", "https://"))
+                and remote_media_cache_enabled()
+            ):
+                # Same rationale as the dict-block branch above: fetch
+                # remote media client-side so the backend never has to.
+                remote_local_path, remote_err = localize_remote_url(
+                    url_str
+                )
+                if remote_local_path:
+                    source.url = remote_local_path
+                else:
+                    mt = getattr(source, "media_type", "") or ""
+                    media_name = mt.split("/")[0] or "media"
+                    logger.warning(
+                        "Failed to localize remote media %s (%s), "
+                        "replacing with placeholder",
+                        url_str,
+                        remote_err,
+                    )
+                    items[i] = TextBlock(
+                        type="text",
+                        text=(
+                            f"[{media_name.title()} unavailable"
+                            f" — remote fetch failed: {remote_err}]"
+                        ),
+                    )
         elif btype == "file":
             if isinstance(block, dict):
                 source = block.get("source") or {}

--- a/src/qwenpaw/agents/remote_media_cache.py
+++ b/src/qwenpaw/agents/remote_media_cache.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""Client-side localization of remote media URLs.
+
+When a conversation history contains media blocks referencing remote
+HTTP(S) URLs (e.g. images returned by web tools), the URL is forwarded
+to the model backend verbatim.  Backends then fetch the URL
+*server-side*, which fails for hotlink-protected hosts (HTTP 403) or
+unreachable networks.  Worse, several backends (e.g. vLLM) reject the
+whole request when any media URL cannot be fetched — a single dead URL
+poisons every subsequent turn of the session.
+
+This module downloads such URLs *client-side* (with per-host ``Referer``
+fix-ups for known hotlink-protected sites), caches them on disk, and
+returns a local file path that can be embedded safely.  Failures degrade
+gracefully: a negative-cache entry prevents repeated attempts within
+``NEGATIVE_CACHE_TTL`` and the caller replaces the media block with a
+text placeholder instead of poisoning the request.
+"""
+
+import hashlib
+import json
+import logging
+import mimetypes
+import os
+import tempfile
+import time
+from typing import Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+# Seconds a failed download stays cached before we retry it.
+NEGATIVE_CACHE_TTL = 24 * 60 * 60
+
+# Maximum media size pulled into the cache (bytes).
+MAX_MEDIA_BYTES = 30 * 1024 * 1024
+
+# Download timeout (seconds).
+FETCH_TIMEOUT = 10
+
+# Environment variable that disables client-side localization entirely
+# (remote URLs are then passed through untouched, legacy behavior).
+KILL_SWITCH_ENV = "QWENPAW_DISABLE_REMOTE_MEDIA_CACHE"
+
+# Environment variable overriding the on-disk cache location.
+CACHE_DIR_ENV = "QWENPAW_REMOTE_MEDIA_CACHE_DIR"
+
+# Known hotlink-protected hosts mapped to the ``Referer`` their CDN
+# expects.  Matched against the URL netloc (exact, or any subdomain).
+_HOTLINK_REFERER_MAP = {
+    "i.pximg.net": "https://app.pixiv.net/",
+}
+
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+
+class MediaFetchError(Exception):
+    """Raised when a remote media URL cannot be downloaded."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def remote_media_cache_enabled() -> bool:
+    """Return True unless the kill-switch env var is set."""
+    return os.environ.get(KILL_SWITCH_ENV, "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def remote_media_cache_dir() -> str:
+    """Return the cache directory, creating it if necessary."""
+    cache_dir = os.environ.get(CACHE_DIR_ENV) or os.path.join(
+        os.path.expanduser("~"),
+        ".qwenpaw",
+        "media_cache",
+    )
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def _hotlink_referer(url: str) -> Optional[str]:
+    """Return the expected ``Referer`` for hotlink-protected hosts."""
+    netloc = urlparse(url).netloc.lower()
+    for host, referer in _HOTLINK_REFERER_MAP.items():
+        if netloc == host or netloc.endswith("." + host):
+            return referer
+    return None
+
+
+def _download(url: str) -> Tuple[bytes, str]:
+    """Fetch ``url`` and return ``(payload, content_type)``.
+
+    Raises :class:`MediaFetchError` with a human-readable reason on
+    failure.  Split out from :func:`localize_remote_url` so tests can
+    monkeypatch it and stay offline.
+    """
+    request = Request(url, headers={"User-Agent": _USER_AGENT})
+    referer = _hotlink_referer(url)
+    if referer:
+        request.add_header("Referer", referer)
+    try:
+        with urlopen(request, timeout=FETCH_TIMEOUT) as response:
+            content_type = response.headers.get("Content-Type", "")
+            payload = response.read(MAX_MEDIA_BYTES + 1)
+    except HTTPError as exc:
+        raise MediaFetchError(f"HTTP {exc.code}") from exc
+    except (URLError, OSError) as exc:
+        reason = getattr(exc, "reason", None) or exc
+        raise MediaFetchError(str(reason)) from exc
+    if len(payload) > MAX_MEDIA_BYTES:
+        raise MediaFetchError(f"payload exceeds {MAX_MEDIA_BYTES} bytes")
+    return payload, content_type
+
+
+def _cache_key(url: str) -> str:
+    """Return a stable cache filename for ``url``.
+
+    SHA-1 is sufficient here: the key only maps URLs to cache entries,
+    it is not used for any cryptographic purpose.
+    """
+    return hashlib.sha1(url.encode("utf-8")).hexdigest()
+
+
+def _positive_cache_path(cache_dir: str, key: str) -> Optional[str]:
+    """Return the cached media file for ``key`` if one exists."""
+    prefix = key + "."
+    try:
+        for name in os.listdir(cache_dir):
+            if (
+                name.startswith(prefix)
+                and not name.endswith(".failed.json")
+                and not name.endswith(".part")
+            ):
+                return os.path.join(cache_dir, name)
+    except OSError:
+        return None
+    return None
+
+
+def _write_negative_entry(
+    cache_dir: str,
+    key: str,
+    url: str,
+    reason: str,
+) -> None:
+    try:
+        with open(
+            os.path.join(cache_dir, key + ".failed.json"),
+            "w",
+            encoding="utf-8",
+        ) as fh:
+            json.dump({"url": url, "reason": reason}, fh)
+    except OSError:
+        logger.debug("Could not write negative cache entry", exc_info=True)
+
+
+def _negative_cache_reason(
+    cache_dir: str,
+    key: str,
+) -> Optional[str]:
+    """Return the cached failure reason if still fresh, else None."""
+    path = os.path.join(cache_dir, key + ".failed.json")
+    try:
+        if time.time() - os.path.getmtime(path) > NEGATIVE_CACHE_TTL:
+            return None
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh).get("reason")
+    except (OSError, ValueError):
+        return None
+
+
+def localize_remote_url(url: str) -> Tuple[Optional[str], Optional[str]]:
+    """Download ``url`` into the cache and return a local path.
+
+    Returns ``(local_path, None)`` on success or ``(None, reason)`` on
+    failure (network error, non-media content type, unwritable cache).
+    Failures are negative-cached for :data:`NEGATIVE_CACHE_TTL` so a
+    dead URL is not retried on every request.
+    """
+    key = _cache_key(url)
+    try:
+        cache_dir = remote_media_cache_dir()
+    except OSError as exc:
+        return None, f"cache dir unavailable: {exc}"
+
+    cached_reason = _negative_cache_reason(cache_dir, key)
+    if cached_reason:
+        return None, cached_reason
+
+    cached_path = _positive_cache_path(cache_dir, key)
+    if cached_path:
+        return cached_path, None
+
+    try:
+        payload, content_type = _download(url)
+    except MediaFetchError as exc:
+        _write_negative_entry(cache_dir, key, url, exc.reason)
+        return None, exc.reason
+
+    media_type = content_type.split(";")[0].strip().lower()
+    if not media_type.startswith(("image/", "audio/", "video/")):
+        reason = f"non-media content type: {media_type or 'unknown'}"
+        _write_negative_entry(cache_dir, key, url, reason)
+        return None, reason
+
+    ext = mimetypes.guess_extension(media_type) or ".bin"
+    dest = os.path.join(cache_dir, key + ext)
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=cache_dir, suffix=".part")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+        os.replace(tmp_path, dest)
+    except OSError as exc:
+        return None, f"cache write failed: {exc}"
+
+    logger.debug("Localized remote media %s -> %s", url, dest)
+    return dest, None

--- a/tests/unit/agents/test_remote_media_cache.py
+++ b/tests/unit/agents/test_remote_media_cache.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Tests for client-side localization of remote media URLs."""
+
+# pylint: disable=protected-access,redefined-outer-name
+import os
+
+import pytest
+from agentscope.message import DataBlock, URLSource
+
+from qwenpaw.agents import model_factory, remote_media_cache
+from qwenpaw.agents.remote_media_cache import MediaFetchError
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+REMOTE_URL = "https://i.pximg.net/img-original/a.png"
+
+
+@pytest.fixture(autouse=True)
+def _cache_dir(tmp_path, monkeypatch):
+    """Isolate the on-disk cache and clear the kill switch."""
+    cache_dir = str(tmp_path / "media_cache")
+    monkeypatch.setenv(remote_media_cache.CACHE_DIR_ENV, cache_dir)
+    monkeypatch.delenv(remote_media_cache.KILL_SWITCH_ENV, raising=False)
+    return cache_dir
+
+
+def _remote_dict_block() -> dict:
+    return {
+        "type": "image",
+        "source": {"type": "url", "url": REMOTE_URL},
+    }
+
+
+def _remote_data_block() -> DataBlock:
+    return DataBlock(
+        source=URLSource(url=REMOTE_URL, media_type="image/png"),
+    )
+
+
+def test_localize_success_caches_on_disk(monkeypatch):
+    calls = []
+
+    def fake_download(url):
+        calls.append(url)
+        return PNG_BYTES, "image/png"
+
+    monkeypatch.setattr(remote_media_cache, "_download", fake_download)
+
+    path1, err1 = remote_media_cache.localize_remote_url(REMOTE_URL)
+    path2, err2 = remote_media_cache.localize_remote_url(REMOTE_URL)
+
+    assert err1 is None and err2 is None
+    assert path1 == path2
+    assert os.path.isfile(path1)
+    assert len(calls) == 1  # second call served from disk cache
+
+
+def test_localize_failure_negative_cached(monkeypatch):
+    calls = []
+
+    def fake_download(url):
+        calls.append(url)
+        raise MediaFetchError("HTTP 403")
+
+    monkeypatch.setattr(remote_media_cache, "_download", fake_download)
+
+    path1, reason1 = remote_media_cache.localize_remote_url(REMOTE_URL)
+    path2, reason2 = remote_media_cache.localize_remote_url(REMOTE_URL)
+
+    assert path1 is None and path2 is None
+    assert reason1 == "HTTP 403" and reason2 == "HTTP 403"
+    assert len(calls) == 1  # second call served from negative cache
+
+
+def test_non_media_content_type_rejected(monkeypatch):
+    monkeypatch.setattr(
+        remote_media_cache,
+        "_download",
+        lambda url: (b"<html>404</html>", "text/html"),
+    )
+
+    path, reason = remote_media_cache.localize_remote_url(REMOTE_URL)
+
+    assert path is None
+    assert "non-media" in reason
+
+
+def test_fixup_dict_block_localizes_remote_url(monkeypatch):
+    monkeypatch.setattr(
+        remote_media_cache,
+        "_download",
+        lambda url: (PNG_BYTES, "image/png"),
+    )
+    items = [_remote_dict_block()]
+
+    model_factory._fixup_media_list(items)
+
+    url = items[0]["source"]["url"]
+    assert url != REMOTE_URL
+    assert os.path.isfile(url)
+
+
+def test_fixup_dict_block_degrades_on_failure(monkeypatch):
+    def fake_download(url):
+        raise MediaFetchError("HTTP 403")
+
+    monkeypatch.setattr(remote_media_cache, "_download", fake_download)
+    items = [_remote_dict_block()]
+
+    model_factory._fixup_media_list(items)
+
+    # Degraded dict blocks are replaced by TextBlock objects.
+    assert items[0].type == "text"
+    assert "remote fetch failed: HTTP 403" in items[0].text
+
+
+def test_fixup_data_block_localizes_remote_url(monkeypatch):
+    monkeypatch.setattr(
+        remote_media_cache,
+        "_download",
+        lambda url: (PNG_BYTES, "image/png"),
+    )
+    items = [_remote_data_block()]
+
+    model_factory._fixup_media_list(items)
+
+    url = str(items[0].source.url)
+    assert url != REMOTE_URL
+    assert os.path.isfile(url)
+
+
+def test_fixup_data_block_degrades_on_failure(monkeypatch):
+    def fake_download(url):
+        raise MediaFetchError("HTTP 422")
+
+    monkeypatch.setattr(remote_media_cache, "_download", fake_download)
+    items = [_remote_data_block()]
+
+    model_factory._fixup_media_list(items)
+
+    assert items[0].type == "text"
+    assert "remote fetch failed: HTTP 422" in items[0].text
+
+
+def test_kill_switch_passes_remote_urls_through(
+    monkeypatch,
+    _cache_dir,
+):
+    monkeypatch.setenv(remote_media_cache.KILL_SWITCH_ENV, "1")
+    monkeypatch.setattr(
+        remote_media_cache,
+        "_download",
+        lambda url: pytest.fail("download must not run when disabled"),
+    )
+    dict_items = [_remote_dict_block()]
+    data_items = [_remote_data_block()]
+
+    model_factory._fixup_media_list(dict_items)
+    model_factory._fixup_media_list(data_items)
+
+    assert dict_items[0]["source"]["url"] == REMOTE_URL
+    assert str(data_items[0].source.url) == REMOTE_URL


### PR DESCRIPTION
## Problem

When a conversation history contains media blocks referencing remote HTTP(S) URLs (e.g. images returned by web tools), the URL is forwarded to the model backend verbatim. Backends then fetch the URL **server-side**, which fails for hotlink-protected hosts (HTTP 403) or networks the backend cannot reach. Several backends (e.g. vLLM) reject the **whole request** when any media URL cannot be fetched — and since the URL stays in the conversation history, a single dead URL poisons **every subsequent turn** of the session, even for prompts that never touch that image.

Repro sketch (vLLM backend):

1. A tool returns an image URL from a hotlink-protected host (e.g. `i.pximg.net`).
2. The URL lands in message history as a dict `image` block (1.x) or `DataBlock` (2.0).
3. Every following model request fails with HTTP 422 (`Image download failed`) until the session is reset.

## Solution

Localize remote media **client-side** in `_fixup_media_list`:

- Download the URL (10s timeout, 30 MB cap) with per-host `Referer` fix-ups for known hotlink-protected sites; cache under `~/.qwenpaw/media_cache`, keyed by URL hash.
- Rewrite the media block to the cached local path; backends embed it as usual.
- On failure, degrade the block to a text placeholder (consistent with the existing "file deleted from disk" path) and negative-cache the URL for 24 h so dead URLs are not retried on every request.
- Covers both the dict-block (1.x) and `DataBlock` (2.0) paths.

## Configuration

- `QWENPAW_DISABLE_REMOTE_MEDIA_CACHE=1` restores the legacy pass-through behavior.
- `QWENPAW_REMOTE_MEDIA_CACHE_DIR` overrides the cache location.

## Testing

- New offline unit tests in `tests/unit/agents/test_remote_media_cache.py` (8 tests): positive disk-cache hit, negative cache, non-media content-type rejection, dict/DataBlock rewrite + graceful degradation, kill-switch pass-through. Downloads are monkeypatched, so no network access is needed in CI.
- Existing `test_model_factory_message_normalization.py` shows no regression; the 13 failures I see on that file in my local env are pre-existing on `main` (older local agentscope build; verified byte-identical failure lists with and without this patch).
