### PR TITLE
fix(workspace): preserve CRLF line endings on Windows

### DIFF
--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -989,7 +989,7 @@ async def write_code_file(
 
     def _write() -> int:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
+        target.write_bytes(content.encode("utf-8"))
         return target.stat().st_size
 
     try:

--- a/src/qwenpaw/services/workspace_files.py
+++ b/src/qwenpaw/services/workspace_files.py
@@ -371,7 +371,7 @@ def save_text_file(
         token = secrets.token_hex(8)
         temporary = target.with_name(f".{target.name}.{token}.qwenpaw.tmp")
         try:
-            temporary.write_text(content, encoding="utf-8")
+            temporary.write_bytes(content.encode("utf-8"))
             os.replace(temporary, target)
         except BaseException:
             temporary.unlink(missing_ok=True)

--- a/tests/unit/app/routers/test_workspace_files_router.py
+++ b/tests/unit/app/routers/test_workspace_files_router.py
@@ -45,6 +45,11 @@ def fixture_files_client(
         "get_project_dir_for_request",
         get_project_dir,
     )
+    monkeypatch.setattr(
+        workspace_router,
+        "get_agent_project_dir",
+        lambda _workspace: project_dir,
+    )
     app = FastAPI()
     app.state.project_dir = project_dir
     app.state.workspace_dir = workspace_dir
@@ -133,6 +138,53 @@ def test_save_if_match_rejects_an_externally_deleted_file(
 
     assert response.status_code == 409
     assert not target.exists()
+
+
+def test_save_preserves_crlf_bytes_across_repeated_writes(
+    files_client: TestClient,
+) -> None:
+    """Repeated workspace saves must not expand CRLF into CRCRLF."""
+    target = files_client.app.state.project_dir / "source.ts"
+    content = "const first = 1;\r\nconst second = 2;\r\n"
+    expected = content.encode("utf-8")
+    target.write_bytes(expected)
+    metadata = files_client.get(
+        "/api/workspace/file-metadata",
+        params={"path": "source.ts"},
+    ).json()
+
+    etag = metadata["etag"]
+    for _index in range(2):
+        response = files_client.put(
+            "/api/workspace/file-content",
+            params={"path": "source.ts"},
+            headers={"If-Match": etag},
+            json={"content": content},
+        )
+
+        assert response.status_code == 200
+        etag = response.json()["etag"]
+        assert target.read_bytes() == expected
+        assert b"\r\r\n" not in target.read_bytes()
+
+
+def test_legacy_code_save_preserves_crlf_bytes(
+    files_client: TestClient,
+) -> None:
+    """The legacy coding endpoint must write line endings byte-for-byte."""
+    target = files_client.app.state.project_dir / "legacy.ts"
+    content = "const first = 1;\r\nconst second = 2;\r\n"
+    expected = content.encode("utf-8")
+
+    for _index in range(2):
+        response = files_client.put(
+            "/api/workspace/code-files/legacy.ts",
+            json={"content": content},
+        )
+
+        assert response.status_code == 200
+        assert target.read_bytes() == expected
+        assert b"\r\r\n" not in target.read_bytes()
 
 
 def test_upload_requests_policy_only_for_conflicting_files(


### PR DESCRIPTION
## Description

Fix unexpected blank lines being inserted when files with CRLF line endings are saved from the workspace editor on Windows.

Path.write_text() performs platform newline translation on Windows. When the editor sends content that already contains CRLF line endings, each \n can be translated again, turning \r\n into \r\r\n. Subsequent reads display the extra carriage returns as blank lines.

This PR:

Writes UTF-8 bytes directly in the unified workspace save path.

Applies the same fix to the legacy Coding Mode save endpoint.

Adds regression coverage for repeated CRLF saves and verifies that CRCRLF is never produced.

Related Issue: Fixes #7018

<img width="2568" height="1400" alt="image" src="https://github.com/user-attachments/assets/91f6a54d-b0e8-4583-a680-b45608caad3e" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
