### PR TITLE
fix(desktop): repair TUI session start in packaged builds

### DIFF
--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -24,6 +24,7 @@ import click
 from ..constant import LOG_LEVEL_ENV, WORKING_DIR
 from ..utils.logging import setup_logger
 from ..utils.port import get_stable_port
+from ..utils.self_invoke import qwenpaw_cli_command
 
 try:
     import webview
@@ -239,6 +240,22 @@ def desktop_cmd(
     else:
         logger.warning("SSL_CERT_FILE not set on environment")
 
+    # Resolve the child argv before releasing the held socket: a packaged
+    # build with no CLI binary to re-invoke should fail with a clean message
+    # rather than after giving up the port.
+    try:
+        server_argv = qwenpaw_cli_command(
+            "app",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--log-level",
+            log_level,
+        )
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
     is_windows = sys.platform == "win32"
     proc = None
     manually_terminated = (
@@ -252,18 +269,7 @@ def desktop_cmd(
             held_socket.close()
 
         proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "qwenpaw",
-                "app",
-                "--host",
-                host,
-                "--port",
-                str(port),
-                "--log-level",
-                log_level,
-            ],
+            server_argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE if is_windows else sys.stdout,
             stderr=subprocess.PIPE if is_windows else sys.stderr,

--- a/src/qwenpaw/cli/tui/launch.py
+++ b/src/qwenpaw/cli/tui/launch.py
@@ -6,9 +6,11 @@
 ``qwenpaw tui --agent NAME``   chat with a specific agent
 ``qwenpaw tui --resume ID``    resume a previous session and continue it
 
-The TUI spawns ``qwenpaw acp`` using the *current* interpreter
-(``python -m qwenpaw acp --local-diagnostics``), so it always drives the same
-install/venv it ships in -- no reliance on ``qwenpaw`` being on ``PATH``.
+The TUI spawns ``qwenpaw acp`` from this very install (``python -m qwenpaw acp
+--local-diagnostics`` under a real interpreter, the packaged binary's own
+``acp`` subcommand in the Desktop build -- see ``qwenpaw.utils.self_invoke``),
+so it always drives the same install/venv it ships in -- no reliance on
+``qwenpaw`` being on ``PATH``.
 
 Textual and the transport are imported lazily so ``qwenpaw --help`` and other
 subcommands stay fast.
@@ -136,33 +138,34 @@ def _build_transport(
 ):
     """Return ``(transport, description)`` for the requested target.
 
-    ``command=None`` lets :class:`AcpTransport` use its default,
-    ``[sys.executable, "-m", "qwenpaw", "acp", "--local-diagnostics"]`` --
-    the same interpreter the TUI is running under. The ``--agent`` suffix is
-    *not* appended here: ``AcpTransport`` appends ``--agent <id>`` itself when
-    ``agent`` is set, so doing it here too would double it.
+    ``command=None`` lets :class:`AcpTransport` resolve its own default, which
+    re-invokes this very install (see ``qwenpaw.utils.self_invoke``). The
+    ``--agent`` suffix is *not* appended here: ``AcpTransport`` appends
+    ``--agent <id>`` itself when ``agent`` is set, so doing it here too would
+    double it.
     """
     from .transport.acp import AcpTransport
 
     project_dir = _resolve_project_dir(project)
-    description = (
-        f"qwenpaw acp ({sys.executable} -m qwenpaw acp --local-diagnostics)"
+    # Project-bound TUI sessions start ACP in the project root and also send
+    # explicit metadata so Coding Mode can apply a request overlay.
+    transport = AcpTransport(
+        agent=agent,
+        cwd=project_dir,
+        command=None,
+        project_dir=project_dir,
+        resume_session_id=resume,
     )
+    # Render the argv the transport actually resolved, so what we show can
+    # never drift from what gets spawned. An empty argv means resolution
+    # failed; ``start()`` reports the reason inside the TUI.
+    argv = transport.command
+    rendered = " ".join(argv) if argv else "unresolved"
+    description = f"qwenpaw acp ({rendered})"
     if project_dir:
         description = f"{description} cwd={project_dir}"
 
-    return (
-        # Project-bound TUI sessions start ACP in the project root and also
-        # send explicit metadata so Coding Mode can apply a request overlay.
-        AcpTransport(
-            agent=agent,
-            cwd=project_dir,
-            command=None,
-            project_dir=project_dir,
-            resume_session_id=resume,
-        ),
-        description,
-    )
+    return transport, description
 
 
 def run_tui(

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 import time
 import uuid
 from contextlib import AsyncExitStack
@@ -41,6 +40,7 @@ from ....agents.acp.meta import (
     ACP_PROJECT_DIR_META_KEY,
     ACP_EPHEMERAL_META_KEY,
 )
+from ....utils.self_invoke import qwenpaw_cli_command
 from ..__version__ import __version__
 from ..events import (
     BackendWarmed,
@@ -367,20 +367,27 @@ class AcpTransport:
         # When set, ``start()`` resumes this session (load + replay) instead
         # of opening a fresh one.
         self._resume_session_id = resume_session_id
-        # Default: re-invoke this very interpreter as `python -m qwenpaw acp`.
+        # Default: re-invoke this very install as `qwenpaw acp` (as
+        # `python -m qwenpaw acp` when running under a real interpreter; see
+        # qwenpaw_cli_command for why the packaged build differs).
         # The TUI owns that subprocess, so opt it into local diagnostics.
         # Copy the caller's list so appending options never mutates it.
+        self._command: list[str] = []
+        # A resolution failure is held here and re-raised from ``start()``, so
+        # the TUI shows it as an in-app "transport: ..." error like any other
+        # startup failure instead of a traceback in place of the whole UI.
+        self._command_error: str | None = None
         if command is None:
-            self._command = [
-                sys.executable,
-                "-m",
-                "qwenpaw",
-                "acp",
-                "--local-diagnostics",
-            ]
+            try:
+                self._command = qwenpaw_cli_command(
+                    "acp",
+                    "--local-diagnostics",
+                )
+            except RuntimeError as exc:
+                self._command_error = str(exc)
         else:
             self._command = list(command)
-        if agent:
+        if agent and self._command:
             self._command += ["--agent", agent]
 
         self._queue: asyncio.Queue[Any] = asyncio.Queue()
@@ -399,12 +406,19 @@ class AcpTransport:
     def session_id(self) -> str | None:
         return self._session_id
 
+    @property
+    def command(self) -> list[str]:
+        """The resolved argv this transport spawns (for display/debugging)."""
+        return list(self._command)
+
     def _session_kwargs(self) -> dict[str, str]:
         if not self._project_dir:
             return {}
         return {ACP_PROJECT_DIR_META_KEY: self._project_dir}
 
     async def start(self) -> Connected:
+        if self._command_error is not None:
+            raise RuntimeError(self._command_error)
         self._stack = AsyncExitStack()
         cmd, *args = self._command
         self._stderr_fd, self._stderr_path = _open_agent_stderr_log()

--- a/src/qwenpaw/utils/self_invoke.py
+++ b/src/qwenpaw/utils/self_invoke.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Build argv that re-invokes this QwenPaw installation as a subprocess.
+
+``[sys.executable, "-m", "qwenpaw", ...]`` is only correct when
+``sys.executable`` is a Python interpreter. In the packaged Desktop build it is
+a frozen PyInstaller binary that has no ``-m``, so that argv dies with
+``Error: No such option '-m'`` before writing a byte -- which is what an ACP
+client sees as ``transport: Connection closed``.
+
+Re-execing the bundled CPython (the trick ``tauri/entry.py`` uses for plugins
+that spawn ``sys.executable -m <pkg>``) cannot help here: qwenpaw itself lives
+inside the PyInstaller archive and is not importable from an external
+interpreter. The packaged CLI binary takes subcommands directly instead.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Name of the packaged CLI binary (``scripts/pack-tauri/qwenpaw.spec``, the
+# ``cli_exe`` EXE); its sibling in the same COLLECT dir is ``qwenpaw-backend``.
+_CLI_STEM = "qwenpaw"
+
+
+def qwenpaw_cli_command(*args: str) -> list[str]:
+    """Return argv running ``qwenpaw <args>`` with this install's own code.
+
+    Keyed on ``sys.frozen`` rather than ``tauri.env.DESKTOP_APP_ENV``: the
+    question is whether *this very executable* accepts ``-m``, not whether we
+    happen to be running inside the Desktop product. A pip-installed qwenpaw
+    launched from a Desktop-spawned terminal inherits that env var but is still
+    a normal interpreter.
+    """
+    if not bool(getattr(sys, "frozen", False)):
+        return [sys.executable, "-m", "qwenpaw", *args]
+
+    exe = Path(sys.executable)
+    # The packaged CLI binary *is* the click entry point (tauri/cli_entry.py).
+    if exe.stem.lower() == _CLI_STEM:
+        return [str(exe), *args]
+
+    # The packaged backend binary (tauri/entry.py) ignores argv and starts the
+    # API server, so handing it a subcommand would silently boot a server that
+    # never speaks the expected protocol on stdio. Use its sibling CLI instead.
+    sibling = exe.with_name(_CLI_STEM + exe.suffix)
+    if sibling.is_file():
+        return [str(sibling), *args]
+
+    raise RuntimeError(
+        f"cannot locate the QwenPaw CLI binary next to {exe}; "
+        f"unable to spawn 'qwenpaw {' '.join(args)}'",
+    )


### PR DESCRIPTION
## Description

`qwenpaw tui` cannot start a session in the packaged Desktop build: the Textual UI opens, the status flips to `error`, and the transcript shows `transport: Connection closed`.

**Root cause.** The TUI built its ACP backend argv as `[sys.executable, "-m", "qwenpaw", "acp", "--local-diagnostics"]`. `sys.executable` is only a Python interpreter in pip/venv installs — in the PyInstaller build it is the frozen `qwenpaw.exe`, which has no `-m`, so the child dies inside click's argument parsing (`Error: No such option '-m'`) before writing a byte. The TUI deliberately routes the child's stderr to `logs/acp.log` (an unread PIPE can fill its 64 KB buffer and deadlock the agent — see `_open_agent_stderr_log`), so that diagnostic never reaches the screen; all the user observes is the stdio pipe closing during the ACP `initialize` handshake, reported as `transport: Connection closed`. The message describes the consequence, not the cause.

**The same wrong assumption was live in a second place**: `qwenpaw desktop` spawned `[sys.executable, "-m", "qwenpaw", "app", ...]` and fails identically in the packaged build. These are two outlets of one root cause, not two bugs, so both are fixed here. A sweep of `src/` confirms these were the only two `-m qwenpaw` self-invocations.

**Fix.** Both call sites now go through a new `qwenpaw.utils.self_invoke.qwenpaw_cli_command()`, which keys on `sys.frozen` and re-enters this very install:

| `sys.executable` | resolved argv |
| --- | --- |
| `python` (pip/venv) | `python -m qwenpaw acp --local-diagnostics` — byte-identical to before |
| `qwenpaw.exe` (frozen CLI) | `qwenpaw.exe acp --local-diagnostics` |
| `qwenpaw-backend.exe` (frozen sidecar) | same-directory `qwenpaw.exe acp --local-diagnostics` |

This does not invent an interface: shipping a `qwenpaw` binary that takes subcommands, and putting its directory on `PATH`, is exactly what #4779 built (`nsis-hooks.nsh` verifies `binaries\qwenpaw-backend\qwenpaw.exe` exists before registering that directory). The bug is that the self-invocation call sites predate #4779 and were never migrated to it.

Three deliberate choices worth reviewing:

- **Keyed on `sys.frozen`, not `DESKTOP_APP_ENV`.** The question is whether *this executable* accepts `-m`, not whether we are inside the Desktop product. That env var is inherited, so a pip-installed qwenpaw launched from a Desktop-spawned terminal would be misclassified.
- **The sidecar branch is not redundant.** `qwenpaw-backend.exe` ignores argv and starts the API server, so handing it `acp` would silently boot a server that never speaks ACP on stdio — a hang instead of an error. Hence the explicit hop to its sibling, rather than the `[sys.executable, "acp", ...]` the report suggested.
- **The #5260 subprocess guard cannot cover this case.** That guard redirects interpreter-shaped argv to the bundled CPython, which has no qwenpaw in it (`stage_python_runtime.py` stages it purely to `pip install` plugin deps); qwenpaw's own code lives in the PyInstaller archive. It is also installed only in `entry.py` (the sidecar), never in `cli_entry.py`. Redirecting to a real interpreter works for third-party modules (`-m pip`, `-m pylsp`) but structurally cannot serve a *qwenpaw* self-invocation.

**Related Issue:** fixes  #7007

**Security Considerations:** None. No auth, credential, env, or config handling is touched. The child argv is composed from `sys.executable` plus fixed literal subcommands — no user input reaches it. Notably the resolver never does a `PATH` lookup: it uses the running executable itself or its same-directory sibling, so it cannot be redirected by a hijacked `PATH`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes — ran it **scoped to the changed files** instead (`pre-commit run --files …`); every hook passes, output in Evidence
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks — no hook modified anything
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) — the module docstring and the `launch.py` header carry the rationale; no user-facing docs affected
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

**Not verified end-to-end on a packaged Windows build** — no Desktop build was available here. Everything below is argv-level and regression verification; a reviewer with the 2.1.0 Desktop app should confirm `qwenpaw tui` reaches a usable session before this ships.

- Ran `cli_entry.py` — the exact entry file the frozen `qwenpaw.exe` wraps — with bare subcommand argv: `acp --help` and `tui --help` dispatch correctly and `--local-diagnostics` is present. Passing `-m qwenpaw acp` to the same entry reproduces the reported `Error: No such option: -m` verbatim. PyInstaller freezes this script without altering click's argv semantics.
- Exercised all four resolver branches by patching `sys.frozen` / `sys.executable`: real interpreter, frozen CLI exe, frozen sidecar exe (Windows `.exe` and bare-POSIX naming), and the unresolvable case.
- Unresolvable case degrades gracefully instead of taking down the UI: `AcpTransport.__init__` no longer raises, so `run_tui` still builds; the failure surfaces from `start()` and is rendered by the existing handler in `app.py` as an in-app `transport: …` error with `state=error`. `qwenpaw desktop` raises `click.ClickException` for a one-line `Error: …` rather than a traceback, and resolves argv *before* releasing the held socket so a failure cannot cost an already-reserved port.
- Non-frozen path is byte-identical to the previous behaviour, which the pre-existing `test_launch.py` assertions pin.
- The TUI target line shown to the user is now rendered from the argv the transport actually resolved (new `AcpTransport.command` property) instead of a hand-written duplicate string, so display can no longer drift from what gets spawned. Had this been in place, the bad argv would have been visible in the TUI itself.

## Evidence

The frozen build's entry file dispatches bare subcommands, and reproduces the reported error when given `-m`:

```bash
$ python src/qwenpaw/tauri/cli_entry.py acp --help
Usage: cli_entry.py acp [OPTIONS]
  Start QwenPaw as an ACP agent (stdio).
Options:
  --agent TEXT          Agent ID to use (defaults to active agent)
  --local-diagnostics   Surface raw unexpected error text to the ACP client. ...

$ python src/qwenpaw/tauri/cli_entry.py -m qwenpaw acp
Usage: cli_entry.py [OPTIONS] COMMAND [ARGS]...
Error: No such option: -m          # <- the reported failure, reproduced
```

All four resolver branches (paths elided):

```text
1. normal:               ['…/bin/python', '-m', 'qwenpaw', 'acp', '--local-diagnostics']
2. frozen qwenpaw.exe:   ['…/qwenpaw.exe', 'acp', '--local-diagnostics']
3. frozen backend.exe:   ['…/qwenpaw.exe', 'acp']          # hopped to the sibling
4. frozen backend posix: ['…/qwenpaw',     'acp']
5. no sibling -> RuntimeError: cannot locate the QwenPaw CLI binary next to
   …/qwenpaw-backend.exe; unable to spawn 'qwenpaw acp'
```

Graceful degradation through the real TUI path (frozen, sibling missing):

```text
init ok, description: qwenpaw acp (unresolved) cwd=…
command: []
start() -> RuntimeError: cannot locate the QwenPaw CLI binary next to
           …/qwenpaw-backend.exe; unable to spawn 'qwenpaw acp --local-diagnostics'
# app.py renders this as: transport: cannot locate the QwenPaw CLI binary …
```

Regression suites:

```bash
$ pytest tests/unit/cli/ tests/unit/tauri/ -q
278 passed in 34.18s
```

Scoped pre-commit run:

```bash
$ pre-commit run --files src/qwenpaw/utils/self_invoke.py src/qwenpaw/cli/desktop_cmd.py \
    src/qwenpaw/cli/tui/launch.py src/qwenpaw/cli/tui/transport/acp.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

- **No unit tests for the new module in this PR** — a deliberate call for this round, and the honest gap: the frozen branches are the entire point of the fix and carry no coverage. The natural follow-up is `tests/unit/utils/test_self_invoke.py` covering the four branches.
- **`_CLI_STEM = "qwenpaw"` is hardcoded** with nothing binding it to the spec's `cli_exe` name, and `test_pyinstaller_spec.py` does not assert that name either. Correct for today's build (the whole `COLLECT` directory is copied verbatim, nothing is renamed), but renaming the packaged CLI would silently degrade to the branch-5 `RuntimeError`. A drift-guard assertion tying the two together is worth adding with the tests above.
- `src/qwenpaw/utils/self_invoke.py` is a new file; it must be staged (`git add`) or both importers will fail at startup.
- Users on pip/venv installs are unaffected — that argv is unchanged. The documented workaround (`python -m qwenpaw tui` in a 3.11 venv) worked precisely because both prerequisites held there: `python.exe` accepts `-m`, and qwenpaw is importable from site-packages.
