### PR TITLE
docs: add self-hosted deployment pointer to README (#7044)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Your personal AI assistant — deploy locally or in the cloud, extend with Skill
 - [API Key](#api-key)
 - [Local Models](#local-models)
 - [Security Features](#security-features)
+- [Self-Hosted Deployment](#self-hosted-deployment)
 - [Documentation](#documentation)
 - [FAQ](#faq)
 - [Roadmap](#roadmap)
@@ -394,6 +395,16 @@ QwenPaw includes four core security layers:
 - **Skill Scanner** — Pre-activation scanning with block / warn / off modes and whitelist support. Detects prompt injection, hardcoded secrets, data exfiltration, and more.
 
 See [Security](https://qwenpaw.agentscope.io/docs/security) for details.
+
+---
+
+## Self-Hosted Deployment
+
+Running QwenPaw on your own server (VPS, homelab, or production)? The Quick Start options above are built for it:
+
+- [Option 3: Docker](#option-3-docker) — containerized deployment with images on Docker Hub
+- [Option 4: Deploy on Alibaba Cloud ECS](#option-4-deploy-on-alibaba-cloud-ecs) — one-click cloud setup
+- Online guide with all deployment options and verification steps: [Quick Start](https://qwenpaw.agentscope.io/docs/quickstart)
 
 ---
 


### PR DESCRIPTION
## Description

Users who want to run their own instance had no obvious pointer in the README beyond scrolling the Quick Start options. This adds a `Self-Hosted Deployment` section — placed with the operational topics, right before `Documentation`, and listed in the Table of Contents — that links:

- `#option-3-docker` — containerized deployment (Docker Hub images)
- `#option-4-deploy-on-alibaba-cloud-ecs` — one-click cloud setup
- the online guide at `https://qwenpaw.agentscope.io/docs/quickstart`

Note: the URL proposed in the issue (`https://qwenpaw.agentscope.io/self-hosted`) returns **404** (as does `/docs/self-hosted`). The section therefore links to `/docs/quickstart`, which is the real deployment guide and the same URL the existing Documentation table already uses.

Split from #7123 (which combined two docs issues) per maintainer preference for one PR per issue.

**Related Issue:** Fixes #7044

**Security Considerations:** None — documentation-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Anchors and links verified against the README and the live docs site
- [x] Ready for review

## Testing

Documentation-only change; verified by inspection:

- README anchors `#option-3-docker` and `#option-4-deploy-on-alibaba-cloud-ecs` match existing headings; ToC entry added and ordered.
- `https://qwenpaw.agentscope.io/docs/quickstart` is the same live URL already referenced by the README Documentation table (the issue-proposed `/self-hosted` URL was checked and returns 404).

## Evidence

```
$ curl -s -o /dev/null -w "%{http_code}" https://qwenpaw.agentscope.io/self-hosted
404                            # issue-proposed URL is dead -> link /docs/quickstart

$ grep -n "^### Option 3: Docker\|^### Option 4: Deploy on Alibaba Cloud ECS" README.md
223:### Option 3: Docker
270:### Option 4: Deploy on Alibaba Cloud ECS    # both anchors exist

Diff: README.md only (+11).
```
