### PR TITLE
docs: add self-hosted deployment pointer and CLI --agent-id guide (#7044, #7047)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Your personal AI assistant — deploy locally or in the cloud, extend with Skill
 - [API Key](#api-key)
 - [Local Models](#local-models)
 - [Security Features](#security-features)
+- [Self-Hosted Deployment](#self-hosted-deployment)
 - [Documentation](#documentation)
 - [FAQ](#faq)
 - [Roadmap](#roadmap)
@@ -394,6 +395,16 @@ QwenPaw includes four core security layers:
 - **Skill Scanner** — Pre-activation scanning with block / warn / off modes and whitelist support. Detects prompt injection, hardcoded secrets, data exfiltration, and more.
 
 See [Security](https://qwenpaw.agentscope.io/docs/security) for details.
+
+---
+
+## Self-Hosted Deployment
+
+Running QwenPaw on your own server (VPS, homelab, or production)? The Quick Start options above are built for it:
+
+- [Option 3: Docker](#option-3-docker) — containerized deployment with images on Docker Hub
+- [Option 4: Deploy on Alibaba Cloud ECS](#option-4-deploy-on-alibaba-cloud-ecs) — one-click cloud setup
+- Online guide with all deployment options and verification steps: [Quick Start](https://qwenpaw.agentscope.io/docs/quickstart)
 
 ---
 

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -96,7 +96,7 @@ the app is not running).
 | `qwenpaw daemon version`       | Version and paths                                                                         |
 | `qwenpaw daemon logs [-n N]`   | Last N lines of log (default 100; from `qwenpaw.log` in working dir)                      |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw daemon status                     # Default agent status
@@ -185,6 +185,26 @@ Restore by copying files from the `files/` subtree back into your working
 directory using the same relative paths.
 
 > Avoid `--no-backup` unless you are sure you do not need rollback.
+
+---
+
+## Targeting a specific agent (`--agent-id`)
+
+QwenPaw can run multiple agents side by side. Per-agent CLI commands operate
+on the agent given by `--agent-id`; if you omit the flag, the built-in
+`default` agent is used.
+
+- **Available on:** the `agents`, `channels`, `chats`, `cron`, `daemon`,
+  `skills`, and `task` command groups (per-subcommand coverage varies —
+  `qwenpaw <group> <command> --help` shows whether a command accepts it).
+- **Default:** `default` (the built-in agent).
+- **Discover ids:** `qwenpaw agents list` prints every configured agent id.
+
+```
+qwenpaw cron list --agent-id my_bot   # cron jobs of agent "my_bot"
+qwenpaw chats list --agent-id my_bot  # chats of agent "my_bot"
+qwenpaw cron list                     # same, for the "default" agent
+```
 
 ---
 
@@ -313,7 +333,7 @@ subcommand); use `remove` to uninstall custom channels (no `uninstall`).
 | `qwenpaw channels send`   | Send a one-way message to a user/session via a channel (requires all 5 parameters) |
 | `qwenpaw channels config` | Interactively enable/disable channels and fill in credentials                      |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw channels list                    # See default agent's channels
@@ -518,7 +538,7 @@ ask QwenPaw and send the reply". **Requires `qwenpaw app` to be running.**
 | `qwenpaw cron resume <job_id>` | Resume a paused job                           |
 | `qwenpaw cron run <job_id>`    | Run once immediately                          |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ### Creating jobs
 
@@ -658,7 +678,7 @@ Manage chat sessions via the API. **Requires `qwenpaw app` to be running.**
 | `qwenpaw chats update <id> --name "..."` | Rename a session                                              |
 | `qwenpaw chats delete <id>`              | Delete a session                                              |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw chats list                        # Default agent's chats
@@ -687,7 +707,7 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 | `qwenpaw skills config`    | Interactively enable/disable skills (checkbox UI)         |
 | `qwenpaw skills info`      | Show local details for one workspace skill                |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # Import into the local skill pool

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -87,7 +87,7 @@ Docker 镜像或 pip 安装包已内置控制台，无需单独构建。
 | `qwenpaw daemon version`       | 版本与路径                                                                     |
 | `qwenpaw daemon logs [-n N]`   | 最近 N 行日志（默认 100，来自工作目录 `qwenpaw.log`）                          |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw daemon status                     # 默认智能体状态
@@ -173,6 +173,24 @@ qwenpaw doctor fix -y --only seed-missing-agent-json,reset-invalid-agent-json
 恢复时，将 `files/` 子树中的文件按相同相对路径复制回工作目录即可。
 
 > 除非你非常确定不需要回滚，否则不建议使用 `--no-backup`。
+
+---
+
+## 指定智能体（`--agent-id`）
+
+QwenPaw 支持同时运行多个智能体。按智能体划分的 CLI 命令通过 `--agent-id`
+选择目标智能体；省略时使用内置的 `default` 智能体。
+
+- **支持的命令组：** `agents`、`channels`、`chats`、`cron`、`daemon`、`skills`、`task`
+  （各子命令的支持情况略有差异，以 `qwenpaw <组> <命令> --help` 为准）。
+- **默认值：** `default`（内置智能体）。
+- **查看可用 id：** `qwenpaw agents list` 列出所有已配置的智能体 id。
+
+```
+qwenpaw cron list --agent-id my_bot   # 查看智能体 "my_bot" 的定时任务
+qwenpaw chats list --agent-id my_bot  # 查看智能体 "my_bot" 的会话
+qwenpaw cron list                     # 同上，但针对 "default" 智能体
+```
 
 ---
 
@@ -298,7 +316,7 @@ qwenpaw env delete TAVILY_API_KEY
 | `qwenpaw channels send`   | 向用户/会话单向发送消息（需要全部 5 个参数） |
 | `qwenpaw channels config` | 交互式启用/禁用频道并填写凭据                |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw channels list                    # 看默认智能体的频道状态
@@ -503,7 +521,7 @@ qwenpaw agents chat \
 | `qwenpaw cron resume <job_id>` | 恢复暂停的任务                 |
 | `qwenpaw cron run <job_id>`    | 立刻执行一次                   |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ### 创建任务
 
@@ -641,7 +659,7 @@ JSON 结构见 `qwenpaw cron get <job_id>` 的返回。
 | `qwenpaw chats update <id> --name "..."` | 重命名会话                                         |
 | `qwenpaw chats delete <id>`              | 删除会话                                           |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw chats list                        # 默认智能体的会话
@@ -670,7 +688,7 @@ qwenpaw chats delete <chat_id>
 | `qwenpaw skills config`    | 交互式启用/禁用技能（复选框界面）  |
 | `qwenpaw skills info`      | 查看某个 workspace 技能的本地详情  |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # 导入到本地技能池


### PR DESCRIPTION
## Description

Two documentation gaps, one PR:

**1. README: self-hosted deployment pointer (issue #7044)**

Users who want to run their own instance had no obvious pointer in the README beyond scrolling the Quick Start options. Added a `Self-Hosted Deployment` section (placed with the operational topics, right before `Documentation`, and listed in the ToC) that links:

- `#option-3-docker` — containerized deployment (Docker Hub images)
- `#option-4-deploy-on-alibaba-cloud-ecs` — one-click cloud setup
- the online guide at `https://qwenpaw.agentscope.io/docs/quickstart`

Note: the URL proposed in the issue (`https://qwenpaw.agentscope.io/self-hosted`) returns **404** (as does `/docs/self-hosted`). The section therefore links to `/docs/quickstart`, which is the real deployment guide and the same URL the existing Documentation table already uses.

**2. CLI docs: `--agent-id` guide (issue #7047), en + zh**

- New dedicated section `Targeting a specific agent (--agent-id)` / `指定智能体（--agent-id）`, placed after Getting started: what the flag does, the command groups that accept it (`agents`, `channels`, `chats`, `cron`, `daemon`, `skills`, `task`), the default (`default`, the built-in agent), and how to discover ids (`qwenpaw agents list`).
- Corrected the five per-section "Multi-Agent Support" notes in each language, which overclaimed ("All commands support --agent-id"): global commands such as `models`/`doctor` do not take the flag, and `daemon` has one subcommand without it. The notes now say the section's commands accept the flag and point to the dedicated section.

All CLI facts were verified against `src/qwenpaw/cli/*.py` (flag definitions, `default="default"`, `@agents_group.command("list")`, lazy group `task`) and `src/qwenpaw/config/config.py` (`_RESERVED_AGENT_IDS = {"default"}`).

**Related Issue:** Fixes #7044, Fixes #7047

**Security Considerations:** None — documentation-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Content verified against the codebase (CLI flag coverage, defaults, anchors, links)
- [x] Ready for review

## Testing

Documentation-only change; verified by inspection:

- README anchors `#option-3-docker` and `#option-4-deploy-on-alibaba-cloud-ecs` match existing headings; ToC entry added and ordered.
- `https://qwenpaw.agentscope.io/docs/quickstart` is the same live URL already referenced by the README Documentation table (the issue-proposed `/self-hosted` URL was checked and returns 404).
- CLI examples use real commands (`qwenpaw cron list`, `qwenpaw chats list`, `qwenpaw agents list`).

## Evidence

Fact-check trail for the CLI content (run against `origin/main`):

```
$ grep -c '"--agent-id"' src/qwenpaw/cli/{cron,channels,chats,skills,daemon,task,agents}_cmd.py
cron=9 channels=3 chats=5 skills=6 daemon=4 task=1 agents=2   # all 7 groups accept it

$ grep -A2 '"--agent-id"' src/qwenpaw/cli/cron_cmd.py
    default="default",
    help="Agent ID (defaults to 'default')",

$ grep -n 'command("list")' src/qwenpaw/cli/agents_cmd.py
470:@agents_group.command("list")          # qwenpaw agents list exists

$ grep -n '_RESERVED_AGENT_IDS' src/qwenpaw/config/config.py
154:_RESERVED_AGENT_IDS = frozenset({"default"})   # "default" is the built-in agent

$ curl -s -o /dev/null -w "%{http_code}" https://qwenpaw.agentscope.io/self-hosted
404                                          # issue-proposed URL is dead -> use /docs/quickstart
```

Diff: 3 files (README.md, website/public/docs/cli.en.md, website/public/docs/cli.zh.md).
