### PR TITLE
Refactor(cli): refactor skill cli, add search, add batch enable/disable

### DIFF
--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -11,13 +11,14 @@ from ..agents.skill_system import (
     SkillConflictError,
     SkillPoolService,
     SkillService,
+    get_skill_pool_dir,
     get_workspace_skills_dir,
     read_skill_pool_manifest,
     read_skill_manifest,
     reconcile_pool_manifest,
     reconcile_workspace_manifest,
+    resolve_pool_skill_dir,
 )
-from ..agents.skill_system.registry import list_workspaces
 from ..agents.skill_system.store import validate_skill_content
 from ..agents.skill_system.hub import (
     aclose_hub_client,
@@ -26,39 +27,30 @@ from ..agents.skill_system.hub import (
 )
 from ..agents.utils.file_handling import read_text_file_with_encoding_fallback
 from ..config import load_config
-from ..constant import WORKING_DIR
 from ..exceptions import SkillsError
 from ..security.skill_scanner import SkillScanError, scan_skill_directory
 from .utils import prompt_checkbox, prompt_confirm
 
 
 def _get_agent_workspace(agent_id: str) -> Path:
-    """Get agent workspace directory."""
-    try:
-        config = load_config()
-        if agent_id in config.agents.profiles:
-            ref = config.agents.profiles[agent_id]
-            workspace_dir = Path(ref.workspace_dir).expanduser()
-            return workspace_dir
-    except Exception:
-        pass
-    return WORKING_DIR
-
-
-def _require_agent_workspace(agent_id: str) -> Path:
+    """Resolve an agent workspace without falling back to another scope."""
     normalized_agent_id = str(agent_id or "").strip()
     if not normalized_agent_id:
         raise click.ClickException("Agent ID cannot be empty.")
-    workspaces = list_workspaces()
-    for workspace in workspaces:
-        if workspace.get("agent_id") == normalized_agent_id:
-            return Path(str(workspace["workspace_dir"])).expanduser()
 
-    available_agents = sorted(
-        str(workspace.get("agent_id") or "")
-        for workspace in workspaces
-        if str(workspace.get("agent_id") or "")
-    )
+    try:
+        config = load_config()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to load agent configuration: {exc}",
+        ) from exc
+
+    profiles = config.agents.profiles
+    ref = profiles.get(normalized_agent_id)
+    if ref is not None:
+        return Path(ref.workspace_dir).expanduser()
+
+    available_agents = sorted(str(name) for name in profiles)
     if available_agents:
         raise click.ClickException(
             "Agent "
@@ -126,13 +118,39 @@ def _validate_skill_frontmatter(skill_dir: Path) -> None:
         ) from exc
 
 
-def _resolve_skill_test_dir(skill: str, agent_id: str) -> Path:
+def _resolve_scope(
+    agent_id: str | None,
+    pool: bool,
+    *,
+    default_pool: bool = False,
+) -> str | None:
+    """Return an agent ID, or ``None`` for the shared skill pool."""
+    normalized_agent_id = str(agent_id or "").strip()
+    if pool and normalized_agent_id:
+        raise click.ClickException(
+            "--pool and --agent-id are mutually exclusive.",
+        )
+    if pool or (default_pool and not normalized_agent_id):
+        return None
+    return normalized_agent_id or "default"
+
+
+def _resolve_skill_test_dir(
+    skill: str,
+    agent_id: str | None,
+    *,
+    pool: bool = False,
+) -> Path:
     """Resolve a skill argument as a path first, then workspace skill name."""
     candidate = Path(skill).expanduser()
     if candidate.exists():
         return candidate.resolve()
 
-    working_dir = _get_agent_workspace(agent_id)
+    if pool:
+        reconcile_pool_manifest()
+        return resolve_pool_skill_dir(skill) or get_skill_pool_dir() / skill
+
+    working_dir = _get_agent_workspace(agent_id or "default")
     return get_workspace_skills_dir(working_dir) / skill
 
 
@@ -160,59 +178,116 @@ def _run_skill_test(skill_dir: Path) -> str:
     return skill_name
 
 
+def _install_selected_skills(
+    pool_service: SkillPoolService | None,
+    working_dir: Path,
+    to_install: set[str],
+    installed_names: set[str],
+) -> tuple[set[str], list[str]]:
+    """Install selected pool entries and return installed names + failures."""
+    installed_now = set(installed_names)
+    failures: list[str] = []
+    if pool_service is None:
+        for name in sorted(to_install):
+            failure = f"install {name} (pool unavailable)"
+            failures.append(failure)
+            click.echo(click.style(f"  ✗ Failed to {failure}", fg="red"))
+        return installed_now, failures
+
+    for name in sorted(to_install):
+        try:
+            result = pool_service.download_to_workspace(
+                name,
+                working_dir,
+                overwrite=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - report every item
+            result = {"success": False, "reason": str(exc)}
+        if result.get("success"):
+            installed_now.add(name)
+            click.echo(f"  ✓ Installed: {name}")
+            continue
+        reason = str(result.get("reason") or "operation failed")
+        failures.append(f"install {name} ({reason})")
+        click.echo(
+            click.style(
+                f"  ✗ Failed to install: {name} ({reason})",
+                fg="red",
+            ),
+        )
+    return installed_now, failures
+
+
+def _apply_skill_state_changes(
+    skill_service: SkillService,
+    skill_names: set[str],
+    *,
+    enabled: bool,
+) -> list[str]:
+    """Apply one state to exact skill names and return failure summaries."""
+    failures: list[str] = []
+    action = "enable" if enabled else "disable"
+    past_tense = "Enabled" if enabled else "Disabled"
+
+    for name in sorted(skill_names):
+        try:
+            result = (
+                skill_service.enable_skill(name)
+                if enabled
+                else skill_service.disable_skill(name)
+            )
+        except Exception as exc:  # noqa: BLE001 - report every item
+            result = {"success": False, "reason": str(exc)}
+        if result.get("success"):
+            click.echo(f"  ✓ {past_tense}: {name}")
+            continue
+        reason = str(result.get("reason") or "operation failed")
+        failures.append(f"{action} {name} ({reason})")
+        click.echo(
+            click.style(
+                f"  ✗ Failed to {action}: {name} ({reason})",
+                fg="red",
+            ),
+        )
+    return failures
+
+
 def _apply_skill_changes(
     skill_service: SkillService,
     pool_service: SkillPoolService | None,
     working_dir: Path,
+    *,
     to_install: set[str],
     to_enable: set[str],
     to_disable: set[str],
     installed_names: set[str],
 ) -> None:
     """Install from pool, enable, and disable skills."""
-    installed_now = set(installed_names)
-    if to_install and pool_service is not None:
-        for name in sorted(to_install):
-            result = pool_service.download_to_workspace(
-                name,
-                working_dir,
-                overwrite=False,
-            )
-            if result.get("success"):
-                installed_now.add(name)
-                click.echo(f"  ✓ Installed: {name}")
-            else:
-                click.echo(
-                    click.style(
-                        f"  ✗ Failed to install: {name}",
-                        fg="red",
-                    ),
-                )
+    installed_now, failures = _install_selected_skills(
+        pool_service,
+        working_dir,
+        to_install,
+        installed_names,
+    )
+    failures.extend(
+        _apply_skill_state_changes(
+            skill_service,
+            (to_enable | to_install) & installed_now,
+            enabled=True,
+        ),
+    )
+    failures.extend(
+        _apply_skill_state_changes(
+            skill_service,
+            to_disable,
+            enabled=False,
+        ),
+    )
 
-    for name in sorted((to_enable | to_install) & installed_now):
-        result = skill_service.enable_skill(name)
-        if result.get("success"):
-            click.echo(f"  ✓ Enabled: {name}")
-        else:
-            click.echo(
-                click.style(
-                    f"  ✗ Failed to enable: {name}",
-                    fg="red",
-                ),
-            )
-
-    for name in sorted(to_disable):
-        result = skill_service.disable_skill(name)
-        if result.get("success"):
-            click.echo(f"  ✓ Disabled: {name}")
-        else:
-            click.echo(
-                click.style(
-                    f"  ✗ Failed to disable: {name}",
-                    fg="red",
-                ),
-            )
-
+    if failures:
+        raise click.ClickException(
+            f"{len(failures)} skill change(s) failed: " + "; ".join(failures),
+        )
     click.echo("\n✓ Skills configuration updated!")
 
 
@@ -254,8 +329,7 @@ def configure_skills_interactive(
     }
     installed_names = set(installed_by_name)
     candidate_names = installed_names | set(pool_candidates)
-
-    default_checked = enabled if enabled else candidate_names
+    default_checked = enabled
 
     options: list[tuple[str, str]] = []
     for skill_name in sorted(candidate_names):
@@ -269,13 +343,17 @@ def configure_skills_interactive(
         options.append((label, skill.name))
 
     click.echo("\n=== Skills Configuration ===")
-    click.echo("Use ↑/↓ to move, <space> to toggle, <enter> to confirm.\n")
+    click.echo(
+        "Type to filter, use ↑/↓ to move, <space> to toggle, "
+        "<enter> to confirm.\n",
+    )
 
     selected = prompt_checkbox(
         "Select skills to enable:",
         options=options,
         checked=default_checked,
         select_all_option=False,
+        searchable=True,
     )
 
     if selected is None:
@@ -302,29 +380,63 @@ def configure_skills_interactive(
         skill_service,
         pool_service,
         working_dir,
-        to_install,
-        to_enable,
-        to_disable,
-        installed_names,
+        to_install=to_install,
+        to_enable=to_enable,
+        to_disable=to_disable,
+        installed_names=installed_names,
     )
 
 
 @click.group("skills")
 def skills_group() -> None:
-    """Manage skills (list / configure)."""
+    """Manage workspace and skill-pool skills."""
 
 
 @skills_group.command("list")
 @click.option(
     "--agent-id",
-    default="default",
-    help="Agent ID (defaults to 'default')",
+    default=None,
+    help="Target agent ID (defaults to 'default').",
 )
-def list_cmd(agent_id: str) -> None:
-    """Show all skills and their enabled/disabled status."""
-    working_dir = _get_agent_workspace(agent_id)
+@click.option(
+    "--pool",
+    is_flag=True,
+    help="List the shared skill pool instead of an agent workspace.",
+)
+@click.option(
+    "--status",
+    type=click.Choice(["all", "enabled", "disabled"], case_sensitive=False),
+    default="all",
+    show_default=True,
+    help="Filter by enabled status.",
+)
+def list_cmd(agent_id: str | None, pool: bool, status: str) -> None:
+    """Show skills in an agent workspace or the shared pool."""
+    scope = _resolve_scope(agent_id, pool)
+    if scope is None:
+        if status.lower() != "all":
+            raise click.ClickException(
+                "--status is not supported with --pool; pool skills have no "
+                "enabled state.",
+            )
+        reconcile_pool_manifest()
+        all_skills = SkillPoolService().list_all_skills()
+        click.echo("Skills in shared pool:\n")
+        if not all_skills:
+            click.echo("No skills found.")
+            return
+        click.echo(f"{'─' * 50}")
+        click.echo(f"  {'Skill Name':<30s} Source")
+        click.echo(f"{'─' * 50}")
+        for skill in sorted(all_skills, key=lambda item: item.name):
+            click.echo(f"  {skill.name:<30s} {skill.source}")
+        click.echo(f"{'─' * 50}")
+        click.echo(f"  Total: {len(all_skills)} skills\n")
+        return
 
-    click.echo(f"Skills for agent: {agent_id}\n")
+    working_dir = _get_agent_workspace(scope)
+
+    click.echo(f"Skills for agent: {scope}\n")
 
     reconcile_workspace_manifest(working_dir)
     skill_service = SkillService(working_dir)
@@ -341,11 +453,25 @@ def list_cmd(agent_id: str) -> None:
         click.echo("No skills found.")
         return
 
+    normalized_status = status.lower()
+    visible_skills = []
+    for skill in all_skills:
+        is_enabled = skill.name in enabled
+        if normalized_status == "enabled" and not is_enabled:
+            continue
+        if normalized_status == "disabled" and is_enabled:
+            continue
+        visible_skills.append(skill)
+
+    if not visible_skills:
+        click.echo("No skills match the current filters.")
+        return
+
     click.echo(f"\n{'─' * 50}")
     click.echo(f"  {'Skill Name':<30s} {'Source':<12s} Status")
     click.echo(f"{'─' * 50}")
 
-    for skill in sorted(all_skills, key=lambda s: s.name):
+    for skill in sorted(visible_skills, key=lambda s: s.name):
         status = (
             click.style("✓ enabled", fg="green")
             if skill.name in enabled
@@ -354,11 +480,11 @@ def list_cmd(agent_id: str) -> None:
         click.echo(f"  {skill.name:<30s} {skill.source:<12s} {status}")
 
     click.echo(f"{'─' * 50}")
-    enabled_count = sum(1 for s in all_skills if s.name in enabled)
+    enabled_count = sum(1 for s in visible_skills if s.name in enabled)
     click.echo(
-        f"  Total: {len(all_skills)} skills, "
+        f"  Showing: {len(visible_skills)} of {len(all_skills)} skills, "
         f"{enabled_count} enabled, "
-        f"{len(all_skills) - enabled_count} disabled\n",
+        f"{len(visible_skills) - enabled_count} disabled\n",
     )
 
 
@@ -373,19 +499,140 @@ def configure_cmd(agent_id: str) -> None:
     configure_skills_interactive(agent_id=agent_id)
 
 
-@skills_group.command("info")
-@click.argument("skill_name", required=True)
+def _set_skills_enabled(
+    skill_names: tuple[str, ...],
+    agent_id: str,
+    *,
+    enabled: bool,
+) -> None:
+    """Set exact workspace skill names and report every failure."""
+    working_dir = _get_agent_workspace(agent_id)
+    manifest = reconcile_workspace_manifest(working_dir).get("skills", {})
+    service = SkillService(working_dir)
+    action = "enable" if enabled else "disable"
+    past_tense = "Enabled" if enabled else "Disabled"
+    failures: list[str] = []
+    seen: set[str] = set()
+
+    for raw_name in skill_names:
+        name = str(raw_name or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        if name not in manifest:
+            failures.append(f"{name} (not found)")
+            click.echo(
+                click.style(
+                    f"  ✗ Failed to {action}: {name} (not found)",
+                    fg="red",
+                ),
+            )
+            continue
+
+        try:
+            result = (
+                service.enable_skill(name)
+                if enabled
+                else service.disable_skill(name)
+            )
+        except Exception as exc:  # noqa: BLE001 - continue batch reporting
+            result = {"success": False, "reason": str(exc)}
+
+        if result.get("success"):
+            click.echo(f"  ✓ {past_tense}: {name}")
+            continue
+
+        reason = str(result.get("reason") or "operation failed")
+        failures.append(f"{name} ({reason})")
+        click.echo(
+            click.style(
+                f"  ✗ Failed to {action}: {name} ({reason})",
+                fg="red",
+            ),
+        )
+
+    if failures:
+        raise click.ClickException(
+            f"Failed to {action} {len(failures)} skill(s): "
+            + "; ".join(failures),
+        )
+
+
+@skills_group.command("enable")
+@click.argument("skill_names", nargs=-1, required=True)
 @click.option(
     "--agent-id",
     default="default",
     help="Agent ID (defaults to 'default')",
 )
+def enable_cmd(skill_names: tuple[str, ...], agent_id: str) -> None:
+    """Enable one or more exact workspace skill names."""
+    _set_skills_enabled(skill_names, agent_id, enabled=True)
+
+
+@skills_group.command("disable")
+@click.argument("skill_names", nargs=-1, required=True)
+@click.option(
+    "--agent-id",
+    default="default",
+    help="Agent ID (defaults to 'default')",
+)
+def disable_cmd(skill_names: tuple[str, ...], agent_id: str) -> None:
+    """Disable one or more exact workspace skill names."""
+    _set_skills_enabled(skill_names, agent_id, enabled=False)
+
+
+@skills_group.command("info")
+@click.argument("skill_name", required=True)
+@click.option(
+    "--agent-id",
+    default=None,
+    help="Target agent ID (defaults to 'default').",
+)
+@click.option(
+    "--pool",
+    is_flag=True,
+    help="Inspect the skill in the shared pool.",
+)
 def info_cmd(
     skill_name: str,
-    agent_id: str,
+    agent_id: str | None,
+    pool: bool,
 ) -> None:
-    """Show local details for a specific workspace skill."""
-    working_dir = _get_agent_workspace(agent_id)
+    """Show local details for a workspace or pool skill."""
+    scope = _resolve_scope(agent_id, pool)
+    if scope is None:
+        reconcile_pool_manifest()
+        skill_map = {
+            skill.name: skill for skill in SkillPoolService().list_all_skills()
+        }
+        skill = skill_map.get(skill_name)
+        if skill is None:
+            raise click.ClickException(
+                f"Skill '{skill_name}' was not found in the skill pool.",
+            )
+        entry = (
+            read_skill_pool_manifest()
+            .get("skills", {})
+            .get(
+                skill_name,
+                {},
+            )
+        )
+        skill_dir = resolve_pool_skill_dir(skill_name) or (
+            get_skill_pool_dir() / skill_name
+        )
+        click.echo(f"Skill: {skill.name}")
+        click.echo("Scope: pool")
+        click.echo(f"Source: {skill.source}")
+        click.echo(f"Path: {skill_dir}")
+        click.echo(f"Description: {skill.description or 'No description.'}")
+        tags = entry.get("tags") or []
+        if tags:
+            click.echo(f"Tags: {', '.join(str(tag) for tag in tags)}")
+        return
+
+    working_dir = _get_agent_workspace(scope)
     reconcile_workspace_manifest(working_dir)
 
     skill_service = SkillService(working_dir)
@@ -396,7 +643,7 @@ def info_cmd(
     skill = skill_map.get(skill_name)
     if skill is None:
         raise click.ClickException(
-            f"Skill '{skill_name}' was not found for agent '{agent_id}'.",
+            f"Skill '{skill_name}' was not found for agent '{scope}'.",
         )
 
     entry = manifest.get(skill_name, {})
@@ -423,6 +670,11 @@ def info_cmd(
     help="Install directly into the given agent workspace.",
 )
 @click.option(
+    "--pool",
+    is_flag=True,
+    help="Install into the shared skill pool (the default for compatibility).",
+)
+@click.option(
     "--enable/--no-enable",
     default=True,
     help="Enable after import when installing into an agent workspace.",
@@ -430,6 +682,7 @@ def info_cmd(
 def install_cmd(
     bundle_url: str,
     agent_id: str,
+    pool: bool,
     enable: bool,
 ) -> None:
     """Install a skill from a URL.
@@ -437,9 +690,18 @@ def install_cmd(
     Without ``--agent-id``, the skill is imported into the local skill pool.
     With ``--agent-id``, the skill is imported directly into that workspace.
     """
-    normalized_agent_id = str(agent_id or "").strip()
+    normalized_agent_id = _resolve_scope(
+        agent_id,
+        pool,
+        default_pool=True,
+    )
+    if normalized_agent_id is None and not enable:
+        raise click.ClickException(
+            "--no-enable is only supported with --agent-id; "
+            "pool skills have no enabled state.",
+        )
     workspace_dir = (
-        _require_agent_workspace(normalized_agent_id)
+        _get_agent_workspace(normalized_agent_id)
         if normalized_agent_id
         else None
     )
@@ -487,20 +749,30 @@ def install_cmd(
     default="",
     help="Remove the skill from the given agent workspace.",
 )
+@click.option(
+    "--pool",
+    is_flag=True,
+    help="Remove from the shared skill pool (the default for compatibility).",
+)
 def uninstall_cmd(
     skill_name: str,
     agent_id: str,
+    pool: bool,
 ) -> None:
     """Uninstall a skill from the skill pool or one agent workspace."""
     normalized_skill_name = str(skill_name or "").strip()
     if not normalized_skill_name:
         raise click.ClickException("Skill name cannot be empty.")
 
-    normalized_agent_id = str(agent_id or "").strip()
+    normalized_agent_id = _resolve_scope(
+        agent_id,
+        pool,
+        default_pool=True,
+    )
 
     try:
         if normalized_agent_id:
-            workspace_dir = _require_agent_workspace(normalized_agent_id)
+            workspace_dir = _get_agent_workspace(normalized_agent_id)
             manifest = read_skill_manifest(workspace_dir).get("skills", {})
             if normalized_skill_name not in manifest:
                 raise click.ClickException(
@@ -560,12 +832,22 @@ def uninstall_cmd(
 @click.argument("skill", required=True)
 @click.option(
     "--agent-id",
-    default="default",
-    help="Agent ID (defaults to 'default')",
+    default=None,
+    help="Target agent ID (defaults to 'default').",
 )
-def test_cmd(skill: str, agent_id: str) -> None:
-    """Validate a workspace skill or local skill directory."""
-    skill_dir = _resolve_skill_test_dir(skill, agent_id)
+@click.option(
+    "--pool",
+    is_flag=True,
+    help="Resolve the skill name from the shared pool.",
+)
+def test_cmd(skill: str, agent_id: str | None, pool: bool) -> None:
+    """Validate a workspace skill, pool skill, or local skill directory."""
+    scope = _resolve_scope(agent_id, pool)
+    skill_dir = _resolve_skill_test_dir(
+        skill,
+        scope,
+        pool=scope is None,
+    )
     skill_name = _run_skill_test(skill_dir)
     click.echo(f"Skill test passed: {skill_name}")
     click.echo(f"Path: {skill_dir}")

--- a/src/qwenpaw/cli/utils.py
+++ b/src/qwenpaw/cli/utils.py
@@ -154,6 +154,7 @@ def prompt_checkbox(
     *,
     checked: Optional[set[str]] = None,
     select_all_option: bool = True,
+    searchable: bool = False,
 ) -> Optional[list[str]]:
     """Let the user pick multiple items from a list with checkboxes.
 
@@ -169,6 +170,7 @@ def prompt_checkbox(
         checked:   Set of *values* that should be pre-checked.
                    ``None`` → nothing checked.
         select_all_option: Whether to show a "Select All" toggle.
+        searchable: Whether typing should filter the visible choices.
 
     Returns:
         List of selected *values*, or ``None`` on Ctrl+C.
@@ -205,6 +207,7 @@ def prompt_checkbox(
             question,
             choices=items,
             use_jk_keys=False,
+            use_search_filter=searchable,
         ).ask()
 
         if result is None:

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -679,31 +679,41 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 
 ### qwenpaw skills
 
-| Command                    | What it does                                              |
-| -------------------------- | --------------------------------------------------------- |
-| `qwenpaw skills install`   | Install a skill from a supported URL source               |
-| `qwenpaw skills uninstall` | Remove a skill from the skill pool or one agent workspace |
-| `qwenpaw skills list`      | Show all skills and their enabled/disabled status         |
-| `qwenpaw skills config`    | Interactively enable/disable skills (checkbox UI)         |
-| `qwenpaw skills info`      | Show local details for one workspace skill                |
-
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+| Usage                                  | Positional arguments                                        | Options                                                                                                                                                                                                                         |
+| -------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `qwenpaw skills list`                  | None                                                        | `--agent-id ID` (default `default`) or `--pool`; workspaces support `--status all\|enabled\|disabled` (default `all`), while the Pool does not support status filtering                                                         |
+| `qwenpaw skills config`                | None                                                        | `--agent-id ID` (default `default`); workspace only                                                                                                                                                                             |
+| `qwenpaw skills enable SKILL_NAME...`  | One or more exact workspace skill names                     | `--agent-id ID` (default `default`)                                                                                                                                                                                             |
+| `qwenpaw skills disable SKILL_NAME...` | One or more exact workspace skill names                     | `--agent-id ID` (default `default`)                                                                                                                                                                                             |
+| `qwenpaw skills info SKILL_NAME`       | One exact skill name                                        | `--agent-id ID` (default `default`) or `--pool`                                                                                                                                                                                 |
+| `qwenpaw skills install BUNDLE_URL`    | A skill URL from a supported source                         | `--pool` imports to the Pool; `--agent-id ID` installs into that workspace; they are mutually exclusive; for compatibility, omitting both still targets the Pool; `--enable/--no-enable` is workspace-only (enabled by default) |
+| `qwenpaw skills uninstall SKILL_NAME`  | One exact skill name                                        | `--pool` removes it from the Pool; `--agent-id ID` removes it from that workspace; they are mutually exclusive; for compatibility, omitting both still targets the Pool                                                         |
+| `qwenpaw skills test SKILL`            | A local skill directory or exact name in the selected scope | `--agent-id ID` (default `default`) or `--pool`                                                                                                                                                                                 |
 
 ```bash
-qwenpaw skills install https://skills.sh/owner/repo/skill  # Import into the local skill pool
+qwenpaw skills install https://skills.sh/owner/repo/skill --pool  # Import into the local skill pool
 qwenpaw skills install https://skills.sh/owner/repo/skill --agent-id abc123  # Import directly into a specific agent workspace
-qwenpaw skills uninstall skill-creator  # Remove from the local skill pool
+qwenpaw skills uninstall skill-creator --pool  # Remove from the local skill pool
 qwenpaw skills uninstall skill-creator --agent-id abc123  # Remove from a specific agent workspace
-qwenpaw skills list                   # See default agent's skills
+qwenpaw skills list --status enabled      # Show only enabled skills for the default agent
+qwenpaw skills list --pool                # List the shared Pool (which has no enabled state)
 qwenpaw skills list --agent-id abc123 # See specific agent's skills
-qwenpaw skills config                 # Configure default agent
+qwenpaw skills config                 # Configure installed skills interactively
 qwenpaw skills config --agent-id abc123 # Configure specific agent
+qwenpaw skills enable pdf docx --agent-id abc123  # Batch-enable exact names
+qwenpaw skills disable pdf --agent-id abc123      # Disable without uninstalling
 qwenpaw skills info [skill_name]               # See default agent's skill details
+qwenpaw skills info [skill_name] --pool        # See details in the Pool
 qwenpaw skills info [skill_name] --agent-id abc123 # See specific agent's skill details
 ```
 
-In the interactive UI: ↑/↓ to navigate, Space to toggle, Enter to confirm.
-A preview of changes is shown before applying.
+In the `skills config` checkbox, type a contiguous substring to narrow the
+choices immediately instead of stepping through them one by one. Use ↑/↓ to
+navigate, Space to toggle, and Enter to confirm. Enabled choices
+remain selected while hidden by a filter. A preview is shown before applying.
+`config`, `enable`, and `disable` are workspace-only because the shared Pool
+has no enabled state. For commands that support `--pool`, it cannot be combined
+with `--agent-id`.
 
 > For built-in skill details and custom skill authoring, see [Skills](./skills).
 
@@ -784,7 +794,7 @@ See [Config & Working Directory](./config) and [Multi-Agent](./multi-agent) for 
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    Partial ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |     **Yes**      |
 | `qwenpaw chats`     | `list` · `get` · `create` · `update` · `delete`                                      |     **Yes**      |
-| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `info`                                 |        No        |
+| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `enable` · `disable` · `info` · `test` |        No        |
 | `qwenpaw task`      | —                                                                                    |        No        |
 | `qwenpaw auth`      | `reset-password`                                                                     |        No        |
 | `qwenpaw plugin`    | `install` · `list` · `info` · `uninstall` · `validate`                               |        No        |

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -662,30 +662,39 @@ qwenpaw chats delete <chat_id>
 
 ### qwenpaw skills
 
-| 命令                       | 说明                               |
-| -------------------------- | ---------------------------------- |
-| `qwenpaw skills install`   | 从受支持的 URL 来源安装技能        |
-| `qwenpaw skills uninstall` | 从技能池或单个智能体工作区移除技能 |
-| `qwenpaw skills list`      | 列出所有技能及启用/禁用状态        |
-| `qwenpaw skills config`    | 交互式启用/禁用技能（复选框界面）  |
-| `qwenpaw skills info`      | 查看某个 workspace 技能的本地详情  |
-
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+| 用法                                   | 位置参数                             | 选项                                                                                                                                                             |
+| -------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `qwenpaw skills list`                  | 无                                   | `--agent-id ID`（默认 `default`）或 `--pool`；workspace 支持 `--status all\|enabled\|disabled`（默认 `all`），Pool 不支持状态筛选                                |
+| `qwenpaw skills config`                | 无                                   | `--agent-id ID`（默认 `default`）；仅支持 workspace                                                                                                              |
+| `qwenpaw skills enable SKILL_NAME...`  | 一个或多个精确的 workspace 技能名    | `--agent-id ID`（默认 `default`）                                                                                                                                |
+| `qwenpaw skills disable SKILL_NAME...` | 一个或多个精确的 workspace 技能名    | `--agent-id ID`（默认 `default`）                                                                                                                                |
+| `qwenpaw skills info SKILL_NAME`       | 一个精确的技能名                     | `--agent-id ID`（默认 `default`）或 `--pool`                                                                                                                     |
+| `qwenpaw skills install BUNDLE_URL`    | 支持来源的技能 URL                   | `--pool` 导入 Pool；`--agent-id ID` 直接安装到该 workspace；二者互斥；为兼容旧用法，两者都不传时仍导入 Pool；`--enable/--no-enable` 仅支持 workspace（默认启用） |
+| `qwenpaw skills uninstall SKILL_NAME`  | 一个精确的技能名                     | `--pool` 从 Pool 删除；`--agent-id ID` 从该 workspace 删除；二者互斥；为兼容旧用法，两者都不传时仍操作 Pool                                                      |
+| `qwenpaw skills test SKILL`            | 本地技能目录，或作用域内的精确技能名 | `--agent-id ID`（默认 `default`）或 `--pool`                                                                                                                     |
 
 ```bash
-qwenpaw skills install https://skills.sh/owner/repo/skill  # 导入到本地技能池
+qwenpaw skills install https://skills.sh/owner/repo/skill --pool  # 导入到本地技能池
 qwenpaw skills install https://skills.sh/owner/repo/skill --agent-id abc123  # 直接导入到特定智能体工作区
-qwenpaw skills uninstall skill-creator  # 从本地技能池移除
+qwenpaw skills uninstall skill-creator --pool  # 从本地技能池移除
 qwenpaw skills uninstall skill-creator --agent-id abc123  # 从特定智能体工作区移除
-qwenpaw skills list                   # 看默认智能体的技能
+qwenpaw skills list --status enabled      # 只列出默认智能体已启用的技能
+qwenpaw skills list --pool                # 列出共享 Pool（Pool 没有启用状态）
 qwenpaw skills list --agent-id abc123 # 看特定智能体的技能
-qwenpaw skills config                 # 交互式配置默认智能体
+qwenpaw skills config                 # 交互式配置已安装技能
 qwenpaw skills config --agent-id abc123 # 交互式配置特定智能体
+qwenpaw skills enable pdf docx --agent-id abc123  # 按精确名称批量启用
+qwenpaw skills disable pdf --agent-id abc123      # 禁用但不卸载
 qwenpaw skills info [skill_name]               # 看默认智能体的技能详情
+qwenpaw skills info [skill_name] --pool        # 看 Pool 中的技能详情
 qwenpaw skills info [skill_name] --agent-id abc123 # 看特定智能体的技能详情
 ```
 
-交互界面中：↑/↓ 选择、空格 切换、回车 确认。确认前会预览变更。
+`skills config` 的复选框中可直接输入连续文本，即时缩小候选范围，无需用 ↑/↓
+逐条寻找；↑/↓ 仍可移动，空格切换，回车确认。
+当前已启用项始终保持勾选，搜索隐藏的选择不会丢失，确认前会预览变更。
+`config`、`enable`、`disable` 只适用于 workspace，因为共享 Pool 没有启用/禁用状态。
+支持 `--pool` 的命令中，`--pool` 与 `--agent-id` 不能同时使用。
 
 > 内置技能说明和自定义技能编写方法，请看 [技能](./skills)。
 
@@ -766,7 +775,7 @@ qwenpaw --host 0.0.0.0 --port 9090 cron list
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    部分需要 ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |      **是**       |
 | `qwenpaw chats`     | `list` · `get` · `create` · `update` · `delete`                                      |      **是**       |
-| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `info`                                 |        否         |
+| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `enable` · `disable` · `info` · `test` |        否         |
 | `qwenpaw task`      | —                                                                                    |        否         |
 | `qwenpaw auth`      | `reset-password`                                                                     |        否         |
 | `qwenpaw plugin`    | `install` · `list` · `info` · `uninstall` · `validate`                               |        否         |

--- a/website/public/docs/skills.en.md
+++ b/website/public/docs/skills.en.md
@@ -224,15 +224,28 @@ CLI supports the same URL-based import flow:
 **Workspace targeting:** use `--agent-id` when targeting a single agent workspace; without it, `install` / `uninstall` act on the skill pool.
 
 ```bash
-qwenpaw skills install <skill_url>
+qwenpaw skills install <skill_url> --pool
 qwenpaw skills install <skill_url> --agent-id <agent_id>
 ```
 
 CLI also supports uninstalling from the shared pool or one workspace:
 
 ```bash
-qwenpaw skills uninstall <skill_name>
+qwenpaw skills uninstall <skill_name> --pool
 qwenpaw skills uninstall <skill_name> --agent-id <agent_id>
+```
+
+Workspace skills can be enabled or disabled directly by exact name, or managed
+in a checkbox UI with immediate text filtering. The Pool is a separate shared
+scope selected with `--pool` on commands that support it. Because Pool skills
+have no enabled state, `config`, `enable`, and `disable` are workspace-only:
+
+```bash
+qwenpaw skills enable <skill_name>... --agent-id <agent_id>
+qwenpaw skills disable <skill_name>... --agent-id <agent_id>
+qwenpaw skills list --status enabled --agent-id <agent_id>
+qwenpaw skills list --pool
+qwenpaw skills info <skill_name> --pool
 ```
 
 #### Steps

--- a/website/public/docs/skills.zh.md
+++ b/website/public/docs/skills.zh.md
@@ -194,15 +194,27 @@ CLI 支持相同的基于 URL 的导入方式：
 **指定工作区：** 指定单个智能体工作区时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
 
 ```bash
-qwenpaw skills install <skill_url>
+qwenpaw skills install <skill_url> --pool
 qwenpaw skills install <skill_url> --agent-id <agent_id>
 ```
 
 CLI 也支持从共享技能池或单个工作区卸载技能：
 
 ```bash
-qwenpaw skills uninstall <skill_name>
+qwenpaw skills uninstall <skill_name> --pool
 qwenpaw skills uninstall <skill_name> --agent-id <agent_id>
+```
+
+Workspace 技能可以按精确名称直接启用或禁用，也可以用支持即时文本过滤的复选界面
+批量配置。Pool 是独立的共享作用域，可在支持的命令中用 `--pool` 选择；它没有
+启用/禁用状态，因此 `config`、`enable`、`disable` 只支持 workspace：
+
+```bash
+qwenpaw skills enable <skill_name>... --agent-id <agent_id>
+qwenpaw skills disable <skill_name>... --agent-id <agent_id>
+qwenpaw skills list --status enabled --agent-id <agent_id>
+qwenpaw skills list --pool
+qwenpaw skills info <skill_name> --pool
 ```
 
 #### 步骤


### PR DESCRIPTION
## Description

Refactor the skills CLI to clarify workspace vs. pool behavior and improve skill management.
- Add searchable filtering to skills config
- Preserve the real enabled state; an all-disabled workspace now starts unchecked
- Keep config, enable, and disable workspace-only
- Add batch skills enable and skills disable
- Add explicit --pool support to list, info, test, install, and uninstall
- Add workspace status filtering to skills list
- Reject unknown agents instead of falling back to another directory
- Report partial batch failures with a non-zero exit code
- Update English and Chinese documentation

**Related Issue:** Fixes #7090 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review