### PR TITLE
fix(tools): resolve PEP 563 annotations before agentscope schema extraction (#7082)

### DIFF
--- a/src/qwenpaw/agents/memory/proactive/proactive_responder.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_responder.py
@@ -118,18 +118,28 @@ async def _initialize_single_proactive_agent(
 
     model, formatter = create_model_and_formatter(agent_id=agent_config.id)
 
+    # This path constructs ``FunctionTool`` directly, bypassing the guarded
+    # wrappers that normally resolve PEP 563 annotations, so apply the fix
+    # here too or agentscope's schema extraction can fail (QwenPaw #7082).
+    from ....utils.tool_annotations import resolve_tool_annotations
+
     tools = [
-        FunctionTool(web_search),
-        FunctionTool(web_fetch),
-        FunctionTool(read_file),
-        FunctionTool(execute_shell_command),
-        FunctionTool(browser),
+        FunctionTool(resolve_tool_annotations(func))
+        for func in (
+            web_search,
+            web_fetch,
+            read_file,
+            execute_shell_command,
+            browser,
+        )
     ]
 
     from ...prompt import get_active_model_supports_multimodal
 
     if get_active_model_supports_multimodal():
-        tools.append(FunctionTool(desktop_screenshot))
+        tools.append(
+            FunctionTool(resolve_tool_annotations(desktop_screenshot)),
+        )
 
     toolkit = Toolkit(tools=tools)
 

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -150,6 +150,14 @@ def _policy_tool_init(
 ) -> None:
     from agentscope.tool import FunctionTool
 
+    from ..utils.tool_annotations import resolve_tool_annotations
+
+    # Resolve PEP 563 stringified annotations to real types before agentscope
+    # builds the tool's input schema. Tools defined in modules using
+    # ``from __future__ import annotations`` otherwise expose string
+    # annotations (e.g. "Optional[Path]") that agentscope cannot resolve,
+    # aborting registration with a PydanticUserError (QwenPaw #7082).
+    resolve_tool_annotations(func)
     FunctionTool.__init__(self, func, **kwargs)
     self._qp_governor = governor
     self._qp_request_context = request_context or {}

--- a/src/qwenpaw/runtime/tool_guard.py
+++ b/src/qwenpaw/runtime/tool_guard.py
@@ -64,6 +64,14 @@ def _guarded_tool_init(
 ) -> None:
     from agentscope.tool import FunctionTool
 
+    from ..utils.tool_annotations import resolve_tool_annotations
+
+    # Resolve PEP 563 stringified annotations to real types before agentscope
+    # builds the tool's input schema (QwenPaw #7082). Mirrors
+    # ``PolicyGuardedTool`` — this degraded-governance fallback wraps the
+    # same tool functions and would hit the identical schema-extraction
+    # failure without it.
+    resolve_tool_annotations(func)
     FunctionTool.__init__(self, func, **kwargs)
     self._qp_agent_id = agent_id  # pylint: disable=protected-access
     # pylint: disable=protected-access

--- a/src/qwenpaw/utils/tool_annotations.py
+++ b/src/qwenpaw/utils/tool_annotations.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Resolve stringified (PEP 563) tool annotations to real type objects.
+
+agentscope's ``FunctionTool`` builds a Pydantic model from a tool function's
+signature — it iterates ``inspect.signature(func).parameters`` and feeds each
+``param.annotation`` into ``pydantic.create_model()`` under the name
+``_StructuredOutputDynamicClass``, then calls ``.model_json_schema()``.
+
+When the tool's *module* uses ``from __future__ import annotations`` (PEP 563),
+those annotations are plain strings (e.g. ``"Optional[Path]"``). Pydantic then
+treats each string as a forward reference and resolves it in the model's module
+namespace — which is *agentscope's* ``tool/_utils.py`` and only imports
+``Any``/``Dict``/``Callable``. Any tool parameter typed with ``Optional`` /
+``Union`` / a custom class therefore raises::
+
+    pydantic.errors.PydanticUserError: `_StructuredOutputDynamicClass` is not
+    fully defined; you should define `Optional`, then call
+    `_StructuredOutputDynamicClass.model_rebuild()`.
+
+which aborts tool registration at startup (QwenPaw issue #7082).
+
+Resolving the annotations to concrete objects in the function's *own* module
+namespace (where ``Optional`` etc. are imported) before agentscope introspects
+the function sidesteps the failure: agentscope then sees real types and never
+creates an unresolved forward reference.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import typing
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_tool_annotations(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Best-effort replace stringified annotations on *func* with real types.
+
+    Mutates the underlying function's ``__annotations__`` in place and returns
+    *func* so callers can wrap inline. It is a no-op when the annotations are
+    already concrete objects, when the function exposes no annotations, or when
+    the type hints cannot be resolved (in which case the original — possibly
+    stringified — annotations are left untouched, i.e. behaviour is no worse
+    than before).
+    """
+    target = func
+    if isinstance(target, functools.partial):
+        target = target.func
+    target = inspect.unwrap(target)
+
+    raw = getattr(target, "__annotations__", None)
+    if not isinstance(raw, dict) or not raw:
+        return func
+    if not any(isinstance(value, str) for value in raw.values()):
+        # Already concrete (no PEP 563 strings, or pre-resolved).
+        return func
+
+    try:
+        hints = typing.get_type_hints(target)
+    except Exception as exc:  # noqa: BLE001 - defensive; never break tool init
+        logger.debug(
+            "resolve_tool_annotations: could not resolve hints for %r (%s); "
+            "leaving annotations untouched",
+            getattr(target, "__name__", target),
+            exc,
+        )
+        return func
+
+    # Only overwrite the entries we actually resolved; keep anything else
+    # (e.g. names get_type_hints could not evaluate) exactly as it was.
+    resolved = {name: hints[name] for name in raw if name in hints}
+    if resolved:
+        target.__annotations__ = {**raw, **resolved}
+    return func

--- a/tests/unit/utils/test_tool_annotations.py
+++ b/tests/unit/utils/test_tool_annotations.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Tests for qwenpaw.utils.tool_annotations (QwenPaw #7082).
+
+Under ``from __future__ import annotations`` (PEP 563) a tool function's
+annotations are plain strings. agentscope's ``FunctionTool`` feeds those
+strings into ``pydantic.create_model(...).model_json_schema()`` and — because
+agentscope's own ``tool/_utils.py`` only imports ``Any``/``Dict``/``Callable``
+— fails to resolve names such as ``Optional`` with::
+
+    PydanticUserError: `_StructuredOutputDynamicClass` is not fully defined;
+    you should define `Optional`, ...
+
+which aborts tool registration at startup. ``resolve_tool_annotations``
+rewrites the annotations to real objects (resolved in the function's own
+module namespace) before agentscope introspects the function.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from qwenpaw.utils.tool_annotations import resolve_tool_annotations
+
+
+def test_resolves_pep563_optional_annotations() -> None:
+    async def tool(
+        operation: str,
+        file_path: Optional[Path] = None,
+        count: Optional[int] = None,
+    ) -> Any:
+        return operation
+
+    # PEP 563: annotations start life as strings.
+    assert isinstance(tool.__annotations__["file_path"], str)
+
+    result = resolve_tool_annotations(tool)
+
+    assert result is tool
+    assert tool.__annotations__["operation"] is str
+    assert tool.__annotations__["file_path"] == Optional[Path]
+    assert tool.__annotations__["count"] == Optional[int]
+
+
+def test_noop_when_function_has_no_annotations() -> None:
+    def tool():  # noqa: ANN202
+        return None
+
+    tool.__annotations__ = {}
+    assert resolve_tool_annotations(tool) is tool
+    assert tool.__annotations__ == {}
+
+
+def test_noop_when_annotations_already_concrete() -> None:
+    def tool(x, y):  # noqa: ANN001,ANN202
+        return None
+
+    # Real objects, not strings — nothing to resolve.
+    tool.__annotations__ = {"x": int, "y": str}
+    resolve_tool_annotations(tool)
+    assert tool.__annotations__ == {"x": int, "y": str}
+
+
+def test_unresolvable_string_annotation_is_left_untouched() -> None:
+    def tool(x):  # noqa: ANN001,ANN202
+        return None
+
+    tool.__annotations__ = {"x": "DefinitelyNotADefinedName"}
+    resolve_tool_annotations(tool)
+    assert tool.__annotations__ == {"x": "DefinitelyNotADefinedName"}
+
+
+def test_agentscope_functiontool_builds_after_resolve() -> None:
+    """End-to-end: agentscope schema extraction fails before, works after."""
+    pytest.importorskip("agentscope")
+    from agentscope.tool import FunctionTool
+    from pydantic.errors import PydanticUserError
+
+    async def tool(
+        operation: str,
+        file_path: Optional[Path] = None,
+    ) -> Any:
+        """A demo tool.
+
+        Args:
+            operation (str): the operation.
+            file_path (Optional[Path]): optional path.
+        """
+        return operation
+
+    # Reproduces #7082: unresolved PEP 563 string annotations.
+    with pytest.raises(PydanticUserError, match="not fully defined"):
+        FunctionTool(tool)
+
+    resolve_tool_annotations(tool)
+
+    built = FunctionTool(tool)
+    assert getattr(built, "input_schema", None) is not None


### PR DESCRIPTION
## Description

Starting the console (or any agent run) can abort during tool registration with:

```
pydantic.errors.PydanticUserError: `_StructuredOutputDynamicClass` is not fully
defined; you should define `Optional`, then call
`_StructuredOutputDynamicClass.model_rebuild()`.
```

**Root cause.** agentscope's `FunctionTool` derives each tool's JSON schema in [`agentscope/tool/_utils.py::_extract_input_schema`](https://github.com/agentscope-ai/agentscope/blob/v2.0.6/src/agentscope/tool/_utils.py#L137-L155): it iterates `inspect.signature(func).parameters` and feeds `param.annotation` **verbatim** into `create_model("_StructuredOutputDynamicClass", ...)`, then calls `.model_json_schema()`.

Tool functions defined in modules that use `from __future__ import annotations` (PEP 563 — 548 modules under `src/` do) expose their annotations as *strings* at runtime, e.g. `"Optional[Path]"`. Pydantic treats each string as a forward reference and resolves it against the module that created the model — agentscope's `tool/_utils.py`, whose namespace only contains:

```python
import inspect
from typing import Any, Dict, Callable
from docstring_parser import parse
from pydantic import Field, create_model, ConfigDict
```

There is no `Optional` and no `Path` there, so the model stays "not fully defined" and `model_json_schema()` raises. In short: **the annotation string is written in QwenPaw's module but evaluated in agentscope's module.** The suggested `model_rebuild()` is unreachable from the QwenPaw side, and `agentscope==2.0.6` is a pinned third-party dependency.

This also explains why the failure looks intermittent — it depends on whether a registered tool happens to use a name that is *not* resolvable in agentscope's namespace:

| Parameter annotation | String under PEP 563 | Result |
|---|---|---|
| `code: str`, `n: int` | `"str"`, `"int"` | OK — builtins resolve anywhere |
| `d: Dict[str, Any]` | `"Dict[str, Any]"` | OK — only because agentscope imports `Dict`/`Any` |
| `p: Optional[Path]` | `"Optional[Path]"` | **fails** |
| `x: MyCustomType` | `"MyCustomType"` | **fails** |

**Fix.** Resolve stringified annotations to real type objects in the function's *own* module namespace (via `typing.get_type_hints`, which evaluates against `func.__globals__` where `Optional`/`Path` are imported) **before** agentscope introspects the function. agentscope then receives concrete types and Pydantic never creates an unresolved forward reference.

New helper `qwenpaw/utils/tool_annotations.py::resolve_tool_annotations`:
- Unwraps `functools.partial` / decorators so it mutates the same object agentscope inspects (agentscope uses `inspect.signature(...)` with the default `follow_wrapped=True`).
- Idempotent — after the first pass the annotations are no longer strings, so repeat registration is a no-op.
- No-op for unannotated functions and for already-concrete annotations.
- On `get_type_hints` failure it returns **before** writing anything, so annotations are never left partially resolved (behaviour is no worse than before the fix).
- Assigns a freshly merged dict in a single rebind, so readers never observe a half-updated mapping.

Wired into the three places that hand a tool function to agentscope's `FunctionTool`:

| Location | Path |
|---|---|
| `governance/tool_adapter.py::_policy_tool_init` | `PolicyGuardedTool` — main path for every workspace tool |
| `runtime/tool_guard.py::_guarded_tool_init` | `GuardedFunctionTool` — degraded-governance fallback |
| `agents/memory/proactive/proactive_responder.py` | direct `FunctionTool(...)`, which bypasses both wrappers |

The third site is hardening: it wires `browser`, which *is* a PEP 563 module, and is safe today only because its sole parameter is `code: str` (a builtin). Adding any `Optional[...]` parameter there would reintroduce this bug, so it now goes through the same helper.

**Related Issue:** Fixes #7082

**Security Considerations:** None. No change to permissions, sandboxing, or governance decisions — only type-annotation normalisation for schema generation. Guard/policy behaviour is untouched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran tests locally and they pass (see Evidence for scope and limitations)
- [x] Verified against the pinned dependency version (`agentscope==2.0.6`)
- [x] No new lint violations (`max-line-length = 79` respected in all touched files)
- [x] Ready for review

## Testing

New unit test module `tests/unit/utils/test_tool_annotations.py`:

1. `test_resolves_pep563_optional_annotations` — asserts annotations start as strings and become `Optional[Path]` / `Optional[int]` / `str`.
2. `test_noop_when_function_has_no_annotations`
3. `test_noop_when_annotations_already_concrete`
4. `test_unresolvable_string_annotation_is_left_untouched`
5. `test_agentscope_functiontool_builds_after_resolve` — end-to-end regression: `FunctionTool(tool)` raises `PydanticUserError` matching `"not fully defined"` **before** the fix, and builds a valid `input_schema` **after** it.

Manual check of the produced schema after resolution:

```json
"file_path": {"anyOf": [{"format": "path", "type": "string"}, {"type": "null"}], "default": null}
```

## Evidence

Verified against the pinned dependency in an isolated Python 3.11 venv with real `agentscope==2.0.6` (not mocked).

**1. Reproduced the exact reported failure**, then confirmed the fix, on a tool module using `from __future__ import annotations` + `Optional[Path]`:

```
raw __annotations__ (PEP 563 -> strings):
  {'operation': 'str', 'file_path': 'Optional[Path]', 'count': 'Optional[int]'}

--- BEFORE FIX ---
error type   : PydanticUserError
error message: `_StructuredOutputDynamicClass` is not fully defined; you should
               define `Optional`, then call
               `_StructuredOutputDynamicClass.model_rebuild()`.

resolved __annotations__:
  {'operation': <class 'str'>, 'file_path': typing.Optional[pathlib.Path],
   'count': typing.Optional[int]}

--- AFTER FIX ---
FunctionTool built OK; name = demo_tool
input_schema = {"properties": {"operation": {"description": "op.", "type":
  "string"}, "file_path": {"anyOf": [{"format": "path", "type": "string"},
  {"type": "null"}], "default": null, ...}, "count": {"anyOf": [{"type":
  "integer"}, {"type": "null"}], "default": null, ...}},
  "required": ["operation"], "type": "object"}
```

**2. Unit tests — 5/5 pass** against real agentscope 2.0.6:

```
PASS: test_agentscope_functiontool_builds_after_resolve
PASS: test_noop_when_annotations_already_concrete
PASS: test_noop_when_function_has_no_annotations
PASS: test_resolves_pep563_optional_annotations
PASS: test_unresolvable_string_annotation_is_left_untouched
5/5 passed
```

Because test 5 asserts the narrow `pydantic.errors.PydanticUserError` type (not a bare `Exception`), its passing also confirms the precise exception class reported in the issue.

**3. Lint / syntax**

```
$ python -m py_compile <all 5 touched files>        -> OK

$ character-accurate check for lines > 79 chars
  (.flake8 max-line-length = 79) across all 5 files -> violations: 0
```

Diff: **5 files changed** (2 new, 3 modified).

