### PR TITLE
feat(cli): add skill search filtering

### DIFF
--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -29,7 +29,53 @@ from ..config import load_config
 from ..constant import WORKING_DIR
 from ..exceptions import SkillsError
 from ..security.skill_scanner import SkillScanError, scan_skill_directory
-from .utils import prompt_checkbox, prompt_confirm
+from .utils import prompt_checkbox, prompt_confirm, prompt_text
+
+
+def _filter_skill_options(
+    options: list[tuple[str, str]],
+    query: str,
+) -> list[tuple[str, str]]:
+    """Filter skill options by name using a case-insensitive substring."""
+    normalized_query = query.strip().casefold()
+    if not normalized_query:
+        return options
+    return [
+        option
+        for option in options
+        if normalized_query in option[1].casefold()
+    ]
+
+
+def _merge_filtered_skill_selection(
+    selected: list[str],
+    visible_names: set[str],
+    enabled: set[str],
+) -> set[str]:
+    """Preserve enabled skills hidden by a search filter."""
+    return (enabled - visible_names) | set(selected)
+
+
+def _prompt_filtered_skill_options(
+    options: list[tuple[str, str]],
+) -> list[tuple[str, str]] | None:
+    """Prompt for a search query until it matches at least one skill."""
+    while True:
+        search_query = prompt_text(
+            "Search skills (leave blank to show all):",
+        )
+        if search_query is None:
+            return None
+
+        visible_options = _filter_skill_options(options, search_query)
+        if visible_options:
+            if search_query.strip():
+                click.echo(
+                    f"Showing {len(visible_options)} of "
+                    f"{len(options)} skills.",
+                )
+            return visible_options
+        click.echo(f'No skills match "{search_query.strip()}". Try again.\n')
 
 
 def _get_agent_workspace(agent_id: str) -> Path:
@@ -269,11 +315,15 @@ def configure_skills_interactive(
         options.append((label, skill.name))
 
     click.echo("\n=== Skills Configuration ===")
+    visible_options = _prompt_filtered_skill_options(options)
+    if visible_options is None:
+        click.echo("\n\nOperation cancelled.")
+        return
     click.echo("Use ↑/↓ to move, <space> to toggle, <enter> to confirm.\n")
 
     selected = prompt_checkbox(
         "Select skills to enable:",
-        options=options,
+        options=visible_options,
         checked=default_checked,
         select_all_option=False,
     )
@@ -282,7 +332,12 @@ def configure_skills_interactive(
         click.echo("\n\nOperation cancelled.")
         return
 
-    selected_set = set(selected)
+    visible_names = {value for _, value in visible_options}
+    selected_set = _merge_filtered_skill_selection(
+        selected,
+        visible_names,
+        enabled,
+    )
     to_install = selected_set - installed_names
     to_enable = (selected_set & installed_names) - enabled
     to_disable = enabled - selected_set

--- a/src/qwenpaw/cli/utils.py
+++ b/src/qwenpaw/cli/utils.py
@@ -67,6 +67,14 @@ def prompt_path(label: str, *, default: str = "") -> str:
         # Otherwise loop and re-prompt
 
 
+def prompt_text(question: str, *, default: str = "") -> Optional[str]:
+    """Prompt the user for a line of text.
+
+    Returns the entered text, or ``None`` on Ctrl+C.
+    """
+    return questionary.text(question, default=default).ask()
+
+
 def prompt_choice(
     question: str,
     options: list[str],

--- a/tests/unit/cli/test_skills_cmd.py
+++ b/tests/unit/cli/test_skills_cmd.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from qwenpaw.cli import skills_cmd
+from qwenpaw.cli.skills_cmd import (
+    _filter_skill_options,
+    _merge_filtered_skill_selection,
+)
+
+
+def test_filter_skill_options_matches_names_case_insensitively() -> None:
+    options = [
+        ("GitHub  [pool] (hub)", "GitHub"),
+        ("Google Calendar  [pool] (hub)", "google-calendar"),
+        ("Local Notes  [✓] (local)", "local-notes"),
+    ]
+
+    assert _filter_skill_options(options, "  GOOGLE  ") == [options[1]]
+
+
+def test_filter_skill_options_blank_query_returns_all_options() -> None:
+    options = [("GitHub", "github"), ("Slack", "slack")]
+
+    assert _filter_skill_options(options, "  ") == options
+
+
+def test_merge_filtered_selection_preserves_hidden_enabled_skills() -> None:
+    selected = ["visible-new"]
+    visible_names = {"visible-old", "visible-new"}
+    enabled = {"visible-old", "hidden-enabled"}
+
+    assert _merge_filtered_skill_selection(
+        selected,
+        visible_names,
+        enabled,
+    ) == {"visible-new", "hidden-enabled"}
+
+
+def test_merge_filtered_selection_does_not_select_hidden_pool_skills() -> None:
+    selected = ["visible-skill"]
+
+    assert _merge_filtered_skill_selection(
+        selected,
+        {"visible-skill"},
+        set(),
+    ) == {"visible-skill"}
+
+
+def test_configure_skills_filters_options_and_preserves_hidden_enabled(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    skills = [
+        SimpleNamespace(name="hidden-enabled", source="local"),
+        SimpleNamespace(name="visible-disabled", source="local"),
+    ]
+    search_queries = iter(["missing", "VISIBLE"])
+    captured_options: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        skills_cmd,
+        "SkillService",
+        lambda working_dir: SimpleNamespace(list_all_skills=lambda: skills),
+    )
+    monkeypatch.setattr(
+        skills_cmd,
+        "reconcile_workspace_manifest",
+        lambda working_dir: None,
+    )
+    monkeypatch.setattr(
+        skills_cmd,
+        "read_skill_manifest",
+        lambda working_dir: {"skills": {"hidden-enabled": {"enabled": True}}},
+    )
+    monkeypatch.setattr(
+        skills_cmd,
+        "prompt_text",
+        lambda question: next(search_queries),
+    )
+
+    def fake_prompt_checkbox(_question, options, **_kwargs):
+        captured_options.extend(options)
+        return []
+
+    monkeypatch.setattr(skills_cmd, "prompt_checkbox", fake_prompt_checkbox)
+
+    skills_cmd.configure_skills_interactive(working_dir=tmp_path)
+
+    assert [value for _, value in captured_options] == ["visible-disabled"]
+    assert 'No skills match "missing". Try again.' in capsys.readouterr().out


### PR DESCRIPTION
# Description

Improve skill selection in the interactive CLI by allowing users to filter large skill lists by name before opening the checkbox prompt.

When the skill pool contains many entries, users previously had to navigate the entire list with the arrow keys. This change adds a text search step that performs case-insensitive substring matching and shows how many skills match. An empty query displays the full list, while a query with no matches prompts the user to try again.

The selection merge also preserves enabled skills hidden by the active filter. Hidden enabled skills are not accidentally disabled, and hidden pool skills are not accidentally installed.

This PR:

- Adds a reusable `prompt_text()` helper for Questionary-based CLI input.
- Adds case-insensitive skill-name filtering to the interactive skill configuration flow.
- Retries the search prompt when no skills match.
- Preserves enabled skills hidden by the filter.
- Adds regression coverage for filtering and selection-state merging.

Related Issue: Fixes [#7090](https://github.com/agentscope-ai/QwenPaw/issues/7090)

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

# Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

# Checklist

- [x] I ran the pre-commit checks for the changed files locally and they pass
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

# For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This PR only changes the interactive CLI and its unit tests.

# Testing

Run the focused unit tests:

```bash
.venv/bin/python -m pytest tests/unit/cli/test_skills_cmd.py -q
```

Manual verification with skill-pool candidates:

```bash
.venv/bin/python -c 'from qwenpaw.cli.skills_cmd import configure_skills_interactive; configure_skills_interactive(include_pool_candidates=True)'
```

Verify that partial names filter the list case-insensitively, an empty query displays all skills, a query with no matches can be retried, and applying a filtered selection preserves enabled skills hidden by the filter.

# Evidence

<img width="1652" height="304" alt="image" src="https://github.com/user-attachments/assets/47d56a9d-3109-42ba-92dc-c130a393e087" />

Focused unit test result:

```text
..... [100%]
5 passed in 0.21s
```

The commit-time pre-commit checks passed:

```text
check python ast: Passed
fix python encoding pragma: Passed
detect private key: Passed
trim trailing whitespace: Passed
Add trailing commas: Passed
mypy: Passed
black: Passed
flake8: Passed
pylint: Passed
```

# Additional Notes

This implementation filters the list after the user submits a search query. It does not provide live, per-keystroke filtering inside `questionary.checkbox`, which does not support that behavior natively.

No Console or web frontend code is changed.