### PR TITLE
ci(datapaw): add a standalone version-driven release pipeline

### DIFF
--- a/.github/workflows/datapaw-release.yml
+++ b/.github/workflows/datapaw-release.yml
@@ -1,0 +1,341 @@
+# Standalone release pipeline for the QwenPaw-Data (datapaw) plugin.
+#
+# Unlike plugins-release.yml (which publishes ALL plugins on every main
+# QwenPaw GitHub Release), this workflow is driven by the datapaw plugin's
+# own version: it fires when plugins/apps/datapaw/plugin.json changes, and
+# only uploads to OSS when that version is not yet on the CDN. Can also be
+# run manually via the Actions tab (with an optional force flag).
+#
+# The datapaw frontend embeds the datapaw-context console as vendored
+# static assets. They are not committed to this repo, so the upload job
+# checks out the public QwenPaw-Data repository at a pinned ref and runs
+# the plugin's sync-context-ui.sh before building ui/dist. The packer's
+# pack_requires validation (declared in plugin.json) fails the run if any
+# required artifact is missing.
+
+name: QwenPaw Data Plugin Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "plugins/apps/datapaw/plugin.json"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Re-upload even if this version already exists on OSS"
+        required: false
+        type: boolean
+        default: false
+      data_ref:
+        description: "QwenPaw-Data ref to vendor the context console from"
+        required: false
+        type: string
+
+# Least-privilege token: this workflow only reads the repo; all uploads
+# go through ossutil with OSS secrets.
+permissions:
+  contents: read
+
+concurrency:
+  # Shared with plugins-release.yml so index merges never run concurrently.
+  group: plugins-release
+  cancel-in-progress: false
+
+env:
+  PLUGIN_DIR: plugins/apps/datapaw
+  PLUGIN_ID: datapaw
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read datapaw plugin version
+        id: version
+        run: |
+          version=$(jq -r '.version' "${PLUGIN_DIR}/plugin.json")
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "ERROR: no version in ${PLUGIN_DIR}/plugin.json" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "datapaw plugin version: $version"
+
+      - name: Install ossutil
+        run: |
+          wget -q https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip
+          unzip -q ossutil-v1.7.18-linux-amd64.zip
+          chmod +x ossutil-v1.7.18-linux-amd64/ossutil64
+          sudo mv ossutil-v1.7.18-linux-amd64/ossutil64 /usr/local/bin/ossutil
+          ossutil --version
+
+      - name: Configure ossutil
+        run: |
+          ossutil config -e ${{ secrets.OSS_ENDPOINT }} \
+            -i ${{ secrets.OSS_ACCESS_KEY_ID }} \
+            -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
+            -L CH
+
+      - name: Decide whether to publish
+        id: decide
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          FORCE: ${{ github.event.inputs.force }}
+        run: |
+          # Publish only when this exact version is missing from the plugins
+          # index (or when forced via workflow_dispatch). Keeps re-runs and
+          # non-version edits to plugin.json idempotent.
+          #
+          # Read the authoritative index straight from OSS, matching
+          # creator-release.yml / plugins-release.yml. The public CDN is NOT
+          # trustworthy here: overseas edges were observed serving gzip
+          # bodies without content negotiation and intermittent 403s on
+          # origin pulls.
+          #
+          # Fail closed: only a confirmed NoSuchKey/404 counts as "no index
+          # yet". Auth, network or JSON failures abort the run instead of
+          # being misread as a green light to overwrite published objects.
+          file_id="${PLUGIN_ID}-${VERSION}"
+          if [[ "$FORCE" == "true" ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Force publish requested for ${file_id}."
+            exit 0
+          fi
+          if stat_out=$(ossutil stat \
+            "oss://qwenpaw-download/metadata/plugins/index.json" 2>&1); then
+            ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
+              plugins-index.json
+            published=$(jq -r --arg id "$file_id" '.files | has($id)' \
+              plugins-index.json) || {
+              echo "ERROR: OSS plugins index is not valid JSON." >&2
+              exit 1
+            }
+          elif grep -qiE 'NoSuchKey|StatusCode=404' <<< "$stat_out"; then
+            published="false"
+          else
+            echo "ERROR: could not stat the plugins index on OSS:" >&2
+            echo "$stat_out" >&2
+            exit 1
+          fi
+          if [[ "$published" == "true" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "${file_id} already on CDN; skipping upload."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "${file_id} not on CDN yet; will publish."
+          fi
+
+  upload-oss:
+    runs-on: ubuntu-latest
+    needs: check-version
+    if: needs.check-version.outputs.should_publish == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout QwenPaw-Data (context console sources)
+        uses: actions/checkout@v4
+        with:
+          repository: agentscope-ai/QwenPaw-Data
+          # Pinned for reproducible vendoring; bump together with the
+          # plugin version, or override per-run via the data_ref input.
+          ref: ${{ github.event.inputs.data_ref || 'v0.2.0' }}
+          path: qwenpaw-data
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: plugins/apps/datapaw/ui/package-lock.json
+
+      - name: Vendor the context console
+        run: |
+          # Builds the datapaw-context frontend from the QwenPaw-Data
+          # checkout, patches it for static hash routing, injects the auth
+          # bridge, and lands the output in ui/public/context-console.
+          DATAPAW_SOURCE_DIR="${GITHUB_WORKSPACE}/qwenpaw-data" \
+            "${PLUGIN_DIR}/scripts/sync-context-ui.sh"
+
+      - name: Build datapaw plugin frontend
+        run: |
+          npm --prefix "${PLUGIN_DIR}/ui" ci
+          npm --prefix "${PLUGIN_DIR}/ui" run build
+
+      - name: Pack datapaw plugin and build index
+        run: |
+          # pack_requires in plugin.json makes this step fail loudly when
+          # ui/dist or the vendored console assets are missing.
+          python scripts/pack/generate_plugin_metadata.py \
+            --plugins-root plugins \
+            --dist dist/plugins \
+            --metadata-out dist/plugins/index.json \
+            --cdn-prefix /files/plugins \
+            --only "${PLUGIN_ID}"
+
+      - name: Verify packaged zip is runtime-only
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          # Fail closed before OSS upload: entry files must be present and
+          # pack_exclude'd dev-only trees must not leak into the zip.
+          zip_path="dist/plugins/apps/${PLUGIN_ID}/${PLUGIN_ID}-${VERSION}.zip"
+          if [[ ! -f "$zip_path" ]]; then
+            echo "ERROR: expected zip not found: $zip_path" >&2
+            exit 1
+          fi
+          names=$(unzip -Z1 "$zip_path")
+          for required in \
+            "${PLUGIN_ID}/plugin.json" \
+            "${PLUGIN_ID}/backend/main.py" \
+            "${PLUGIN_ID}/ui/dist/index.js" \
+            "${PLUGIN_ID}/ui/dist/context-console/index.html" \
+            "${PLUGIN_ID}/ui/dist/app/logo-mark-v4.png"; do
+            if ! grep -qxF "$required" <<< "$names"; then
+              echo "ERROR: required file missing from zip: $required" >&2
+              exit 1
+            fi
+          done
+          if forbidden=$(grep -E \
+            "^${PLUGIN_ID}/(ui/(src|public|node_modules)/|\.venv-datapaw/|\.datapaw-dev/)" \
+            <<< "$names"); then
+            echo "ERROR: dev-only files leaked into the zip:" >&2
+            echo "$forbidden" | head -20 >&2
+            exit 1
+          fi
+          echo "Zip verified: $(wc -l <<< "$names") files, runtime-only."
+
+      - name: Install ossutil
+        run: |
+          wget -q https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip
+          unzip -q ossutil-v1.7.18-linux-amd64.zip
+          chmod +x ossutil-v1.7.18-linux-amd64/ossutil64
+          sudo mv ossutil-v1.7.18-linux-amd64/ossutil64 /usr/local/bin/ossutil
+          ossutil --version
+
+      - name: Configure ossutil
+        run: |
+          ossutil config -e ${{ secrets.OSS_ENDPOINT }} \
+            -i ${{ secrets.OSS_ACCESS_KEY_ID }} \
+            -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
+            -L CH
+
+      - name: Sync datapaw plugin zip to OSS (long-cache, immutable)
+        env:
+          FORCE: ${{ github.event.inputs.force }}
+        run: |
+          shopt -s nullglob
+          while IFS= read -r -d '' f; do
+            rel="${f#dist/plugins/}"
+            # Versioned zips are advertised as immutable; never overwrite
+            # an existing object except on an explicit manual force run.
+            # A stat failure other than NoSuchKey aborts instead of
+            # risking an overwrite.
+            if [[ "$FORCE" != "true" ]]; then
+              if stat_out=$(ossutil stat \
+                "oss://qwenpaw-download/files/plugins/${rel}" 2>&1); then
+                echo "Skipping ${rel}: already published and immutable."
+                continue
+              elif ! grep -qiE 'NoSuchKey|StatusCode=404' <<< "$stat_out"; then
+                echo "ERROR: could not stat files/plugins/${rel} on OSS:" >&2
+                echo "$stat_out" >&2
+                exit 1
+              fi
+            fi
+            echo "Uploading $f -> files/plugins/${rel}"
+            ossutil cp "$f" \
+              "oss://qwenpaw-download/files/plugins/${rel}" \
+              --acl public-read \
+              --force \
+              --meta "Cache-Control:public, max-age=31536000, immutable"
+          done < <(find "dist/plugins/apps/${PLUGIN_ID}" -type f -name '*.zip' -print0 2>/dev/null || true)
+
+      - name: Merge historical versions into index
+        run: |
+          # Fail closed: a fetch error must never masquerade as "no index
+          # yet" and shrink the authoritative file list to this plugin.
+          # Only a confirmed NoSuchKey/404 may bootstrap an empty index.
+          if stat_out=$(ossutil stat \
+            "oss://qwenpaw-download/metadata/plugins/index.json" 2>&1); then
+            ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
+              existing-index.json
+            python3 -c 'import json; json.load(open("existing-index.json"))' || {
+              echo "ERROR: existing plugins index is not valid JSON." >&2
+              exit 1
+            }
+          elif grep -qiE 'NoSuchKey|StatusCode=404' <<< "$stat_out"; then
+            echo "No plugins index on OSS yet; bootstrapping an empty one."
+            echo '{}' > existing-index.json
+          else
+            echo "ERROR: could not stat the plugins index on OSS:" >&2
+            echo "$stat_out" >&2
+            exit 1
+          fi
+
+          python3 scripts/pack/merge_plugin_index.py \
+            --new dist/plugins/index.json \
+            --old existing-index.json \
+            --out dist/plugins/index.json
+
+      - name: Upload plugins index (short-cache)
+        run: |
+          ossutil cp dist/plugins/index.json \
+            "oss://qwenpaw-download/metadata/plugins/index.json" \
+            --acl public-read \
+            --force \
+            --meta "Cache-Control:public, max-age=60, must-revalidate"
+
+      - name: Patch main metadata index to advertise plugins product
+        run: |
+          # Same fail-closed rule for the top-level product index: only a
+          # confirmed NoSuchKey/404 may bootstrap a fresh skeleton.
+          if stat_out=$(ossutil stat \
+            "oss://qwenpaw-download/metadata/index.json" 2>&1); then
+            ossutil cp "oss://qwenpaw-download/metadata/index.json" \
+              main-index.json
+            python3 -c 'import json; json.load(open("main-index.json"))' || {
+              echo "ERROR: existing main index is not valid JSON." >&2
+              exit 1
+            }
+          elif grep -qiE 'NoSuchKey|StatusCode=404' <<< "$stat_out"; then
+            echo "No main index on OSS yet; bootstrapping a skeleton."
+            cat > main-index.json << 'EOF'
+          {
+            "version": "1.0",
+            "updated_at": "",
+            "products": {}
+          }
+          EOF
+          else
+            echo "ERROR: could not stat the main index on OSS:" >&2
+            echo "$stat_out" >&2
+            exit 1
+          fi
+
+          python3 scripts/pack/patch_main_index.py \
+            --index main-index.json \
+            --out   main-index.json
+
+          ossutil cp main-index.json \
+            "oss://qwenpaw-download/metadata/index.json" \
+            --acl public-read \
+            --force \
+            --meta "Cache-Control:public, max-age=60, must-revalidate"
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          echo "datapaw plugin ${VERSION} published. Index:"
+          cat dist/plugins/index.json | python3 -m json.tool | head -40 || true

--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -53,6 +53,10 @@ jobs:
               echo "Skipping ${app_dir} (released via creator-release.yml)"
               continue
             fi
+            if [[ "$(basename "$app_dir")" == "datapaw" ]]; then
+              echo "Skipping ${app_dir} (released via datapaw-release.yml)"
+              continue
+            fi
             if [[ -f "$app_dir/ui/package-lock.json" ]]; then
               echo "Building ${app_dir}/ui"
               npm --prefix "$app_dir/ui" ci
@@ -61,13 +65,12 @@ jobs:
           done
 
       - name: Pack plugins and build index
-        # datapaw is excluded until its vendored context console
-        # (ui/public/context-console, produced by
-        # plugins/apps/datapaw/scripts/sync-context-ui.sh from a
-        # QwenPaw-Data checkout) can be staged in CI. Its plugin.json
-        # declares pack_requires, so removing the exclude without staging
-        # the assets fails this step loudly instead of shipping a broken
-        # artifact.
+        # qwenpaw-creator and datapaw are released through their own
+        # version-driven pipelines (creator-release.yml,
+        # datapaw-release.yml); datapaw additionally needs the vendored
+        # context console staged before packing. Their plugin.json
+        # pack_requires declarations make an accidental un-exclude fail
+        # this step loudly instead of shipping a broken artifact.
         run: |
           python scripts/pack/generate_plugin_metadata.py \
             --plugins-root plugins \

--- a/plugins/apps/datapaw/plugin.json
+++ b/plugins/apps/datapaw/plugin.json
@@ -22,7 +22,12 @@
   "pack_exclude": [
     ".venv-datapaw",
     ".datapaw-dev",
-    "ui/public/context-console"
+    "ui/public",
+    "ui/src",
+    "ui/package.json",
+    "ui/package-lock.json",
+    "ui/tsconfig.json",
+    "ui/vite.config.ts"
   ],
   "dependencies": [],
   "qwenpaw_version": {


### PR DESCRIPTION
## Description

Give the datapaw plugin its own version-driven release pipeline, mirroring the
established `creator-release.yml` pattern, so it publishes to the official
plugin CDN independently of the main QwenPaw release cadence.

PR #6940 shipped the datapaw app but left it excluded from
`plugins-release.yml`: its frontend embeds the datapaw-context console as
vendored static assets that are not committed to this repo, so the shared
pipeline could never produce a complete artifact. This PR closes that gap.

**What's included:**

- **`datapaw-release.yml`** (new): fires when `plugins/apps/datapaw/plugin.json`
  changes on main (or via manual dispatch with `force`). Two-job structure
  copied from `creator-release.yml`:
  - `check-version` consults the authoritative OSS plugins index fail-closed
    (only a confirmed NoSuchKey/404 counts as "not published"), making re-runs
    and non-version manifest edits idempotent.
  - `upload-oss` checks out the public `agentscope-ai/QwenPaw-Data` repo at a
    pinned ref (`v0.2.0`, overridable per-run via the `data_ref` input), runs
    the plugin's `sync-context-ui.sh` to vendor the context console, builds
    `ui/dist`, packs with `--only datapaw`, verifies the zip is runtime-only,
    then uploads the immutable versioned zip and the history-preserving merged
    index. Shares the `plugins-release` concurrency group so index merges
    never race.
- **`plugins-release.yml`**: skips datapaw's UI build the same way it skips
  the creator's, with the pack-step comment updated to point at the dedicated
  pipeline. The `pack_requires` declaration keeps an accidental un-exclude
  failing loudly instead of shipping a broken artifact.
- **`plugin.json`**: `pack_exclude` tightened to runtime-only (drops `ui/src`,
  `ui/public`, and frontend build configs from the zip; `scripts/` stays
  because the `RUNTIME_MISSING` remediation references `setup-dev.sh`).

**Related Issue:** Follow-up to #6940 (resolves the "datapaw excluded from
release" gap called out in its review).

**Security Considerations:** Least-privilege workflow token
(`contents: read`); all uploads go through ossutil with existing OSS secrets;
versioned zips are immutable (never overwritten without an explicit manual
force); the QwenPaw-Data checkout is pinned to a tag for reproducible
vendoring.

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Local rehearsal of the exact `upload-oss` job body (minus the OSS upload,
which needs repo secrets):

1. `DATAPAW_SOURCE_DIR=~/dev/QwenPaw-Data plugins/apps/datapaw/scripts/sync-context-ui.sh`
   (QwenPaw-Data at `v0.2.0` / `4cd2abf`, same ref the workflow pins)
2. `npm --prefix plugins/apps/datapaw/ui ci && npm --prefix plugins/apps/datapaw/ui run build`
3. `python3 scripts/pack/generate_plugin_metadata.py --only datapaw ...`
4. The workflow's zip-verification script, verbatim

After merge, nothing publishes until the next `plugin.json` version bump (a
manual `workflow_dispatch` can exercise it earlier). Post-publish
verification:

```bash
curl -s https://download.qwenpaw.agentscope.io/metadata/plugins/index.json \
  | jq '.files["datapaw-<version>"]'
# download the zip and compare sha256 with the index entry
# re-run the workflow: check-version must print "already on CDN; skipping upload"
```

## Evidence

```
$ pre-commit run --files .github/workflows/datapaw-release.yml \
    .github/workflows/plugins-release.yml plugins/apps/datapaw/plugin.json
check yaml...............................................................Passed
check json...............................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Lint GitHub Actions workflow files.......................................Passed

$ pytest tests/unit/pack tests/unit/pawapp -q
71 passed, 1 warning in 0.91s

Local release rehearsal:
  vendor context-console (QwenPaw-Data v0.2.0/4cd2abf) OK
  ui/dist built (318 kB) OK
  datapaw-0.2.0.zip packed: 1.9 MB, 63 files OK
  Zip verified: 5/5 required files present, 0 dev files leaked OK
  index entry: url=/files/plugins/apps/datapaw/datapaw-0.2.0.zip + sha256 OK
```

## Additional Notes

- The workflow only becomes functional on `agentscope-ai/QwenPaw` main where
  the OSS secrets live; it is inert on forks.
- `DATA_REF` is pinned to `v0.2.0` and should be bumped together with the
  plugin version when the vendored console needs newer QwenPaw-Data sources.
