### PR TITLE
fix(deps): enable Ollama embedding backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "QwenPaw is a **personal assistant** that runs in your own environ
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "agentscope==2.0.6",
+    "agentscope[model-ollama]==2.0.6",
     "httpx>=0.27.0",
     "websockets>=15.0.1,<16",
     "packaging>=24.0",


### PR DESCRIPTION
## Summary

- install AgentScope with the `model-ollama` extra
- ensure the Ollama SDK is available for the embedding backend

## Testing

- `uv lock --check`
- verified `OllamaCredential.get_embedding_model_class()` resolves to `OllamaEmbeddingModel`