### PR TITLE
ci: slim PR-gate unit job (drop console build, dev,test extras)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,27 +77,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js (for console build)
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: console/package-lock.json
-
-      - name: Build console frontend
-        shell: bash
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-        run: |
-          cd console && npm ci && npm run build
-
-      - name: Copy console build into package
-        shell: bash
-        run: |
-          rm -rf src/qwenpaw/console/*
-          mkdir -p src/qwenpaw/console
-          cp -R console/dist/* src/qwenpaw/console/
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -107,8 +86,14 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          # Slim install for the unit tier: unit tests neither serve the
+          # console frontend nor require the optional heavy extras
+          # (whisper/torch, codex, qoder). Optional-dependency tests are
+          # guarded with pytest.importorskip and still run in the nightly
+          # full sweep, which keeps the full extra. Keeping this job lean
+          # cuts the Windows matrix entry from tens of minutes to a few.
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test,full]"
+          pip install -e ".[dev,test]"
 
       - name: Run unit tests
         shell: bash


### PR DESCRIPTION
## Summary

Slim down the PR-gate unit test job to reduce CI runtime.

## Changes

- **Remove console frontend build steps** (Node.js setup, console build, copy console build): The unit test tier does not serve the console frontend, so these steps are unnecessary.
- **Limit dependency installation to `dev,test` extras** (instead of `full`): Unit tests neither require the optional heavy extras (whisper/torch, codex, qoder) nor the console frontend. Optional-dependency tests are guarded with `pytest.importorskip` and still run in the nightly full sweep, which keeps the full extra.

## Impact

- Faster PR feedback for the unit test tier.
- No test coverage loss: all unit tests still run; optional-dependency tests are skipped gracefully when the extras are not installed, and they continue to run in the nightly full sweep.

---

🤖 Generated with [QwenPaw][1]

[1]: https://qwenpaw.agentscope.io/