### PR TITLE
fix(chat): restore scroll history after compaction

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -9,6 +9,7 @@ import sqlite3
 import sys
 import threading
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,16 @@ logger = logging.getLogger(__name__)
 
 _BUSY_TIMEOUT_MS = 5000
 _UNSET = object()
+
+
+@dataclass(frozen=True)
+class SessionHistoryRow:
+    """One structured row loaded from a persisted Scroll session."""
+
+    seq: int
+    dedup_key: str | None
+    entry: LogEntry
+
 
 # The recall tool's own turns — the model's ``ms.*`` Python source and its
 # printed stdout/stderr — are written through to history like any turn, but
@@ -750,6 +761,79 @@ class HistoryStore:
 
     def __repr__(self) -> str:
         return f"<HistoryStore path={self._path}>"
+
+
+def read_session_entries(
+    db_path: str | Path,
+    *,
+    session_id: str,
+    agent_id: str | None = None,
+) -> list[SessionHistoryRow]:
+    """Read one persisted session without creating or mutating its database.
+
+    The chat API calls this function from a worker thread. A separate
+    read-only SQLite connection can safely coexist with Scroll's WAL writer.
+    Legacy rows without an ``agent_id`` remain visible to their session.
+    """
+    path = Path(db_path).expanduser()
+    if not path.is_file():
+        return []
+
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    try:
+        connection.row_factory = sqlite3.Row
+        connection.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+        where = ["session_id = ?"]
+        params: list[Any] = [session_id]
+        if agent_id:
+            where.append("(agent_id = ? OR agent_id IS NULL)")
+            params.append(agent_id)
+        where_sql = " AND ".join(where)
+        rows = connection.execute(
+            f"SELECT seq, kind, role, name, content, tool_call_id, "
+            f"tool_input, tool_state, headline, blocks, metadata, "
+            f"created_at, dedup_key FROM conversation_history WHERE "
+            f"{where_sql} ORDER BY seq",
+            params,
+        ).fetchall()
+    finally:
+        connection.close()
+
+    return [_session_history_row(row) for row in rows]
+
+
+def _session_history_row(row: sqlite3.Row) -> SessionHistoryRow:
+    """Convert one SQLite result into the shared structured entry type."""
+    blocks = _json_value(row["blocks"])
+    metadata = _json_value(row["metadata"])
+    return SessionHistoryRow(
+        seq=int(row["seq"]),
+        dedup_key=row["dedup_key"],
+        entry=LogEntry(
+            kind=row["kind"],
+            role=row["role"],
+            name=row["name"],
+            content=row["content"],
+            metadata=metadata if isinstance(metadata, dict) else {},
+            tool_call_id=row["tool_call_id"],
+            tool_input=_json_value(row["tool_input"]),
+            tool_state=row["tool_state"],
+            headline=row["headline"],
+            blocks=blocks if isinstance(blocks, list) else None,
+            created_at=row["created_at"],
+        ),
+    )
+
+
+def _json_value(value: Any) -> Any:
+    """Decode stored JSON while preserving legacy unencoded strings."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
 
 
 def _to_json(value) -> str | None:

--- a/src/qwenpaw/agents/context/scroll/serialize.py
+++ b/src/qwenpaw/agents/context/scroll/serialize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -345,3 +346,109 @@ def msg_to_entries(msg: Msg) -> list[LogEntry]:
             ),
         )
     return entries
+
+
+def entries_to_msgs(
+    entries: Sequence[tuple[str | None, LogEntry]],
+) -> list[Msg]:
+    """Rebuild transcript messages from ordered durable Scroll entries.
+
+    Scroll stores an accumulated assistant message as one model-turn row plus
+    separate tool-result rows. Group adjacent results back into that message
+    and place each result after its matching tool call so the chat UI keeps
+    the original tool interaction order.
+    """
+    messages: list[Msg] = []
+    index = 0
+    while index < len(entries):
+        dedup_key, entry = entries[index]
+        index += 1
+        if entry.kind == "tool_result":
+            messages.append(_entry_to_msg(dedup_key, entry))
+            continue
+        results: list[LogEntry] = []
+        while index < len(entries):
+            _, candidate = entries[index]
+            if candidate.kind != "tool_result" or candidate.role != entry.role:
+                break
+            results.append(candidate)
+            index += 1
+        messages.append(
+            _entry_to_msg(
+                dedup_key,
+                entry,
+                tool_results=results,
+            ),
+        )
+    return messages
+
+
+def _entry_to_msg(
+    dedup_key: str | None,
+    entry: LogEntry,
+    *,
+    tool_results: Sequence[LogEntry] = (),
+) -> Msg:
+    """Restore one base entry and its tool results as an AgentScope message."""
+    blocks = _entry_blocks(entry)
+    if tool_results:
+        blocks = _merge_tool_result_blocks(blocks, tool_results)
+    role = entry.role
+    if role not in {"user", "assistant", "system"}:
+        role = "assistant"
+    msg_kwargs: dict[str, Any] = {}
+    if entry.created_at:
+        msg_kwargs["created_at"] = entry.created_at
+    msg = Msg(
+        name=role,
+        role=role,
+        content=blocks,
+        metadata=deepcopy(entry.metadata),
+        **msg_kwargs,
+    )
+    if dedup_key:
+        msg.id = dedup_key
+    return msg
+
+
+def _entry_blocks(entry: LogEntry) -> list[dict[str, Any]]:
+    """Return structured blocks, with scalar fallbacks for legacy rows."""
+    if entry.blocks:
+        return deepcopy(entry.blocks)
+    if entry.kind == "tool_result":
+        block: dict[str, Any] = {
+            "type": "tool_result",
+            "id": entry.tool_call_id or "",
+            "name": entry.name or "",
+            "output": entry.content or "",
+        }
+        if entry.tool_state is not None:
+            block["state"] = entry.tool_state
+        return [block]
+    return [{"type": "text", "text": entry.content or ""}]
+
+
+def _merge_tool_result_blocks(
+    blocks: list[dict[str, Any]],
+    tool_results: Sequence[LogEntry],
+) -> list[dict[str, Any]]:
+    """Insert stored results immediately after their matching tool calls."""
+    pending = [
+        block for entry in tool_results for block in _entry_blocks(entry)
+    ]
+    merged: list[dict[str, Any]] = []
+    consumed: set[int] = set()
+    for block in blocks:
+        merged.append(block)
+        if block.get("type") not in {"tool_call", "tool_use"}:
+            continue
+        call_id = block.get("id")
+        for index, result in enumerate(pending):
+            if index in consumed or result.get("id") != call_id:
+                continue
+            merged.append(result)
+            consumed.add(index)
+    merged.extend(
+        result for index, result in enumerate(pending) if index not in consumed
+    )
+    return merged

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
@@ -22,7 +23,12 @@ from .models import (
     ChatUpdate,
     ChatHistory,
 )
-from .utils import agentscope_msg_to_message, parse_legacy_memory_state
+from .utils import (
+    agentscope_msg_to_message,
+    merge_scroll_history,
+    parse_legacy_memory_state,
+)
+from ...agents.context.scroll.history import read_session_entries
 from ...services.project_directory import (
     resolve_effective_project_dir,
     session_project_dir,
@@ -39,6 +45,39 @@ def _is_app_owned_chat(chat: ChatSpec) -> bool:
     """Return whether a chat belongs to a PawApp-owned dialogue surface."""
     owner = chat.meta.get("pawapp") if isinstance(chat.meta, dict) else None
     return isinstance(owner, dict) and bool(owner.get("app_id"))
+
+
+async def _restore_scroll_chat_history(
+    workspace,
+    session_id: str,
+    live_messages: list[Msg],
+) -> list[Msg]:
+    """Restore evicted Scroll turns and overlay the current context tail."""
+    try:
+        config = workspace.config
+        light_context = config.running.light_context_config
+        if config.backend != "qwenpaw" or light_context.strategy != "scroll":
+            return live_messages
+        db_path = (
+            Path(workspace.workspace_dir)
+            / light_context.scroll_config.db_filename
+        )
+        rows = await asyncio.to_thread(
+            read_session_entries,
+            db_path,
+            session_id=session_id,
+            agent_id=workspace.agent_id,
+        )
+        if not rows:
+            return live_messages
+        return merge_scroll_history(rows, live_messages)
+    except (AttributeError, OSError, sqlite3.Error, ValueError):
+        logger.warning(
+            f"Failed to restore durable chat history for "
+            f"session_id={session_id}",
+            exc_info=True,
+        )
+        return live_messages
 
 
 async def get_workspace(request: Request):
@@ -413,28 +452,31 @@ async def get_chat(
                 exc_info=True,
             )
     status = await workspace.task_tracker.get_status(chat_id)
-    if not state:
-        return ChatHistory(messages=[], status=status)
-
-    agent_raw = state.get("agent", {})
     memories: list[Msg] = []
+    if state:
+        agent_raw = state.get("agent", {})
+        state_raw = agent_raw.get("state")
+        if isinstance(state_raw, dict):
+            try:
+                agent_state = AgentState.model_validate(state_raw)
+                memories = list(agent_state.context)
+            except Exception:
+                logger.debug(
+                    "Failed to parse agent.state, falling back to legacy",
+                    exc_info=True,
+                )
 
-    state_raw = agent_raw.get("state")
-    if isinstance(state_raw, dict):
-        try:
-            agent_state = AgentState.model_validate(state_raw)
-            memories = list(agent_state.context)
-        except Exception:
-            logger.debug(
-                "Failed to parse agent.state, falling back to legacy",
-                exc_info=True,
-            )
+        # Legacy fallback: 1.x ``agent.memory`` format.
+        if not memories:
+            memory_raw = agent_raw.get("memory", {})
+            if memory_raw:
+                memories, _summary = parse_legacy_memory_state(memory_raw)
 
-    # Legacy fallback: 1.x ``agent.memory`` format.
-    if not memories:
-        memory_raw = agent_raw.get("memory", {})
-        if memory_raw:
-            memories, _summary = parse_legacy_memory_state(memory_raw)
+    memories = await _restore_scroll_chat_history(
+        workspace,
+        chat_spec.session_id,
+        memories,
+    )
 
     messages = agentscope_msg_to_message(memories)
     return ChatHistory(messages=messages, status=status)

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -4,12 +4,17 @@ import logging
 import platform
 import re
 from datetime import datetime, timezone
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from agentscope.message import Msg
-from qwenpaw.agents.context.scroll.serialize import strip_headline
+from qwenpaw.agents.context.scroll.history import SessionHistoryRow
+from qwenpaw.agents.context.scroll.serialize import (
+    entries_to_msgs,
+    msg_to_entries,
+    strip_headline,
+)
 from qwenpaw.schemas import (
     Message,
     TextContent,
@@ -109,6 +114,53 @@ def _is_synthetic_user_message(msg: Msg) -> bool:
         and metadata.get(QWENPAW_MESSAGE_TAG_KEY)
         in SYNTHETIC_USER_MESSAGE_TAGS
     )
+
+
+def merge_scroll_history(
+    persisted: Sequence[SessionHistoryRow],
+    live: Sequence[Msg],
+) -> list[Msg]:
+    """Merge durable Scroll history with the newest live context tail.
+
+    Durable rows supply turns evicted by compaction. Live messages replace
+    their persisted counterparts so an in-progress assistant message keeps
+    blocks that have not reached SQLite yet. Remaining live messages are
+    appended in context order.
+    """
+    durable = entries_to_msgs(
+        [(row.dedup_key, row.entry) for row in persisted],
+    )
+    visible_live = [
+        msg
+        for msg in live
+        if not _is_scroll_memory_placeholder(msg)
+        and not _is_synthetic_user_message(msg)
+    ]
+    live_by_id = {
+        msg.id: msg for msg in visible_live if getattr(msg, "id", None)
+    }
+    live_by_result_id: dict[str, Msg] = {}
+    for msg in visible_live:
+        for entry in msg_to_entries(msg):
+            if entry.kind == "tool_result" and entry.tool_call_id:
+                live_by_result_id[entry.tool_call_id] = msg
+
+    merged: list[Msg] = []
+    used_live_ids: set[int] = set()
+    for durable_msg in durable:
+        live_msg = live_by_id.get(durable_msg.id)
+        if live_msg is None:
+            live_msg = live_by_result_id.get(durable_msg.id)
+        if live_msg is None:
+            merged.append(durable_msg)
+            continue
+        identity = id(live_msg)
+        if identity not in used_live_ids:
+            merged.append(live_msg)
+            used_live_ids.add(identity)
+
+    merged.extend(msg for msg in visible_live if id(msg) not in used_live_ids)
+    return merged
 
 
 def parse_legacy_memory_state(

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -14,7 +14,10 @@ from pathlib import Path
 
 import pytest
 
-from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.history import (
+    HistoryStore,
+    read_session_entries,
+)
 from qwenpaw.agents.context.types import LogEntry
 
 
@@ -37,6 +40,51 @@ def test_append_assigns_increasing_seq_and_counts(store: HistoryStore):
     assert s2 > s1
     assert store.count("s") == 2
     assert store.count("other") == 0
+
+
+def test_read_session_entries_restores_structure_and_scopes_agent(
+    store: HistoryStore,
+):
+    store.append(
+        session_id="shared",
+        agent_id="agent-a",
+        dedup_key="message-a",
+        entry=_entry(
+            "hello",
+            blocks=[{"type": "text", "text": "hello"}],
+            metadata={"source": "test"},
+            tool_input={"path": "file.txt"},
+        ),
+    )
+    store.append(
+        session_id="shared",
+        agent_id="agent-b",
+        dedup_key="message-b",
+        entry=_entry("private"),
+    )
+    store.append(
+        session_id="shared",
+        dedup_key="legacy",
+        entry=_entry("legacy"),
+    )
+
+    rows = read_session_entries(
+        store.path,
+        session_id="shared",
+        agent_id="agent-a",
+    )
+
+    assert [row.dedup_key for row in rows] == ["message-a", "legacy"]
+    assert rows[0].entry.blocks == [{"type": "text", "text": "hello"}]
+    assert rows[0].entry.metadata == {"source": "test"}
+    assert rows[0].entry.tool_input == {"path": "file.txt"}
+
+
+def test_read_session_entries_does_not_create_missing_database(tmp_path: Path):
+    db_path = tmp_path / "missing" / "history.db"
+
+    assert read_session_entries(db_path, session_id="s") == []
+    assert not db_path.exists()
 
 
 def test_created_at_index_exists_for_date_filtered_recall(

--- a/tests/unit/agents/context/test_serialize.py
+++ b/tests/unit/agents/context/test_serialize.py
@@ -6,11 +6,65 @@ import pytest
 from qwenpaw.agents.context.scroll.prompt import build_scroll_system_prompt
 from qwenpaw.agents.context.scroll.serialize import (
     HeadlineDeltaState,
+    entries_to_msgs,
     extract_headline,
     flush_headline_delta,
     strip_headline,
     strip_headline_delta,
 )
+from qwenpaw.agents.context.types import LogEntry
+
+
+def test_entries_to_msgs_restores_tool_result_order_and_identity() -> None:
+    entries = [
+        (
+            "message-1",
+            LogEntry(
+                kind="model_turn",
+                role="assistant",
+                blocks=[
+                    {"type": "text", "text": "calling"},
+                    {
+                        "type": "tool_call",
+                        "id": "call-1",
+                        "name": "read_file",
+                        "input": '{"path": "a.txt"}',
+                    },
+                    {"type": "text", "text": "finished"},
+                ],
+                metadata={"source": "history"},
+                created_at="2026-08-18T10:00:00+00:00",
+            ),
+        ),
+        (
+            "call-1",
+            LogEntry(
+                kind="tool_result",
+                role="assistant",
+                tool_call_id="call-1",
+                blocks=[
+                    {
+                        "type": "tool_result",
+                        "id": "call-1",
+                        "name": "read_file",
+                        "output": "contents",
+                    },
+                ],
+            ),
+        ),
+    ]
+
+    [message] = entries_to_msgs(entries)
+
+    assert message.id == "message-1"
+    assert message.metadata == {"source": "history"}
+    assert message.created_at == "2026-08-18T10:00:00+00:00"
+    assert [block.type for block in message.content] == [
+        "text",
+        "tool_call",
+        "tool_result",
+        "text",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app/chats/test_api.py
+++ b/tests/unit/app/chats/test_api.py
@@ -1,14 +1,23 @@
 # -*- coding: utf-8 -*-
 """Ownership-boundary tests for the global chat API."""
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from agentscope.message import Msg
+from agentscope.state import AgentState
 from fastapi import HTTPException
 
+from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.serialize import msg_to_entries
 from qwenpaw.app.chats.api import get_chat, list_chats
 from qwenpaw.app.chats.models import ChatSpec
+from qwenpaw.constant import (
+    QWENPAW_MESSAGE_TAG_KEY,
+    SCROLL_MEMORY_MESSAGE_TAG,
+)
 
 
 def _chat(chat_id: str, *, app_id: str | None = None) -> ChatSpec:
@@ -29,6 +38,76 @@ def _chat(chat_id: str, *, app_id: str | None = None) -> ChatSpec:
         channel="console",
         meta=meta,
     )
+
+
+def _message(role: str, text: str, message_id: str) -> Msg:
+    return Msg(
+        id=message_id,
+        name=role,
+        role=role,
+        content=[{"type": "text", "text": text}],
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+    *,
+    backend: str = "qwenpaw",
+    strategy: str = "scroll",
+):
+    config = SimpleNamespace(
+        backend=backend,
+        running=SimpleNamespace(
+            light_context_config=SimpleNamespace(
+                strategy=strategy,
+                scroll_config=SimpleNamespace(db_filename="history.db"),
+            ),
+        ),
+    )
+    return SimpleNamespace(
+        agent_id="default",
+        config=config,
+        workspace_dir=tmp_path,
+        task_tracker=SimpleNamespace(
+            get_status=AsyncMock(return_value="idle"),
+        ),
+    )
+
+
+def _persist_messages(
+    db_path: Path,
+    session_id: str,
+    messages: list[Msg],
+) -> None:
+    store = HistoryStore(db_path)
+    try:
+        for message in messages:
+            entries = msg_to_entries(message)
+            assert len(entries) == 1
+            store.append(
+                session_id=session_id,
+                agent_id="default",
+                dedup_key=message.id,
+                entry=entries[0],
+            )
+    finally:
+        store.close()
+
+
+def _session_state(messages: list[Msg]) -> dict:
+    state = AgentState(context=messages).model_dump(mode="json")
+    return {"agent": {"state": state}}
+
+
+def _message_texts(history) -> list[str]:
+    return [
+        "".join(
+            content.text
+            for content in message.content
+            if getattr(content, "text", None) is not None
+        )
+        for message in history.messages
+    ]
 
 
 @pytest.mark.asyncio
@@ -69,3 +148,146 @@ async def test_get_chat_hides_app_owned_dialogue_when_caller_opts_out():
         )
 
     assert raised.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_chat_restores_evicted_scroll_history_and_live_tail(
+    tmp_path: Path,
+):
+    chat = _chat("normal")
+    old_user = _message("user", "old question", "old-user")
+    old_assistant = _message("assistant", "old answer", "old-assistant")
+    current_user = _message("user", "current question", "current-user")
+    persisted_reply = _message(
+        "assistant",
+        "partial reply",
+        "current-assistant",
+    )
+    live_reply = _message(
+        "assistant",
+        "complete reply",
+        "current-assistant",
+    )
+    _persist_messages(
+        tmp_path / "history.db",
+        chat.session_id,
+        [old_user, old_assistant, current_user, persisted_reply],
+    )
+    session = SimpleNamespace(
+        get_session_state_dict=AsyncMock(
+            return_value=_session_state([current_user, live_reply]),
+        ),
+    )
+
+    history = await get_chat(
+        chat_id=chat.id,
+        include_app_owned=True,
+        mgr=SimpleNamespace(get_chat=AsyncMock(return_value=chat)),
+        session=session,
+        workspace=_workspace(tmp_path),
+    )
+
+    assert _message_texts(history) == [
+        "old question",
+        "old answer",
+        "current question",
+        "complete reply",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_chat_falls_back_to_live_state_without_scroll_database(
+    tmp_path: Path,
+):
+    chat = _chat("normal")
+    live_user = _message("user", "still visible", "live-user")
+    session = SimpleNamespace(
+        get_session_state_dict=AsyncMock(
+            return_value=_session_state([live_user]),
+        ),
+    )
+
+    history = await get_chat(
+        chat_id=chat.id,
+        include_app_owned=True,
+        mgr=SimpleNamespace(get_chat=AsyncMock(return_value=chat)),
+        session=session,
+        workspace=_workspace(tmp_path),
+    )
+
+    assert _message_texts(history) == ["still visible"]
+    assert not (tmp_path / "history.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_get_chat_restores_without_snapshot_and_hides_scroll_placeholder(
+    tmp_path: Path,
+):
+    chat = _chat("normal")
+    old_user = _message("user", "durable question", "old-user")
+    placeholder = Msg(
+        id="visual-placeholder",
+        name="memory",
+        role="user",
+        content=[{"type": "text", "text": "compressed context"}],
+        metadata={
+            QWENPAW_MESSAGE_TAG_KEY: SCROLL_MEMORY_MESSAGE_TAG,
+        },
+    )
+    _persist_messages(
+        tmp_path / "history.db",
+        chat.session_id,
+        [old_user, placeholder],
+    )
+    session = SimpleNamespace(
+        get_session_state_dict=AsyncMock(return_value={}),
+    )
+
+    history = await get_chat(
+        chat_id=chat.id,
+        include_app_owned=True,
+        mgr=SimpleNamespace(get_chat=AsyncMock(return_value=chat)),
+        session=session,
+        workspace=_workspace(tmp_path),
+    )
+
+    assert _message_texts(history) == ["durable question"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("backend", "strategy"),
+    [("codex", "scroll"), ("qwenpaw", "native")],
+)
+async def test_get_chat_does_not_mix_inactive_scroll_history(
+    tmp_path: Path,
+    backend: str,
+    strategy: str,
+):
+    chat = _chat("normal")
+    hidden_old = _message("user", "stale history", "stale-user")
+    live_user = _message("user", "active history", "live-user")
+    _persist_messages(
+        tmp_path / "history.db",
+        chat.session_id,
+        [hidden_old],
+    )
+    session = SimpleNamespace(
+        get_session_state_dict=AsyncMock(
+            return_value=_session_state([live_user]),
+        ),
+    )
+
+    history = await get_chat(
+        chat_id=chat.id,
+        include_app_owned=True,
+        mgr=SimpleNamespace(get_chat=AsyncMock(return_value=chat)),
+        session=session,
+        workspace=_workspace(
+            tmp_path,
+            backend=backend,
+            strategy=strategy,
+        ),
+    )
+
+    assert _message_texts(history) == ["active history"]


### PR DESCRIPTION
## Summary

Fixes #7065.

After Scroll context compaction, `GET /chats/{id}` returned only the remaining live `AgentState.context`, causing older conversation rounds to disappear from the chat UI.

This change restores the complete transcript from Scroll's durable history database and merges it with the latest live context.

## Changes

- Add read-only loading of durable Scroll history, scoped by session and agent.
- Reconstruct AgentScope messages while preserving structured content, metadata, timestamps, IDs, and tool-result ordering.
- Merge persisted history with the live context tail, preferring live messages when IDs overlap.
- Filter internal Scroll and synthetic placeholder messages from the displayed transcript.
- Run SQLite reads in a worker thread to avoid blocking the async API.
- Apply the behavior only to the `qwenpaw` backend with the `scroll` strategy.
- Fall back to the existing session state when the history database is missing or unreadable.
- Add regression tests for compaction recovery, message deduplication, agent isolation, empty snapshots, tool results, and inactive backends.

## Validation

- `530 passed` across the relevant Scroll and chat test suites.
- All pre-commit checks passed, including mypy, Black, Flake8, and Pylint.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
