### PR TITLE
fix: recover from remote media download timeouts

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -38,6 +38,7 @@ from ..constant import (
     LOOP_CONTINUATION_MESSAGE_TAG,
     MEDIA_UNSUPPORTED_PLACEHOLDER,
     QWENPAW_MESSAGE_TAG_KEY,
+    REMOTE_MEDIA_UNAVAILABLE_PLACEHOLDER,
     WORKING_DIR,
 )
 from ..loop.gates import StopAction, StopHandlerResult
@@ -136,6 +137,22 @@ _REQUEST_SCOPED_MEDIA_LIMIT_SIGNALS = (
     "per image",
     "file size",
 )
+
+_REMOTE_MEDIA_DOWNLOAD_ERROR_MARKERS = (
+    "timeout while downloading url",
+    "timed out while downloading url",
+)
+_REMOTE_MEDIA_LOADED_TEXT_PREFIXES = (
+    "image loaded from url:",
+    "video loaded from url:",
+)
+
+
+def _block_value(value: Any, key: str, default: Any = None) -> Any:
+    """Read one field from either a serialized block or a block object."""
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
 
 
 def _effective_artifact_retention_days(light_context_config: Any) -> int:
@@ -831,11 +848,19 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 self._last_wire_request_had_audio()
                 and self._is_audio_fallback_error(e)
             )
+            remote_media_download_retry = (
+                self._last_wire_request_had_media()
+                and self._is_remote_media_download_error(e)
+            )
             media_capability_retry = (
                 self._last_wire_request_had_media()
                 and self._is_explicit_media_capability_error(e)
             )
-            if not (audio_fallback_retry or media_capability_retry):
+            if not (
+                audio_fallback_retry
+                or remote_media_download_retry
+                or media_capability_retry
+            ):
                 if self._uses_request_time_media_normalization():
                     if should_strip_media:
                         self._set_formatter_media_strip(False)
@@ -848,7 +873,23 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 media_capability_retry
                 and self._is_global_media_capability_error(e)
             )
-            if audio_fallback_retry:
+            if remote_media_download_retry:
+                degraded = self._degrade_failed_remote_media(e)
+                if degraded <= 0:
+                    if self._uses_request_time_media_normalization():
+                        if should_strip_media:
+                            self._set_formatter_media_strip(False)
+                        if should_strip_audio:
+                            self._set_formatter_audio_strip(False)
+                    raise
+                logger.warning(
+                    "_reasoning failed because the provider could not "
+                    "download remote media (%s); degraded %d matching "
+                    "media block(s) and retrying once.",
+                    e,
+                    degraded,
+                )
+            elif audio_fallback_retry:
                 logger.warning(
                     "_reasoning failed because the provider rejected an "
                     "audio payload (%s); stripping audio and retrying.",
@@ -1047,6 +1088,127 @@ class QwenPawAgent(CodingModeMixin, Agent):
             pattern.search(error_str) is not None
             for pattern in _GLOBAL_MEDIA_CAPABILITY_PATTERNS
         )
+
+    @staticmethod
+    def _is_remote_media_download_error(exc: Exception) -> bool:
+        """Return whether a provider failed while fetching a remote URL.
+
+        Keep this deliberately narrower than the generic ``MODEL_TIMEOUT``
+        conversion. A normal inference timeout must not mutate conversation
+        history or remove otherwise valid media.
+        """
+        error_str = " ".join(str(exc).lower().split())
+        return any(
+            marker in error_str
+            for marker in _REMOTE_MEDIA_DOWNLOAD_ERROR_MARKERS
+        )
+
+    @classmethod
+    def _remote_media_url(cls, block: Any) -> str | None:
+        """Return an HTTP(S) URL carried by a media ``DataBlock``."""
+        if _block_value(block, "type") != "data":
+            return None
+
+        source = _block_value(block, "source")
+        source_type = _block_value(source, "type")
+        media_type = _block_value(source, "media_type", "") or ""
+        raw_url = _block_value(source, "url")
+        if (
+            source_type != "url"
+            or not str(media_type).startswith(cls._MEDIA_MIME_PREFIXES)
+            or raw_url is None
+        ):
+            return None
+        url = str(raw_url)
+        return url if url.lower().startswith(("http://", "https://")) else None
+
+    @staticmethod
+    def _is_remote_media_loaded_text(
+        block: Any,
+        failed_urls: set[str],
+    ) -> bool:
+        """Identify the text companion emitted beside a remote media block."""
+        if _block_value(block, "type") != "text":
+            return False
+        text = _block_value(block, "text", "") or ""
+        normalized = text.lstrip().lower()
+        return normalized.startswith(
+            _REMOTE_MEDIA_LOADED_TEXT_PREFIXES,
+        ) and any(url in text for url in failed_urls)
+
+    @classmethod
+    def _degrade_remote_media_blocks(
+        cls,
+        blocks: list[Any],
+        error_text: str,
+    ) -> tuple[list[Any], int]:
+        """Replace matching remote media blocks with a durable text stub."""
+        direct_failed_urls = {
+            url
+            for block in blocks
+            if (url := cls._remote_media_url(block)) and url in error_text
+        }
+        degraded = 0
+        rewritten: list[Any] = []
+
+        for block in blocks:
+            remote_url = cls._remote_media_url(block)
+            if remote_url in direct_failed_urls:
+                rewritten.append(
+                    TextBlock(
+                        type="text",
+                        text=REMOTE_MEDIA_UNAVAILABLE_PLACEHOLDER,
+                    ),
+                )
+                degraded += 1
+                continue
+
+            if cls._is_remote_media_loaded_text(block, direct_failed_urls):
+                continue
+
+            if _block_value(block, "type") == "tool_result":
+                output = _block_value(block, "output")
+                if isinstance(output, list):
+                    (
+                        new_output,
+                        nested_degraded,
+                    ) = cls._degrade_remote_media_blocks(
+                        output,
+                        error_text,
+                    )
+                    if nested_degraded:
+                        if isinstance(block, dict):
+                            block["output"] = new_output
+                        else:
+                            block.output = new_output
+                        degraded += nested_degraded
+
+            rewritten.append(block)
+
+        return rewritten, degraded
+
+    def _degrade_failed_remote_media(self, exc: Exception) -> int:
+        """Degrade only remote media URLs explicitly named by *exc*.
+
+        Mutating ``state.context`` rather than the formatted wire request is
+        intentional: normal session persistence then repairs future turns too.
+        """
+        if not self._is_remote_media_download_error(exc):
+            return 0
+        error_text = str(exc)
+        degraded = 0
+        for msg in self.state.context:
+            content = getattr(msg, "content", None)
+            if not isinstance(content, list):
+                continue
+            rewritten, count = self._degrade_remote_media_blocks(
+                content,
+                error_text,
+            )
+            if count:
+                msg.content = rewritten
+                degraded += count
+        return degraded
 
     def _is_media_block(self, block: Any) -> bool:
         """Return True if *block* carries image/audio/video data."""

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -445,3 +445,10 @@ TRUNCATION_NOTICE_MARKER = "<<<TRUNCATED>>>"
 MEDIA_UNSUPPORTED_PLACEHOLDER = (
     "[Media content removed - model does not support this media type]"
 )
+
+# Placeholder persisted when a model provider cannot fetch a remote media URL.
+# Keep the failed URL out of model-visible text so the agent does not retry the
+# same ``view_image`` / ``view_video`` call on a later reasoning step.
+REMOTE_MEDIA_UNAVAILABLE_PLACEHOLDER = (
+    "[Remote media unavailable - model provider could not download it]"
+)

--- a/tests/unit/agents/test_remote_media_download_recovery.py
+++ b/tests/unit/agents/test_remote_media_download_recovery.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
+"""Tests for one-shot recovery from provider-side remote media failures."""
+
+from types import SimpleNamespace
+
+import pytest
+from agentscope.agent import Agent
+from agentscope.message import (
+    DataBlock,
+    Msg,
+    TextBlock,
+    ToolResultBlock,
+    URLSource,
+)
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.constant import REMOTE_MEDIA_UNAVAILABLE_PLACEHOLDER
+from qwenpaw.loop.gates import StopAction, StopHandlerResult
+
+_BAD_URL = "https://example.com/unreachable.jpg"
+_GOOD_URL = "https://example.com/available.jpg"
+
+
+def _media(url: str) -> DataBlock:
+    return DataBlock(
+        source=URLSource(url=url, media_type="image/jpeg"),
+    )
+
+
+def _tool_result_with_remote_media() -> ToolResultBlock:
+    return ToolResultBlock(
+        id="call-view-image",
+        name="view_image",
+        output=[
+            _media(_BAD_URL),
+            TextBlock(text=f"Image loaded from URL: {_BAD_URL}"),
+            _media(_GOOD_URL),
+            TextBlock(text=f"Image loaded from URL: {_GOOD_URL}"),
+        ],
+    )
+
+
+def _agent() -> QwenPawAgent:
+    agent = object.__new__(QwenPawAgent)
+    agent._context_manager = None
+    agent._gate_pending_stop = None
+    agent._request_context = {}
+    agent.state = SimpleNamespace(
+        context=[
+            Msg(
+                name="agent",
+                role="assistant",
+                content=[_tool_result_with_remote_media()],
+            ),
+        ],
+        reply_id="reply",
+    )
+    agent.name = "agent"
+    agent.model = SimpleNamespace(model_key="provider:model")
+    agent._model_rejects_media = lambda: False
+    agent._uses_request_time_media_normalization = lambda: True
+    agent.formatter = SimpleNamespace(
+        _qwenpaw_last_wire_media_count=2,
+        _qwenpaw_last_wire_audio_count=0,
+        _qwenpaw_force_strip_media=False,
+        _qwenpaw_force_strip_audio=False,
+    )
+
+    async def stop_handlers(final_msg):
+        return StopHandlerResult(
+            action=StopAction.TERMINATE,
+            final_message=final_msg,
+        )
+
+    agent._run_stop_handlers = stop_handlers
+    return agent
+
+
+def _download_error(url: str = _BAD_URL) -> RuntimeError:
+    return RuntimeError(f"Timeout while downloading url: {url}")
+
+
+def _skip_proactive_media_strip(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "qwenpaw.agents.model_factory._supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+
+def test_remote_media_download_classifier_is_narrow() -> None:
+    assert QwenPawAgent._is_remote_media_download_error(
+        _download_error(),
+    )
+    assert QwenPawAgent._is_remote_media_download_error(
+        RuntimeError(f"Timed out while downloading URL: {_BAD_URL}"),
+    )
+    assert not QwenPawAgent._is_remote_media_download_error(
+        RuntimeError("Model inference timed out"),
+    )
+
+
+def test_degrade_failed_remote_media_only_rewrites_matching_url() -> None:
+    agent = _agent()
+
+    degraded = agent._degrade_failed_remote_media(_download_error())
+
+    assert degraded == 1
+    result = agent.state.context[0].content[0]
+    assert isinstance(result, ToolResultBlock)
+    assert any(
+        isinstance(block, TextBlock)
+        and block.text == REMOTE_MEDIA_UNAVAILABLE_PLACEHOLDER
+        for block in result.output
+    )
+    assert not any(_BAD_URL in str(block) for block in result.output)
+    assert any(
+        isinstance(block, DataBlock) and str(block.source.url) == _GOOD_URL
+        for block in result.output
+    )
+    assert any(
+        isinstance(block, TextBlock) and _GOOD_URL in block.text
+        for block in result.output
+    )
+
+
+def test_degrade_failed_remote_media_requires_url_from_context() -> None:
+    agent = _agent()
+
+    degraded = agent._degrade_failed_remote_media(
+        _download_error("https://example.com/not-in-context.jpg"),
+    )
+
+    assert degraded == 0
+    result = agent.state.context[0].content[0]
+    assert any(_BAD_URL in str(block) for block in result.output)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_degrades_failed_url_and_retries_once(
+    monkeypatch,
+) -> None:
+    _skip_proactive_media_strip(monkeypatch)
+    agent = _agent()
+    calls = 0
+
+    async def provider_reasoning(self, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _download_error()
+        result = agent.state.context[0].content[0]
+        assert not any(_BAD_URL in str(block) for block in result.output)
+        yield Msg(
+            name="agent",
+            role="assistant",
+            content=[TextBlock(text="done")],
+        )
+
+    monkeypatch.setattr(Agent, "_reasoning", provider_reasoning)
+
+    events = [event async for event in agent._reasoning()]
+
+    assert calls == 2
+    assert events[-1].get_text_content() == "done"
+    assert agent.formatter._qwenpaw_force_strip_media is False
+    assert agent.formatter._qwenpaw_force_strip_audio is False
+
+
+@pytest.mark.asyncio
+async def test_reasoning_does_not_retry_without_a_matching_url(
+    monkeypatch,
+) -> None:
+    _skip_proactive_media_strip(monkeypatch)
+    agent = _agent()
+    calls = 0
+
+    async def provider_reasoning(self, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        if tool_choice == "unreachable-test-sentinel":
+            yield None
+        raise _download_error("https://example.com/not-in-context.jpg")
+
+    monkeypatch.setattr(Agent, "_reasoning", provider_reasoning)
+
+    with pytest.raises(RuntimeError, match="not-in-context"):
+        async for _ in agent._reasoning():
+            pass
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reasoning_recovery_retries_at_most_once(monkeypatch) -> None:
+    _skip_proactive_media_strip(monkeypatch)
+    agent = _agent()
+    calls = 0
+
+    async def provider_reasoning(self, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        if tool_choice == "unreachable-test-sentinel":
+            yield None
+        raise _download_error()
+
+    monkeypatch.setattr(Agent, "_reasoning", provider_reasoning)
+
+    with pytest.raises(RuntimeError, match="downloading url"):
+        async for _ in agent._reasoning():
+            pass
+
+    assert calls == 2


### PR DESCRIPTION
# Description

Fix conversations getting stuck when a model provider fails to download a remote image or video.

When the provider returns `Timeout while downloading url`, the failed media block is already stored in the conversation history. Later messages resend the same URL and fail again, so the conversation cannot continue unless it is cleared.

This change handles that specific provider error by replacing the failed media block in the saved context with a text placeholder, then retrying the request once. It only replaces the URL mentioned in the error and leaves other media unchanged.

This PR:

- Detects provider errors containing `Timeout while downloading url` or `Timed out while downloading url`.
- Replaces only the failed remote media block in the saved conversation context.
- Removes the matching `Image loaded from URL` or `Video loaded from URL` text block.
- Retries the model request once after repairing the context.
- Adds unit tests for matching, context cleanup, and retry behavior.

Related Issue: Fixes [#7110](https://github.com/agentscope-ai/QwenPaw/issues/7110)

# Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

# Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

# Checklist

- [x] I ran the pre-commit checks for the changed files locally and they pass
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

# For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This PR only changes backend agent recovery behavior and its unit tests.

# Testing

Run the focused unit tests:

```bash
.venv/bin/python -m pytest tests/unit/agents/test_remote_media_download_recovery.py -q
```

Run the complete agent unit-test suite:

```bash
.venv/bin/python -m pytest tests/unit/agents -q
```

I was not able to verify this case manually in the browser because the DeepSeek API key I use does not provide a multimodal model. QwenPaw removes media from requests sent to text-only models, so the provider-side remote image download error cannot be reproduced with this setup.

# Evidence

Focused unit test result:

```text
......                                                                   [100%]
6 passed in 0.43s
```

Complete agent unit-test suite result:

```text
1386 passed, 3 skipped
```

# Additional Notes

This only handles remote media download errors. A normal model timeout does not modify the conversation history.

QwenPaw still passes remote media URLs to the model provider instead of downloading them locally.

No Console or web frontend code is changed.
