### PR TITLE
refactor(config): make agent config loading async by default

### DIFF
--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -1330,7 +1330,7 @@ class QwenPawACPAgent(Agent):
                     )
 
             agent_id = self._resolve_agent_id()
-            agent_config = load_agent_config(agent_id)
+            agent_config = await load_agent_config(agent_id)
             active = agent_config.active_model
             if active and active.provider_id and active.model:
                 current_model_id = f"{active.provider_id}:{active.model}"
@@ -1544,7 +1544,7 @@ class QwenPawACPAgent(Agent):
         )
 
         agent_id = self._resolve_agent_id()
-        agent_config = load_agent_config(agent_id)
+        agent_config = await load_agent_config(agent_id)
         agent_config.active_model = ModelSlotConfig(
             provider_id=provider_id,
             model=model_id,

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -21,7 +21,11 @@ from .middlewares import (
     reset_auto_memory_turn_state,
 )
 from .utils.context_stats import format_history_str
-from ..config.config import load_agent_config, get_model_max_input_length
+from ..config.config import (
+    _load_agent_config,
+    get_model_max_input_length,
+    load_agent_config,
+)
 from ..constant import DEBUG_HISTORY_FILE, MAX_LOAD_HISTORY_COUNT
 from ..exceptions import SystemCommandException
 from ..loop.gates.runner import clear_pending_gate_state
@@ -194,8 +198,8 @@ class CommandHandler(ConversationCommandHandlerMixin):
     def _get_agent_config(self):
         """Get hot-reloaded agent config."""
         if self.memory_manager is not None:
-            return load_agent_config(self.memory_manager.agent_id)
-        return load_agent_config(self._agent_id)
+            return _load_agent_config(self.memory_manager.agent_id)
+        return _load_agent_config(self._agent_id)
 
     async def _get_agent_config_async(self):
         """Get hot-reloaded agent config without blocking the event loop."""
@@ -1347,10 +1351,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
 
         # Get current agent ID and language
         active_agent_id = get_current_agent_id()
-        agent_config = await run_sync_io(
-            load_agent_config,
-            active_agent_id,
-        )
+        agent_config = await load_agent_config(active_agent_id)
         agent_lang = getattr(agent_config, "language", "en")
 
         # Define warnings in both languages

--- a/src/qwenpaw/agents/context/scroll/sync.py
+++ b/src/qwenpaw/agents/context/scroll/sync.py
@@ -792,7 +792,7 @@ def sync_all_scroll_agents() -> None:
 def _sync_all_scroll_agents() -> None:
     # Imported lazily to keep this module importable without the app config.
     from ....config import load_config
-    from ....config.config import load_agent_config
+    from ....config.config import _load_agent_config
     from .history import HistoryStore
 
     config = load_config()
@@ -802,7 +802,7 @@ def _sync_all_scroll_agents() -> None:
 
     for agent_id, agent_ref in config.agents.profiles.items():
         try:
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
         except Exception as exc:  # noqa: BLE001
             logger.debug(
                 "session-sync[%s]: config load failed: %s",

--- a/src/qwenpaw/agents/fork_project.py
+++ b/src/qwenpaw/agents/fork_project.py
@@ -352,9 +352,9 @@ def resolve_git_project_dir(
             aid = None
     if aid is not None:
         try:
-            from ..config.config import load_agent_config
+            from ..config.config import _load_agent_config
 
-            cfg = load_agent_config(aid)
+            cfg = _load_agent_config(aid)
             project_dir = getattr(cfg, "project_dir", None)
             if project_dir:
                 candidates.append(
@@ -394,12 +394,12 @@ def _matching_agent_id_for_workspace(
     """Return active agent_id only when it owns *workspace_dir*."""
     try:
         from ..app.agent_context import get_current_agent_id
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
         aid = get_current_agent_id() or None
         if not aid:
             return None
-        cfg = load_agent_config(aid)
+        cfg = _load_agent_config(aid)
         raw = getattr(cfg, "workspace_dir", None)
         if not raw:
             return None
@@ -662,9 +662,9 @@ def _fallback_agent_workspace_dir(
     if not aid:
         return None
     try:
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
-        cfg = load_agent_config(aid)
+        cfg = _load_agent_config(aid)
         raw = getattr(cfg, "workspace_dir", None)
         if not raw:
             return None

--- a/src/qwenpaw/agents/memory/adbpg_memory_manager.py
+++ b/src/qwenpaw/agents/memory/adbpg_memory_manager.py
@@ -23,7 +23,7 @@ from .adbpg_client import (
 )
 from .adbpg_prompts import ADBPG_MEMORY_GUIDANCE_EN, ADBPG_MEMORY_GUIDANCE_ZH
 from .base_memory_manager import BaseMemoryManager, memory_registry
-from ...config.config import load_agent_config
+from ...config.config import _load_agent_config, load_agent_config
 from ...exceptions import ConfigurationException as ConfigurationError
 from ...utils.io_utils import run_sync_io
 
@@ -55,7 +55,7 @@ class ADBPGMemoryManager(BaseMemoryManager):
 
     async def start(self) -> None:
         """Initialize ADBPGMemoryClient from agent config."""
-        agent_config = await run_sync_io(load_agent_config, self.agent_id)
+        agent_config = await load_agent_config(self.agent_id)
         self._adbpg_config = getattr(
             agent_config.running,
             "adbpg_memory_config",
@@ -136,12 +136,12 @@ class ADBPGMemoryManager(BaseMemoryManager):
 
     def get_memory_config(self) -> Any:
         """Return ADBPG memory configuration."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         return agent_config.running.adbpg_memory_config
 
     def get_memory_prompt(self) -> str:
         """Return ADBPG memory guidance prompt."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         language = getattr(agent_config, "language", "zh") or "zh"
         prompts = {
             "zh": ADBPG_MEMORY_GUIDANCE_ZH,
@@ -222,7 +222,7 @@ class ADBPGMemoryManager(BaseMemoryManager):
 
     def _load_auto_search_config(self) -> tuple[Any, float]:
         """Load ADBPG search settings and token estimate configuration."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         return (
             agent_config.running.adbpg_memory_config,
             self._resolve_token_estimate_divisor(agent_config),

--- a/src/qwenpaw/agents/memory/agent_md_manager.py
+++ b/src/qwenpaw/agents/memory/agent_md_manager.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from ..utils.file_handling import read_text_file_with_encoding_fallback
-from ...config.config import load_agent_config
+from ...config.config import _load_agent_config
 
 
 class AgentMdManager:
@@ -33,7 +33,7 @@ class AgentMdManager:
 
         # Dynamically get memory_dir from config if agent_id provided
         if agent_id:
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
             reme_config = agent_config.running.reme_light_memory_config
             memory_dir_name = reme_config.daily_dir
             digest_dir_name = reme_config.digest_dir

--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -209,9 +209,9 @@ class BaseMemoryManager(ABC):
     def _get_token_estimate_divisor(self) -> float:
         """Return configured byte/token divisor for lightweight estimates."""
         try:
-            from ...config.config import load_agent_config
+            from ...config.config import _load_agent_config
 
-            agent_config = load_agent_config(self.agent_id)
+            agent_config = _load_agent_config(self.agent_id)
             return self._resolve_token_estimate_divisor(agent_config)
         except Exception:
             logger.debug(

--- a/src/qwenpaw/agents/memory/proactive/proactive_responder.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_responder.py
@@ -35,7 +35,6 @@ from .proactive_utils import (
     ensure_tz_aware,
     is_agent_busy,
 )
-from ....utils.io_utils import run_sync_io
 
 if TYPE_CHECKING:
     from ....app.workspace import Workspace
@@ -112,7 +111,7 @@ async def _initialize_single_proactive_agent(
     # as that would pollute the global cache and cause user settings to be
     # silently overwritten when save_agent_config() is later triggered.
     _PROACTIVE_MAX_ITERS = 50
-    agent_config = await run_sync_io(load_agent_config, agent_id)
+    agent_config = await load_agent_config(agent_id)
 
     # Create model and formatter for the agent
     from ...model_factory import create_model_and_formatter_async
@@ -268,8 +267,7 @@ async def _generate_final_message(
 
     gathered_info = f"Query: {result.query}\nResult: {result.data}\n\n"
 
-    agent_config = await run_sync_io(load_agent_config, active_agent_id)
-    agent_language = agent_config.language
+    agent_language = (await load_agent_config(active_agent_id)).language
     proactive_content = PROACTIVE_USER_FACING_MESSAGE_PROMPT.format(
         gathered_info=gathered_info,
         language=agent_language,

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -32,8 +32,8 @@ from ...app.inbox_store import append_event as append_inbox_event
 from ...app.crons.contracts import ServiceCronJob
 from ...config import load_config
 from ...config.config import (
+    _load_agent_config,
     load_agent_config,
-    load_agent_config_async,
     update_agent_config_async,
     AgentProfileConfig,
     EmbeddingModelConfig,
@@ -109,7 +109,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         self._lifecycle_operation: str | None = None
         self._tested_embedding: tuple[tuple[Any, ...], Any] | None = None
         self._active_embedding_config: EmbeddingModelConfig | None = None
-        # Reranker config is not cached here; load_agent_config() already
+        # Reranker config is not cached here; _load_agent_config() already
         # provides mtime-based caching, so every call reads fresh data.
         logger.info(
             "ReMeLightMemoryManager init: agent_id=%s working_dir=%s",
@@ -125,7 +125,9 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         try:
             from reme import ReMe as ReMeApp  # type: ignore
 
-            agent_config: AgentProfileConfig = load_agent_config(self.agent_id)
+            agent_config: AgentProfileConfig = _load_agent_config(
+                self.agent_id,
+            )
             memory_config = agent_config.running.reme_light_memory_config
             self._active_embedding_config = (
                 memory_config.embedding_model_config.model_copy(deep=True)
@@ -221,7 +223,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
     def get_memory_prompt(self) -> str:
         """Return memory guidance for system prompt injection."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         cfg = agent_config.running.reme_light_memory_config
         return build_memory_guidance_prompt(
             agent_config.language,
@@ -232,7 +234,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
     def get_memory_config(self) -> Any:
         """Return ReMe Light memory configuration."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         return agent_config.running.reme_light_memory_config
 
     def list_cron_jobs(self) -> list[ServiceCronJob]:
@@ -272,7 +274,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
     def get_auto_memory_interval(self) -> int:
         """Return ReMe light auto-memory cadence from agent config."""
-        agent_config = load_agent_config(self.agent_id)
+        agent_config = _load_agent_config(self.agent_id)
         interval = (
             agent_config.running.reme_light_memory_config.auto_memory_interval
         )
@@ -944,14 +946,14 @@ class ReMeLightMemoryManager(BaseMemoryManager):
     async def _get_reranker_config(self) -> RerankerConfig | None:
         """Return the reranker config, or None if not enabled.
 
-        Config is read fresh on every call — ``load_agent_config()``
+        Config is read fresh on every call — ``_load_agent_config()``
         already provides its own mtime-based caching, so an additional
         layer here would risk stale values (the user may change the
         API key, base URL, model, or disable reranking without restarting
         the agent process).
         """
         try:
-            agent_cfg = await load_agent_config_async(self.agent_id)
+            agent_cfg = await load_agent_config(self.agent_id)
             cfg = getattr(
                 agent_cfg.running.reme_light_memory_config,
                 "reranker_config",
@@ -1087,7 +1089,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         """Auto-search memory and expose it as a completed tool interaction."""
         del agent_name
         del kwargs
-        agent_config = await load_agent_config_async(self.agent_id)
+        agent_config = await load_agent_config(self.agent_id)
         memory_cfg = agent_config.running.reme_light_memory_config
         if not memory_cfg.auto_memory_search_config.enabled:
             return None

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1818,11 +1818,11 @@ def _load_agent_model_settings(
 
     try:
         if agent_config is None:
-            from ..config.config import load_agent_config
+            from ..config.config import _load_agent_config
 
             if not agent_id:
                 return settings
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
         settings.model_slot = agent_config.active_model
         settings.thinking_level = getattr(
             agent_config,

--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -297,10 +297,10 @@ def build_system_prompt_from_working_dir(
     if enabled_files is None:
         # Use agent-specific config if agent_id provided
         if agent_id:
-            from ..config.config import load_agent_config
+            from ..config.config import _load_agent_config
 
             try:
-                agent_config = load_agent_config(agent_id)
+                agent_config = _load_agent_config(agent_id)
                 enabled_files = agent_config.system_prompt_files
             except (ValueError, FileNotFoundError, ConfigurationException):
                 # Agent not found in config, fallback to global config
@@ -395,7 +395,7 @@ def _get_active_model_info():
     """
     try:
         from ..app.agent_context import get_current_agent_id
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
         from ..providers.provider_manager import ProviderManager
 
         manager = ProviderManager.get_instance()
@@ -404,7 +404,7 @@ def _get_active_model_info():
         active = None
         try:
             agent_id = get_current_agent_id()
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
             if agent_config.active_model:
                 active = agent_config.active_model
         except Exception:

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -1168,7 +1168,7 @@ def list_workspaces() -> list[dict[str, str]]:
     workspaces: list[dict[str, str]] = []
     try:
         from ...config.utils import load_config
-        from ...config.config import load_agent_config
+        from ...config.config import _load_agent_config
 
         config = load_config()
         # Only return agents that are still in the configuration
@@ -1176,7 +1176,7 @@ def list_workspaces() -> list[dict[str, str]]:
         for agent_id, profile in sorted(config.agents.profiles.items()):
             agent_name = agent_id
             try:
-                agent_name = load_agent_config(agent_id).name or agent_id
+                agent_name = _load_agent_config(agent_id).name or agent_id
             except Exception:
                 pass
             workspaces.append(

--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -99,9 +99,9 @@ def get_workspace_identity(workspace_dir: Path) -> dict[str, str]:
     workspace_id = workspace_dir.name
     workspace_name = workspace_id
     try:
-        from ...config.config import load_agent_config
+        from ...config.config import _load_agent_config
 
-        workspace_name = load_agent_config(workspace_id).name or workspace_id
+        workspace_name = _load_agent_config(workspace_id).name or workspace_id
     except Exception:
         pass
     return {

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -1019,10 +1019,7 @@ async def _build_subagent_request_context(
     """Build request_context with approval routing + tool/skill filters."""
     rc = _build_spawn_request_context(current_agent_id)
     try:
-        agent_config = await asyncio.to_thread(
-            load_agent_config,
-            current_agent_id,
-        )
+        agent_config = await load_agent_config(current_agent_id)
         subagent_model = agent_config.subagent_model
         if subagent_model is not None:
             rc["model_slot_override"] = subagent_model.model_dump()

--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -70,7 +70,7 @@ def _resolve_execution_cwd(cwd: str, workspace_dir: Path) -> Path:
 def _get_acp_service() -> Any:
     from ...app.agent_context import get_current_agent_id
     from ...config.config import ACPConfig
-    from ...config.config import load_agent_config
+    from ...config.config import _load_agent_config
 
     # pylint: disable=no-name-in-module
     # ``get_acp_service`` / ``init_acp_service`` are exposed via the
@@ -84,7 +84,7 @@ def _get_acp_service() -> Any:
     )
 
     agent_id = get_current_agent_id()
-    agent_config = load_agent_config(agent_id)
+    agent_config = _load_agent_config(agent_id)
     acp_config = agent_config.acp or ACPConfig()
     service = get_service(agent_id)
     if service is None or getattr(service, "config", None) != acp_config:
@@ -94,10 +94,10 @@ def _get_acp_service() -> Any:
 
 def _get_available_acp_runners() -> list[str]:
     from ...app.agent_context import get_current_agent_id
-    from ...config.config import ACPConfig, load_agent_config
+    from ...config.config import ACPConfig, _load_agent_config
 
     agent_id = get_current_agent_id()
-    agent_config = load_agent_config(agent_id)
+    agent_config = _load_agent_config(agent_id)
     acp_config = agent_config.acp or ACPConfig()
     return sorted(
         name

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -199,7 +199,7 @@ async def _probe_multimodal_if_needed(
             from ...config.config import load_agent_config
 
             agent_id = get_current_agent_id()
-            agent_config = load_agent_config(agent_id)
+            agent_config = await load_agent_config(agent_id)
             if agent_config.active_model:
                 active = agent_config.active_model
         except Exception:

--- a/src/qwenpaw/app/agent_config_watcher.py
+++ b/src/qwenpaw/app/agent_config_watcher.py
@@ -17,7 +17,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from ..config.config import (
     _AgentConfigFingerprint,
     _agent_config_fingerprint,
-    load_agent_config,
+    _load_agent_config,
 )
 from ..utils.io_utils import run_sync_io
 
@@ -39,7 +39,7 @@ def _load_config_snapshot(
     """Load config while the observed disk fingerprint stays stable."""
     for _attempt in range(_SNAPSHOT_RETRIES):
         before = _agent_config_fingerprint(config_path)
-        agent_config = load_agent_config(agent_id)
+        agent_config = _load_agent_config(agent_id)
         after = _agent_config_fingerprint(config_path)
         if before == after:
             return agent_config, after

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -142,11 +142,11 @@ def get_agent_project_dir(workspace: "Workspace") -> Path:
 
     The Coding tools switch does not participate in directory resolution.
     """
-    from ..config.config import load_agent_config
+    from ..config.config import _load_agent_config
     from ..services.project_directory import resolve_effective_project_dir
 
     try:
-        config = load_agent_config(workspace.agent_id)
+        config = _load_agent_config(workspace.agent_id)
         project_dir = config.project_dir
     except Exception:
         project_dir = None
@@ -162,7 +162,7 @@ async def get_project_dir_for_request(
     workspace: "Workspace",
 ) -> Path:
     """Resolve the effective project directory for a Files API request."""
-    from ..config.config import load_agent_config
+    from ..config.config import _load_agent_config
     from ..services.project_directory import (
         resolve_effective_project_dir,
         session_project_dir,
@@ -183,7 +183,7 @@ async def get_project_dir_for_request(
 
     def _resolve() -> Path:
         try:
-            config = load_agent_config(workspace.agent_id)
+            config = _load_agent_config(workspace.agent_id)
             agent_project_dir = config.project_dir
         except Exception:
             agent_project_dir = None

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -626,7 +626,7 @@ class ChannelManager:
                     " on ChannelManager",
                 )
 
-            agent_config = load_agent_config(agent_id)
+            agent_config = await load_agent_config(agent_id)
             channels_cfg = agent_config.channels
             if channels_cfg is None:
                 raise RuntimeError(

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -96,10 +96,10 @@ class ProjectDirectoryUpdate(BaseModel):
 
 async def _project_directory_response(chat: ChatSpec, workspace) -> dict:
     """Build the effective Session project directory response."""
-    from ...config.config import load_agent_config
+    from ...config.config import _load_agent_config
 
     def _build() -> dict:
-        agent_config = load_agent_config(workspace.agent_id)
+        agent_config = _load_agent_config(workspace.agent_id)
         project_dir, source = resolve_effective_project_dir(
             workspace.workspace_dir,
             agent_project_dir=agent_config.project_dir,

--- a/src/qwenpaw/app/chats/title_generator.py
+++ b/src/qwenpaw/app/chats/title_generator.py
@@ -21,7 +21,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from qwenpaw.exceptions import AppBaseException
-from qwenpaw.utils.io_utils import run_sync_io
 from qwenpaw.utils.model_response import consume_model_response
 
 from .models import ChatUpdate
@@ -85,10 +84,7 @@ async def generate_and_update_title(
         from ...config.config import load_agent_config
 
         try:
-            agent_config = await run_sync_io(
-                load_agent_config,
-                workspace.agent_id,
-            )
+            agent_config = await load_agent_config(workspace.agent_id)
             cfg = agent_config.running
         except (ValueError, AppBaseException) as exc:
             logger.debug(

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -399,7 +399,7 @@ async def list_agents(request: Request = None) -> AgentListResponse:
             )
         )
         try:
-            agent_config = await run_sync_io(load_agent_config, agent_id)
+            agent_config = await load_agent_config(agent_id)
             description = agent_config.description or ""
 
             profile_desc = await run_sync_io(
@@ -549,7 +549,7 @@ async def set_agent_pinned(
 async def get_agent(agentId: str = PathParam(...)) -> AgentProfileConfig:
     """Get agent configuration."""
     try:
-        agent_config = await run_sync_io(load_agent_config, agentId)
+        agent_config = await load_agent_config(agentId)
         return agent_config
     except (ValueError, AppBaseException) as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
@@ -898,7 +898,7 @@ async def copy_agent(
         )
 
     try:
-        source_config = await run_sync_io(load_agent_config, agentId)
+        source_config = await load_agent_config(agentId)
     except (ValueError, AppBaseException) as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
 
@@ -1060,7 +1060,7 @@ async def rebuild_agent_memory_index(
             detail=f"Agent '{agentId}' not found",
         )
 
-    agent_config = await run_sync_io(load_agent_config, agentId)
+    agent_config = await load_agent_config(agentId)
     if agent_config.running.memory_manager_backend != "remelight":
         raise HTTPException(
             status_code=400,
@@ -1112,7 +1112,7 @@ async def get_agent_memory_runtime_status(
             detail=f"Agent '{agentId}' not found",
         )
 
-    agent_config = await run_sync_io(load_agent_config, agentId)
+    agent_config = await load_agent_config(agentId)
     if agent_config.running.memory_manager_backend != "remelight":
         raise HTTPException(
             status_code=400,
@@ -1149,7 +1149,7 @@ async def get_agent_memory_status(
             detail=f"Agent '{agentId}' not found",
         )
 
-    agent_config = await run_sync_io(load_agent_config, agentId)
+    agent_config = await load_agent_config(agentId)
     if agent_config.running.memory_manager_backend != "remelight":
         raise HTTPException(
             status_code=400,
@@ -1215,16 +1215,13 @@ async def get_agent_memory_graph(
 ) -> MemoryGraphSnapshot:
     """Return a frontend-ready graph snapshot from embedded ReMe."""
 
-    def load_memory_configs() -> AgentProfileConfig:
-        config = load_config()
-        if agentId not in config.agents.profiles:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Agent '{agentId}' not found",
-            )
-        return load_agent_config(agentId)
-
-    agent_config = await run_sync_io(load_memory_configs)
+    config = await run_sync_io(load_config)
+    if agentId not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agentId}' not found",
+        )
+    agent_config = await load_agent_config(agentId)
     if agent_config.running.memory_manager_backend != "remelight":
         raise HTTPException(
             status_code=400,

--- a/src/qwenpaw/app/routers/coding_mode.py
+++ b/src/qwenpaw/app/routers/coding_mode.py
@@ -36,13 +36,13 @@ async def get_coding_mode(request: Request) -> dict:
     browser cache.
     """
     import asyncio
-    from ...config.config import load_agent_config
+    from ...config.config import _load_agent_config
 
     workspace = await get_agent_for_request(request)
     loop = asyncio.get_running_loop()
     config = await loop.run_in_executor(
         None,
-        load_agent_config,
+        _load_agent_config,
         workspace.agent_id,
     )
     cm = config.coding_mode
@@ -68,14 +68,14 @@ async def post_coding_mode_toggle(
         Dict with ``enabled`` field reflecting the new state.
     """
     import asyncio
-    from ...config.config import load_agent_config, save_agent_config
+    from ...config.config import _load_agent_config, save_agent_config
 
     workspace = await get_agent_for_request(request)
 
     loop = asyncio.get_running_loop()
     config = await loop.run_in_executor(
         None,
-        load_agent_config,
+        _load_agent_config,
         workspace.agent_id,
     )
 

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -364,14 +364,14 @@ async def post_console_chat(
             chat,
             native_payload,
         )
-        from ...config.config import load_agent_config
+        from ...config.config import _load_agent_config
         from ...services.project_directory import (
             resolve_effective_project_dir,
             session_project_dir,
         )
 
         agent_config = await asyncio.to_thread(
-            load_agent_config,
+            _load_agent_config,
             workspace.agent_id,
         )
         project_dir, project_source = await asyncio.to_thread(
@@ -825,14 +825,14 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
         )
         fork_scope_id = str(rc.get("fork_scope_id") or "")
 
-    from ...config.config import load_agent_config
+    from ...config.config import _load_agent_config
     from ...services.project_directory import (
         resolve_effective_project_dir,
         session_project_dir,
     )
 
     agent_config = await asyncio.to_thread(
-        load_agent_config,
+        _load_agent_config,
         workspace.agent_id,
     )
     project_dir, project_source = await asyncio.to_thread(

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from ...config.config import load_agent_config
+from ...config.config import _load_agent_config
 from ..chats.session import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def _get_project_dir(agent_id: str) -> Optional[Path]:
     or None if no valid git repo is found (in-place fork).
     """
     try:
-        config = load_agent_config(agent_id)
+        config = _load_agent_config(agent_id)
     except Exception as exc:
         raise HTTPException(
             status_code=404,
@@ -84,7 +84,7 @@ def _get_project_dir(agent_id: str) -> Optional[Path]:
 def _get_sessions_dir(agent_id: str) -> Path:
     """Resolve the sessions directory for the agent."""
     try:
-        config = load_agent_config(agent_id)
+        config = _load_agent_config(agent_id)
         workspace = Path(config.workspace_dir).expanduser().resolve()
     except Exception as exc:
         raise HTTPException(

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -275,7 +275,7 @@ def _sync_plugin_tools_to_agents(loader, plugin_id: str) -> None:
         from ...config.utils import load_config
         from ...config.config import (
             BuiltinToolConfig,
-            load_agent_config,
+            _load_agent_config,
             save_agent_config,
         )
 
@@ -285,7 +285,7 @@ def _sync_plugin_tools_to_agents(loader, plugin_id: str) -> None:
 
         for agent_id in config.agents.profiles:
             try:
-                agent_cfg = load_agent_config(agent_id)
+                agent_cfg = _load_agent_config(agent_id)
                 changed = False
                 for tool_name in tool_names:
                     if tool_name in agent_cfg.tools.builtin_tools:
@@ -318,7 +318,7 @@ def _remove_named_tools_from_agents(
 
     try:
         from ...config.utils import load_config
-        from ...config.config import load_agent_config, save_agent_config
+        from ...config.config import _load_agent_config, save_agent_config
 
         config = load_config()
         if not config.agents or not config.agents.profiles:
@@ -326,7 +326,7 @@ def _remove_named_tools_from_agents(
 
         for agent_id in config.agents.profiles:
             try:
-                agent_cfg = load_agent_config(agent_id)
+                agent_cfg = _load_agent_config(agent_id)
                 changed = False
                 for tool_name in tool_names:
                     if tool_name in agent_cfg.tools.builtin_tools:

--- a/src/qwenpaw/app/routers/project_directory.py
+++ b/src/qwenpaw/app/routers/project_directory.py
@@ -72,9 +72,9 @@ def _save_project_dir(agent_id: str, project_dir: str | None) -> None:
 
     Intended to run inside an executor thread.
     """
-    from ...config.config import load_agent_config, save_agent_config
+    from ...config.config import _load_agent_config, save_agent_config
 
-    config = load_agent_config(agent_id)
+    config = _load_agent_config(agent_id)
     config.project_dir = project_dir
     save_agent_config(config.id, config)
 

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -35,7 +35,6 @@ from ...providers.provider import (
 )
 from ...config.config import ActiveModelsInfo
 from ...providers.provider_manager import ProviderManager
-from ...utils.io_utils import run_sync_io
 from ...utils.logging import sanitize_log_value
 from ...providers.openrouter_provider import OpenRouterProvider
 from ...config.config import ModelSlotConfig
@@ -273,10 +272,7 @@ async def _load_agent_model(
 ) -> ModelSlotConfig | None:
     """Load the model configured for a specific agent."""
     workspace = await get_agent_for_request(request, agent_id=agent_id)
-    agent_config = await run_sync_io(
-        load_agent_config,
-        workspace.agent_id,
-    )
+    agent_config = await load_agent_config(workspace.agent_id)
     return agent_config.active_model
 
 

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -189,7 +189,7 @@ async def list_tools(
     from ...config.config import load_agent_config
 
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
 
     # Ensure tools config exists with defaults
     if not agent_config.tools or not agent_config.tools.builtin_tools:
@@ -229,7 +229,7 @@ async def toggle_tool(
     from ...config.config import load_agent_config, save_agent_config
 
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
 
     if (
         not agent_config.tools
@@ -276,7 +276,7 @@ async def update_tool_async_execution(
     from ...config.config import load_agent_config, save_agent_config
 
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
 
     if (
         not agent_config.tools

--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -1188,7 +1188,7 @@ async def write_memory_file(
 async def get_agent_language(request: Request) -> dict:
     """Get agent language setting for current agent."""
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
     return {
         "language": agent_config.language,
         "agent_id": workspace.agent_id,
@@ -1227,7 +1227,7 @@ async def put_agent_language(
     workspace = await get_agent_for_request(request)
     agent_id = workspace.agent_id
 
-    agent_config = load_agent_config(agent_id)
+    agent_config = await load_agent_config(agent_id)
     old_language = agent_config.language
 
     agent_config.language = language
@@ -1551,7 +1551,7 @@ async def get_agents_running_config(
 ) -> AgentsRunningConfig:
     """Get agent running configuration."""
     workspace = await get_agent_for_request(request)
-    agent_config = await run_sync_io(load_agent_config, workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
     running = agent_config.running or AgentsRunningConfig()
     running.approval_level = getattr(agent_config, "approval_level", "AUTO")
     return running
@@ -1796,7 +1796,7 @@ async def get_system_prompt_files(
 ) -> list[str]:
     """Get list of enabled system prompt files."""
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
     return agent_config.system_prompt_files or []
 
 
@@ -1815,7 +1815,7 @@ async def put_system_prompt_files(
 ) -> list[str]:
     """Update list of enabled system prompt files."""
     workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_config = await load_agent_config(workspace.agent_id)
     agent_config.system_prompt_files = files
     save_agent_config(workspace.agent_id, agent_config)
 

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -31,7 +31,7 @@ from ..task_tracker import TaskTracker
 from ..chats.session import SafeJSONSession
 from ..crons.manager import CronManager
 from ..crons.repo.json_repo import JsonJobRepository
-from ...config.config import load_agent_config
+from ...config.config import _load_agent_config, load_agent_config
 from ...utils.logging import sanitize_log_value
 
 logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ class Workspace:
         """
         current_mtime = self._agent_config_file_mtime()
         if self._config is None or current_mtime != self._config_mtime:
-            self._config = load_agent_config(self.agent_id)
+            self._config = _load_agent_config(self.agent_id)
             self._config_mtime = current_mtime
         return self._config
 
@@ -316,7 +316,7 @@ class Workspace:
 
         Drop-in replacement for the old ``Runner.stream_query()``.
         """
-        config = load_agent_config(self.agent_id)
+        config = await load_agent_config(self.agent_id)
         backend = config.backend
         if backend != "qwenpaw":
             settings = dict(getattr(config, "backend_settings", {}))
@@ -567,7 +567,7 @@ class Workspace:
 
         try:
             # 1. Load agent configuration
-            self._config = load_agent_config(self.agent_id)
+            self._config = await load_agent_config(self.agent_id)
             logger.debug(
                 "Loaded config for agent: "
                 f"{sanitize_log_value(self.agent_id)}",

--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -25,7 +25,7 @@ from ..config.config import (
     QQConfig,
     VoiceChannelConfig,
     WeChatConfig,
-    load_agent_config,
+    _load_agent_config,
     save_agent_config,
 )
 from ..config.utils import get_plugins_dir
@@ -858,7 +858,7 @@ def _channel_enabled(ch) -> bool:
 def list_cmd(agent_id: str) -> None:
     """Show current channel configuration."""
     try:
-        agent_config = load_agent_config(agent_id)
+        agent_config = _load_agent_config(agent_id)
         click.echo(f"Channels for agent: {agent_id}\n")
 
         if not agent_config.channels:
@@ -906,7 +906,7 @@ def list_cmd(agent_id: str) -> None:
 def configure_cmd(agent_id: str) -> None:
     """Interactively configure channels."""
     try:
-        agent_config = load_agent_config(agent_id)
+        agent_config = _load_agent_config(agent_id)
         click.echo(f"Configuring channels for agent: {agent_id}\n")
 
         # Create a temporary Config object for the interactive configurator

--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -33,6 +33,7 @@ from ..config.config import (
     MCPConfig,
     SecurityConfig,
     ToolsConfig,
+    _load_agent_config,
     load_agent_config,
 )
 from ..config.utils import (
@@ -579,7 +580,7 @@ def memory_embedding_notes(cfg: Config) -> list[str]:
     notes: list[str] = []
     for agent_id in cfg.agents.profiles:
         try:
-            ac = load_agent_config(agent_id)
+            ac = _load_agent_config(agent_id)
         except Exception:  # pylint: disable=broad-exception-caught
             continue
         emb = ac.running.reme_light_memory_config.embedding_model_config
@@ -719,10 +720,10 @@ def check_agent_json_profiles(cfg: Config) -> tuple[bool, str]:
 
 
 def check_enabled_agents_load_agent_config(cfg: Config) -> tuple[bool, str]:
-    """Dry-run :func:`~qwenpaw.config.config.load_agent_config` for enabled.
+    """Dry-run :func:`~qwenpaw.config.config._load_agent_config` for enabled.
 
     Matches ``MultiAgentManager.start_all_configured_agents``. When
-    ``agent.json`` is missing, we do **not** call ``load_agent_config`` (that
+    ``agent.json`` is missing, we do **not** call ``_load_agent_config`` (that
     would write a fallback on disk); we report FAIL for enabled agents.
     """
     problems: list[str] = []
@@ -743,7 +744,7 @@ def check_enabled_agents_load_agent_config(cfg: Config) -> tuple[bool, str]:
             )
             continue
         try:
-            load_agent_config(agent_id)
+            _load_agent_config(agent_id)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             problems.append(f"{agent_id}: load_agent_config failed — {exc}")
             continue
@@ -1153,7 +1154,7 @@ async def check_enabled_agents_model_connections(
         if not getattr(ref, "enabled", True):
             continue
         try:
-            ac = load_agent_config(agent_id)
+            ac = await load_agent_config(agent_id)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             all_ok = False
             lines.append(

--- a/src/qwenpaw/cli/plugin_commands.py
+++ b/src/qwenpaw/cli/plugin_commands.py
@@ -363,7 +363,7 @@ def _sync_tool_plugin_to_agents(manifest: dict):
 
     from ..config.config import (
         BuiltinToolConfig,
-        load_agent_config,
+        _load_agent_config,
         save_agent_config,
     )
 
@@ -371,7 +371,7 @@ def _sync_tool_plugin_to_agents(manifest: dict):
     for agent_id in config.agents.profiles.keys():
         try:
             # Load agent config using agent_id
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
 
             # Check if tool already exists
             if tool_name in agent_config.tools.builtin_tools:
@@ -422,7 +422,7 @@ def _remove_tool_plugin_from_agents(manifest: dict):
         click.echo("   No agents found, skipping cleanup")
         return
 
-    from ..config.config import load_agent_config, save_agent_config
+    from ..config.config import _load_agent_config, save_agent_config
 
     removed_count = 0
     for agent_dir in agent_dirs:
@@ -432,7 +432,7 @@ def _remove_tool_plugin_from_agents(manifest: dict):
 
         try:
             # Load agent config using Pydantic model
-            config = load_agent_config(str(agent_dir))
+            config = _load_agent_config(str(agent_dir))
 
             # Check if tool exists
             if tool_name not in config.tools.builtin_tools:

--- a/src/qwenpaw/cli/task_cmd.py
+++ b/src/qwenpaw/cli/task_cmd.py
@@ -256,7 +256,7 @@ def task_cmd(
     agent_id: str,
 ) -> None:
     """Run a single task instruction headlessly (no web server)."""
-    from ..config.config import load_agent_config
+    from ..config.config import _load_agent_config
     from ..config.config import ModelSlotConfig
     from ..exceptions import ConfigurationException
     from ..utils.logging import setup_logger
@@ -269,7 +269,7 @@ def task_cmd(
         sys.exit(1)
 
     try:
-        agent_config = load_agent_config(agent_id)
+        agent_config = _load_agent_config(agent_id)
     except (ConfigurationException, ValueError) as exc:
         click.echo(f"Error loading agent config: {exc}", err=True)
         sys.exit(1)

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2862,7 +2862,7 @@ def build_fallback_agent_profile_config(
     """Build the same profile as when ``agent.json``
     is missing (no disk read/write).
 
-    Used by :func:`load_agent_config` and ``qwenpaw doctor fix``
+    Used by :func:`_load_agent_config` and ``qwenpaw doctor fix``
     so defaults stay in sync.
     """
     if agent_id not in config.agents.profiles:
@@ -3031,7 +3031,8 @@ def migrate_project_directory_config(data: object) -> bool:
     return True
 
 
-def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
+# pylint: disable-next=too-many-branches,too-many-statements
+def _load_agent_config(
     agent_id: str,
 ) -> AgentProfileConfig:
     """Load an agent configuration with fingerprint-based caching.
@@ -3311,17 +3312,17 @@ def mutate_agent_config(
     from .utils import _agent_config_lock
 
     with _agent_config_lock:
-        candidate = load_agent_config(agent_id)
+        candidate = _load_agent_config(agent_id)
         mutator(candidate)
         save_agent_config(agent_id, candidate)
         return candidate.model_copy(deep=True)
 
 
-async def load_agent_config_async(agent_id: str) -> AgentProfileConfig:
+async def load_agent_config(agent_id: str) -> AgentProfileConfig:
     """Load an agent configuration without blocking the event loop."""
     from ..utils.io_utils import run_sync_io
 
-    return await run_sync_io(load_agent_config, agent_id)
+    return await run_sync_io(_load_agent_config, agent_id)
 
 
 async def update_agent_config_async(

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -35,7 +35,7 @@ from .config import (
     HeartbeatConfig,
     LastApiConfig,
     LastDispatchConfig,
-    load_agent_config,
+    _load_agent_config,
     migrate_channel_display_fields,
 )
 
@@ -725,7 +725,7 @@ def get_heartbeat_config(agent_id: Optional[str] = None) -> HeartbeatConfig:
     """
     if agent_id is not None:
         try:
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
             hb = agent_config.heartbeat
             return hb if hb is not None else HeartbeatConfig()
         except Exception:

--- a/src/qwenpaw/drivers/handler.py
+++ b/src/qwenpaw/drivers/handler.py
@@ -72,9 +72,9 @@ def _resolve_driver_execution_level(
             agent_id = "default"
 
     try:
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
-        profile = load_agent_config(agent_id)
+        profile = _load_agent_config(agent_id)
         return ToolExecutionLevel.from_config(
             getattr(profile, "approval_level", None),
         )

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -91,9 +91,9 @@ def _resolve_effective_approval_level(
     if not agent_id:
         return None
     try:
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
-        profile = load_agent_config(agent_id)
+        profile = _load_agent_config(agent_id)
         raw = getattr(profile, "approval_level", None)
         return ToolExecutionLevel.from_config(raw)
     except Exception:

--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -90,7 +90,7 @@ class ContextVarsSetupHook(LifecycleHook):
         try:
             from ...config.config import load_agent_config
 
-            cfg = load_agent_config(ctx.agent_id)
+            cfg = await load_agent_config(ctx.agent_id)
             running = cfg.running
             pruning_cfg = (
                 running.light_context_config.tool_result_pruning_config

--- a/src/qwenpaw/modes/coding/__init__.py
+++ b/src/qwenpaw/modes/coding/__init__.py
@@ -36,9 +36,9 @@ class CodingMode(AgentMode):
         cfg = ctx.agent_config
         if cfg is None:
             try:
-                from ...config.config import load_agent_config
+                from ...config.config import _load_agent_config
 
-                cfg = load_agent_config(ctx.agent_id)
+                cfg = _load_agent_config(ctx.agent_id)
             except Exception:
                 return False
         cm = getattr(cfg, "coding_mode", None)

--- a/src/qwenpaw/modes/coding/hooks.py
+++ b/src/qwenpaw/modes/coding/hooks.py
@@ -21,7 +21,7 @@ class ProjectDirInjectionHook(ModeGatedHook):
             try:
                 from ...config.config import load_agent_config
 
-                cfg = load_agent_config(ctx.agent_id)
+                cfg = await load_agent_config(ctx.agent_id)
             except Exception:
                 return HookResult()
         project_dir = getattr(cfg, "project_dir", None)

--- a/src/qwenpaw/modes/coding/mixin.py
+++ b/src/qwenpaw/modes/coding/mixin.py
@@ -157,7 +157,7 @@ class CodingModeMixin:
 
         Returns None when no project has been set (use workspace default).
         """
-        from ...config.config import load_agent_config
+        from ...config.config import _load_agent_config
 
         agent_config = getattr(self, "_agent_config", None)
         agent_id: str | None = None
@@ -176,7 +176,7 @@ class CodingModeMixin:
             return project_dir
 
         try:
-            config = load_agent_config(agent_id)
+            config = _load_agent_config(agent_id)
             if config.project_dir:
                 return config.project_dir
         except Exception:

--- a/src/qwenpaw/pawapp/agent.py
+++ b/src/qwenpaw/pawapp/agent.py
@@ -28,7 +28,7 @@ from qwenpaw.config.config import (
     MCPConfig,
     PlanConfig,
     ToolsConfig,
-    load_agent_config,
+    _load_agent_config,
     save_agent_config,
     validate_agent_id,
 )
@@ -144,7 +144,7 @@ class ManagedAgentProfile:
                 plan=PlanConfig(enabled=self.spec.plan_enabled),
             )
         else:
-            profile = load_agent_config(agent_id)
+            profile = _load_agent_config(agent_id)
             if profile.template_id not in {
                 self.spec.template_id,
                 self.spec.agent_id,
@@ -167,7 +167,7 @@ class ManagedAgentProfile:
         if ref is None:
             return False
         try:
-            profile = load_agent_config(self.spec.agent_id)
+            profile = _load_agent_config(self.spec.agent_id)
         except Exception:  # pragma: no cover - corrupted profile is not owned
             return False
         if profile.template_id != self.spec.template_id:

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -262,7 +262,7 @@ def _write_tool_config(
     """Persist BuiltinToolConfig entry to the agent config file."""
     from ..config.config import (
         BuiltinToolConfig,
-        load_agent_config,
+        _load_agent_config,
         save_agent_config,
     )
     from ..app.agent_context import get_current_agent_id
@@ -276,7 +276,7 @@ def _write_tool_config(
         )
         return
 
-    agent_config = load_agent_config(agent_id)
+    agent_config = _load_agent_config(agent_id)
 
     if not agent_config.tools:
         from ..config.config import ToolsConfig

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -1054,9 +1054,9 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
             Tool configuration dict or None
         """
         try:
-            from ..config.config import load_agent_config
+            from ..config.config import _load_agent_config
 
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
             if (
                 not agent_config.tools
                 or tool_name not in agent_config.tools.builtin_tools
@@ -1084,11 +1084,11 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         """
         try:
             from ..config.config import (
-                load_agent_config,
+                _load_agent_config,
                 save_agent_config,
             )
 
-            agent_config = load_agent_config(agent_id)
+            agent_config = _load_agent_config(agent_id)
             if (
                 not agent_config.tools
                 or tool_name not in agent_config.tools.builtin_tools

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -249,7 +249,7 @@ class AgentBuilder:
         from ..providers.provider_manager import ProviderManager
 
         agent_id = getattr(ctx, "agent_id", None) or "default"
-        agent_config = await run_sync_io(load_agent_config, agent_id)
+        agent_config = await load_agent_config(agent_id)
         request_context = self._build_request_context(ctx)
         agent_config = self._apply_request_project(
             agent_config,
@@ -475,9 +475,9 @@ class AgentBuilder:
         from ..constant import WORKING_DIR
 
         if agent_config is None:
-            from ..config.config import load_agent_config
+            from ..config.config import _load_agent_config
 
-            agent_config = load_agent_config(
+            agent_config = _load_agent_config(
                 getattr(ctx, "agent_id", "default"),
             )
 

--- a/src/qwenpaw/runtime/builtin_commands.py
+++ b/src/qwenpaw/runtime/builtin_commands.py
@@ -36,19 +36,19 @@ def _make_daemon_adapter(subcommand: str) -> CommandSpec:
             DaemonCommandHandlerMixin,
             DaemonContext,
         )
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config, load_agent_config
 
         agent_id = getattr(ctx, "agent_id", None) or "default"
         workspace = getattr(ctx, "workspace", None)
 
         try:
-            cfg = load_agent_config(agent_id)
+            cfg = await load_agent_config(agent_id)
             agent_name = cfg.name if cfg and cfg.name else "QwenPaw"
         except Exception:
             agent_name = "QwenPaw"
 
         daemon_ctx = DaemonContext(
-            load_config_fn=lambda: load_agent_config(agent_id),
+            load_config_fn=lambda: _load_agent_config(agent_id),
             memory_manager=getattr(workspace, "memory_manager", None),
             manager=getattr(workspace, "_manager", None),
             agent_id=agent_id,
@@ -82,7 +82,7 @@ def _make_daemon_compound_adapter() -> CommandSpec:
             DaemonContext,
             parse_daemon_query,
         )
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config, load_agent_config
 
         full_query = f"/daemon {args}".strip()
         parsed = parse_daemon_query(full_query)
@@ -104,13 +104,13 @@ def _make_daemon_compound_adapter() -> CommandSpec:
         workspace = getattr(ctx, "workspace", None)
 
         try:
-            cfg = load_agent_config(agent_id)
+            cfg = await load_agent_config(agent_id)
             agent_name = cfg.name if cfg and cfg.name else "QwenPaw"
         except Exception:
             agent_name = "QwenPaw"
 
         daemon_ctx = DaemonContext(
-            load_config_fn=lambda: load_agent_config(agent_id),
+            load_config_fn=lambda: _load_agent_config(agent_id),
             memory_manager=getattr(
                 workspace,
                 "memory_manager",
@@ -436,7 +436,7 @@ def _make_conversation_adapter(
 
                 from ..config.config import load_agent_config
 
-                cfg = load_agent_config(agent_id)
+                cfg = await load_agent_config(agent_id)
                 lcc = cfg.running.light_context_config
                 # Under scroll, dialog archiving is opt-in (history.db is the
                 # source of truth); only wire an offloader for the commands
@@ -458,7 +458,7 @@ def _make_conversation_adapter(
             pass
 
         try:
-            cfg = load_agent_config(agent_id)
+            cfg = await load_agent_config(agent_id)
             agent_name = cfg.name if cfg and cfg.name else "QwenPaw"
         except Exception:
             agent_name = "QwenPaw"

--- a/src/qwenpaw/runtime/commands/daemon.py
+++ b/src/qwenpaw/runtime/commands/daemon.py
@@ -108,10 +108,10 @@ def run_daemon_status(context: DaemonContext) -> str:
             try:
                 from ...config.config import (
                     get_model_max_input_length,
-                    load_agent_config,
+                    _load_agent_config,
                 )
 
-                agent_cfg = load_agent_config(agent_id)
+                agent_cfg = _load_agent_config(agent_id)
                 max_in = get_model_max_input_length(agent_cfg)
             except Exception:
                 pass

--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -293,13 +293,13 @@ class CodingModeContributor(SyncPromptContributor):
         if project_dir:
             return project_dir
 
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
         agent_id = getattr(agent_config, "id", None)
         if not agent_id:
             return None
         try:
-            fresh = load_agent_config(agent_id)
+            fresh = _load_agent_config(agent_id)
             if fresh.project_dir:
                 return fresh.project_dir
         except Exception:

--- a/src/qwenpaw/runtime/tool_guard.py
+++ b/src/qwenpaw/runtime/tool_guard.py
@@ -92,9 +92,9 @@ def _guarded_tool_resolve_execution_level(self: Any) -> str:
     if not agent_id:
         return "bypass"
     try:
-        from ..config.config import load_agent_config
+        from ..config.config import _load_agent_config
 
-        profile = load_agent_config(agent_id)
+        profile = _load_agent_config(agent_id)
         raw = getattr(profile, "approval_level", None)
         return ToolExecutionLevel.from_config(raw).value
     except Exception as exc:

--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -70,7 +70,7 @@ async def snapshot_context_usage_for_state(
 
         max_input_length = int(preferred_max_input_length or 0)
         if max_input_length <= 0:
-            agent_config = load_agent_config(agent_id)
+            agent_config = await load_agent_config(agent_id)
             max_input_length = int(
                 get_model_max_input_length(agent_config) or 0,
             )

--- a/tests/integration/test_driver_mcp_approval_level_policy.py
+++ b/tests/integration/test_driver_mcp_approval_level_policy.py
@@ -477,7 +477,7 @@ async def test_driver_mcp_policy_ask_agent_off_auto_allows_no_persist(
         lambda: service,
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(approval_level="OFF"),
     )
     manager = await _registry_with_policy(
@@ -542,7 +542,7 @@ async def test_driver_mcp_policy_ask_agent_auto_requires_approval(
         lambda: service,
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(approval_level="AUTO"),
     )
     manager = await _registry_with_policy(
@@ -603,7 +603,7 @@ async def test_driver_mcp_policy_ask_active_agent_off_auto_allows(
         return SimpleNamespace(approval_level="OFF")
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         fake_load_agent_config,
     )
     manager = await _registry_with_policy(

--- a/tests/unit/agents/context/test_sync.py
+++ b/tests/unit/agents/context/test_sync.py
@@ -930,7 +930,7 @@ def _stub_config_loaders(
     monkeypatch.setattr(cfg, "load_config", lambda: config, raising=False)
     monkeypatch.setattr(
         cfgcfg,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _id: agent_config,
         raising=False,
     )

--- a/tests/unit/agents/memory/test_async_config_io.py
+++ b/tests/unit/agents/memory/test_async_config_io.py
@@ -42,7 +42,7 @@ async def test_reme_auto_search_loads_config_in_worker_thread(monkeypatch):
         return agent_config
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         load_config,
     )
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
@@ -75,7 +75,7 @@ async def test_reme_inbox_config_loads_in_worker_thread(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "qwenpaw.agents.memory.reme_light_memory_manager.load_agent_config",
+        "qwenpaw.agents.memory.reme_light_memory_manager._load_agent_config",
         load_config,
     )
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
@@ -107,7 +107,10 @@ async def test_proactive_final_message_loads_config_in_worker_thread(
     async def send_message(**_kwargs):
         return None
 
-    monkeypatch.setattr(proactive_responder, "load_agent_config", load_config)
+    monkeypatch.setattr(
+        "qwenpaw.config.config._load_agent_config",
+        load_config,
+    )
     monkeypatch.setattr(
         proactive_responder,
         "send_proactive_message_via_http",

--- a/tests/unit/agents/memory/test_base_memory_manager.py
+++ b/tests/unit/agents/memory/test_base_memory_manager.py
@@ -410,7 +410,7 @@ class TestAutoMemorySearchSanitization:
             )
 
         monkeypatch.setattr(
-            "qwenpaw.config.config.load_agent_config",
+            "qwenpaw.config.config._load_agent_config",
             fake_load_agent_config,
         )
 

--- a/tests/unit/agents/memory/test_reme_daily_paper.py
+++ b/tests/unit/agents/memory/test_reme_daily_paper.py
@@ -159,7 +159,7 @@ def test_memory_prompt_omits_disabled_search_tool() -> None:
     )
 
     config_loader = (
-        "qwenpaw.agents.memory.reme_light_memory_manager.load_agent_config"
+        "qwenpaw.agents.memory.reme_light_memory_manager._load_agent_config"
     )
     with patch(
         config_loader,
@@ -187,7 +187,7 @@ def test_memory_prompt_includes_enabled_search_tool() -> None:
     )
 
     with patch(
-        "qwenpaw.agents.memory.reme_light_memory_manager.load_agent_config",
+        "qwenpaw.agents.memory.reme_light_memory_manager._load_agent_config",
         return_value=agent_config,
     ):
         prompt = manager.get_memory_prompt()
@@ -257,8 +257,7 @@ async def test_automatic_search_works_when_agent_tool_is_hidden() -> None:
     manager.get_memory_config = lambda: memory_config
 
     with patch(
-        "qwenpaw.agents.memory.reme_light_memory_manager."
-        "load_agent_config_async",
+        "qwenpaw.agents.memory.reme_light_memory_manager.load_agent_config",
         AsyncMock(return_value=agent_config),
     ):
         result = await manager.auto_memory_search([object()])

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -49,7 +49,7 @@ async def test_agent_config_load_runs_in_worker_thread(monkeypatch) -> None:
         return SimpleNamespace()
 
     monkeypatch.setattr(
-        "qwenpaw.agents.command_handler.load_agent_config",
+        "qwenpaw.agents.command_handler._load_agent_config",
         load_config,
     )
     handler = CommandHandler(

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -82,7 +82,7 @@ def _patch_dependencies(monkeypatch):
 
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         _patched_load_agent_config,
     )
     monkeypatch.setattr(
@@ -299,7 +299,7 @@ def test_preloaded_agent_config_preserves_model_settings(monkeypatch):
     )
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: pytest.fail("preloaded config must be reused"),
     )
     providers = {
@@ -387,7 +387,7 @@ def test_each_fallback_model_gets_its_own_formatter(monkeypatch):
     )
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
     providers = {
@@ -452,7 +452,7 @@ def test_model_override_disables_persisted_fallback_chain(monkeypatch):
     )
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
     providers = {
@@ -509,7 +509,7 @@ def test_invalid_fallback_slots_are_skipped(monkeypatch):
     )
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
     providers = {

--- a/tests/unit/agents/test_fork_project.py
+++ b/tests/unit/agents/test_fork_project.py
@@ -96,7 +96,7 @@ def test_gate_allows_no_project_when_flag_true(
         lambda: "other-agent",
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: SimpleNamespace(
             coding_mode=SimpleNamespace(
                 enabled=True,
@@ -294,7 +294,7 @@ def test_finalize_does_not_resurrect_pruned_fork(
         lambda: "other-agent",
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: SimpleNamespace(
             coding_mode=SimpleNamespace(
                 enabled=True,
@@ -341,7 +341,7 @@ def test_matching_agent_dual_root_bind(tmp_path: Path, monkeypatch) -> None:
         lambda: "agent-a",
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: SimpleNamespace(
             project_dir=str(project),
             workspace_dir=str(workspace),

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -536,31 +536,25 @@ async def test_spawn_subagent_inherits_approval_level(monkeypatch):
     assert context["approval_level"] == "off"
 
 
-async def test_subagent_model_config_load_runs_off_event_loop(monkeypatch):
+async def test_subagent_model_config_uses_async_loader(monkeypatch):
     calls = []
 
     class Config:
         subagent_model = None
 
-    def fake_load_agent_config(agent_id):
+    async def fake_load_agent_config(agent_id):
         calls.append(("load", agent_id))
         return Config()
-
-    async def fake_to_thread(func, *args, **kwargs):
-        calls.append(("thread", func))
-        return func(*args, **kwargs)
 
     monkeypatch.setattr(
         agent_management,
         "load_agent_config",
         fake_load_agent_config,
     )
-    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
 
     await agent_management._build_subagent_request_context("bot-a")
 
-    assert calls[0] == ("thread", fake_load_agent_config)
-    assert calls[1] == ("load", "bot-a")
+    assert calls == [("load", "bot-a")]
 
 
 async def test_subagent_model_becomes_request_override(monkeypatch):
@@ -572,10 +566,13 @@ async def test_subagent_model_becomes_request_override(monkeypatch):
             },
         )
 
+    async def load_agent_config(_agent_id):
+        return Config()
+
     monkeypatch.setattr(
         agent_management,
         "load_agent_config",
-        lambda _agent_id: Config(),
+        load_agent_config,
     )
 
     context = await agent_management._build_subagent_request_context(

--- a/tests/unit/app/routers/test_agents_router.py
+++ b/tests/unit/app/routers/test_agents_router.py
@@ -256,7 +256,7 @@ def test_get_agent_returns_config(client):
 
 
 async def test_get_agent_loads_config_off_event_loop(monkeypatch):
-    """Route config reads through ``run_sync_io``."""
+    """The public async loader keeps route config reads off the loop."""
     cfg = AgentProfileConfig(
         id="bot",
         name="Bot",
@@ -264,24 +264,22 @@ async def test_get_agent_loads_config_off_event_loop(monkeypatch):
     )
     calls = []
 
-    async def fake_run_sync_io(func, *args):
-        calls.append((func, args))
-        return func(*args)
+    event_loop_thread = threading.get_ident()
+
+    def load_config(agent_id):
+        calls.append((agent_id, threading.get_ident()))
+        return cfg
 
     monkeypatch.setattr(
-        "qwenpaw.app.routers.agents.run_sync_io",
-        fake_run_sync_io,
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.routers.agents.load_agent_config",
-        lambda _agent_id: cfg,
+        "qwenpaw.config.config._load_agent_config",
+        load_config,
     )
 
     result = await get_agent("bot")
 
     assert result is cfg
-    assert len(calls) == 1
-    assert calls[0][1] == ("bot",)
+    assert calls[0][0] == "bot"
+    assert calls[0][1] != event_loop_thread
 
 
 def test_update_backend_settings_from_chat(client):
@@ -918,7 +916,7 @@ async def test_get_memory_graph_config_io_does_not_block_loop(
     )
     monkeypatch.setattr(
         "qwenpaw.app.routers.agents.load_agent_config",
-        lambda _agent_id: agent_config,
+        AsyncMock(return_value=agent_config),
     )
     monkeypatch.setattr(
         "qwenpaw.app.routers.agents._get_multi_agent_manager",

--- a/tests/unit/app/routers/test_config_router.py
+++ b/tests/unit/app/routers/test_config_router.py
@@ -602,7 +602,7 @@ async def test_run_heartbeat_once_uses_configured_timeout(
         ),
     )
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(last_dispatch=last_dispatch),
     )
     monkeypatch.setattr(

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -143,7 +143,7 @@ async def _submit_forked_task(
 
     monkeypatch.setattr(console, "get_agent_for_request", _get_workspace)
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(project_dir=None),
     )
     request_context = {

--- a/tests/unit/app/routers/test_console_chat_task_timeout.py
+++ b/tests/unit/app/routers/test_console_chat_task_timeout.py
@@ -127,7 +127,7 @@ def console_workspace(workspace_mock, monkeypatch):
     workspace_mock.workspace_dir = "/tmp/qwenpaw-test-workspace"
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: MagicMock(project_dir=None),
     )
     monkeypatch.setattr(

--- a/tests/unit/app/test_agent_config_watcher.py
+++ b/tests/unit/app/test_agent_config_watcher.py
@@ -45,7 +45,7 @@ async def test_watcher_ignores_mutated_cache_without_disk_change(
     )
     monkeypatch.setattr(
         watcher_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
 
@@ -77,7 +77,7 @@ async def test_watcher_reloads_after_disk_and_channel_change(
     )
     monkeypatch.setattr(
         watcher_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
 

--- a/tests/unit/app/test_agent_context_project_dir.py
+++ b/tests/unit/app/test_agent_context_project_dir.py
@@ -35,7 +35,7 @@ async def test_pending_session_project_dir_is_used(
 ) -> None:
     """Use the pending directory before a backend Chat exists."""
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(project_dir=None),
     )
     workspace = SimpleNamespace(
@@ -58,7 +58,7 @@ async def test_pending_session_project_dir_must_exist(
 ) -> None:
     """Reject an unavailable pending directory."""
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _agent_id: SimpleNamespace(project_dir=None),
     )
     workspace = SimpleNamespace(
@@ -87,7 +87,7 @@ async def test_project_resolution_does_not_block_the_event_loop(
         return SimpleNamespace(project_dir=None)
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         _slow_load,
     )
     workspace = SimpleNamespace(

--- a/tests/unit/app/test_agents_ordering.py
+++ b/tests/unit/app/test_agents_ordering.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
@@ -81,7 +82,7 @@ async def test_list_agents_uses_persisted_order(monkeypatch):
     monkeypatch.setattr(
         agents_router,
         "load_agent_config",
-        _agent_config,
+        AsyncMock(side_effect=_agent_config),
     )
 
     response = await agents_router.list_agents()
@@ -105,7 +106,7 @@ async def test_list_agents_appends_missing_ids(monkeypatch):
     monkeypatch.setattr(
         agents_router,
         "load_agent_config",
-        _agent_config,
+        AsyncMock(side_effect=_agent_config),
     )
 
     response = await agents_router.list_agents()
@@ -129,7 +130,11 @@ async def test_list_agents_marks_pawapp_profiles_as_app_managed(monkeypatch):
         return profile
 
     monkeypatch.setattr(agents_router, "load_config", lambda: config)
-    monkeypatch.setattr(agents_router, "load_agent_config", load_profile)
+    monkeypatch.setattr(
+        agents_router,
+        "load_agent_config",
+        AsyncMock(side_effect=load_profile),
+    )
 
     response = await agents_router.list_agents()
     by_id = {agent.id: agent for agent in response.agents}
@@ -155,7 +160,7 @@ async def test_list_agents_groups_default_and_pinned_without_reordering_peers(
     monkeypatch.setattr(
         agents_router,
         "load_agent_config",
-        _agent_config,
+        AsyncMock(side_effect=_agent_config),
     )
 
     response = await agents_router.list_agents()

--- a/tests/unit/app/test_workspace_config_pinning.py
+++ b/tests/unit/app/test_workspace_config_pinning.py
@@ -24,7 +24,7 @@ from qwenpaw.config.config import (
     AgentsConfig,
     Config,
     HeartbeatConfig,
-    load_agent_config,
+    _load_agent_config,
     save_agent_config,
 )
 
@@ -88,7 +88,7 @@ def test_patch_then_save_idiom_persists(isolated_agent):
     ws.config.heartbeat = HeartbeatConfig(enabled=True, every="6h")
     save_agent_config(ws.agent_id, ws.config)
 
-    reloaded = load_agent_config("agent")
+    reloaded = _load_agent_config("agent")
     assert reloaded.heartbeat is not None
     assert reloaded.heartbeat.enabled is True
     assert reloaded.heartbeat.every == "6h"
@@ -102,7 +102,7 @@ def test_config_property_refreshes_after_external_save(isolated_agent):
     ws = _pinned_workspace(isolated_agent)
     assert ws.config.description == "original"
 
-    external = load_agent_config("agent")
+    external = _load_agent_config("agent")
     external.description = "updated-elsewhere"
     save_agent_config("agent", external)
 

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -53,7 +53,7 @@ def test_task_command_registered_in_cli() -> None:
 
 def test_task_rejects_empty_instruction(monkeypatch) -> None:
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         MagicMock(),
     )
     result = CliRunner().invoke(cli, ["task", "-i", "   "])
@@ -76,7 +76,7 @@ def test_task_reports_missing_agent_without_traceback(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         _raise_missing_agent,
     )
 
@@ -108,7 +108,7 @@ def test_model_flag_overrides_agent_config(monkeypatch) -> None:
 
     fake_config = AgentProfileConfig(id="default", name="Default")
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: fake_config,
     )
     monkeypatch.setattr(
@@ -133,7 +133,7 @@ def test_model_flag_without_slash(monkeypatch) -> None:
 
     fake_config = AgentProfileConfig(id="default", name="Default")
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: fake_config,
     )
     monkeypatch.setattr(
@@ -160,7 +160,7 @@ def test_output_dir_writes_result_json(monkeypatch, tmp_path) -> None:
 
     fake_config = AgentProfileConfig(id="default", name="Default")
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: fake_config,
     )
 
@@ -207,7 +207,7 @@ def test_exit_code_one_on_failure(monkeypatch, status) -> None:
     from qwenpaw.config.config import AgentProfileConfig
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: AgentProfileConfig(id="default", name="Default"),
     )
     monkeypatch.setattr(
@@ -230,7 +230,7 @@ def test_stdout_json_and_default_context(monkeypatch) -> None:
     from qwenpaw.config.config import AgentProfileConfig
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: AgentProfileConfig(id="default", name="Default"),
     )
 
@@ -284,7 +284,7 @@ def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
     )
     (tmp_path / "workspace").mkdir()
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         lambda _aid: fake_config,
     )
 

--- a/tests/unit/config/test_agent_config_loading.py
+++ b/tests/unit/config/test_agent_config_loading.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Tests for synchronous and asynchronous agent config loading."""
+
+import asyncio
+import threading
+
+from qwenpaw.config import config as config_module
+
+
+def test_load_agent_config_supports_separate_event_loops(monkeypatch) -> None:
+    """The public loader offloads work on each caller's event loop."""
+    caller_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    sentinel = object()
+
+    def fake_load_agent_config(agent_id: str) -> object:
+        assert agent_id == "agent"
+        worker_threads.append(threading.get_ident())
+        return sentinel
+
+    monkeypatch.setattr(
+        config_module,
+        "_load_agent_config",
+        fake_load_agent_config,
+    )
+
+    assert asyncio.run(config_module.load_agent_config("agent")) is sentinel
+    assert asyncio.run(config_module.load_agent_config("agent")) is sentinel
+    assert len(worker_threads) == 2
+    assert all(thread_id != caller_thread for thread_id in worker_threads)

--- a/tests/unit/config/test_agent_config_persistence.py
+++ b/tests/unit/config/test_agent_config_persistence.py
@@ -20,7 +20,7 @@ from qwenpaw.config.config import (
     AgentsConfig,
     Config,
     _migrate_access_control_fields,
-    load_agent_config,
+    _load_agent_config,
 )
 from qwenpaw.config.utils import read_last_dispatch, update_last_dispatch
 from qwenpaw.exceptions import AgentConfigConflictError
@@ -72,7 +72,7 @@ def test_acl_migration_replaces_long_agent_json_completely(
     agent_path.write_text(json.dumps(raw), encoding="utf-8")
     old_size = agent_path.stat().st_size
 
-    load_agent_config("agent")
+    _load_agent_config("agent")
 
     migrated_content = agent_path.read_text(encoding="utf-8")
     migrated = json.loads(migrated_content)
@@ -108,7 +108,7 @@ def test_cache_detects_same_mtime_atomic_replacement(
 ) -> None:
     """A same-mtime replacement invalidates the cached model."""
     agent_path, raw = _prepare_agent(tmp_path, monkeypatch)
-    assert load_agent_config("agent").name == "Old"
+    assert _load_agent_config("agent").name == "Old"
     old_stat = agent_path.stat()
     raw["name"] = "New"
     replacement = agent_path.with_name("replacement.json")
@@ -120,7 +120,7 @@ def test_cache_detects_same_mtime_atomic_replacement(
     os.replace(replacement, agent_path)
 
     assert agent_path.stat().st_mtime_ns == old_stat.st_mtime_ns
-    assert load_agent_config("agent").name == "New"
+    assert _load_agent_config("agent").name == "New"
 
 
 def test_cache_returns_an_isolated_config_copy(
@@ -129,10 +129,10 @@ def test_cache_returns_an_isolated_config_copy(
 ) -> None:
     """Mutating one loaded config cannot change a later cache hit."""
     _agent_path, _raw = _prepare_agent(tmp_path, monkeypatch)
-    first = load_agent_config("agent")
+    first = _load_agent_config("agent")
     first.description = "updated"
 
-    second = load_agent_config("agent")
+    second = _load_agent_config("agent")
 
     assert second is not first
     assert second.description == ""
@@ -144,7 +144,7 @@ def test_stale_loaded_config_cannot_overwrite_external_update(
 ) -> None:
     """A loaded model cannot replace a newer external file version."""
     agent_path, raw = _prepare_agent(tmp_path, monkeypatch)
-    stale = load_agent_config("agent")
+    stale = _load_agent_config("agent")
     raw["name"] = "New"
     write_json_atomic(agent_path, raw)
     stale.description = "stale update"
@@ -163,7 +163,7 @@ def test_loaded_config_cannot_recreate_externally_deleted_file(
 ) -> None:
     """A loaded model cannot silently recreate an externally deleted file."""
     agent_path, _raw = _prepare_agent(tmp_path, monkeypatch)
-    stale = load_agent_config("agent")
+    stale = _load_agent_config("agent")
     agent_path.unlink()
 
     with pytest.raises(AgentConfigConflictError, match="changed on disk"):
@@ -179,7 +179,7 @@ def test_failed_save_evicts_mutated_cached_config(
 ) -> None:
     """A failed write cannot leave a mutated model in the shared cache."""
     _agent_path, _raw = _prepare_agent(tmp_path, monkeypatch)
-    loaded = load_agent_config("agent")
+    loaded = _load_agent_config("agent")
     loaded.description = "not persisted"
 
     def fail_write(*_args, **_kwargs):
@@ -199,7 +199,7 @@ def test_successful_save_updates_model_version(
 ) -> None:
     """The same loaded model can be saved repeatedly after local changes."""
     agent_path, _raw = _prepare_agent(tmp_path, monkeypatch)
-    loaded = load_agent_config("agent")
+    loaded = _load_agent_config("agent")
     loaded.description = "first"
     config_module.save_agent_config("agent", loaded)
     loaded.description = "second"
@@ -223,7 +223,7 @@ def test_last_dispatch_migration_publishes_state_then_removes_legacy(
     }
     agent_path.write_text(json.dumps(raw), encoding="utf-8")
 
-    loaded = load_agent_config("agent")
+    loaded = _load_agent_config("agent")
 
     persisted = json.loads(agent_path.read_text(encoding="utf-8"))
     state_path = agent_path.parent / "state" / "last_dispatch.json"
@@ -261,7 +261,7 @@ def test_migration_rejects_an_external_update_before_replacement(
     )
 
     with pytest.raises(AgentConfigConflictError):
-        load_agent_config("agent")
+        _load_agent_config("agent")
 
     persisted = json.loads(agent_path.read_text(encoding="utf-8"))
     assert persisted["name"] == "External"
@@ -294,7 +294,7 @@ def test_migration_checks_source_before_publishing_state(
     )
 
     with pytest.raises(AgentConfigConflictError):
-        load_agent_config("agent")
+        _load_agent_config("agent")
 
     state_path = agent_path.parent / "state" / "last_dispatch.json"
     assert not state_path.exists()
@@ -322,7 +322,7 @@ def test_last_dispatch_migration_keeps_existing_valid_state(
         },
     )
 
-    load_agent_config("agent")
+    _load_agent_config("agent")
 
     dispatch = read_last_dispatch("agent")
     persisted = json.loads(agent_path.read_text(encoding="utf-8"))
@@ -356,8 +356,8 @@ def test_last_dispatch_migration_failure_keeps_legacy_and_retries(
         fail_state_write,
     )
 
-    first = load_agent_config("agent")
-    second = load_agent_config("agent")
+    first = _load_agent_config("agent")
+    second = _load_agent_config("agent")
 
     persisted = json.loads(agent_path.read_text(encoding="utf-8"))
     assert first.last_dispatch is not None

--- a/tests/unit/config/test_channel_display_migration.py
+++ b/tests/unit/config/test_channel_display_migration.py
@@ -9,7 +9,7 @@ from qwenpaw.config.config import (
     AgentProfileRef,
     AgentsConfig,
     Config,
-    load_agent_config,
+    _load_agent_config,
     migrate_channel_display_fields,
 )
 from qwenpaw.config import utils as config_utils
@@ -104,7 +104,7 @@ def test_loaded_agent_config_migration_persists(
     monkeypatch.setattr(config_utils, "_agent_config_cache", {})
     monkeypatch.setattr(config_utils, "_agent_config_lock", Lock())
 
-    config = load_agent_config("agent")
+    config = _load_agent_config("agent")
     persisted = json.loads(agent_config_path.read_text(encoding="utf-8"))
 
     assert config.channels.slack.show_tool_calls is False

--- a/tests/unit/config/test_config_transactions.py
+++ b/tests/unit/config/test_config_transactions.py
@@ -17,7 +17,7 @@ from qwenpaw.config.config import (
     AgentProfileRef,
     AgentsConfig,
     Config,
-    load_agent_config,
+    _load_agent_config,
     mutate_agent_config,
     save_agent_config,
 )
@@ -116,10 +116,10 @@ def isolated_agent(isolated_config, tmp_path: Path):
 
 def test_load_agent_config_returns_detached_cache_copy(isolated_agent):
     """Agent cache state is not exposed as a mutable canonical object."""
-    loaded = load_agent_config("agent")
+    loaded = _load_agent_config("agent")
     loaded.description = "unsaved"
 
-    assert load_agent_config("agent").description == "original"
+    assert _load_agent_config("agent").description == "original"
 
 
 def test_concurrent_agent_mutations_retain_both_changes(isolated_agent):
@@ -147,7 +147,7 @@ def test_concurrent_agent_mutations_retain_both_changes(isolated_agent):
         for future in futures:
             future.result()
 
-    reloaded = load_agent_config("agent")
+    reloaded = _load_agent_config("agent")
     assert reloaded.description == "updated"
     assert reloaded.language == "zh"
 
@@ -168,4 +168,4 @@ def test_failed_agent_write_preserves_disk_and_cache(isolated_agent):
 
     after = json.loads(isolated_agent.read_text(encoding="utf-8"))
     assert after == before
-    assert load_agent_config("agent").description == "original"
+    assert _load_agent_config("agent").description == "original"

--- a/tests/unit/harnesses/test_workspace_routing.py
+++ b/tests/unit/harnesses/test_workspace_routing.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -37,7 +38,7 @@ async def test_coding_mode_routes_directly_to_harness(
     )
     monkeypatch.setattr(
         "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: config,
+        AsyncMock(return_value=config),
     )
     workspace = Workspace("agent-1", str(tmp_path / "workspace"))
     runtime = FakeHarnessRuntime()

--- a/tests/unit/runtime/test_agent_config_io.py
+++ b/tests/unit/runtime/test_agent_config_io.py
@@ -30,7 +30,7 @@ async def test_build_loads_agent_config_once_in_worker_thread(monkeypatch):
 
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         load_agent_config,
     )
     monkeypatch.setattr(
@@ -70,7 +70,7 @@ async def test_build_constructs_model_in_worker_thread(monkeypatch):
 
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
     monkeypatch.setattr(
@@ -158,7 +158,7 @@ async def test_build_constructs_prompt_in_worker_thread(monkeypatch):
 
     monkeypatch.setattr(
         config_module,
-        "load_agent_config",
+        "_load_agent_config",
         lambda _agent_id: config,
     )
     monkeypatch.setattr(

--- a/tests/unit/runtime/test_project_dir_override.py
+++ b/tests/unit/runtime/test_project_dir_override.py
@@ -99,7 +99,7 @@ def test_coding_prompt_prefers_request_project(monkeypatch, tmp_path):
         raise AssertionError("request project should be used first")
 
     monkeypatch.setattr(
-        "qwenpaw.config.config.load_agent_config",
+        "qwenpaw.config.config._load_agent_config",
         fail_load_agent_config,
     )
 

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -565,7 +565,7 @@ async def test_auto_memory_search_uses_reranker(manager):
 
     with patch.object(
         mgr,
-        "load_agent_config_async",
+        "load_agent_config",
         AsyncMock(return_value=agent_config),
     ):
         result = await manager.auto_memory_search(

--- a/tests/unit/workspace/test_agent_model.py
+++ b/tests/unit/workspace/test_agent_model.py
@@ -10,7 +10,7 @@ from qwenpaw.exceptions import (
 from qwenpaw.config.config import (
     AgentProfileConfig,
     AgentsRunningConfig,
-    load_agent_config,
+    _load_agent_config,
     save_agent_config,
 )
 from qwenpaw.constant import (
@@ -68,7 +68,7 @@ def test_agent_model_config_defaults_to_none(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test that agent model config defaults to None."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
     assert agent_config.active_model is None
 
 
@@ -76,7 +76,7 @@ def test_agent_model_config_can_be_set(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test setting agent-specific model config."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
 
     # Set active model
     agent_config.active_model = ModelSlotConfig(
@@ -86,7 +86,7 @@ def test_agent_model_config_can_be_set(
     save_agent_config("test_agent", agent_config)
 
     # Reload and verify
-    reloaded_config = load_agent_config("test_agent")
+    reloaded_config = _load_agent_config("test_agent")
     assert reloaded_config.active_model is not None
     assert reloaded_config.active_model.provider_id == "openai"
     assert reloaded_config.active_model.model == "gpt-4"
@@ -96,7 +96,7 @@ def test_agent_model_config_persists_across_reloads(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test that model config persists across multiple save/load cycles."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
 
     # Set model
     agent_config.active_model = ModelSlotConfig(
@@ -107,7 +107,7 @@ def test_agent_model_config_persists_across_reloads(
 
     # Reload multiple times
     for _ in range(3):
-        reloaded = load_agent_config("test_agent")
+        reloaded = _load_agent_config("test_agent")
         assert reloaded.active_model is not None
         assert reloaded.active_model.provider_id == "anthropic"
         assert reloaded.active_model.model == "claude-3-5-sonnet-20241022"
@@ -117,7 +117,7 @@ def test_agent_model_config_can_be_cleared(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test that model config can be set to None."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
 
     # Set a model
     agent_config.active_model = ModelSlotConfig(
@@ -131,7 +131,7 @@ def test_agent_model_config_can_be_cleared(
     save_agent_config("test_agent", agent_config)
 
     # Verify it's cleared
-    reloaded = load_agent_config("test_agent")
+    reloaded = _load_agent_config("test_agent")
     assert reloaded.active_model is None
 
 
@@ -200,8 +200,8 @@ def test_different_agents_have_independent_models(tmp_path, monkeypatch):
     save_agent_config("agent2", config2)
 
     # Verify they're independent
-    reloaded1 = load_agent_config("agent1")
-    reloaded2 = load_agent_config("agent2")
+    reloaded1 = _load_agent_config("agent1")
+    reloaded2 = _load_agent_config("agent2")
 
     assert reloaded1.active_model.provider_id == "openai"
     assert reloaded1.active_model.model == "gpt-4"
@@ -214,7 +214,7 @@ def test_model_config_excluded_when_none(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name
     """Test that active_model is excluded from agent.json when None."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
     agent_config.active_model = None
     save_agent_config("test_agent", agent_config)
 
@@ -233,7 +233,7 @@ def test_model_config_included_when_set(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name
     """Test that active_model is included in agent.json when set."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
     agent_config.active_model = ModelSlotConfig(
         provider_id="openai",
         model="gpt-4-turbo",
@@ -257,7 +257,7 @@ def test_agent_running_config_has_llm_retry_defaults(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test that agent running config exposes LLM retry defaults."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
 
     assert agent_config.running.llm_retry_enabled is (LLM_MAX_RETRIES > 0)
     assert agent_config.running.llm_max_retries == max(LLM_MAX_RETRIES, 1)
@@ -269,7 +269,7 @@ def test_agent_running_config_llm_retry_persists(
     mock_agent_workspace,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Test that LLM retry settings persist in agent.json."""
-    agent_config = load_agent_config("test_agent")
+    agent_config = _load_agent_config("test_agent")
     agent_config.running = AgentsRunningConfig(
         llm_retry_enabled=False,
         llm_max_retries=5,
@@ -278,7 +278,7 @@ def test_agent_running_config_llm_retry_persists(
     )
     save_agent_config("test_agent", agent_config)
 
-    reloaded_config = load_agent_config("test_agent")
+    reloaded_config = _load_agent_config("test_agent")
 
     assert reloaded_config.running.llm_retry_enabled is False
     assert reloaded_config.running.llm_max_retries == 5

--- a/tests/unit/workspace/test_cli_agent_id.py
+++ b/tests/unit/workspace/test_cli_agent_id.py
@@ -54,7 +54,7 @@ def test_channels_list_default_agent(
 
     runner = CliRunner()
 
-    with patch("qwenpaw.cli.channels_cmd.load_agent_config") as mock_load:
+    with patch("qwenpaw.cli.channels_cmd._load_agent_config") as mock_load:
         mock_load.return_value = agent_config
         runner.invoke(channels_group, ["list"])
 
@@ -82,7 +82,7 @@ def test_channels_list_custom_agent(
 
     runner = CliRunner()
 
-    with patch("qwenpaw.cli.channels_cmd.load_agent_config") as mock_load:
+    with patch("qwenpaw.cli.channels_cmd._load_agent_config") as mock_load:
         mock_load.return_value = agent_config
         runner.invoke(
             channels_group,


### PR DESCRIPTION
## Summary

This PR makes the non-blocking agent configuration loader the default public API:

- Renames the synchronous implementation from `load_agent_config` to the private `_load_agent_config`.
- Renames `load_agent_config_async` to the public `load_agent_config`.
- Migrates asynchronous call sites to `await load_agent_config(...)`.
- Keeps synchronous code paths, atomic configuration transactions, synchronous callbacks, and fingerprinted watcher snapshots on `_load_agent_config(...)`.
- Removes redundant `run_sync_io(load_agent_config, ...)` and `asyncio.to_thread(load_agent_config, ...)` wrappers now that the public loader owns the thread offload.
- Updates mocks and tests to match the new sync/async boundary.

## Motivation

Agent configuration loading performs filesystem I/O and migration work. Exposing the synchronous loader under the primary public name made it easy for asynchronous request handlers, background jobs, memory flows, runtime builders, and subagent setup to call it directly and block the event loop.

The new naming makes the safe behavior the default:

```python
agent_config = await load_agent_config(agent_id)
```

Synchronous callers must opt into the private implementation explicitly:

```python
agent_config = _load_agent_config(agent_id)
```

This also avoids carrying two public names whose only distinction is an `_async` suffix.

## Event-loop and concurrency behavior

The public loader delegates each call to `run_sync_io(_load_agent_config, ...)`, which uses `asyncio.to_thread` on the caller's currently running event loop. It does not cache a loop, task, or future, so the loader can be used safely from separate event loops.

The existing cancellation behavior is preserved: cancellation waits for the worker-thread operation to finish before propagating, preventing a caller from releasing surrounding locks while filesystem work is still running.

Atomic read-modify-write operations continue to use the synchronous `mutate_agent_config` transaction in one worker thread. This preserves the shared re-entrant lock across the complete transaction and avoids introducing an `await` boundary between loading and saving.

The latest main-branch behavior is also preserved for:

- detached cache copies and optimistic file-version checks;
- fingerprint-stable `AgentConfigWatcher` snapshots;
- last-dispatch state-file migration and reads;
- workspace-pinned configuration snapshots.

## Compatibility review

All Python call sites under `src/` and `tests/` were audited:

- Public `load_agent_config` calls are awaited.
- Direct `_load_agent_config` calls remain only in synchronous functions, synchronous callbacks, or composed worker-thread operations.
- No `load_agent_config_async` references remain.
- No public async loader is passed to `run_sync_io` or `asyncio.to_thread`.
- Subagent request-context construction now awaits the public loader directly.
- Test patches use async mocks for the public API and patch the private implementation when validating worker-thread execution.

This is an intentional API rename: callers that previously used synchronous `load_agent_config` must use `_load_agent_config` in synchronous internal code, while asynchronous callers should await `load_agent_config`.

## Tests

- `uv run pytest -q tests/unit`
  - **7320 passed, 17 skipped**
- Targeted post-rebase coverage for config persistence, config watching, async I/O boundaries, runtime building, agent routes, model creation, and subagent setup
  - **242 passed**
- Dedicated regression coverage invokes the public loader through two separate `asyncio.run(...)` event loops and verifies that the synchronous implementation runs outside the caller thread.
- `uv run pre-commit run --all-files`
  - Python AST, YAML/XML/TOML/JSON, encoding, private-key detection, whitespace, trailing commas, mypy, Black, flake8, pylint, Prettier, and actionlint all pass.
