### PR TITLE
feat(matrix): retry login on transient homeserver failures

### DIFF
--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -90,6 +90,24 @@ ROOM_HISTORY_MAX_ROOMS = 256
 VERIFICATION_STATE_MAX_ENTRIES = 1_024
 VERIFICATION_STATE_TTL_S = 60 * 60
 
+# nio retries transport-level failures (connection refused, timeouts)
+# inside _send(), but it does NOT retry when the homeserver returns an
+# unparseable HTTP response (e.g. 502 from a reverse proxy before
+# Synapse is ready).  login()/whoami() then return a LoginError or
+# WhoamiError with status_code=None, and start() would permanently
+# give up.  These constants drive a retry loop in MatrixChannel that
+# covers that gap, leaving credential errors as one-shot failures.
+_NON_RETRYABLE_AUTH_CODES = frozenset(
+    {
+        "M_FORBIDDEN",
+        "M_MISSING_TOKEN",
+        "M_UNKNOWN_TOKEN",
+        "M_USER_DEACTIVATED",
+    },
+)
+_LOGIN_RETRY_INITIAL_DELAY = 5.0
+_LOGIN_RETRY_MAX_DELAY = 60.0
+
 # Known QwenPaw slash commands — used to decide whether to strip
 # @mention prefix
 _SLASH_COMMANDS = frozenset(
@@ -573,6 +591,19 @@ class MatrixChannel(BaseChannel):
                     "device_id; E2EE store may not be reusable",
                 )
 
+    def _is_retryable_auth_failure(self, response: Any) -> bool:
+        """Return True if a login/whoami error may recover on retry.
+
+        nio's ErrorResponse subclasses carry a ``status_code`` that is
+        either a Matrix errcode string (e.g. ``M_FORBIDDEN``) or
+        ``None`` when the response body could not be parsed — the
+        latter happens when the homeserver is not fully ready yet
+        (e.g. 502 from a reverse proxy before Synapse starts).
+        Credential errors are never retryable; everything else is.
+        """
+        code = getattr(response, "status_code", None)
+        return code not in _NON_RETRYABLE_AUTH_CODES
+
     async def _login_with_password(
         self,
         login_user: str,
@@ -587,58 +618,94 @@ class MatrixChannel(BaseChannel):
             login_kwargs,
             resolved_device_id,
         )
-        resp, last_exc = await self._try_password_login_variants(attempts)
-        if last_exc is not None:
-            raise last_exc
-        if isinstance(resp, LoginResponse):
-            self._handle_password_login_success(resp)
-            return True
-        logger.error("MatrixChannel: password login failed: %s", resp)
-        return False
+        delay = _LOGIN_RETRY_INITIAL_DELAY
+        while True:
+            resp, last_exc = await self._try_password_login_variants(
+                attempts,
+            )
+            if last_exc is not None:
+                raise last_exc
+            if isinstance(resp, LoginResponse):
+                self._handle_password_login_success(resp)
+                return True
+            if not self._is_retryable_auth_failure(resp):
+                logger.error(
+                    "MatrixChannel: password login rejected: %s",
+                    resp,
+                )
+                return False
+            logger.warning(
+                "MatrixChannel: password login temporarily "
+                "failed, retrying in %.1fs: %s",
+                delay,
+                resp,
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _LOGIN_RETRY_MAX_DELAY)
 
     async def _login_with_access_token(self) -> bool:
         self._client.access_token = self.access_token
-        whoami = await self._client.whoami()
-        if isinstance(whoami, WhoamiResponse):
-            if self.matrix_user_id and self.matrix_user_id != whoami.user_id:
+        delay = _LOGIN_RETRY_INITIAL_DELAY
+        while True:
+            whoami = await self._client.whoami()
+            if isinstance(whoami, WhoamiResponse):
+                return self._handle_token_login_success(whoami)
+            if not self._is_retryable_auth_failure(whoami):
                 logger.error(
-                    "MatrixChannel: configured user_id=%s does not match "
-                    "access_token owner=%s; refusing stale credentials",
-                    self.matrix_user_id,
-                    whoami.user_id,
+                    "MatrixChannel: token login rejected: %s",
+                    whoami,
                 )
                 return False
-            self._user_id = whoami.user_id
-            self._client.user_id = whoami.user_id
-            self._client.user = whoami.user_id
-            # E2EE requires device_id to associate Olm keys with this
-            # device
-            if whoami.device_id:
-                self._client.device_id = whoami.device_id
-            logger.info(
-                "MatrixChannel: logged in as %s (token, device=%s)",
-                self._user_id,
-                whoami.device_id,
+            logger.warning(
+                "MatrixChannel: token login temporarily failed, "
+                "retrying in %.1fs: %s",
+                delay,
+                whoami,
             )
-            self._save_auth_state()
-            # Load crypto store after user_id and device_id are set
-            if self.encryption and self._client.store_path:
-                if self._client.device_id:
-                    self._client.load_store()
-                    logger.info(
-                        "MatrixChannel: crypto store loaded from %s",
-                        self._client.store_path,
-                    )
-                else:
-                    logger.error(
-                        "MatrixChannel: E2EE enabled but whoami returned "
-                        "no device_id — encryption disabled "
-                        "(token may lack device scope)",
-                    )
-                    self.encryption = False
-            return True
-        logger.error("MatrixChannel: token login failed: %s", whoami)
-        return False
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _LOGIN_RETRY_MAX_DELAY)
+
+    def _handle_token_login_success(
+        self,
+        whoami: WhoamiResponse,
+    ) -> bool:
+        if self.matrix_user_id and self.matrix_user_id != whoami.user_id:
+            logger.error(
+                "MatrixChannel: configured user_id=%s does not match "
+                "access_token owner=%s; refusing stale credentials",
+                self.matrix_user_id,
+                whoami.user_id,
+            )
+            return False
+        self._user_id = whoami.user_id
+        self._client.user_id = whoami.user_id
+        self._client.user = whoami.user_id
+        # E2EE requires device_id to associate Olm keys with this
+        # device
+        if whoami.device_id:
+            self._client.device_id = whoami.device_id
+        logger.info(
+            "MatrixChannel: logged in as %s (token, device=%s)",
+            self._user_id,
+            whoami.device_id,
+        )
+        self._save_auth_state()
+        # Load crypto store after user_id and device_id are set
+        if self.encryption and self._client.store_path:
+            if self._client.device_id:
+                self._client.load_store()
+                logger.info(
+                    "MatrixChannel: crypto store loaded from %s",
+                    self._client.store_path,
+                )
+            else:
+                logger.error(
+                    "MatrixChannel: E2EE enabled but whoami returned "
+                    "no device_id — encryption disabled "
+                    "(token may lack device scope)",
+                )
+                self.encryption = False
+        return True
 
     def _register_plain_room_callbacks(self) -> None:
         self._client.add_event_callback(

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -90,13 +90,10 @@ ROOM_HISTORY_MAX_ROOMS = 256
 VERIFICATION_STATE_MAX_ENTRIES = 1_024
 VERIFICATION_STATE_TTL_S = 60 * 60
 
-# nio retries transport-level failures (connection refused, timeouts)
-# inside _send(), but it does NOT retry when the homeserver returns an
-# unparseable HTTP response (e.g. 502 from a reverse proxy before
-# Synapse is ready).  login()/whoami() then return a LoginError or
-# WhoamiError with status_code=None, and start() would permanently
-# give up.  These constants drive a retry loop in MatrixChannel that
-# covers that gap, leaving credential errors as one-shot failures.
+# nio's _send() retries transport errors but not unparseable HTTP
+# responses (e.g. 502 before Synapse is ready).  login()/whoami()
+# return LoginError/WhoamiError with status_code=None and start()
+# gives up.  These constants drive a retry loop covering that gap.
 _NON_RETRYABLE_AUTH_CODES = frozenset(
     {
         "M_FORBIDDEN",
@@ -266,6 +263,7 @@ class MatrixChannel(BaseChannel):
         self._client: Optional[AsyncClient] = None
         self._user_id: Optional[str] = None
         self._sync_task: Optional[asyncio.Task] = None
+        self._stop_event: Optional[asyncio.Event] = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._room_histories: OrderedDict[
             str,
@@ -591,18 +589,41 @@ class MatrixChannel(BaseChannel):
                     "device_id; E2EE store may not be reusable",
                 )
 
+    def _is_stopping(self) -> bool:
+        """Return True if stop() has been requested."""
+        return self._stop_event is not None and self._stop_event.is_set()
+
     def _is_retryable_auth_failure(self, response: Any) -> bool:
         """Return True if a login/whoami error may recover on retry.
 
-        nio's ErrorResponse subclasses carry a ``status_code`` that is
-        either a Matrix errcode string (e.g. ``M_FORBIDDEN``) or
-        ``None`` when the response body could not be parsed — the
-        latter happens when the homeserver is not fully ready yet
-        (e.g. 502 from a reverse proxy before Synapse starts).
-        Credential errors are never retryable; everything else is.
+        Checks both the Matrix errcode (``status_code``) and the
+        underlying HTTP status -- only 5xx / 408 / 429 are retried.
         """
         code = getattr(response, "status_code", None)
-        return code not in _NON_RETRYABLE_AUTH_CODES
+        if code in _NON_RETRYABLE_AUTH_CODES:
+            return False
+        http_status = getattr(
+            getattr(response, "transport_response", None),
+            "status",
+            None,
+        )
+        if http_status is None:
+            return True
+        return http_status >= 500 or http_status in (408, 429)
+
+    async def _wait_backoff_or_stop(self, delay: float) -> bool:
+        """Sleep for delay; return True if stop() was called."""
+        if self._stop_event is None:
+            await asyncio.sleep(delay)
+            return False
+        try:
+            await asyncio.wait_for(
+                self._stop_event.wait(),
+                timeout=delay,
+            )
+            return True
+        except asyncio.TimeoutError:
+            return False
 
     async def _login_with_password(
         self,
@@ -620,12 +641,16 @@ class MatrixChannel(BaseChannel):
         )
         delay = _LOGIN_RETRY_INITIAL_DELAY
         while True:
+            if self._is_stopping():
+                return False
             resp, last_exc = await self._try_password_login_variants(
                 attempts,
             )
             if last_exc is not None:
                 raise last_exc
             if isinstance(resp, LoginResponse):
+                if self._is_stopping():
+                    return False
                 self._handle_password_login_success(resp)
                 return True
             if not self._is_retryable_auth_failure(resp):
@@ -640,15 +665,20 @@ class MatrixChannel(BaseChannel):
                 delay,
                 resp,
             )
-            await asyncio.sleep(delay)
+            if await self._wait_backoff_or_stop(delay):
+                return False
             delay = min(delay * 2, _LOGIN_RETRY_MAX_DELAY)
 
     async def _login_with_access_token(self) -> bool:
         self._client.access_token = self.access_token
         delay = _LOGIN_RETRY_INITIAL_DELAY
         while True:
+            if self._is_stopping():
+                return False
             whoami = await self._client.whoami()
             if isinstance(whoami, WhoamiResponse):
+                if self._is_stopping():
+                    return False
                 return self._handle_token_login_success(whoami)
             if not self._is_retryable_auth_failure(whoami):
                 logger.error(
@@ -662,7 +692,8 @@ class MatrixChannel(BaseChannel):
                 delay,
                 whoami,
             )
-            await asyncio.sleep(delay)
+            if await self._wait_backoff_or_stop(delay):
+                return False
             delay = min(delay * 2, _LOGIN_RETRY_MAX_DELAY)
 
     def _handle_token_login_success(
@@ -779,6 +810,7 @@ class MatrixChannel(BaseChannel):
                 "MatrixChannel: homeserver not configured, skipping",
             )
             return
+        self._stop_event = asyncio.Event()
         self._preflight_e2ee_dependencies()
         login_user = (self.matrix_user_id or "").strip()
         has_password_creds = bool(login_user and self.password)
@@ -819,6 +851,8 @@ class MatrixChannel(BaseChannel):
         logger.info("MatrixChannel: sync loop started")
 
     async def stop(self) -> None:
+        if self._stop_event:
+            self._stop_event.set()
         if self._sync_task:
             self._sync_task.cancel()
             try:

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -928,6 +928,29 @@ class TestMatrixChannelLoginRetry:
         assert ok is False
         assert mock_async_client.login.call_count == 1
 
+    async def test_password_login_no_retry_on_404(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Non-JSON 404 (wrong URL) is not retried."""
+        matrix_channel.access_token = ""
+        matrix_channel.password = "test_password"
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        mock_transport = MagicMock(status=404)
+        err = LoginError(message="unknown error")
+        err.transport_response = mock_transport
+        mock_async_client.login = AsyncMock(return_value=err)
+
+        ok = await matrix_channel._login_with_password(
+            "@bot:example.com",
+            "DEV",
+        )
+
+        assert ok is False
+        assert mock_async_client.login.call_count == 1
+
     async def test_token_login_retries_then_succeeds(
         self,
         matrix_channel,
@@ -978,6 +1001,39 @@ class TestMatrixChannelLoginRetry:
 
         assert ok is False
         assert mock_async_client.whoami.call_count == 1
+
+    async def test_token_login_stops_during_backoff(
+        self,
+        matrix_channel,
+        mock_async_client,
+        monkeypatch,
+    ):
+        """stop() during login retry terminates the loop."""
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.matrix.channel"
+            "._LOGIN_RETRY_INITIAL_DELAY",
+            100.0,
+        )
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        matrix_channel._stop_event = asyncio.Event()
+        call_count = 0
+
+        def whoami_and_set_stop(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                matrix_channel._stop_event.set()
+            return WhoamiError(message="unknown error")
+
+        mock_async_client.whoami = AsyncMock(
+            side_effect=whoami_and_set_stop,
+        )
+
+        ok = await matrix_channel._login_with_access_token()
+
+        assert ok is False
+        assert call_count == 1
 
     async def test_login_retry_cancelled_during_sleep(
         self,

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -3,10 +3,12 @@
 
 # pylint: disable=redefined-outer-name,unused-import
 # pylint: disable=protected-access,unused-argument
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from nio import (
+    LoginResponse,
     MatrixRoom,
     RoomMessageAudio,
     RoomMessageFile,
@@ -17,7 +19,11 @@ from nio import (
     UploadError,
     UploadResponse,
 )
-from nio.responses import WhoamiResponse
+from nio.responses import (
+    LoginError,
+    WhoamiError,
+    WhoamiResponse,
+)
 
 from qwenpaw.schemas import (
     AgentRequest,
@@ -850,6 +856,157 @@ class TestMatrixChannelStartStop:
         """Test stop when channel was never started."""
         # Should not raise
         await matrix_channel.stop()
+
+
+class TestMatrixChannelLoginRetry:
+    """Test login retry behavior for transient homeserver failures.
+
+    nio retries transport-level errors (connection refused, timeouts)
+    inside _send(), but does not retry when the homeserver returns an
+    unparseable response (e.g. 502 from a reverse proxy before Synapse
+    is ready).  MatrixChannel wraps login()/whoami() with its own
+    retry loop to cover that gap (#6684).
+    """
+
+    async def test_password_login_retries_then_succeeds(
+        self,
+        matrix_channel,
+        mock_async_client,
+        monkeypatch,
+    ):
+        """Unparseable login response is retried until ready."""
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.matrix.channel"
+            "._LOGIN_RETRY_INITIAL_DELAY",
+            0.0,
+        )
+        matrix_channel.access_token = ""
+        matrix_channel.password = "test_password"
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        mock_async_client.login = AsyncMock(
+            side_effect=[
+                LoginError(message="unknown error"),
+                LoginResponse(
+                    user_id="@bot:example.com",
+                    device_id="DEV",
+                    access_token="tok",
+                ),
+            ],
+        )
+
+        ok = await matrix_channel._login_with_password(
+            "@bot:example.com",
+            "DEV",
+        )
+
+        assert ok is True
+        assert mock_async_client.login.call_count == 2
+
+    async def test_password_login_no_retry_on_forbidden(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Credential errors (M_FORBIDDEN) are not retried."""
+        matrix_channel.access_token = ""
+        matrix_channel.password = "test_password"
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        mock_async_client.login = AsyncMock(
+            return_value=LoginError(
+                message="Forbidden",
+                status_code="M_FORBIDDEN",
+            ),
+        )
+
+        ok = await matrix_channel._login_with_password(
+            "@bot:example.com",
+            "DEV",
+        )
+
+        assert ok is False
+        assert mock_async_client.login.call_count == 1
+
+    async def test_token_login_retries_then_succeeds(
+        self,
+        matrix_channel,
+        mock_async_client,
+        monkeypatch,
+    ):
+        """Unparseable whoami response is retried until ready."""
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.matrix.channel"
+            "._LOGIN_RETRY_INITIAL_DELAY",
+            0.0,
+        )
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        good = WhoamiResponse(
+            user_id="@bot:example.com",
+            device_id=None,
+            is_guest=False,
+        )
+        mock_async_client.whoami = AsyncMock(
+            side_effect=[
+                WhoamiError(message="unknown error"),
+                good,
+            ],
+        )
+
+        ok = await matrix_channel._login_with_access_token()
+
+        assert ok is True
+        assert mock_async_client.whoami.call_count == 2
+
+    async def test_token_login_no_retry_on_unknown_token(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Invalid token (M_UNKNOWN_TOKEN) is not retried."""
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        mock_async_client.whoami = AsyncMock(
+            return_value=WhoamiError(
+                message="Unknown token",
+                status_code="M_UNKNOWN_TOKEN",
+            ),
+        )
+
+        ok = await matrix_channel._login_with_access_token()
+
+        assert ok is False
+        assert mock_async_client.whoami.call_count == 1
+
+    async def test_login_retry_cancelled_during_sleep(
+        self,
+        matrix_channel,
+        mock_async_client,
+        monkeypatch,
+    ):
+        """CancelledError propagates through the retry loop."""
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.matrix.channel"
+            "._LOGIN_RETRY_INITIAL_DELAY",
+            0.0,
+        )
+        matrix_channel._client = mock_async_client
+        matrix_channel._save_auth_state = Mock()
+        mock_async_client.whoami = AsyncMock(
+            return_value=WhoamiError(message="unknown error"),
+        )
+
+        async def raise_cancelled(_delay: float) -> None:
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.matrix.channel.asyncio.sleep",
+            raise_cancelled,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await matrix_channel._login_with_access_token()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When QwenPaw starts before the Matrix homeserver is fully ready (e.g. a reverse proxy is up but Synapse is still booting), the login/whoami request receives an HTTP response that matrix-nio cannot parse as a valid login or whoami response. matrix-nio returns a `LoginError`/`WhoamiError` with `status_code=None`, and because its internal retry in `_send()` only covers transport-level exceptions (`ClientConnectionError`, `TimeoutError`), it does **not** retry this case. `MatrixChannel.start()` then returned immediately, leaving the channel permanently offline until a manual restart.

Closes #6684.

## Root cause

`nio.AsyncClient._send()` has a `while True` loop that retries only on transport-level exceptions and HTTP 429. When the homeserver returns an unparseable response (e.g. `502 Bad Gateway` HTML from a reverse proxy), `parse_body()` fails to decode JSON and returns `{}`. `LoginResponse.from_dict({})` then returns a `LoginError` (missing `user_id`), and `_send()` exits via `else: break` without retrying. The `login()` and `whoami()` methods are thin wrappers over `_send()` and add no retry of their own.

This means:
- **Connection refused / timeout** → nio retries with exponential backoff (works today).
- **502 / unparseable response** → nio returns an `ErrorResponse` immediately, `start()` gives up permanently (the gap this PR closes).

## Changes

All changes are confined to `MatrixChannel` — `ChannelManager` and the channel lifecycle contract are untouched.

- **`_login_with_password`**: wraps the existing `_try_password_login_variants()` call in a `while True` retry loop with capped exponential backoff (5 s → 10 s → 20 s … 60 s cap). Credential errors (`M_FORBIDDEN`, `M_MISSING_TOKEN`, `M_UNKNOWN_TOKEN`, `M_USER_DEACTIVATED`) return `False` immediately; everything else (including `status_code=None`) retries indefinitely until the homeserver accepts the request or `stop_all()` cancels the task.
- **`_login_with_access_token`**: same retry loop around `whoami()`. The success path is extracted into `_handle_token_login_success()` to keep the loop body readable and avoid re-indenting the existing logic.
- **`_is_retryable_auth_failure`**: shared helper that checks `status_code` against the non-retryable set.
- **`start()` is unchanged**: it still `return`s on `False`, but because the login methods now retry internally, only credential errors or cancellation reach that path.

## What is NOT changed

- `ChannelManager._start_channel` — no new exception contract or shared retry layer.
- `_sync_loop` — runtime reconnect already covered by nio's `max_timeouts=None`.
- `_setup_e2ee_after_login` — `keys_upload` failure retry can be addressed separately.
- The `_sync_loop` `M_UNKNOWN_TOKEN` branch (runtime token invalidation).

## Test plan

5 new unit tests in `TestMatrixChannelLoginRetry`:

| Test | Scenario | Expectation |
|---|---|---|
| `test_password_login_retries_then_succeeds` | `LoginError(status_code=None)` → `LoginResponse` | retries, returns `True`, `login.call_count == 2` |
| `test_password_login_no_retry_on_forbidden` | `LoginError(status_code="M_FORBIDDEN")` | no retry, returns `False`, `login.call_count == 1` |
| `test_token_login_retries_then_succeeds` | `WhoamiError(status_code=None)` → `WhoamiResponse` | retries, returns `True`, `whoami.call_count == 2` |
| `test_token_login_no_retry_on_unknown_token` | `WhoamiError(status_code="M_UNKNOWN_TOKEN")` | no retry, returns `False`, `whoami.call_count == 1` |
| `test_login_retry_cancelled_during_sleep` | retryable error + `asyncio.sleep` raises `CancelledError` | `CancelledError` propagates cleanly |

All 67 existing matrix tests continue to pass. `pre-commit` (mypy, black, flake8, pylint) is green.