### PR TITLE
fix(skill): remove skill bound duplication [ready to merge]

### DIFF
--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -229,17 +229,27 @@ class AgentBuilder:
         workspace_dir: str | None,
         tools: Iterable[Any],
     ) -> list[Any]:
-        """Resolve and load runtime Skills in one synchronous I/O job."""
+        """Load runtime Skills, preferring workspace skills on conflicts."""
         from ..agents.skill_system.runtime_cache import load_runtime_skills
 
-        skill_dirs = cls._resolve_skill_loader_dirs(
+        workspace_skill_dirs = cls._resolve_skill_loader_dirs(
             effective_skills,
             workspace_dir,
         )
-        for extra in _bound_skill_loader_dirs(tools):
-            if extra not in skill_dirs:
-                skill_dirs.append(extra)
-        return load_runtime_skills(skill_dirs)
+        workspace_skills = load_runtime_skills(workspace_skill_dirs)
+        workspace_skill_names = {skill.name for skill in workspace_skills}
+
+        bound_skill_dirs = [
+            skill_dir
+            for skill_dir in dict.fromkeys(_bound_skill_loader_dirs(tools))
+            if skill_dir not in workspace_skill_dirs
+        ]
+        bound_skills = load_runtime_skills(bound_skill_dirs)
+        return workspace_skills + [
+            skill
+            for skill in bound_skills
+            if skill.name not in workspace_skill_names
+        ]
 
     # ----------------------------------------------------------------- build
 

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -239,11 +239,9 @@ class AgentBuilder:
         workspace_skills = load_runtime_skills(workspace_skill_dirs)
         workspace_skill_names = {skill.name for skill in workspace_skills}
 
-        bound_skill_dirs = [
-            skill_dir
-            for skill_dir in dict.fromkeys(_bound_skill_loader_dirs(tools))
-            if skill_dir not in workspace_skill_dirs
-        ]
+        bound_skill_dirs = list(
+            dict.fromkeys(_bound_skill_loader_dirs(tools)),
+        )
         bound_skills = load_runtime_skills(bound_skill_dirs)
         return workspace_skills + [
             skill


### PR DESCRIPTION
## Description

Deduplicate workspace and bound skills by their `SKILL.md` frontmatter name.

Skills are loaded through the runtime cache added in #6990. If an effective workspace skill has the same runtime name as a bound skill, only the workspace version is passed to AgentScope.

## Behavior

- Workspace overrides a same-name bound skill.
- Different runtime names remain available.
- Disabled, missing, or invalid workspace skills fall back to the bound skill.
- No duplicate AgentScope warning.
- No UI, manifest, or naming changes.

Workspace and bound skills are loaded separately to preserve their source.
Both calls use the shared cache, so files are not read twice.

Related to #7073.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review