### PR TITLE
fix(desktop): recover Windows WebView2 after browser crash

### DIFF
--- a/console/src-tauri/Cargo.lock
+++ b/console/src-tauri/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+ "webview2-com",
  "windows",
 ]
 

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "5"
 
 [target.'cfg(windows)'.dependencies]
-webview2-com = "=0.38.2"
+webview2-com = "0.38.2"
 windows = { version = "0.61.3", features = [
     "Foundation",
     "Foundation_Collections",

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "5"
 
 [target.'cfg(windows)'.dependencies]
+webview2-com = "=0.38.2"
 windows = { version = "0.61.3", features = [
     "Foundation",
     "Foundation_Collections",

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ mod external_link;
 mod runtime_env;
 mod tray;
 mod updates;
+#[cfg(windows)]
+mod webview_recovery;
 
 use tauri::{Manager, RunEvent, WebviewWindow, WindowEvent};
 
@@ -57,6 +59,12 @@ pub fn run() {
         .setup(|app| {
             backend::setup(app)?;
             tray::setup(app)?;
+            #[cfg(windows)]
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(err) = webview_recovery::install(&window) {
+                    log::error!("[webview] failed to install browser-process recovery: {err}");
+                }
+            }
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -77,6 +85,12 @@ pub fn run() {
                 // Alt+F4. Programmatic exits from `quit_app` carry a `code` and
                 // fall through to the normal shutdown path below.
                 RunEvent::ExitRequested { api, code, .. } => {
+                    #[cfg(windows)]
+                    if code.is_none() && webview_recovery::is_active() {
+                        api.prevent_exit();
+                        log::warn!("[webview] keeping the app alive while the main window recovers");
+                        return;
+                    }
                     #[cfg(target_os = "macos")]
                     if code.is_none() {
                         api.prevent_exit();

--- a/console/src-tauri/src/webview_recovery.rs
+++ b/console/src-tauri/src/webview_recovery.rs
@@ -1,0 +1,284 @@
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Mutex,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use tauri::{
+    utils::config::WindowConfig, AppHandle, Manager, PhysicalPosition, PhysicalSize, WebviewWindow,
+    WebviewWindowBuilder,
+};
+use webview2_com::{
+    BrowserProcessExitedEventHandler,
+    Microsoft::Web::WebView2::Win32::{
+        ICoreWebView2Environment5, COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND_FAILED,
+    },
+};
+use windows::core::Interface;
+
+const WEBVIEW_TIMEOUT: Duration = Duration::from_secs(5);
+const DESTROY_TIMEOUT: Duration = Duration::from_secs(2);
+const RETRY_DELAY: Duration = Duration::from_millis(250);
+const MAX_ATTEMPTS: usize = 3;
+
+static RECOVERY_LOCK: Mutex<()> = Mutex::new(());
+static ACTIVE_RECOVERIES: AtomicUsize = AtomicUsize::new(0);
+
+struct RecoveryGuard;
+
+impl RecoveryGuard {
+    fn new() -> Self {
+        ACTIVE_RECOVERIES.fetch_add(1, Ordering::AcqRel);
+        Self
+    }
+}
+
+impl Drop for RecoveryGuard {
+    fn drop(&mut self) {
+        ACTIVE_RECOVERIES.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct WindowState {
+    visible: bool,
+    focused: bool,
+    minimized: bool,
+    maximized: bool,
+    fullscreen: bool,
+    position: Option<PhysicalPosition<i32>>,
+    size: Option<PhysicalSize<u32>>,
+}
+
+impl WindowState {
+    fn capture(window: &WebviewWindow, config: &WindowConfig) -> Self {
+        let visible = window.is_visible().unwrap_or(config.visible);
+        let focused = window.is_focused().unwrap_or(config.focus);
+        let minimized = window.is_minimized().unwrap_or(false);
+        let maximized = window.is_maximized().unwrap_or(config.maximized);
+        let fullscreen = window.is_fullscreen().unwrap_or(config.fullscreen);
+
+        // Normalize while hidden so the normal (non-maximized) bounds can be read.
+        let _ = window.hide();
+        if fullscreen {
+            let _ = window.set_fullscreen(false);
+        }
+        if minimized {
+            let _ = window.unminimize();
+        }
+        if maximized {
+            let _ = window.unmaximize();
+        }
+
+        let position = window.outer_position().ok();
+        let size = window.inner_size().ok();
+
+        Self {
+            visible,
+            focused,
+            minimized,
+            maximized,
+            fullscreen,
+            position,
+            size,
+        }
+    }
+
+    fn from_config(config: &WindowConfig) -> Self {
+        Self {
+            visible: config.visible,
+            focused: config.focus,
+            minimized: false,
+            maximized: config.maximized,
+            fullscreen: config.fullscreen,
+            position: None,
+            size: None,
+        }
+    }
+}
+
+pub fn install(window: &WebviewWindow) -> Result<(), String> {
+    let app = window.app_handle().clone();
+    let label = window.label().to_owned();
+    let (sender, receiver) = mpsc::sync_channel(1);
+
+    window
+        .with_webview(move |webview| {
+            let result = (|| {
+                let environment = webview
+                    .environment()
+                    .cast::<ICoreWebView2Environment5>()
+                    .map_err(|err| err.to_string())?;
+                let handler =
+                    BrowserProcessExitedEventHandler::create(Box::new(move |_sender, args| {
+                        let Some(args) = args else {
+                            return Ok(());
+                        };
+                        let mut exit_kind = Default::default();
+                        let mut process_id = 0;
+                        unsafe {
+                            args.BrowserProcessExitKind(&mut exit_kind)?;
+                            args.BrowserProcessId(&mut process_id)?;
+                        }
+                        if exit_kind == COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND_FAILED {
+                            schedule_recovery(app.clone(), label.clone(), process_id);
+                        }
+                        Ok(())
+                    }));
+
+                let mut token = 0;
+                unsafe { environment.add_BrowserProcessExited(&handler, &mut token) }
+                    .map_err(|err| err.to_string())?;
+
+                // Prove the handler is attached to a live browser before recovery proceeds.
+                let core = unsafe { webview.controller().CoreWebView2() }
+                    .map_err(|err| err.to_string())?;
+                let mut process_id = 0;
+                unsafe { core.BrowserProcessId(&mut process_id) }.map_err(|err| err.to_string())?;
+                (process_id != 0)
+                    .then_some(())
+                    .ok_or_else(|| "WebView2 browser process is not running".to_owned())
+            })();
+            let _ = sender.send(result);
+        })
+        .map_err(|err| err.to_string())?;
+
+    receiver
+        .recv_timeout(WEBVIEW_TIMEOUT)
+        .map_err(|err| format!("timed out installing browser-process recovery: {err}"))?
+}
+
+pub fn is_active() -> bool {
+    ACTIVE_RECOVERIES.load(Ordering::Acquire) != 0
+}
+
+fn schedule_recovery(app: AppHandle, label: String, process_id: u32) {
+    let dispatcher = app.clone();
+    // Return from the COM callback before creating or destroying WebView2 controllers.
+    if let Err(err) = dispatcher.run_on_main_thread(move || {
+        if let Err(err) = thread::Builder::new()
+            .name("qwenpaw-webview-recovery".into())
+            .spawn(move || {
+                log::warn!(
+                    "[webview] browser process {process_id} exited unexpectedly; rebuilding {label}"
+                );
+                if let Err(err) = recreate(&app, &label) {
+                    log::error!("[webview] failed to rebuild {label}: {err}");
+                }
+            })
+        {
+            log::error!("[webview] failed to start recovery worker: {err}");
+        }
+    }) {
+        log::error!("[webview] failed to schedule browser-process recovery: {err}");
+    }
+}
+
+fn recreate(app: &AppHandle, label: &str) -> Result<(), String> {
+    let _active = RecoveryGuard::new();
+    let _guard = RECOVERY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == label)
+        .cloned()
+        .ok_or_else(|| format!("window configuration not found: {label}"))?;
+    let state = app
+        .get_webview_window(label)
+        .map(|window| WindowState::capture(&window, &config))
+        .unwrap_or_else(|| WindowState::from_config(&config));
+
+    let mut last_error = String::new();
+    for attempt in 1..=MAX_ATTEMPTS {
+        match recreate_window(app, label, &config, state) {
+            Ok(()) => {
+                log::info!("[webview] rebuilt {label} after browser-process failure");
+                return Ok(());
+            }
+            Err(err) => {
+                last_error = err;
+                log::warn!(
+                    "[webview] recovery attempt {attempt}/{MAX_ATTEMPTS} for {label} failed: {last_error}"
+                );
+                if attempt < MAX_ATTEMPTS {
+                    thread::sleep(RETRY_DELAY);
+                }
+            }
+        }
+    }
+
+    log::error!("[webview] recovery exhausted; keeping the application and backend alive");
+    Err(last_error)
+}
+
+fn recreate_window(
+    app: &AppHandle,
+    label: &str,
+    config: &WindowConfig,
+    state: WindowState,
+) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window(label) {
+        window.destroy().map_err(|err| err.to_string())?;
+        wait_until_destroyed(app, label)?;
+    }
+
+    let window = WebviewWindowBuilder::from_config(app, config)
+        .map_err(|err| err.to_string())?
+        .visible(false)
+        .focused(false)
+        .maximized(false)
+        .fullscreen(false)
+        .build()
+        .map_err(|err| err.to_string())?;
+    install(&window)?;
+    restore_state(&window, state)?;
+    Ok(())
+}
+
+fn wait_until_destroyed(app: &AppHandle, label: &str) -> Result<(), String> {
+    let deadline = Instant::now() + DESTROY_TIMEOUT;
+    while app.get_webview_window(label).is_some() {
+        if Instant::now() >= deadline {
+            return Err(format!("timed out destroying window: {label}"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+fn restore_state(window: &WebviewWindow, state: WindowState) -> Result<(), String> {
+    if let Some(position) = state.position {
+        window
+            .set_position(position)
+            .map_err(|err| err.to_string())?;
+    }
+    if let Some(size) = state.size {
+        window.set_size(size).map_err(|err| err.to_string())?;
+    }
+    if state.fullscreen {
+        window.set_fullscreen(true).map_err(|err| err.to_string())?;
+    } else if state.maximized {
+        window.maximize().map_err(|err| err.to_string())?;
+    }
+    if state.visible {
+        window.show().map_err(|err| err.to_string())?;
+        if state.minimized {
+            window.minimize().map_err(|err| err.to_string())?;
+        } else if state.focused {
+            window.set_focus().map_err(|err| err.to_string())?;
+        }
+    } else {
+        if state.minimized {
+            window.minimize().map_err(|err| err.to_string())?;
+        }
+        window.hide().map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

Recover the supported Windows Tauri desktop when the WebView2 browser process exits unexpectedly.

- Subscribe to WebView2 browser-process exit notifications on the main window.
- Rebuild only the failed WebView window while keeping the Tauri host and Python backend alive.
- Preserve visibility, focus, minimized/maximized/fullscreen state, and physical window bounds.
- Bound recovery to three attempts and verify that the replacement browser and recovery handler are live before reporting success.

**Related Issue:** Relates to #6647

**Security Considerations:** No new permissions, external inputs, or network access. Recovery is Windows-only and starts only for a WebView2 browser process reported as failed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this Windows runtime recovery)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this changes the Tauri desktop host rather than a channel contract.

## Testing

```text
cargo check --locked --manifest-path console/src-tauri/Cargo.toml --lib
# Passed on the latest upstream/main (2 existing dead-code warnings)

cargo build --locked --manifest-path console/src-tauri/Cargo.toml
# Passed

rustfmt --edition 2021 --check console/src-tauri/src/webview_recovery.rs
git diff --check upstream/main...HEAD
# Passed
```

Windows fault-injection validation used the same source build and environment before and after the patch:

1. Baseline: terminating the WebView2 browser process left the Tauri host and Python backend alive, but the UI window did not return.
2. Patched: the same failure rebuilt the WebView with a new browser PID and native window handle while the host and backend PIDs remained unchanged.
3. Window state: restored physical bounds exactly and retained hidden and maximized states.
4. Failure bound: repeated injected recovery failures exhausted three attempts without terminating the host or backend.

## Evidence

```text
Baseline:
  WebView2 browser terminated -> no replacement WebView
  Tauri host alive; Python backend alive

Patched physical-bounds run:
  browser PID 13468 -> 14840
  native HWND 9243282 -> 9308818
  Tauri host PID 14732 unchanged
  Python backend PID 40600 unchanged
  restored physical rectangle matched exactly

Hidden-state run:
  browser PID 14840 -> 25436
  native HWND 9308818 -> 9374354
  window remained hidden and physical rectangle matched exactly

Bounded fallback:
  recovery stopped after 3 attempts
  Tauri host and Python backend remained alive
```

## Additional Notes

- The change is compiled only on Windows; macOS behavior is unchanged.
- A full NSIS installer build was not run. The source-built Windows Tauri application was exercised directly.
