### PR TITLE
fix(console): improve dark session group states

### DIFF
--- a/console/src/components/SessionGroupDnd/SessionGroupDnd.module.less
+++ b/console/src/components/SessionGroupDnd/SessionGroupDnd.module.less
@@ -41,3 +41,17 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+:global(.dark-mode) {
+  .dropActive {
+    background: rgba(255, 127, 22, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(255, 143, 50, 0.44);
+  }
+
+  .overlay {
+    border-color: rgba(255, 143, 50, 0.42);
+    background: #1f1f1f;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.42);
+    color: rgba(255, 255, 255, 0.95);
+  }
+}

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -340,7 +340,8 @@
     background: rgba(255, 255, 255, 0.06);
     color: rgba(255, 255, 255, 0.88);
 
-    &::placeholder {
+    &::placeholder,
+    :global(.qwenpaw-input)::placeholder {
       color: rgba(255, 255, 255, 0.34);
     }
   }

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -334,6 +334,34 @@
     color: rgba(255, 255, 255, 0.5);
   }
 
+  .searchInput,
+  .groupInput {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.88);
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.34);
+    }
+  }
+
+  .createGroupButton {
+    border-color: rgba(255, 255, 255, 0.14);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.62);
+
+    &:hover {
+      border-color: rgba(255, 143, 50, 0.5);
+      background: rgba(255, 127, 22, 0.1);
+      color: #ff8f32;
+    }
+  }
+
+  .stickyGroupHeader {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, #141414 96%, transparent);
+  }
+
   .topGradient {
     background: linear-gradient(180deg, #141414 0%, rgba(31, 31, 31, 0) 100%);
   }


### PR DESCRIPTION
## Summary

- improve dark-mode contrast for session search, group creation, and sticky group headers
- align drag target and drag overlay colors with the existing dark theme and brand accent

## Verification

- npm run test:run -- src/components/SessionGroupDnd/SessionGroupDnd.test.tsx src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx (16 passed)
- npm run format:check
- pre-commit run --files on the two changed LESS files
- git diff --check

## Baseline note

pre-commit run --all-files still reports pre-existing upstream/main Python mypy, flake8, and pylint failures outside this frontend-only diff.