### PR TITLE
fix(view_image): freeze remote images before persisting tool results

### DIFF
--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 """Load image or video files into the LLM context for analysis."""
 
+import asyncio
+import ipaddress
 import logging
 import mimetypes
 import os
+import socket
 import unicodedata
 import urllib.parse
-from urllib.parse import unquote
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from urllib.parse import unquote
 
+import httpx
 from agentscope.message import (
     DataBlock,
     TextBlock,
@@ -20,10 +25,26 @@ from agentscope.tool import ToolChunk
 
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.io_utils import run_sync_io
+from ...providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .file_io import _path_to_file_url, _resolve_file_path
-from ..utils.image_freezing import freeze_local_image
+from ..utils.image_freezing import freeze_image_bytes, freeze_local_image
 
 logger = logging.getLogger(__name__)
+
+_REMOTE_IMAGE_CHUNK_SIZE = 64 * 1024
+_REMOTE_IMAGE_CONNECT_TIMEOUT = 5.0
+_REMOTE_IMAGE_READ_TIMEOUT = 10.0
+_REMOTE_IMAGE_TOTAL_TIMEOUT = 30.0
+_REMOTE_IMAGE_MAX_REDIRECTS = 3
+
+
+@dataclass(frozen=True)
+class _RemoteImageTarget:
+    """Describe one validated remote target with a DNS-pinned URL."""
+
+    request_url: str
+    host_header: str
+    server_hostname: str
 
 
 def _media_data_block(url: str, modality: str) -> DataBlock:
@@ -64,6 +85,223 @@ _VIDEO_EXTENSIONS = {
 def _is_url(path: str) -> bool:
     """Return True if *path* looks like an HTTP(S) URL."""
     return path.startswith(("http://", "https://"))
+
+
+def _resolve_host_addresses(host: str, port: int) -> tuple[str, ...]:
+    """Resolve a remote host to its candidate IP addresses."""
+    infos = socket.getaddrinfo(
+        host,
+        port,
+        type=socket.SOCK_STREAM,
+    )
+    addresses = (
+        str(info[4][0]).split("%", maxsplit=1)[0] for info in infos if info[4]
+    )
+    return tuple(dict.fromkeys(addresses))
+
+
+def _url_host(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    """Format an IP address for use as a URL host."""
+    return f"[{address}]" if address.version == 6 else str(address)
+
+
+def _host_header(host: str, port: int | None, scheme: str) -> str:
+    """Build the original authority for HTTP virtual hosting."""
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        authority = host.encode("idna").decode("ascii")
+    else:
+        authority = _url_host(literal)
+
+    default_port = 443 if scheme == "https" else 80
+    if port is not None and port != default_port:
+        return f"{authority}:{port}"
+    return authority
+
+
+# pylint: disable-next=too-many-branches,too-many-return-statements
+async def _resolve_remote_image_target(
+    url: str,
+) -> tuple[_RemoteImageTarget | None, str | None]:
+    """Validate a URL and pin its request to one checked IP address."""
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except (UnicodeError, ValueError):
+        return None, "remote image URL is invalid"
+
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None, "remote image URL must use HTTP or HTTPS"
+    if parsed.username is not None or parsed.password is not None:
+        return None, "remote image URL must not contain credentials"
+
+    host = parsed.hostname.rstrip(".")
+    if host.lower() == "localhost":
+        return None, "remote image URL targets a non-public address"
+
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            addresses = await run_sync_io(
+                _resolve_host_addresses,
+                host,
+                port,
+            )
+        except OSError:
+            return None, "remote image host could not be resolved"
+    else:
+        addresses = (str(literal),)
+
+    if not addresses:
+        return None, "remote image host could not be resolved"
+    validated: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for value in addresses:
+        try:
+            address = ipaddress.ip_address(value)
+        except ValueError:
+            return None, "remote image host resolved to an invalid address"
+        if not address.is_global:
+            return None, "remote image URL targets a non-public address"
+        validated.append(address)
+
+    selected = validated[0]
+    request_netloc = _url_host(selected)
+    if parsed.port is not None:
+        request_netloc = f"{request_netloc}:{parsed.port}"
+    request_url = urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            request_netloc,
+            parsed.path,
+            parsed.query,
+            "",
+        ),
+    )
+    try:
+        server_hostname = host.encode("idna").decode("ascii")
+        host_header = _host_header(host, parsed.port, parsed.scheme)
+    except UnicodeError:
+        return None, "remote image URL is invalid"
+    return (
+        _RemoteImageTarget(
+            request_url=request_url,
+            host_header=host_header,
+            server_hostname=server_hostname,
+        ),
+        None,
+    )
+
+
+# pylint: disable-next=too-many-return-statements
+async def _download_remote_image(
+    url: str,
+    max_bytes: int,
+) -> tuple[bytes | None, str | None]:
+    """Download one remote image with bounded resource usage."""
+    current_url = url
+    timeout = httpx.Timeout(
+        _REMOTE_IMAGE_READ_TIMEOUT,
+        connect=_REMOTE_IMAGE_CONNECT_TIMEOUT,
+    )
+    try:
+        async with asyncio.timeout(_REMOTE_IMAGE_TOTAL_TIMEOUT):
+            async with httpx.AsyncClient(
+                follow_redirects=False,
+                timeout=timeout,
+                trust_env=False,
+            ) as client:
+                for _ in range(_REMOTE_IMAGE_MAX_REDIRECTS + 1):
+                    (
+                        target,
+                        validation_error,
+                    ) = await _resolve_remote_image_target(current_url)
+                    if validation_error is not None or target is None:
+                        return None, validation_error
+
+                    # Connect to the checked IP while preserving the origin.
+                    async with client.stream(
+                        "GET",
+                        target.request_url,
+                        headers={"Host": target.host_header},
+                        extensions={
+                            "sni_hostname": target.server_hostname,
+                        },
+                    ) as response:
+                        if response.is_redirect:
+                            location = response.headers.get("location")
+                            if not location:
+                                return (
+                                    None,
+                                    "remote image redirect is missing a URL",
+                                )
+                            current_url = urllib.parse.urljoin(
+                                current_url,
+                                location,
+                            )
+                            continue
+
+                        try:
+                            response.raise_for_status()
+                        except httpx.HTTPStatusError:
+                            return (
+                                None,
+                                "remote server returned HTTP "
+                                f"{response.status_code}",
+                            )
+
+                        content_length = response.headers.get(
+                            "content-length",
+                        )
+                        if content_length:
+                            try:
+                                reported_size = int(content_length)
+                            except ValueError:
+                                reported_size = 0
+                            if 0 < max_bytes < reported_size:
+                                return (
+                                    None,
+                                    "remote image exceeds the size limit",
+                                )
+
+                        content = bytearray()
+                        async for chunk in response.aiter_bytes(
+                            chunk_size=_REMOTE_IMAGE_CHUNK_SIZE,
+                        ):
+                            if 0 < max_bytes < len(content) + len(chunk):
+                                return (
+                                    None,
+                                    "remote image exceeds the size limit",
+                                )
+                            content.extend(chunk)
+                        return bytes(content), None
+                return None, "remote image exceeded redirect limit"
+    except (TimeoutError, httpx.TimeoutException):
+        return None, "remote image download timed out"
+    except (httpx.RequestError, OSError, ValueError):
+        return None, "remote image download failed"
+
+
+def _remote_image_name(url: str) -> str:
+    """Return a display-only filename for a remote image URL."""
+    path = urllib.parse.urlsplit(url).path
+    return Path(unquote(path)).name or "remote-image"
+
+
+def _image_error_chunk(error: str | None) -> ToolChunk:
+    """Build a text-only result for an unavailable remote image."""
+    detail = error or "unknown error"
+    return ToolChunk(
+        is_last=True,
+        state=ToolResultState.SUCCESS,
+        content=[
+            TextBlock(
+                type="text",
+                text=f"Error: failed to load remote image: {detail}",
+            ),
+        ],
+    )
 
 
 def _validate_url_extension(
@@ -229,8 +467,6 @@ async def _probe_multimodal_if_needed(
                 supports,
             )
             # Fire full probe in background to persist video support too
-            import asyncio
-
             asyncio.create_task(
                 manager.probe_model_multimodal(
                     active.provider_id,
@@ -354,13 +590,14 @@ def _get_multimodal_fallback_hint(media_type: str, path: str) -> str:
     ui_icon="🖼️",
     display_to_user=False,
 )
+# pylint: disable-next=too-many-return-statements
 async def view_image(image_path: str) -> ToolChunk:
     """Load an image file into the LLM context so the model can see it.
 
     Use this after desktop_screenshot or any tool that
     produces an image file path.  Also accepts an HTTP(S) URL for
-    online images — the URL is passed directly to the model without
-    downloading.
+    online images. Remote images are downloaded, validated, and frozen
+    before they are added to the model context.
 
     When the model does not support multimodal, the image is still
     returned (so the user/frontend can see it) along with a text hint
@@ -391,16 +628,32 @@ async def view_image(image_path: str) -> ToolChunk:
         )
         if err is not None:
             return err
+
+        image_bytes, download_error = await _download_remote_image(
+            image_path,
+            MAX_INLINE_MEDIA_BYTES,
+        )
+        if download_error is not None or image_bytes is None:
+            return _image_error_chunk(download_error)
+
+        frozen_image, freeze_error = await run_sync_io(
+            freeze_image_bytes,
+            image_bytes,
+            _remote_image_name(image_path),
+        )
+        if freeze_error is not None or frozen_image is None:
+            return _image_error_chunk(freeze_error)
+
         text_msg = (
             fallback_hint
             if fallback_hint
-            else f"Image loaded from URL: {image_path}"
+            else "Image loaded from remote source."
         )
         return ToolChunk(
             is_last=True,
             state=ToolResultState.SUCCESS,
             content=[
-                _media_data_block(image_path, "image"),
+                frozen_image,
                 TextBlock(type="text", text=text_msg),
             ],
         )
@@ -452,8 +705,9 @@ async def view_video(video_path: str) -> ToolChunk:
     """Load a video file into the LLM context so the model can see it.
 
     Use this when the user asks about a video file or when another
-    tool produces a video file path.  Also accepts an HTTP(S) URL —
-    the URL is passed directly to the model without downloading.
+    tool produces a video file path. Unlike remote images, an HTTP(S)
+    video URL is passed directly to the model without downloading or
+    freezing. Durable remote video handling is outside the current scope.
 
     When the model does not support multimodal, the video is still
     returned (so the user/frontend can see it) along with a text hint

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -2,6 +2,7 @@
 """Load image or video files into the LLM context for analysis."""
 
 import asyncio
+import hashlib
 import ipaddress
 import logging
 import mimetypes
@@ -23,11 +24,17 @@ from agentscope.message import (
 )
 from agentscope.tool import ToolChunk
 
+from ...config.context import get_current_workspace_dir
+from ...constant import EnvVarLoader, WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
-from ...utils.io_utils import run_sync_io
+from ...utils.io_utils import make_dirs_async, run_sync_io, write_bytes_async
 from ...providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .file_io import _path_to_file_url, _resolve_file_path
-from ..utils.image_freezing import freeze_image_bytes, freeze_local_image
+from ..utils.image_freezing import (
+    freeze_image_bytes,
+    freeze_local_image,
+    validate_image_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +43,16 @@ _REMOTE_IMAGE_CONNECT_TIMEOUT = 5.0
 _REMOTE_IMAGE_READ_TIMEOUT = 10.0
 _REMOTE_IMAGE_TOTAL_TIMEOUT = 30.0
 _REMOTE_IMAGE_MAX_REDIRECTS = 3
+_REMOTE_IMAGE_DOWNLOAD_MAX_MB_ENV = "QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB"
+_REMOTE_IMAGE_DOWNLOAD_DEFAULT_MB = 50
+_REMOTE_IMAGE_SUFFIXES = {
+    "image/bmp": ".bmp",
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/tiff": ".tiff",
+    "image/webp": ".webp",
+}
 
 
 @dataclass(frozen=True)
@@ -45,6 +62,17 @@ class _RemoteImageTarget:
     request_url: str
     host_header: str
     server_hostname: str
+
+
+def _remote_image_download_max_bytes() -> int:
+    """Return the configured remote image download limit in bytes."""
+    max_mb = EnvVarLoader.get_int(
+        _REMOTE_IMAGE_DOWNLOAD_MAX_MB_ENV,
+        default=_REMOTE_IMAGE_DOWNLOAD_DEFAULT_MB,
+    )
+    if max_mb <= 0:
+        max_mb = _REMOTE_IMAGE_DOWNLOAD_DEFAULT_MB
+    return max_mb * 1024 * 1024
 
 
 def _media_data_block(url: str, modality: str) -> DataBlock:
@@ -262,7 +290,8 @@ async def _download_remote_image(
                             if 0 < max_bytes < reported_size:
                                 return (
                                     None,
-                                    "remote image exceeds the size limit",
+                                    "remote image exceeds the "
+                                    f"{max_bytes}-byte download limit",
                                 )
 
                         content = bytearray()
@@ -272,7 +301,8 @@ async def _download_remote_image(
                             if 0 < max_bytes < len(content) + len(chunk):
                                 return (
                                     None,
-                                    "remote image exceeds the size limit",
+                                    "remote image exceeds the "
+                                    f"{max_bytes}-byte download limit",
                                 )
                             content.extend(chunk)
                         return bytes(content), None
@@ -287,6 +317,49 @@ def _remote_image_name(url: str) -> str:
     """Return a display-only filename for a remote image URL."""
     path = urllib.parse.urlsplit(url).path
     return Path(unquote(path)).name or "remote-image"
+
+
+async def _stage_remote_image_for_compression(
+    image_bytes: bytes,
+    media_type: str,
+) -> Path:
+    """Store an oversized remote image in the current workspace."""
+    workspace_dir = get_current_workspace_dir() or WORKING_DIR
+    downloads_dir = workspace_dir / "downloads"
+    await make_dirs_async(downloads_dir)
+
+    digest = hashlib.sha256(image_bytes).hexdigest()[:16]
+    suffix = _REMOTE_IMAGE_SUFFIXES[media_type]
+    image_path = downloads_dir / f"remote-image-{digest}{suffix}"
+    await write_bytes_async(
+        image_path,
+        image_bytes,
+        new_file_mode=0o644,
+    )
+    return image_path.resolve()
+
+
+def _oversized_remote_image_chunk(
+    image_path: Path,
+    image_size: int,
+) -> ToolChunk:
+    """Tell the agent how to process a downloaded oversized image."""
+    return ToolChunk(
+        is_last=True,
+        state=ToolResultState.SUCCESS,
+        content=[
+            TextBlock(
+                type="text",
+                text=(
+                    f"Remote image is {image_size} bytes and exceeds the "
+                    f"{MAX_INLINE_MEDIA_BYTES}-byte inline image limit. "
+                    f"It was downloaded to: {image_path}. Compress or "
+                    "resize this local file below the inline limit, then "
+                    "call view_image with the compressed file path."
+                ),
+            ),
+        ],
+    )
 
 
 def _image_error_chunk(error: str | None) -> ToolChunk:
@@ -579,7 +652,7 @@ def _get_multimodal_fallback_hint(media_type: str, path: str) -> str:
 
 
 @tool_descriptor(
-    requires_sandbox=("file_read",),
+    requires_sandbox=("file_read", "file_write"),
     async_execution=True,
     tool_type="file",
     target_param="image_path",
@@ -629,12 +702,35 @@ async def view_image(image_path: str) -> ToolChunk:
         if err is not None:
             return err
 
+        download_limit = _remote_image_download_max_bytes()
         image_bytes, download_error = await _download_remote_image(
             image_path,
-            MAX_INLINE_MEDIA_BYTES,
+            download_limit,
         )
         if download_error is not None or image_bytes is None:
             return _image_error_chunk(download_error)
+
+        if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
+            media_type, validation_error = await run_sync_io(
+                validate_image_bytes,
+                image_bytes,
+                _remote_image_name(image_path),
+            )
+            if validation_error is not None or media_type is None:
+                return _image_error_chunk(validation_error)
+            try:
+                local_path = await _stage_remote_image_for_compression(
+                    image_bytes,
+                    media_type,
+                )
+            except OSError as exc:
+                return _image_error_chunk(
+                    f"failed to save oversized remote image: {exc}",
+                )
+            return _oversized_remote_image_chunk(
+                local_path,
+                len(image_bytes),
+            )
 
         frozen_image, freeze_error = await run_sync_io(
             freeze_image_bytes,

--- a/src/qwenpaw/agents/utils/image_freezing.py
+++ b/src/qwenpaw/agents/utils/image_freezing.py
@@ -53,27 +53,19 @@ def _local_path_from_url(url: str) -> Path | None:
     return None
 
 
-def freeze_local_image(
-    image_path: Path,
+def freeze_image_bytes(
+    image_bytes: bytes,
+    display_name: str,
 ) -> tuple[DataBlock | None, str | None]:
-    """Validate and freeze one local image as immutable base64 content."""
-    try:
-        file_size = image_path.stat().st_size
-        if file_size > MAX_INLINE_MEDIA_BYTES:
-            return (
-                None,
-                f"Error: {image_path.name} is {file_size} bytes and "
-                f"exceeds the {MAX_INLINE_MEDIA_BYTES}-byte image limit.",
-            )
-        with image_path.open("rb") as image_file:
-            image_bytes = image_file.read(MAX_INLINE_MEDIA_BYTES + 1)
-        if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
-            return (
-                None,
-                f"Error: {image_path.name} exceeds the "
-                f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
-            )
+    """Validate image bytes and freeze them as immutable base64 content."""
+    if len(image_bytes) > MAX_INLINE_MEDIA_BYTES:
+        return (
+            None,
+            f"Error: {display_name} exceeds the "
+            f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+        )
 
+    try:
         with Image.open(BytesIO(image_bytes)) as image:
             normalized_format = (image.format or "").upper()
             media_type = Image.MIME.get(normalized_format)
@@ -96,7 +88,7 @@ def freeze_local_image(
                 detected = media_type or image.format or "unknown"
                 return (
                     None,
-                    f"Error: {image_path.name} uses unsupported image "
+                    f"Error: {display_name} uses unsupported image "
                     f"format {detected}.",
                 )
     except (
@@ -105,12 +97,12 @@ def freeze_local_image(
         UnidentifiedImageError,
         ValueError,
     ) as exc:
-        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+        return None, f"Error: {display_name} is not a valid image: {exc}"
 
     if len(frozen_bytes) > MAX_INLINE_MEDIA_BYTES:
         return (
             None,
-            f"Error: converted {image_path.name} is "
+            f"Error: converted {display_name} is "
             f"{len(frozen_bytes)} bytes and exceeds the "
             f"{MAX_INLINE_MEDIA_BYTES}-byte image limit.",
         )
@@ -125,6 +117,26 @@ def freeze_local_image(
         ),
         None,
     )
+
+
+def freeze_local_image(
+    image_path: Path,
+) -> tuple[DataBlock | None, str | None]:
+    """Read, validate, and freeze one local image as immutable content."""
+    try:
+        file_size = image_path.stat().st_size
+        if file_size > MAX_INLINE_MEDIA_BYTES:
+            return (
+                None,
+                f"Error: {image_path.name} is {file_size} bytes and "
+                f"exceeds the {MAX_INLINE_MEDIA_BYTES}-byte image limit.",
+            )
+        with image_path.open("rb") as image_file:
+            image_bytes = image_file.read(MAX_INLINE_MEDIA_BYTES + 1)
+    except OSError as exc:
+        return None, f"Error: {image_path.name} is not a valid image: {exc}"
+
+    return freeze_image_bytes(image_bytes, image_path.name)
 
 
 def _replacement_text(value: Any, error: str) -> Any:
@@ -218,6 +230,7 @@ async def freeze_local_images_async(value: Any) -> int:
 
 
 __all__ = [
+    "freeze_image_bytes",
     "freeze_local_image",
     "freeze_local_images",
     "freeze_local_images_async",

--- a/src/qwenpaw/agents/utils/image_freezing.py
+++ b/src/qwenpaw/agents/utils/image_freezing.py
@@ -31,6 +31,37 @@ _NATIVE_IMAGE_MEDIA_TYPES = frozenset(
 _PNG_CONVERTIBLE_IMAGE_FORMATS = frozenset({"BMP", "TIFF"})
 
 
+def validate_image_bytes(
+    image_bytes: bytes,
+    display_name: str,
+) -> tuple[str | None, str | None]:
+    """Validate image bytes and return their detected media type."""
+    try:
+        with Image.open(BytesIO(image_bytes)) as image:
+            normalized_format = (image.format or "").upper()
+            media_type = Image.MIME.get(normalized_format)
+            if (
+                media_type not in _NATIVE_IMAGE_MEDIA_TYPES
+                and normalized_format not in _PNG_CONVERTIBLE_IMAGE_FORMATS
+            ):
+                detected = media_type or image.format or "unknown"
+                return (
+                    None,
+                    f"Error: {display_name} uses unsupported image "
+                    f"format {detected}.",
+                )
+            image.verify()
+    except (
+        Image.DecompressionBombError,
+        OSError,
+        UnidentifiedImageError,
+        ValueError,
+    ) as exc:
+        return None, f"Error: {display_name} is not a valid image: {exc}"
+
+    return media_type, None
+
+
 def _local_path_from_url(url: str) -> Path | None:
     """Resolve a local URL or path without treating remote URLs as local."""
     parsed = urlparse(url)
@@ -234,4 +265,5 @@ __all__ = [
     "freeze_local_image",
     "freeze_local_images",
     "freeze_local_images_async",
+    "validate_image_bytes",
 ]

--- a/tests/unit/agents/tools/test_view_media.py
+++ b/tests/unit/agents/tools/test_view_media.py
@@ -307,8 +307,91 @@ class TestViewImage:
         }
         mock_download.assert_awaited_once_with(
             "https://example.com/photo.jpg",
-            MAX_INLINE_MEDIA_BYTES,
+            50 * 1024 * 1024,
         )
+
+    @pytest.mark.asyncio
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_oversized_url_image_is_staged_for_compression(
+        self,
+        mock_support,
+        mock_download,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        channels = [Image.effect_noise((32, 32), 100) for _ in range(3)]
+        image = Image.merge("RGB", channels)
+        image_buffer = BytesIO()
+        image.save(image_buffer, format="PNG")
+        image_bytes = image_buffer.getvalue()
+        assert len(image_bytes) > 64
+        mock_download.return_value = (image_bytes, None)
+        monkeypatch.setattr(view_media, "MAX_INLINE_MEDIA_BYTES", 64)
+        monkeypatch.setattr(
+            view_media,
+            "get_current_workspace_dir",
+            lambda: tmp_path,
+        )
+
+        result = await view_image("https://example.com/photo.png")
+
+        downloaded_files = list((tmp_path / "downloads").iterdir())
+        assert len(downloaded_files) == 1
+        downloaded_file = downloaded_files[0]
+        assert downloaded_file.name.startswith("remote-image-")
+        assert downloaded_file.suffix == ".png"
+        assert downloaded_file.read_bytes() == image_bytes
+        assert [
+            block.model_dump(
+                mode="json",
+                exclude={"id", "created_at", "finished_at"},
+            )
+            for block in result.content
+        ] == [
+            {
+                "type": "text",
+                "text": (
+                    f"Remote image is {len(image_bytes)} bytes and "
+                    "exceeds the 64-byte inline image limit. It was "
+                    f"downloaded to: {downloaded_file}. Compress or "
+                    "resize this local file below the inline limit, "
+                    "then call view_image with the compressed file path."
+                ),
+            },
+        ]
+
+    @pytest.mark.asyncio
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_invalid_oversized_url_image_is_not_staged(
+        self,
+        mock_support,
+        mock_download,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_support.return_value = True
+        mock_download.return_value = (b"x" * 65, None)
+        monkeypatch.setattr(view_media, "MAX_INLINE_MEDIA_BYTES", 64)
+        monkeypatch.setattr(
+            view_media,
+            "get_current_workspace_dir",
+            lambda: tmp_path,
+        )
+
+        result = await view_image("https://example.com/photo.png")
+
+        assert [block.type for block in result.content] == ["text"]
+        assert "not a valid image" in result.content[0].text
+        assert not (tmp_path / "downloads").exists()
 
     @pytest.mark.asyncio
     @patch(
@@ -655,6 +738,63 @@ class TestFreezeImageBytes:
         assert "not a valid image" in error
 
 
+class TestRemoteImageDownloadLimit:
+    """Tests for the configurable remote image download limit."""
+
+    def test_default_limit(self, monkeypatch):
+        monkeypatch.delenv(
+            "QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            raising=False,
+        )
+        monkeypatch.delenv(
+            "COPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            raising=False,
+        )
+
+        result = view_media._remote_image_download_max_bytes()
+
+        assert result == 50 * 1024 * 1024
+
+    def test_positive_limit_has_no_upper_clamp(self, monkeypatch):
+        monkeypatch.setenv(
+            "QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            "10000",
+        )
+
+        result = view_media._remote_image_download_max_bytes()
+
+        assert result == 10000 * 1024 * 1024
+
+    @pytest.mark.parametrize("value", ["invalid", "0", "-1"])
+    def test_invalid_or_nonpositive_limit_uses_default(
+        self,
+        monkeypatch,
+        value,
+    ):
+        monkeypatch.setenv(
+            "QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            value,
+        )
+
+        result = view_media._remote_image_download_max_bytes()
+
+        assert result == 50 * 1024 * 1024
+
+    def test_legacy_limit_is_supported(self, monkeypatch):
+        monkeypatch.delenv(
+            "QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            raising=False,
+        )
+        monkeypatch.setenv(
+            "COPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB",
+            "75",
+        )
+
+        result = view_media._remote_image_download_max_bytes()
+
+        assert result == 75 * 1024 * 1024
+
+
 class TestDownloadRemoteImage:
     """Tests for bounded remote image downloads."""
 
@@ -773,7 +913,10 @@ class TestDownloadRemoteImage:
                 32,
             )
 
-        assert result == (None, "remote image exceeds the size limit")
+        assert result == (
+            None,
+            "remote image exceeds the 32-byte download limit",
+        )
         assert stream.was_read is False
 
     @pytest.mark.asyncio
@@ -802,7 +945,10 @@ class TestDownloadRemoteImage:
                 32,
             )
 
-        assert result == (None, "remote image exceeds the size limit")
+        assert result == (
+            None,
+            "remote image exceeds the 32-byte download limit",
+        )
 
     @pytest.mark.asyncio
     async def test_total_timeout_is_returned(self, monkeypatch):

--- a/tests/unit/agents/tools/test_view_media.py
+++ b/tests/unit/agents/tools/test_view_media.py
@@ -12,19 +12,24 @@ Covers:
 """
 # pylint: disable=protected-access,unused-argument
 
+import asyncio
 import base64
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from agentscope.message import Base64Source
 from PIL import Image
 
+from qwenpaw.agents.tools import view_media
 from qwenpaw.agents.utils import image_freezing
+from qwenpaw.agents.utils.image_freezing import freeze_image_bytes
 from qwenpaw.agents.tools.view_media import (
     _IMAGE_EXTENSIONS,
     _VIDEO_EXTENSIONS,
     _check_multimodal_support,
+    _download_remote_image,
     _get_multimodal_fallback_hint,
     _is_url,
     _validate_media_path,
@@ -262,13 +267,100 @@ class TestViewImage:
     """Tests for view_image."""
 
     @pytest.mark.asyncio
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
     @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
-    async def test_url_image(self, mock_support):
+    async def test_url_image(self, mock_support, mock_download):
         mock_support.return_value = True
+        image_bytes = BytesIO()
+        Image.new("RGB", (2, 2), color="red").save(
+            image_bytes,
+            format="PNG",
+        )
+        mock_download.return_value = (image_bytes.getvalue(), None)
+
         result = await view_image("https://example.com/photo.jpg")
-        assert result.content is not None
-        types = [getattr(b, "type", None) for b in result.content]
-        assert "data" in types
+
+        assert len(result.content) == 2
+        assert result.content[0].model_dump(
+            mode="json",
+            exclude={"id", "created_at", "finished_at"},
+        ) == {
+            "type": "data",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": base64.b64encode(image_bytes.getvalue()).decode(
+                    "ascii",
+                ),
+            },
+            "name": None,
+        }
+        assert result.content[1].model_dump(
+            mode="json",
+            exclude={"id", "created_at", "finished_at"},
+        ) == {
+            "type": "text",
+            "text": "Image loaded from remote source.",
+        }
+        mock_download.assert_awaited_once_with(
+            "https://example.com/photo.jpg",
+            MAX_INLINE_MEDIA_BYTES,
+        )
+
+    @pytest.mark.asyncio
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_url_download_failure_is_text_only(
+        self,
+        mock_support,
+        mock_download,
+    ):
+        mock_support.return_value = True
+        mock_download.return_value = (None, "remote server returned HTTP 404")
+
+        result = await view_image("https://example.com/missing.png")
+
+        assert [
+            block.model_dump(
+                mode="json",
+                exclude={"id", "created_at", "finished_at"},
+            )
+            for block in result.content
+        ] == [
+            {
+                "type": "text",
+                "text": (
+                    "Error: failed to load remote image: "
+                    "remote server returned HTTP 404"
+                ),
+            },
+        ]
+
+    @pytest.mark.asyncio
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
+    @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
+    async def test_url_invalid_image_is_text_only(
+        self,
+        mock_support,
+        mock_download,
+    ):
+        mock_support.return_value = True
+        mock_download.return_value = (b"<html>not an image</html>", None)
+
+        result = await view_image("https://example.com/image.png")
+
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert "not a valid image" in result.content[0].text
 
     @pytest.mark.asyncio
     @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
@@ -470,10 +562,25 @@ class TestViewImage:
 
     @pytest.mark.asyncio
     @patch("qwenpaw.agents.tools.view_media._probe_multimodal_if_needed")
+    @patch(
+        "qwenpaw.agents.tools.view_media._download_remote_image",
+        new_callable=AsyncMock,
+    )
     @patch("qwenpaw.agents.tools.view_media._check_multimodal_support")
-    async def test_fallback_hint_included(self, mock_support, mock_probe):
+    async def test_fallback_hint_included(
+        self,
+        mock_support,
+        mock_download,
+        mock_probe,
+    ):
         mock_support.return_value = False
         mock_probe.return_value = False
+        image_bytes = BytesIO()
+        Image.new("RGB", (2, 2), color="red").save(
+            image_bytes,
+            format="PNG",
+        )
+        mock_download.return_value = (image_bytes.getvalue(), None)
         result = await view_image("https://example.com/img.jpg")
         text_parts = [
             b.text
@@ -481,6 +588,382 @@ class TestViewImage:
             if getattr(b, "type", None) == "text"
         ]
         assert any("multimodal" in t.lower() for t in text_parts)
+
+
+class TestFreezeImageBytes:
+    """Tests for the shared local/remote image freezing path."""
+
+    @pytest.mark.parametrize(
+        ("image_format", "media_type"),
+        [
+            ("PNG", "image/png"),
+            ("JPEG", "image/jpeg"),
+            ("GIF", "image/gif"),
+            ("WEBP", "image/webp"),
+        ],
+    )
+    def test_native_format_uses_detected_type_and_preserves_bytes(
+        self,
+        image_format,
+        media_type,
+    ):
+        image_bytes = BytesIO()
+        Image.new("RGB", (2, 2), color="blue").save(
+            image_bytes,
+            format=image_format,
+        )
+
+        block, error = freeze_image_bytes(
+            image_bytes.getvalue(),
+            "misleading.jpg",
+        )
+
+        assert error is None
+        assert block is not None
+        assert block.model_dump(
+            mode="json",
+            exclude={"id", "created_at", "finished_at"},
+        ) == {
+            "type": "data",
+            "source": {
+                "type": "base64",
+                "media_type": media_type,
+                "data": base64.b64encode(image_bytes.getvalue()).decode(
+                    "ascii",
+                ),
+            },
+            "name": None,
+        }
+
+    @pytest.mark.parametrize(
+        "invalid_bytes",
+        [
+            b"<html>not an image</html>",
+            b'{"type": "not-an-image"}',
+            b"random-bytes",
+            b"\x89PNG\r\n\x1a\ntruncated",
+        ],
+    )
+    def test_invalid_bytes_are_rejected(self, invalid_bytes):
+        block, error = freeze_image_bytes(
+            invalid_bytes,
+            "image.png",
+        )
+
+        assert block is None
+        assert error is not None
+        assert "not a valid image" in error
+
+
+class TestDownloadRemoteImage:
+    """Tests for bounded remote image downloads."""
+
+    @pytest.mark.asyncio
+    async def test_public_image_is_downloaded(self):
+        requests = []
+
+        def return_image(request):
+            requests.append(request)
+            return httpx.Response(
+                200,
+                content=b"image-bytes",
+                request=request,
+            )
+
+        transport = httpx.MockTransport(return_image)
+        client = httpx.AsyncClient(transport=transport)
+
+        with patch.object(
+            view_media,
+            "_resolve_host_addresses",
+            return_value=("93.184.216.34",),
+        ) as mock_resolve, patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://example.com/image.png",
+                32,
+            )
+
+        assert result == (b"image-bytes", None)
+        mock_resolve.assert_called_once_with("example.com", 443)
+        assert len(requests) == 1
+        assert requests[0].url == httpx.URL(
+            "https://93.184.216.34/image.png",
+        )
+        assert requests[0].headers["host"] == "example.com"
+        assert requests[0].extensions["sni_hostname"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_http_error_is_returned(self):
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                404,
+                request=request,
+            ),
+        )
+        client = httpx.AsyncClient(transport=transport)
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/missing.png",
+                32,
+            )
+
+        assert result == (None, "remote server returned HTTP 404")
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_returned(self):
+        def raise_timeout(request):
+            raise httpx.ReadTimeout(
+                "timed out",
+                request=request,
+            )
+
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(raise_timeout),
+        )
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/slow.png",
+                32,
+            )
+
+        assert result == (None, "remote image download timed out")
+
+    @pytest.mark.asyncio
+    async def test_reported_size_is_rejected_before_reading(self):
+        class TrackingStream(httpx.AsyncByteStream):
+            def __init__(self):
+                self.was_read = False
+
+            async def __aiter__(self):
+                self.was_read = True
+                yield b"a" * 33
+
+        stream = TrackingStream()
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                headers={"content-length": "33"},
+                stream=stream,
+                request=request,
+            ),
+        )
+        client = httpx.AsyncClient(transport=transport)
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/image.png",
+                32,
+            )
+
+        assert result == (None, "remote image exceeds the size limit")
+        assert stream.was_read is False
+
+    @pytest.mark.asyncio
+    async def test_streamed_image_over_limit_is_rejected(self):
+        class ChunkedStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield b"a" * 17
+                yield b"b" * 17
+
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                stream=ChunkedStream(),
+                request=request,
+            ),
+        )
+        client = httpx.AsyncClient(transport=transport)
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/image.png",
+                32,
+            )
+
+        assert result == (None, "remote image exceeds the size limit")
+
+    @pytest.mark.asyncio
+    async def test_total_timeout_is_returned(self, monkeypatch):
+        class SlowStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                await asyncio.sleep(0.05)
+                yield b"image-bytes"
+
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                stream=SlowStream(),
+                request=request,
+            ),
+        )
+        client = httpx.AsyncClient(transport=transport)
+        monkeypatch.setattr(
+            view_media,
+            "_REMOTE_IMAGE_TOTAL_TIMEOUT",
+            0.01,
+        )
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/slow.png",
+                32,
+            )
+
+        assert result == (None, "remote image download timed out")
+
+    @pytest.mark.asyncio
+    async def test_public_redirect_is_downloaded(self):
+        requested_paths = []
+
+        def redirect_then_image(request):
+            requested_paths.append(request.url.path)
+            if request.url.path == "/start.png":
+                return httpx.Response(
+                    302,
+                    headers={"location": "/final.png"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                content=b"image-bytes",
+                request=request,
+            )
+
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(redirect_then_image),
+        )
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/start.png",
+                32,
+            )
+
+        assert result == (b"image-bytes", None)
+        assert requested_paths == ["/start.png", "/final.png"]
+
+    @pytest.mark.asyncio
+    async def test_redirect_limit_is_rejected(self):
+        requested_paths = []
+
+        def redirect_again(request):
+            requested_paths.append(request.url.path)
+            return httpx.Response(
+                302,
+                headers={"location": "/again.png"},
+                request=request,
+            )
+
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(redirect_again),
+        )
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/start.png",
+                32,
+            )
+
+        assert result == (None, "remote image exceeded redirect limit")
+        assert len(requested_paths) == (
+            view_media._REMOTE_IMAGE_MAX_REDIRECTS + 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_loopback_is_rejected(self):
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                302,
+                headers={
+                    "location": "http://127.0.0.1/private.png",
+                },
+                request=request,
+            ),
+        )
+        client = httpx.AsyncClient(transport=transport)
+
+        with patch.object(
+            view_media.httpx,
+            "AsyncClient",
+            return_value=client,
+        ):
+            result = await _download_remote_image(
+                "https://93.184.216.34/start.png",
+                32,
+            )
+
+        assert result == (
+            None,
+            "remote image URL targets a non-public address",
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_public_and_private_dns_answers_are_rejected(self):
+        with patch.object(
+            view_media,
+            "_resolve_host_addresses",
+            return_value=("93.184.216.34", "127.0.0.1"),
+        ):
+            result = await _download_remote_image(
+                "https://example.com/image.png",
+                32,
+            )
+
+        assert result == (
+            None,
+            "remote image URL targets a non-public address",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/image.png",
+            "http://192.168.1.10/image.png",
+        ],
+    )
+    async def test_non_public_target_is_rejected(self, url):
+        data, error = await _download_remote_image(
+            url,
+            MAX_INLINE_MEDIA_BYTES,
+        )
+
+        assert data is None
+        assert error == "remote image URL targets a non-public address"
 
 
 # ---------------------------------------------------------------------------

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -102,15 +102,16 @@ You can customize paths and behavior via environment variables:
 
 **Other configuration:**
 
-| Variable                             | Default         | Description                                                                  |
-| ------------------------------------ | --------------- | ---------------------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)              |
-| `QWENPAW_LOG_MAX_SIZE`               | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB` |
-| `QWENPAW_LOG_MAX_BACKUPS`            | `3`             | Number of rotated log backups to retain; `0` disables backups                |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                             |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                           |
-| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)  |
-| `QWENPAW_CONSOLE_STATIC_DIR`         | _(auto-detect)_ | Console frontend static files path                                           |
+| Variable                                | Default         | Description                                                                                                      |
+| --------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `QWENPAW_LOG_LEVEL`                     | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)                                                  |
+| `QWENPAW_LOG_MAX_SIZE`                  | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB`                                    |
+| `QWENPAW_LOG_MAX_BACKUPS`               | `3`             | Number of rotated log backups to retain; `0` disables backups                                                   |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`      | `100000`        | Character threshold to trigger memory compaction                                                               |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`    | `3`             | Number of recent messages to keep after compaction                                                              |
+| `QWENPAW_MEMORY_COMPACT_RATIO`          | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)                                     |
+| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB`  | `50`            | Remote image download limit for `view_image` in MiB. Any positive integer is accepted; invalid/nonpositive values use the default |
+| `QWENPAW_CONSOLE_STATIC_DIR`            | _(auto-detect)_ | Console frontend static files path                                                                              |
 
 **Security & Authentication:**
 

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -102,16 +102,16 @@ You can customize paths and behavior via environment variables:
 
 **Other configuration:**
 
-| Variable                                | Default         | Description                                                                                                      |
-| --------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                     | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)                                                  |
-| `QWENPAW_LOG_MAX_SIZE`                  | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB`                                    |
-| `QWENPAW_LOG_MAX_BACKUPS`               | `3`             | Number of rotated log backups to retain; `0` disables backups                                                   |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`      | `100000`        | Character threshold to trigger memory compaction                                                               |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`    | `3`             | Number of recent messages to keep after compaction                                                              |
-| `QWENPAW_MEMORY_COMPACT_RATIO`          | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)                                     |
-| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB`  | `50`            | Remote image download limit for `view_image` in MiB. Any positive integer is accepted; invalid/nonpositive values use the default |
-| `QWENPAW_CONSOLE_STATIC_DIR`            | _(auto-detect)_ | Console frontend static files path                                                                              |
+| Variable                               | Default         | Description                                                                                                                       |
+| -------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `QWENPAW_LOG_LEVEL`                    | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)                                                                   |
+| `QWENPAW_LOG_MAX_SIZE`                 | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB`                                                      |
+| `QWENPAW_LOG_MAX_BACKUPS`              | `3`             | Number of rotated log backups to retain; `0` disables backups                                                                     |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`     | `100000`        | Character threshold to trigger memory compaction                                                                                  |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`   | `3`             | Number of recent messages to keep after compaction                                                                                |
+| `QWENPAW_MEMORY_COMPACT_RATIO`         | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)                                                       |
+| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB` | `50`            | Remote image download limit for `view_image` in MiB. Any positive integer is accepted; invalid/nonpositive values use the default |
+| `QWENPAW_CONSOLE_STATIC_DIR`           | _(auto-detect)_ | Console frontend static files path                                                                                                |
 
 **Security & Authentication:**
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -70,15 +70,16 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 
 **其他配置：**
 
-| 变量                                 | 默认值         | 说明                                                            |
-| ------------------------------------ | -------------- | --------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                  | `info`         | 日志级别（`debug` / `info` / `warning` / `error` / `critical`） |
-| `QWENPAW_LOG_MAX_SIZE`               | `5MiB`         | 当前日志文件大小上限，支持字节数及 `10MB`、`1GiB` 等后缀        |
-| `QWENPAW_LOG_MAX_BACKUPS`            | `3`            | 保留的轮转日志份数；设为 `0` 时不保留备份                       |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`       | 触发记忆压缩的字符阈值                                          |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`            | 压缩后保留的最近消息数                                          |
-| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`          | 触发压缩的阈值比例（相对于上下文窗口大小）                      |
-| `QWENPAW_CONSOLE_STATIC_DIR`         | _（自动检测）_ | 控制台前端静态文件路径                                          |
+| 变量                                    | 默认值         | 说明                                                                                              |
+| --------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `QWENPAW_LOG_LEVEL`                     | `info`         | 日志级别（`debug` / `info` / `warning` / `error` / `critical`）                                   |
+| `QWENPAW_LOG_MAX_SIZE`                  | `5MiB`         | 当前日志文件大小上限，支持字节数及 `10MB`、`1GiB` 等后缀                                          |
+| `QWENPAW_LOG_MAX_BACKUPS`               | `3`            | 保留的轮转日志份数；设为 `0` 时不保留备份                                                         |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`      | `100000`       | 触发记忆压缩的字符阈值                                                                            |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`    | `3`            | 压缩后保留的最近消息数                                                                            |
+| `QWENPAW_MEMORY_COMPACT_RATIO`          | `0.7`          | 触发压缩的阈值比例（相对于上下文窗口大小）                                                        |
+| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB`  | `50`           | `view_image` 远程图片下载上限（MiB）。接受任意正整数；非法值、`0` 或负数回退到默认值              |
+| `QWENPAW_CONSOLE_STATIC_DIR`            | _（自动检测）_ | 控制台前端静态文件路径                                                                            |
 
 **安全与认证：**
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -70,16 +70,16 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 
 **其他配置：**
 
-| 变量                                    | 默认值         | 说明                                                                                              |
-| --------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                     | `info`         | 日志级别（`debug` / `info` / `warning` / `error` / `critical`）                                   |
-| `QWENPAW_LOG_MAX_SIZE`                  | `5MiB`         | 当前日志文件大小上限，支持字节数及 `10MB`、`1GiB` 等后缀                                          |
-| `QWENPAW_LOG_MAX_BACKUPS`               | `3`            | 保留的轮转日志份数；设为 `0` 时不保留备份                                                         |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`      | `100000`       | 触发记忆压缩的字符阈值                                                                            |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`    | `3`            | 压缩后保留的最近消息数                                                                            |
-| `QWENPAW_MEMORY_COMPACT_RATIO`          | `0.7`          | 触发压缩的阈值比例（相对于上下文窗口大小）                                                        |
-| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB`  | `50`           | `view_image` 远程图片下载上限（MiB）。接受任意正整数；非法值、`0` 或负数回退到默认值              |
-| `QWENPAW_CONSOLE_STATIC_DIR`            | _（自动检测）_ | 控制台前端静态文件路径                                                                            |
+| 变量                                   | 默认值         | 说明                                                                                 |
+| -------------------------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| `QWENPAW_LOG_LEVEL`                    | `info`         | 日志级别（`debug` / `info` / `warning` / `error` / `critical`）                      |
+| `QWENPAW_LOG_MAX_SIZE`                 | `5MiB`         | 当前日志文件大小上限，支持字节数及 `10MB`、`1GiB` 等后缀                             |
+| `QWENPAW_LOG_MAX_BACKUPS`              | `3`            | 保留的轮转日志份数；设为 `0` 时不保留备份                                            |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`     | `100000`       | 触发记忆压缩的字符阈值                                                               |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT`   | `3`            | 压缩后保留的最近消息数                                                               |
+| `QWENPAW_MEMORY_COMPACT_RATIO`         | `0.7`          | 触发压缩的阈值比例（相对于上下文窗口大小）                                           |
+| `QWENPAW_REMOTE_IMAGE_DOWNLOAD_MAX_MB` | `50`           | `view_image` 远程图片下载上限（MiB）。接受任意正整数；非法值、`0` 或负数回退到默认值 |
+| `QWENPAW_CONSOLE_STATIC_DIR`           | _（自动检测）_ | 控制台前端静态文件路径                                                               |
 
 **安全与认证：**
 


### PR DESCRIPTION
## Description

Prevent remote `view_image` URLs from breaking subsequent conversation turns.

Remote images are now downloaded with bounded size, timeout, redirect, and SSRF protections, validated using the existing local image pipeline, and persisted as immutable `Base64Source` blocks. Download or validation failures degrade to text-only tool results, preventing invalid URLs from entering conversation history.

This is a preventive fix for newly generated `view_image` results. It does not repair remote media URLs already stored in existing sessions, and remote `view_video` handling remains out of scope.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
