### PR TITLE
test(crons): isolate inbox store in CronManager unit tests

### DIFF
--- a/tests/unit/app/crons/test_manager.py
+++ b/tests/unit/app/crons/test_manager.py
@@ -31,6 +31,21 @@ from tests.unit.app.conftest import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_inbox_writes(monkeypatch):
+    """Prevent cron tests from writing to the real inbox store.
+
+    CronManager._execute_once calls append_inbox_event on success,
+    which writes to WORKING_DIR/inbox_events.json.  Without this
+    guard any test that exercises _execute_once (directly or via
+    the scheduler) would leak real data to disk.
+    """
+    monkeypatch.setattr(
+        "qwenpaw.app.crons.manager.append_inbox_event",
+        AsyncMock(),
+    )
+
+
 @pytest.fixture
 def repo() -> InMemoryJobRepository:
     return InMemoryJobRepository()


### PR DESCRIPTION
## Problem

`test_execute_once_records_last_run_in_job_timezone` calls `manager._execute_once()` which invokes the **real** `append_inbox_event`, writing test data to `WORKING_DIR/inbox_events.json`.

## Fix

Add an `autouse` fixture that patches `qwenpaw.app.crons.manager.append_inbox_event` with `AsyncMock()`, ensuring no cron test can write to the real inbox store.

## Verification

- Before: 1 real inbox write per test run
- After: 0 inbox writes, all 21 tests pass