### PR TITLE
docs: add --agent-id targeting guide to CLI docs (#7047)

### DIFF
--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -96,7 +96,7 @@ the app is not running).
 | `qwenpaw daemon version`       | Version and paths                                                                         |
 | `qwenpaw daemon logs [-n N]`   | Last N lines of log (default 100; from `qwenpaw.log` in working dir)                      |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw daemon status                     # Default agent status
@@ -185,6 +185,26 @@ Restore by copying files from the `files/` subtree back into your working
 directory using the same relative paths.
 
 > Avoid `--no-backup` unless you are sure you do not need rollback.
+
+---
+
+## Targeting a specific agent (`--agent-id`)
+
+QwenPaw can run multiple agents side by side. Per-agent CLI commands operate
+on the agent given by `--agent-id`; if you omit the flag, the built-in
+`default` agent is used.
+
+- **Available on:** the `agents`, `channels`, `chats`, `cron`, `daemon`,
+  `skills`, and `task` command groups (per-subcommand coverage varies —
+  `qwenpaw <group> <command> --help` shows whether a command accepts it).
+- **Default:** `default` (the built-in agent).
+- **Discover ids:** `qwenpaw agents list` prints every configured agent id.
+
+```
+qwenpaw cron list --agent-id my_bot   # cron jobs of agent "my_bot"
+qwenpaw chats list --agent-id my_bot  # chats of agent "my_bot"
+qwenpaw cron list                     # same, for the "default" agent
+```
 
 ---
 
@@ -313,7 +333,7 @@ subcommand); use `remove` to uninstall custom channels (no `uninstall`).
 | `qwenpaw channels send`   | Send a one-way message to a user/session via a channel (requires all 5 parameters) |
 | `qwenpaw channels config` | Interactively enable/disable channels and fill in credentials                      |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw channels list                    # See default agent's channels
@@ -518,7 +538,7 @@ ask QwenPaw and send the reply". **Requires `qwenpaw app` to be running.**
 | `qwenpaw cron resume <job_id>` | Resume a paused job                           |
 | `qwenpaw cron run <job_id>`    | Run once immediately                          |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ### Creating jobs
 
@@ -658,7 +678,7 @@ Manage chat sessions via the API. **Requires `qwenpaw app` to be running.**
 | `qwenpaw chats update <id> --name "..."` | Rename a session                                              |
 | `qwenpaw chats delete <id>`              | Delete a session                                              |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw chats list                        # Default agent's chats
@@ -687,7 +707,7 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 | `qwenpaw skills config`    | Interactively enable/disable skills (checkbox UI)         |
 | `qwenpaw skills info`      | Show local details for one workspace skill                |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Multi-Agent Support:** These commands accept `--agent-id` to target a specific agent (defaults to `default`); see the "Targeting a specific agent (`--agent-id`)" section.
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # Import into the local skill pool

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -87,7 +87,7 @@ Docker 镜像或 pip 安装包已内置控制台，无需单独构建。
 | `qwenpaw daemon version`       | 版本与路径                                                                     |
 | `qwenpaw daemon logs [-n N]`   | 最近 N 行日志（默认 100，来自工作目录 `qwenpaw.log`）                          |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw daemon status                     # 默认智能体状态
@@ -173,6 +173,24 @@ qwenpaw doctor fix -y --only seed-missing-agent-json,reset-invalid-agent-json
 恢复时，将 `files/` 子树中的文件按相同相对路径复制回工作目录即可。
 
 > 除非你非常确定不需要回滚，否则不建议使用 `--no-backup`。
+
+---
+
+## 指定智能体（`--agent-id`）
+
+QwenPaw 支持同时运行多个智能体。按智能体划分的 CLI 命令通过 `--agent-id`
+选择目标智能体；省略时使用内置的 `default` 智能体。
+
+- **支持的命令组：** `agents`、`channels`、`chats`、`cron`、`daemon`、`skills`、`task`
+  （各子命令的支持情况略有差异，以 `qwenpaw <组> <命令> --help` 为准）。
+- **默认值：** `default`（内置智能体）。
+- **查看可用 id：** `qwenpaw agents list` 列出所有已配置的智能体 id。
+
+```
+qwenpaw cron list --agent-id my_bot   # 查看智能体 "my_bot" 的定时任务
+qwenpaw chats list --agent-id my_bot  # 查看智能体 "my_bot" 的会话
+qwenpaw cron list                     # 同上，但针对 "default" 智能体
+```
 
 ---
 
@@ -298,7 +316,7 @@ qwenpaw env delete TAVILY_API_KEY
 | `qwenpaw channels send`   | 向用户/会话单向发送消息（需要全部 5 个参数） |
 | `qwenpaw channels config` | 交互式启用/禁用频道并填写凭据                |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw channels list                    # 看默认智能体的频道状态
@@ -503,7 +521,7 @@ qwenpaw agents chat \
 | `qwenpaw cron resume <job_id>` | 恢复暂停的任务                 |
 | `qwenpaw cron run <job_id>`    | 立刻执行一次                   |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ### 创建任务
 
@@ -641,7 +659,7 @@ JSON 结构见 `qwenpaw cron get <job_id>` 的返回。
 | `qwenpaw chats update <id> --name "..."` | 重命名会话                                         |
 | `qwenpaw chats delete <id>`              | 删除会话                                           |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw chats list                        # 默认智能体的会话
@@ -670,7 +688,7 @@ qwenpaw chats delete <chat_id>
 | `qwenpaw skills config`    | 交互式启用/禁用技能（复选框界面）  |
 | `qwenpaw skills info`      | 查看某个 workspace 技能的本地详情  |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**多智能体支持：** 这些命令支持 `--agent-id` 以指定目标智能体（默认为 `default`），详见「指定智能体（`--agent-id`）」一节。
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # 导入到本地技能池


### PR DESCRIPTION
## Description

The CLI docs mentioned `--agent-id` only in scattered per-section notes, and those notes overclaimed ("All commands support the `--agent-id` parameter"). This PR:

1. **Adds a dedicated section** `Targeting a specific agent (--agent-id)` / `指定智能体（--agent-id）` (en + zh), placed after Getting started, explaining:
   - what the flag does (targets a specific agent in multi-agent setups);
   - which command groups accept it: `agents`, `channels`, `chats`, `cron`, `daemon`, `skills`, `task`;
   - the default behavior when omitted (`default`, the built-in agent);
   - how to discover ids (`qwenpaw agents list`).
2. **Corrects the five per-section "Multi-Agent Support" notes** in each language to accurate per-section wording that cross-references the new section (the old "All commands support" claim was wrong: global commands such as `models`/`doctor` do not take the flag, and `daemon` has one subcommand without it).

All facts verified against `src/qwenpaw/cli/*.py` (flag definitions with `default="default"`, `@agents_group.command("list")`, lazy group `task`) and `src/qwenpaw/config/config.py` (`_RESERVED_AGENT_IDS = frozenset({"default"})`).

Split from #7123 (which combined two docs issues) per maintainer preference for one PR per issue.

**Related Issue:** Fixes #7047

**Security Considerations:** None — documentation-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Content verified against the codebase (flag coverage, defaults, subcommand names)
- [x] en and zh kept in sync
- [x] Ready for review

## Testing

Documentation-only change; examples use real commands (`qwenpaw cron list`, `qwenpaw chats list`, `qwenpaw agents list`) verified against the CLI source.

## Evidence

Fact-check trail (run against `origin/main`):

```
$ grep -c '"--agent-id"' src/qwenpaw/cli/{cron,channels,chats,skills,daemon,task,agents}_cmd.py
cron=9 channels=3 chats=5 skills=6 daemon=4 task=1 agents=2   # all 7 groups accept it

$ grep -A2 '"--agent-id"' src/qwenpaw/cli/cron_cmd.py
    default="default",
    help="Agent ID (defaults to 'default')",

$ grep -n 'command("list")' src/qwenpaw/cli/agents_cmd.py
470:@agents_group.command("list")          # qwenpaw agents list exists

$ grep -n '_RESERVED_AGENT_IDS' src/qwenpaw/config/config.py
154:_RESERVED_AGENT_IDS = frozenset({"default"})   # "default" is the built-in agent

Diff: website/public/docs/cli.en.md (+25/-5), website/public/docs/cli.zh.md (+23/-5).
```
