### PR TITLE
fix(security): create the master key file with owner-only permissions

### DIFF
--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -269,14 +269,22 @@ def _read_key_file() -> Optional[str]:
     return None
 
 
+def _chmod_best_effort(path: Path, mode: int) -> None:
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        # Some systems/filesystems do not support chmod semantics.
+        pass
+
+
 def _write_key_file(key_hex: str) -> None:
     path = _master_key_file()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(key_hex, encoding="utf-8")
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _chmod_best_effort(path.parent, 0o700)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(key_hex)
+    _chmod_best_effort(path, 0o600)
 
 
 def _generate_master_key() -> str:

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -255,13 +255,31 @@ def _chmod_best_effort(path: Path, mode: int) -> None:
         pass
 
 
-def _restrict_key_file(path: Path) -> None:
-    """Tighten a key file an older version left group- or world-readable."""
+def _restrict_key_file(path: Path, key_hex: str) -> None:
+    """Migrate a key file an older version left group/world-readable.
+
+    A valid legacy key is never rewritten by ``_write_key_file``, so
+    this is the only chance to take it out of a world-readable inode.
+    ``chmod`` is not enough on its own: the module treats it as best
+    effort, and wherever it is refused the key would stay readable by
+    every local account indefinitely.  Writing the same key material
+    into a fresh ``0o600`` inode makes the mode a property of a file
+    we created; ``chmod`` stays as the fallback for the case where
+    the replacement itself cannot be written.
+    """
     try:
         mode = stat.S_IMODE(path.stat().st_mode)
     except OSError:
         return
-    if mode & 0o077:
+    if not mode & 0o077:
+        return
+    try:
+        _write_key_file(key_hex)
+    except OSError:
+        logger.warning(
+            "Could not replace the group/world-readable master key"
+            " file; falling back to chmod",
+        )
         _chmod_best_effort(path, 0o600)
 
 
@@ -280,7 +298,7 @@ def _read_key_file() -> Optional[str]:
                     len(content),
                 )
                 return None
-            _restrict_key_file(path)
+            _restrict_key_file(path, content)
             return content
         except (OSError, ValueError):
             logger.warning(

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -19,6 +19,8 @@ import hashlib
 import logging
 import os
 import secrets
+import stat
+import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
@@ -245,6 +247,24 @@ def _master_key_file() -> Path:
     return _get_secret_dir() / ".master_key"
 
 
+def _chmod_best_effort(path: Path, mode: int) -> None:
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        # Some systems/filesystems do not support chmod semantics.
+        pass
+
+
+def _restrict_key_file(path: Path) -> None:
+    """Tighten a key file an older version left group- or world-readable."""
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        return
+    if mode & 0o077:
+        _chmod_best_effort(path, 0o600)
+
+
 def _read_key_file() -> Optional[str]:
     path = _master_key_file()
     if path.is_file():
@@ -260,6 +280,7 @@ def _read_key_file() -> Optional[str]:
                     len(content),
                 )
                 return None
+            _restrict_key_file(path)
             return content
         except (OSError, ValueError):
             logger.warning(
@@ -269,22 +290,37 @@ def _read_key_file() -> Optional[str]:
     return None
 
 
-def _chmod_best_effort(path: Path, mode: int) -> None:
-    try:
-        os.chmod(path, mode)
-    except OSError:
-        # Some systems/filesystems do not support chmod semantics.
-        pass
-
-
 def _write_key_file(key_hex: str) -> None:
+    """Persist the master key as an owner-only file.
+
+    The key is written to a freshly created ``0o600`` temporary file and
+    moved into place. Truncating the destination would keep the mode of an
+    existing ``.master_key``, so a file left behind ``0o644`` by an older
+    version would hold the new key while it is world-readable -- and stay
+    that way whenever the best-effort ``chmod`` is refused. Replacing the
+    file makes the mode a property of the inode we created instead.
+    """
     path = _master_key_file()
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     _chmod_best_effort(path.parent, 0o700)
-    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        handle.write(key_hex)
-    _chmod_best_effort(path, 0o600)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(key_hex)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _generate_master_key() -> str:

--- a/tests/unit/security/test_secret_store.py
+++ b/tests/unit/security/test_secret_store.py
@@ -301,6 +301,9 @@ class TestMasterKeyFilePermissions:
         path = secret_dir / ".master_key"
         path.write_text(content, encoding="utf-8")
         os.chmod(path, 0o644)
+        # Under ``_no_chmod`` the call above is a no-op, so state the
+        # precondition rather than assuming it.
+        assert stat.S_IMODE(path.stat().st_mode) == 0o644
         return path
 
     @pytest.mark.usefixtures("_no_chmod")
@@ -359,20 +362,48 @@ class TestMasterKeyFilePermissions:
         assert key_path.read_text(encoding="utf-8") == "ef" * 32
         assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
 
-    def test_reading_a_valid_legacy_key_tightens_it(
+    @pytest.mark.usefixtures("_no_chmod")
+    def test_reading_a_valid_legacy_key_migrates_it(
         self,
         tmp_path: Path,
         monkeypatch,
     ):
-        """A valid 0o644 key is never rewritten, so reading must fix it."""
+        """A valid 0o644 key is never rewritten, so reading must fix it.
+
+        Running without ``chmod`` is the point: tightening the mode of
+        the legacy inode is the best-effort step that cannot be relied
+        on, so the key has to end up in an inode created ``0o600``.
+        """
         import qwenpaw.security.secret_store as mod
 
         secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
         key_path = self._legacy_key_file(secret_dir, "ab" * 32)
+        legacy_inode = key_path.stat().st_ino
 
         assert mod._read_key_file() == "ab" * 32
 
         assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+        assert key_path.stat().st_ino != legacy_inode
+        assert key_path.read_text(encoding="utf-8") == "ab" * 32
+        assert [p.name for p in secret_dir.iterdir()] == [".master_key"]
+
+    @pytest.mark.usefixtures("_no_chmod")
+    def test_owner_only_key_is_read_without_being_rewritten(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """A key that is already 0o600 must not be replaced on read."""
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        mod._write_key_file("ab" * 32)
+        key_path = secret_dir / ".master_key"
+        inode = key_path.stat().st_ino
+
+        assert mod._read_key_file() == "ab" * 32
+
+        assert key_path.stat().st_ino == inode
 
     def test_no_temporary_key_file_is_left_behind(
         self,

--- a/tests/unit/security/test_secret_store.py
+++ b/tests/unit/security/test_secret_store.py
@@ -263,6 +263,17 @@ def _umask_022():
         os.umask(previous)
 
 
+@pytest.fixture
+def _no_chmod(monkeypatch):
+    """Disable ``os.chmod`` so only creation-time modes can pass a test.
+
+    ``secret_store`` calls ``os.chmod`` best effort (``except OSError:
+    pass``), so a mode that only holds because the chmod succeeded is not a
+    guarantee. Everything asserted under this fixture holds without it.
+    """
+    monkeypatch.setattr(os, "chmod", lambda *args, **kwargs: None)
+
+
 @pytest.mark.skipif(
     os.name != "posix",
     reason="POSIX mode bits are not meaningful on Windows",
@@ -272,9 +283,8 @@ class TestMasterKeyFilePermissions:
     """The fallback key file must be owner-only from the moment it exists.
 
     The module docstring promises ``SECRET_DIR/.master_key`` is persisted
-    "with mode ``0o600``", and its own ``os.chmod`` is best effort
-    (``except OSError: pass``), so the mode has to come from the creation
-    itself rather than from a follow-up call.
+    "with mode ``0o600``", so the mode has to come from creating the file
+    rather than from a follow-up call that is allowed to fail.
     """
 
     @staticmethod
@@ -283,7 +293,18 @@ class TestMasterKeyFilePermissions:
         monkeypatch.setattr(mod, "_get_secret_dir", lambda: secret_dir)
         return secret_dir
 
-    def test_key_is_not_world_readable_before_chmod_runs(
+    @staticmethod
+    def _legacy_key_file(secret_dir: Path, content: str) -> Path:
+        """Lay down a key file as a pre-0o600 version would have left it."""
+        secret_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
+        os.chmod(secret_dir, 0o755)
+        path = secret_dir / ".master_key"
+        path.write_text(content, encoding="utf-8")
+        os.chmod(path, 0o644)
+        return path
+
+    @pytest.mark.usefixtures("_no_chmod")
+    def test_new_key_file_is_owner_only(
         self,
         tmp_path: Path,
         monkeypatch,
@@ -291,47 +312,69 @@ class TestMasterKeyFilePermissions:
         import qwenpaw.security.secret_store as mod
 
         secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
-        key_path = secret_dir / ".master_key"
-        observed: dict = {}
-        real_chmod = os.chmod
-
-        def _spy_chmod(path, mode, *args, **kwargs):
-            if Path(path) == key_path and key_path.exists():
-                observed["mode"] = stat.S_IMODE(key_path.stat().st_mode)
-                observed["content"] = key_path.read_text(encoding="utf-8")
-            return real_chmod(path, mode, *args, **kwargs)
-
-        monkeypatch.setattr(os, "chmod", _spy_chmod)
-
-        mod._write_key_file("ab" * 32)
-
-        assert observed, "the key file was never chmod-ed"
-        assert observed["content"] == "ab" * 32
-        assert observed["mode"] == 0o600
-
-    def test_key_is_owner_only_when_chmod_cannot_help(
-        self,
-        tmp_path: Path,
-        monkeypatch,
-    ):
-        import qwenpaw.security.secret_store as mod
-
-        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
-        key_path = secret_dir / ".master_key"
-        real_chmod = os.chmod
-
-        def _chmod_without_the_key_file(path, mode, *args, **kwargs):
-            if Path(path) == key_path:
-                return None
-            return real_chmod(path, mode, *args, **kwargs)
-
-        monkeypatch.setattr(os, "chmod", _chmod_without_the_key_file)
 
         mod._write_key_file("cd" * 32)
 
+        key_path = secret_dir / ".master_key"
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+
+    @pytest.mark.usefixtures("_no_chmod")
+    def test_world_readable_key_file_is_replaced_not_truncated(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """A pre-existing 0o644 file must not host the new key.
+
+        Opening the destination with ``O_TRUNC`` would keep its mode, so
+        the freshly written key would sit in a world-readable inode.
+        """
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        key_path = self._legacy_key_file(secret_dir, "ab" * 32)
+
+        mod._write_key_file("cd" * 32)
+
+        assert key_path.read_text(encoding="utf-8") == "cd" * 32
         assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
 
-    def test_secret_dir_is_owner_only(
+    @pytest.mark.usefixtures("_no_chmod")
+    def test_corrupt_world_readable_key_file_is_replaced(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """The regeneration path starts from the same 0o644 file."""
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        key_path = self._legacy_key_file(secret_dir, "not-a-hex-key")
+
+        assert mod._read_key_file() is None
+
+        mod._write_key_file("ef" * 32)
+
+        assert key_path.read_text(encoding="utf-8") == "ef" * 32
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    def test_reading_a_valid_legacy_key_tightens_it(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """A valid 0o644 key is never rewritten, so reading must fix it."""
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        key_path = self._legacy_key_file(secret_dir, "ab" * 32)
+
+        assert mod._read_key_file() == "ab" * 32
+
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    def test_no_temporary_key_file_is_left_behind(
         self,
         tmp_path: Path,
         monkeypatch,
@@ -340,9 +383,10 @@ class TestMasterKeyFilePermissions:
 
         secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
 
-        mod._write_key_file("ef" * 32)
+        mod._write_key_file("11" * 32)
+        mod._write_key_file("22" * 32)
 
-        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+        assert [p.name for p in secret_dir.iterdir()] == [".master_key"]
 
 
 class TestMasterKeyFileContent:

--- a/tests/unit/security/test_secret_store.py
+++ b/tests/unit/security/test_secret_store.py
@@ -3,6 +3,8 @@
 """Tests for the encrypted secret store layer."""
 from __future__ import annotations
 
+import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -249,3 +251,115 @@ class TestKeyringAccountIsolation:
         monkeypatch.setenv("QWENPAW_SECRET_DIR", "set-to-mark-relocated")
         monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path / "x")
         assert mod._keyring_account() == mod._keyring_account()
+
+
+@pytest.fixture
+def _umask_022():
+    """Pin a permissive umask so mode assertions are deterministic."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX mode bits are not meaningful on Windows",
+)
+@pytest.mark.usefixtures("_umask_022")
+class TestMasterKeyFilePermissions:
+    """The fallback key file must be owner-only from the moment it exists.
+
+    The module docstring promises ``SECRET_DIR/.master_key`` is persisted
+    "with mode ``0o600``", and its own ``os.chmod`` is best effort
+    (``except OSError: pass``), so the mode has to come from the creation
+    itself rather than from a follow-up call.
+    """
+
+    @staticmethod
+    def _secret_dir(mod, monkeypatch, tmp_path: Path) -> Path:
+        secret_dir = tmp_path / "secrets"
+        monkeypatch.setattr(mod, "_get_secret_dir", lambda: secret_dir)
+        return secret_dir
+
+    def test_key_is_not_world_readable_before_chmod_runs(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        key_path = secret_dir / ".master_key"
+        observed: dict = {}
+        real_chmod = os.chmod
+
+        def _spy_chmod(path, mode, *args, **kwargs):
+            if Path(path) == key_path and key_path.exists():
+                observed["mode"] = stat.S_IMODE(key_path.stat().st_mode)
+                observed["content"] = key_path.read_text(encoding="utf-8")
+            return real_chmod(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(os, "chmod", _spy_chmod)
+
+        mod._write_key_file("ab" * 32)
+
+        assert observed, "the key file was never chmod-ed"
+        assert observed["content"] == "ab" * 32
+        assert observed["mode"] == 0o600
+
+    def test_key_is_owner_only_when_chmod_cannot_help(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+        key_path = secret_dir / ".master_key"
+        real_chmod = os.chmod
+
+        def _chmod_without_the_key_file(path, mode, *args, **kwargs):
+            if Path(path) == key_path:
+                return None
+            return real_chmod(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(os, "chmod", _chmod_without_the_key_file)
+
+        mod._write_key_file("cd" * 32)
+
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    def test_secret_dir_is_owner_only(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = self._secret_dir(mod, monkeypatch, tmp_path)
+
+        mod._write_key_file("ef" * 32)
+
+        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+
+
+class TestMasterKeyFileContent:
+    """Tightening the permissions must not change what is written."""
+
+    def test_key_file_is_written_and_replaced(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        secret_dir = tmp_path / "secrets"
+        monkeypatch.setattr(mod, "_get_secret_dir", lambda: secret_dir)
+
+        mod._write_key_file("11" * 32)
+        assert mod._read_key_file() == "11" * 32
+
+        mod._write_key_file("22" * 32)
+        assert mod._read_key_file() == "22" * 32


### PR DESCRIPTION
## Description

`secret_store` persists the Fernet master key to `SECRET_DIR/.master_key`, and the module docstring states the contract in its own words: *"Persisted to `SECRET_DIR/.master_key` with mode `0o600` (fallback)."*

`_write_key_file` does not create it that way:

```python
def _write_key_file(key_hex: str) -> None:
    path = _master_key_file()
    path.parent.mkdir(parents=True, exist_ok=True)
    path.write_text(key_hex, encoding="utf-8")
    try:
        os.chmod(path, 0o600)
    except OSError:
        pass
```

`write_text()` creates the file with `0o666 & ~umask` — `0o644` under the common default — and the mode is only corrected afterwards. Two consequences follow:

1. **The key is on disk, complete, and world-readable before the mode is tightened.** Any local user can read the master key inside that window, and a crash, `SIGKILL` or power loss between the two calls leaves the file at `0o644` permanently. The RED transcript below captures the state at the moment `chmod` is invoked: mode `0o644`, all 64 hex characters already present.
2. **The final mode depends on a call the module itself is prepared to see fail.** The `except OSError: pass` exists precisely for filesystems without POSIX chmod semantics; on those the key simply stays world-readable, and nothing is logged.

The parent directory has the same shape: `mkdir(parents=True, exist_ok=True)` creates `SECRET_DIR` as `0o755`, so the directory holding the master key is world-readable and world-traversable.

What makes this a defect rather than a preference is that **this module is the outlier in its own repository.** Three sibling secret writers already do it correctly:

- `backup/_utils/signing/key.py:55-80` — `os.open(..., O_CREAT|O_EXCL|O_WRONLY[|O_NOFOLLOW], 0o600)`, parent tightened to `0o700`
- `envs/store.py:51-53` — `_prepare_secret_parent()`: `mkdir` + `chmod 0o700`
- `app/auth.py:83-93` — the same helper pair

This change makes `_write_key_file` create the file *with* its mode instead of correcting it afterwards: `os.open(path, O_CREAT|O_WRONLY|O_TRUNC, 0o600)`, the parent created as `0o700`, and the existing best-effort `chmod` kept so that a key file (or directory) left behind by an older version is still tightened on the next write.

**Deliberately not included, offered as a follow-up:** `signing/key.py` also refuses to write through a symlink (`O_NOFOLLOW`) and creates with `O_EXCL`. Both are worth having here, but `O_NOFOLLOW` converts a currently-silent case into an `OSError` raised out of `_get_master_key()` — a behaviour change that deserves its own PR and its own discussion rather than riding along with a permissions fix. Happy to open it if you want it.

Impact is POSIX-only; Windows ACLs are unaffected either way, and the new permission assertions are skipped there.

**Related Issue:** none

**Security Considerations:** this is the change. The master key decrypts every stored provider API key and auth secret (`encrypt`/`decrypt` in this module), so it is the one file under `SECRET_DIR` that must never be readable by another local account — not even briefly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

On the first box, honestly: I ran `pre-commit run --files` against the two changed files rather than `--all-files`. An `--all-files` run on my checkout rewrites line endings across roughly a hundred untouched files, which would bury the diff. The changed-file run is included below and every hook passes.

## Testing

Four tests were added to `tests/unit/security/test_secret_store.py`. The three permission tests are skipped on Windows (`os.name != "posix"`) and pin a `0o022` umask so the assertions are deterministic:

- `test_key_is_not_world_readable_before_chmod_runs` — spies on `os.chmod` and records the on-disk state at the moment it is called. That is the window itself: the test asserts the file is already `0o600` when `chmod` runs, and that the full key is already written.
- `test_key_is_owner_only_when_chmod_cannot_help` — neutralises `chmod` for the key file only, which is the case the module's own `except OSError: pass` anticipates, and asserts the file is still `0o600`.
- `test_secret_dir_is_owner_only` — asserts the freshly created `SECRET_DIR` is `0o700`.
- `test_key_file_is_written_and_replaced` — the over-correction guard, and the only one of the four that runs on every platform: writing must still persist the key and must still replace an existing one. It passes before and after the fix; a "fix" that tightened permissions by failing to write would break it.

## Evidence

The proof is the RED run. With the source change reverted and only the new tests applied, the three permission tests fail while the content guard still passes:

```
$ git stash push src/qwenpaw/security/secret_store.py
$ python -m pytest tests/unit/security/test_secret_store.py -q \
    -k "MasterKeyFilePermissions or MasterKeyFileContent"

FAILED tests/unit/security/test_secret_store.py::TestMasterKeyFilePermissions::test_key_is_not_world_readable_before_chmod_runs
FAILED tests/unit/security/test_secret_store.py::TestMasterKeyFilePermissions::test_key_is_owner_only_when_chmod_cannot_help
FAILED tests/unit/security/test_secret_store.py::TestMasterKeyFilePermissions::test_secret_dir_is_owner_only
3 failed, 1 passed, 22 deselected in 1.51s
```

The assertion values say it plainly — `420` is `0o644`, `384` is `0o600`, `493` is `0o755` and `448` is `0o700` — and `st_size=64` shows the whole key is already on disk while the mode is still world-readable:

```
>       assert observed["mode"] == 0o600
E       assert 420 == 384

>       assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
E       AssertionError: assert 420 == 384
E        +  where 420 = S_IMODE(33188)
E        +    and 33188 = os.stat_result(st_mode=33188, st_nlink=1, st_size=64, ...).st_mode
E        +      where stat = PosixPath('.../secrets/.master_key').stat

>       assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
E       AssertionError: assert 493 == 448
```

With the fix applied the same command passes, and so does the rest of the security suite:

```
$ python -m pytest tests/unit/security/test_secret_store.py -q \
    -k "MasterKeyFilePermissions or MasterKeyFileContent"
4 passed, 22 deselected in 0.72s

$ python -m pytest tests/unit/security/test_secret_store.py -q
26 passed in 1.41s

$ python -m pytest tests/unit/security/ -q
702 passed, 1 skipped in 12.70s
```

Lint on the changed files, through `pre-commit` so the pinned hook versions are used:

```
$ pre-commit run --files src/qwenpaw/security/secret_store.py \n    tests/unit/security/test_secret_store.py

check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

`_chmod_best_effort` is a third private copy of a helper that `envs/store.py` and `app/auth.py` already define independently. I kept it local rather than introducing a shared utility, because hoisting it would mean touching three modules for a one-file fix — say the word if you would prefer the shared version instead.

Environment note: the behaviour under test is POSIX-only, so the runs above were done on Linux (Ubuntu, Python 3.12) rather than on my usual Windows checkout. The YAML/JSON/TOML hooks report "no files to check" for a two-Python-file change, and the `prettier` and `actionlint` hooks do not apply to `.py` files, so the list above is every hook that had something to say.
