### PR TITLE
feat(console): pin chat icon to top of collapsed sidebar rail (#7125)

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -544,6 +544,54 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   // `renderIcon` retained for tree-shaking awareness.
   void renderIcon;
 
+  // Collapsed mode (#7125): the session (chat) entry is pinned above the
+  // scrollable remainder so users can always jump back to chat, even after
+  // scrolling down to reach plugins or settings.
+  const renderCollapsedItem = (item: FlatMenuEntry) => {
+    const isActive =
+      item.key === "core.chat" ? isChatActive : selectedKey === item.key;
+    return (
+      <Tooltip
+        key={item.key}
+        title={item.label}
+        placement="right"
+        overlayInnerStyle={{
+          background: "rgba(0,0,0,0.75)",
+          color: "#fff",
+        }}
+      >
+        <button
+          className={`${styles.collapsedNavItem} ${
+            isActive ? styles.collapsedNavItemActive : ""
+          }${
+            item.key === "core.inbox" && effectiveShake
+              ? ` ${styles.inboxShake}`
+              : ""
+          }`}
+          onClick={() => {
+            if (item.href) {
+              window.open(item.href, "_blank", "noopener,noreferrer");
+            } else {
+              navigate(item.path);
+            }
+          }}
+          onMouseEnter={
+            item.key === "core.inbox" ? handleInboxHover : undefined
+          }
+        >
+          {item.icon}
+        </button>
+      </Tooltip>
+    );
+  };
+
+  const collapsedStickyEntry = collapsedNavItems.find(
+    (item) => item.key === "core.chat",
+  );
+  const collapsedScrollEntries = collapsedNavItems.filter(
+    (item) => item.key !== "core.chat",
+  );
+
   // On mobile, the expanded sidebar shows sessions (like simple mode) instead
   // of the full menu — matching the desktop history panel UX.
   const isSimpleExpanded = (sidebarMode === "simple" || isMobile) && !collapsed;
@@ -566,45 +614,10 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     >
       {collapsed ? (
         <nav className={styles.collapsedNav}>
-          {collapsedNavItems.map((item) => {
-            const isActive =
-              item.key === "core.chat"
-                ? isChatActive
-                : selectedKey === item.key;
-            return (
-              <Tooltip
-                key={item.key}
-                title={item.label}
-                placement="right"
-                overlayInnerStyle={{
-                  background: "rgba(0,0,0,0.75)",
-                  color: "#fff",
-                }}
-              >
-                <button
-                  className={`${styles.collapsedNavItem} ${
-                    isActive ? styles.collapsedNavItemActive : ""
-                  }${
-                    item.key === "core.inbox" && effectiveShake
-                      ? ` ${styles.inboxShake}`
-                      : ""
-                  }`}
-                  onClick={() => {
-                    if (item.href) {
-                      window.open(item.href, "_blank", "noopener,noreferrer");
-                    } else {
-                      navigate(item.path);
-                    }
-                  }}
-                  onMouseEnter={
-                    item.key === "core.inbox" ? handleInboxHover : undefined
-                  }
-                >
-                  {item.icon}
-                </button>
-              </Tooltip>
-            );
-          })}
+          {collapsedStickyEntry && renderCollapsedItem(collapsedStickyEntry)}
+          <div className={styles.collapsedNavScroll}>
+            {collapsedScrollEntries.map(renderCollapsedItem)}
+          </div>
         </nav>
       ) : isSimpleExpanded ? (
         <>

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -176,6 +176,22 @@
     display: flex;
     flex-direction: column;
     padding: 0 8px;
+    // #7125: the rail must not scroll as a whole — the pinned chat entry
+    // stays put while only .collapsedNavScroll scrolls. Mirror the
+    // .siderSimple pattern: make the children wrapper a constrained flex
+    // column so the inner flex chain gets a fixed height. (Global prefix
+    // is "qwenpaw", see App.tsx prefixCls.)
+    overflow: hidden;
+
+    :global {
+      .qwenpaw-layout-sider-children {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
+      }
+    }
 
     .agentSelectorContainer {
       display: flex;
@@ -833,11 +849,23 @@
 /* Collapsed nav (icon-only group list) */
 .collapsedNav {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
   padding: 4px 0;
+}
+
+// #7125: only the non-pinned entries scroll; the chat entry above this
+// container stays visible at the top of the collapsed rail.
+.collapsedNavScroll {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -850,6 +878,10 @@
 .collapsedNavItem {
   width: 40px;
   height: 40px;
+  // #7125: inside the constrained .collapsedNavScroll flex column, items
+  // must keep their 40px box and overflow into the scrollbar instead of
+  // shrinking (flex-shrink default 1 would squash the icons).
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -895,6 +927,12 @@
   .collapsedNav {
     gap: 2px;
     padding: 2px 0;
+  }
+
+  // #7125: keep mobile rail spacing uniform — the scroll container owns
+  // the inter-item gap now.
+  .collapsedNavScroll {
+    gap: 2px;
   }
 
   .collapsedNavItem {


### PR DESCRIPTION
## Description

When the left sidebar is collapsed to the icon-only rail, the entire rail was a single scroll container, so the session (chat) icon — the first entry — scrolled out of view once the user scrolled down to reach plugins/settings. Returning to chat required scrolling back to the top (#7125).

This pins the chat icon to the top of the collapsed rail and lets only the remaining icons scroll below it.

**Changes**

- `console/src/layouts/Sidebar.tsx`: extract the collapsed-item renderer (`renderCollapsedItem`) and render the pinned `core.chat` entry above a new `.collapsedNavScroll` container that holds the rest of the entries. Tooltip, active highlight, inbox unread dot / shake animation, and click/navigation behavior are unchanged (the same JSX was moved into the shared renderer).
- `console/src/layouts/index.module.less`: in the collapsed state, constrain the antd sider children wrapper (`.qwenpaw-layout-sider-children`) to a fixed-height flex column — mirroring the existing `.siderSimple` pattern — so only `.collapsedNavScroll` scrolls. Items keep their fixed 40px box via `flex-shrink: 0` (so a constrained flex column can't squash them), and the mobile media query keeps the 2px gap on the scroll container.

Expanded mode and simple mode are untouched (their scroll/overflow rules are unchanged).

**Related Issue:** Fixes #7125

**Security Considerations:** None — CSS/layout-only change in the console UI.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Verified locally against a running backend + Vite dev server (manual UI check)
- [x] tsc / eslint / prettier pass on the changed files
- [x] Ready for review

## Testing

Manual verification with the console running (backend + `npm run dev`):

1. Collapse the left sidebar to the icon rail.
2. With a short viewport (so icons overflow), scroll the icon list down.
3. The chat icon stays pinned at the top of the rail; the remaining icons scroll below it; the collapse toggle stays at the bottom.
4. Regression checks: icon size/spacing match the pre-change rail (no squashing), tooltips / active highlight / inbox dot still work, expanded-mode menu still scrolls, dark mode unaffected.

## Evidence

```
$ tsc -b                                        -> exit 0
$ eslint src/layouts/Sidebar.tsx                -> exit 0
$ prettier --check src/layouts/{Sidebar.tsx,index.module.less}
  All matched files use Prettier code style!
$ vitest run src/layouts                        -> 40 passed
$ vite build                                    -> built (LESS compiles)
```

Before: the whole collapsed rail scrolls, so the chat icon disappears when scrolled down.
After: chat icon pinned at top; only `.collapsedNavScroll` scrolls; icon box size preserved via `flex-shrink: 0`.

Diff: 2 files (`console/src/layouts/Sidebar.tsx`, `console/src/layouts/index.module.less`).
