### PR TITLE
fix(webui): fix dark mode channel tag selector not working due to LESS & misuse

### DIFF
--- a/console/src/components/SessionItem/sessionItem.module.less
+++ b/console/src/components/SessionItem/sessionItem.module.less
@@ -481,10 +481,10 @@
     color: rgba(255, 255, 255, 0.5);
   }
 
-  .channelTag {
-    .drawer & {
-      color: rgba(255, 255, 255, 0.65);
-      background: rgba(255, 255, 255, 0.1);
+  .drawer {
+    .channelTag {
+      color: rgba(255, 255, 255, 0.88);
+      background: rgba(255, 255, 255, 0.16);
     }
   }
 


### PR DESCRIPTION
## Description

Fixes dark-mode channel tag (channelTag) readability in the "All Chats" session drawer. The dark-mode CSS rule was silently ignored because a LESS `&` misuse compiled the selector to `.drawer .dark-mode .channelTag` — requiring `.dark-mode` to be a descendant of `.drawer` — while in reality `.dark-mode` is on `<html>`. The channel tag therefore kept light-mode colors (dark brown text on near-invisible dark background) in dark mode, making channel labels unreadable.

Restructure the selector to `.drawer { .channelTag { ... } }` so it compiles to the correct `.dark-mode .drawer .channelTag`, and increase contrast (text `rgba(255,255,255,0.65)` → 0.88, background `rgba(255,255,255,0.1)` → 0.16) for clear readability.

**Related Issue:** Fixes #7099

**Security Considerations:** None — CSS-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test__contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_.py` for complex internal logic

## Testing

Reproduced the bug in dark mode ("All Chats" drawer, channel tags unreadable). After the fix:

1. Verified the compiled CSS now contains `.dark-mode .sessionItem-module__drawer__J6BHU .sessionItem-module__channelTag__-gywT` (correct order) instead of the non-matching `.drawer .dark-mode .channelTag`.
2. Rendered a before/after visual mockup (Chromium) and confirmed the channel tag background is visible and the label text is clearly readable in dark mode.

## Evidence

Visual verification of the fix (before → after, dark background #1f1f1f):

- Before: tag background `rgba(255,255,255,0.1)` / text `rgba(255,255,255,0.65)` — low contrast, text looks dim
- After: tag background `rgba(255,255,255,0.16)` / text `rgba(255,255,255,0.88)` — clear and readable

(Note: full `pre-commit`/`pytest`/console-build verification was not run in the contributor environment; this is a 4-line CSS selector fix verified visually.)

## Additional Notes

N/A