### PR TITLE
fix(model-selector): per-provider folding and show all free models by default

### DIFF
--- a/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
+++ b/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
@@ -593,7 +593,7 @@ describe("ModelSelector", () => {
     });
   });
 
-  it("shows only explicitly recommended models by default", async () => {
+  it("shows up to per-provider limit models by default", async () => {
     vi.mocked(providerApi.listProviders).mockResolvedValue([
       {
         ...mockProvider,
@@ -611,9 +611,13 @@ describe("ModelSelector", () => {
 
     await user.click(screen.getAllByText("gpt-4")[0]);
 
-    expect(await screen.findByText("Model 4")).toBeInTheDocument();
-    expect(screen.getByText("Model 6")).toBeInTheDocument();
-    expect(screen.queryByText("Model 1")).not.toBeInTheDocument();
+    // Per-provider limit is 3, so only first 3 models are shown
+    expect(await screen.findByText("Model 0")).toBeInTheDocument();
+    expect(screen.getByText("Model 1")).toBeInTheDocument();
+    expect(screen.getByText("Model 2")).toBeInTheDocument();
+    // Model 3+ are folded
+    expect(screen.queryByText("Model 3")).not.toBeInTheDocument();
+    expect(screen.queryByText("Model 4")).not.toBeInTheDocument();
   });
 
   it("keeps the active model visible when no models are recommended", async () => {
@@ -632,11 +636,12 @@ describe("ModelSelector", () => {
 
     await user.click(screen.getAllByText("GPT-4")[0]);
 
+    // Both models are within per-provider limit of 3, so both visible
     expect(screen.getAllByText("GPT-4").length).toBeGreaterThanOrEqual(2);
-    expect(screen.queryByText("GPT-3.5 Turbo")).not.toBeInTheDocument();
+    expect(await screen.findByText("GPT-3.5 Turbo")).toBeInTheDocument();
   });
 
-  it("keeps pinned models visible without recommending other added models", async () => {
+  it("keeps pinned models visible and shows other models within limit", async () => {
     localStorage.setItem(
       "qwenpaw_model_selector_pinned",
       JSON.stringify(["openai:gpt-3.5-turbo"]),
@@ -664,8 +669,10 @@ describe("ModelSelector", () => {
 
     await user.click(screen.getAllByText("GPT-4")[0]);
 
+    // Pinned model is always visible
     expect(await screen.findByText("GPT-3.5 Turbo")).toBeInTheDocument();
-    expect(screen.queryByText("Added Model")).not.toBeInTheDocument();
+    // With 3 models and per-provider limit of 3, Added Model is also visible
+    expect(await screen.findByText("Added Model")).toBeInTheDocument();
   });
 
   it("keeps recent models visible without showing all models", async () => {
@@ -1428,5 +1435,88 @@ describe("ModelSelector", () => {
     expect(
       screen.getByLabelText("modelSelector.fallbackActive"),
     ).toBeInTheDocument();
+  });
+
+  it("shows each provider's top models when multiple providers exist", async () => {
+    const providerA = {
+      ...mockProvider,
+      id: "provider-a",
+      name: "Provider A",
+      models: Array.from({ length: 5 }, (_, index) => ({
+        ...mockProvider.models[0],
+        id: `pa-model-${index}`,
+        name: `PA Model ${index}`,
+        is_recommended: index === 0,
+      })),
+    };
+    const providerB = {
+      ...mockProvider,
+      id: "provider-b",
+      name: "Provider B",
+      models: Array.from({ length: 4 }, (_, index) => ({
+        ...mockProvider.models[0],
+        id: `pb-model-${index}`,
+        name: `PB Model ${index}`,
+        is_recommended: false,
+      })),
+    };
+    vi.mocked(providerApi.listProviders).mockResolvedValue([
+      providerA,
+      providerB,
+    ]);
+    vi.mocked(providerApi.getActiveModels).mockResolvedValue({
+      active_llm: { provider_id: "provider-a", model: "pa-model-0" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ModelSelector />);
+    await screen.findAllByText("PA Model 0");
+
+    await user.click(screen.getAllByText("PA Model 0")[0]);
+
+    // Provider A shows top 3: PA Model 0, 1, 2
+    expect(screen.getAllByText("PA Model 0").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("PA Model 1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("PA Model 2").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("PA Model 3").length).toBe(0);
+
+    // Provider B shows top 3 (all 4 have is_recommended=false, but first 3 are visible)
+    expect(screen.getAllByText("PB Model 0").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("PB Model 1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("PB Model 2").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("PB Model 3").length).toBe(0);
+  });
+
+  it("free tab shows all models without folding", async () => {
+    const freeProvider = {
+      ...mockProvider,
+      id: "free-provider",
+      name: "Free Provider",
+      is_free_tier: true,
+      models: Array.from({ length: 8 }, (_, index) => ({
+        ...mockProvider.models[0],
+        id: `free-model-${index}`,
+        name: `Free Model ${index}`,
+        is_free: true,
+        is_recommended: false,
+      })),
+    };
+    vi.mocked(providerApi.listProviders).mockResolvedValue([freeProvider]);
+    vi.mocked(providerApi.getActiveModels).mockResolvedValue({
+      active_llm: { provider_id: "free-provider", model: "free-model-0" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ModelSelector />);
+    await screen.findAllByText("Free Model 0");
+
+    await user.click(screen.getAllByText("Free Model 0")[0]);
+    await user.click(screen.getByRole("tab", { name: "FREE" }));
+
+    // All 8 free models should be visible (no folding for free tab)
+    for (let i = 0; i < 8; i++) {
+      const elements = await screen.findAllByText(`Free Model ${i}`);
+      expect(elements.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import type { ActiveModelsInfo } from "../../../api/types";
+import type { ActiveModelsInfo, ModelInfo } from "../../../api/types";
 import { useAgentStore } from "../../../stores/agentStore";
 import { confirmFreeModelSwitch } from "@/utils/freeModelSwitchWarning";
 import { ProviderIcon } from "../../Settings/Models/components/ProviderIconComponent";
@@ -63,7 +63,7 @@ function publishActiveMaxInputLength(
 
 const PINNED_STORAGE_KEY = "qwenpaw_model_selector_pinned";
 const RECENT_STORAGE_KEY = "qwenpaw_model_selector_recent";
-const RECOMMENDED_LIMIT = 6;
+const PER_PROVIDER_LIMIT = 3;
 
 function readStoredModelKeys(key: string): string[] {
   try {
@@ -305,7 +305,10 @@ export default function ModelSelector() {
   const candidateModelsExpanded = Boolean(trimmedSearch) || showCandidateModels;
 
   const rankModels = useCallback(
-    (list: EligibleProvider[]): EligibleProvider[] => {
+    (
+      list: EligibleProvider[],
+      options?: { isFreeTab?: boolean },
+    ): EligibleProvider[] => {
       const ranked = list.flatMap((provider) =>
         provider.models.map((model) => ({ provider, model })),
       );
@@ -326,31 +329,31 @@ export default function ModelSelector() {
           score(rightKey, right.provider.id, right.model.id)
         );
       });
-      let visible = ranked;
-      if (!showAllModels && !trimmedSearch) {
-        const alwaysVisible = ranked.filter(({ provider, model }) => {
-          const key = modelKey(provider.id, model.id);
-          return (
-            pinnedModelKeys.includes(key) ||
-            recentModelKeys.includes(key) ||
-            (provider.id === activeProviderId && model.id === activeModelId)
-          );
-        });
-        const alwaysVisibleKeys = new Set(
-          alwaysVisible.map(({ provider, model }) =>
-            modelKey(provider.id, model.id),
-          ),
-        );
-        const recommended = ranked.filter(({ provider, model }) => {
-          const key = modelKey(provider.id, model.id);
-          return model.is_recommended && !alwaysVisibleKeys.has(key);
-        });
-        const remainingSlots = Math.max(
-          0,
-          RECOMMENDED_LIMIT - alwaysVisible.length,
-        );
-        visible = [...alwaysVisible, ...recommended.slice(0, remainingSlots)];
+
+      let visible: Array<{ provider: EligibleProvider; model: ModelInfo }> =
+        ranked;
+      const shouldFold =
+        !options?.isFreeTab && !showAllModels && !trimmedSearch;
+
+      if (shouldFold) {
+        const providerGroups = new Map<
+          string,
+          Array<{ provider: EligibleProvider; model: ModelInfo }>
+        >();
+        for (const item of ranked) {
+          const existing = providerGroups.get(item.provider.id);
+          if (existing) {
+            existing.push(item);
+          } else {
+            providerGroups.set(item.provider.id, [item]);
+          }
+        }
+        visible = [];
+        for (const items of providerGroups.values()) {
+          visible.push(...items.slice(0, PER_PROVIDER_LIMIT));
+        }
       }
+
       const grouped = new Map<string, EligibleProvider>();
       for (const item of visible) {
         const current = grouped.get(item.provider.id);
@@ -876,8 +879,9 @@ export default function ModelSelector() {
       (p) => !p.supports_oauth && !p.has_api_key && p.require_api_key !== false,
     );
 
+    const rankedReady = rankModels(readyProviders, { isFreeTab: true });
     const hasAny =
-      readyProviders.length > 0 ||
+      rankedReady.length > 0 ||
       oauthOnlyProviders.length > 0 ||
       needsKeyProviders.length > 0;
 
@@ -897,7 +901,7 @@ export default function ModelSelector() {
           <AlertTriangle size={14} className={styles.freeBannerIcon} />
           <span>{t("modelSelector.freeBannerText")}</span>
         </div>
-        {rankModels(readyProviders).map(renderProviderModels)}
+        {rankedReady.map(renderProviderModels)}
         {oauthOnlyProviders.map(renderOAuthConnectEntry)}
         {needsKeyProviders.length > 0 && (
           <>
@@ -952,7 +956,9 @@ export default function ModelSelector() {
       );
     }
 
-    if (filteredPro.length === 0) {
+    const rankedPro = rankModels(filteredPro);
+
+    if (rankedPro.length === 0) {
       return (
         <div className={styles.emptyTip} role="status">
           {trimmedSearch
@@ -967,7 +973,7 @@ export default function ModelSelector() {
         <div className={styles.proBanner}>
           <span>{t("modelSelector.proBannerText")}</span>
         </div>
-        {rankModels(filteredPro).map(renderProviderModels)}
+        {rankedPro.map(renderProviderModels)}
       </>
     );
   };


### PR DESCRIPTION
## Problem

The model selector's default view only shows a small whitelist of models
(pinned / recent / active + `is_recommended`), causing two visible bugs
reported in review:

1. **FREE tab is mostly blank.** Free providers (e.g. OpenCode, Kilo) have no
   `is_recommended` models at all. After `rankModels` folding, none of them
   survive, so the "ready" section renders empty — but `hasAny` still thinks
   there is content (it checks the pre-fold count), so no empty-state tip is
   shown either. The user sees an unexplained blank panel. Only the OAuth
   connect entry (which bypasses `rankModels`) remains.

2. **PRO tab hides configured providers.** `RECOMMENDED_LIMIT = 6` is a *global*
   budget across all providers, not per-provider. The more providers a user
   configures, the fewer models each one exposes. Providers with zero
   `is_recommended` models disappear entirely from the default view, even
   though the management modal (same data source, no folding) lists them all —
   giving the impression that "the configuration was lost".

## Root Cause

- `rankModels` flat-maps all providers then takes the top-N globally, gated by
  `is_recommended`. Providers without recommended models produce no group entry.
- The FREE tab applies the same folding as PRO, so free models get folded away.
- `hasAny` is computed from the raw provider list (`readyProviders.length > 0`),
  while rendering uses the post-`rankModels` result — two different datasets for
  the same decision, so any "folded to empty" case leaks a blank panel.

Note: the management modal and the selector share the same data source; the
divergence is *only* the `rankModels` folding step.

## Changes

### `console/src/pages/Chat/ModelSelector/index.tsx`

1. **Per-provider folding instead of a global budget.**
   `RECOMMENDED_LIMIT = 6` → `PER_PROVIDER_LIMIT = 3`. `rankModels` now groups
   models by `provider.id` and applies the limit *per provider*, so every
   ready provider always exposes its top 3 models — no provider disappears just
   because it has no `is_recommended` entries. The limit is no longer a
   shared budget that one provider can starve out of others.

2. **FREE tab skips folding.**
   `rankModels` accepts an `{ isFreeTab }` option. When set, the fold step is
   bypassed entirely, so all free models are shown by default. Free providers
   typically have only a few models, so folding brings confusion, not savings.

3. **Fix `hasAny` consistency.**
   `renderFreeTab` now computes `hasAny` from the `rankedReady` result
   (`rankedReady.length > 0 || ...`), not the raw `readyProviders` count.
   `renderProTab` already uses `rankedPro.length === 0` for its empty state, so
   both tabs now judge emptiness on the same dataset they render — a folded-to-
   empty case correctly shows the empty-state tip instead of a blank panel.

### `console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx`

- Updated "shows only explicitly recommended models" → "shows up to
  per-provider limit models", asserting the top 3 per provider regardless of
  `is_recommended`.
- Updated "keeps the active model visible" / "keeps pinned models" tests to
  match per-provider folding.
- Fixed "shows each provider's top models" to use `getAllByText` (model name now
  appears in both trigger and list).
- New test "free tab shows all models without folding" verifies all 8 free
  models are visible with no folding.

## Behavior Summary

| Case | Before | After |
|------|--------|-------|
| FREE tab, no recommended models | blank panel, no empty-state | all free models shown |
| PRO tab, provider w/o recommended | provider disappears | top 3 models shown |
| PRO tab, many providers configured | global 6 budget starves others | 3 per provider |
| Folded-to-empty edge case | blank panel (hasAny mismatch) | correct empty-state tip |

## Testing

- `npx vitest run src/pages/Chat/ModelSelector/ModelSelector.test.tsx`
  → **44 / 44 passed**
- Manual E2E: `npm run build` in `console/`, then `qwenpaw app` serves the new
  build; verified FREE tab shows all free models and PRO tab shows top 3 per
  provider with no blank panels.
<img width="585" height="930" alt="free" src="https://github.com/user-attachments/assets/61612e9c-32aa-4198-be14-52caf821114b" />
<img width="593" height="969" alt="pro" src="https://github.com/user-attachments/assets/245024ec-95b3-4216-925a-c161da81bdbf" />

