### PR TITLE
fix(xiaoyi): report proactive send failures and normalize session IDs

### DIFF
--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -38,6 +38,7 @@ from ....schemas import (
 
 from ....config.config import XiaoYiConfig as XiaoYiChannelConfig
 from ....constant import DEFAULT_MEDIA_DIR
+from ....exceptions import ChannelError
 from ..renderer import ChannelDisplayConfig
 from ..base import (
     BaseChannel,
@@ -812,24 +813,25 @@ class XiaoYiChannel(BaseChannel):
         self,
         session_id: str,
         msg: Dict[str, Any],
-    ) -> None:
+    ) -> bool:
         """Route outgoing message to the server that owns the session."""
         target = self._session_server_map.get(session_id, "primary")
 
         # Try target server first, fallback to the other
         if target == "backup":
             if self._conn_backup and await self._conn_backup.send_json(msg):
-                return
+                return True
             # Fallback to primary
             if self._conn_primary and await self._conn_primary.send_json(msg):
-                return
+                return True
         else:
             if self._conn_primary and await self._conn_primary.send_json(msg):
-                return
+                return True
             # Fallback to backup
             if self._conn_backup and await self._conn_backup.send_json(msg):
-                return
+                return True
         logger.warning("XiaoYi: No connection available to send message")
+        return False
 
     async def _handle_a2a_request(self, message: Dict[str, Any]) -> None:
         """Handle A2A request message."""
@@ -1096,16 +1098,26 @@ class XiaoYiChannel(BaseChannel):
         at TEXT_CHUNK_LIMIT characters to avoid WebSocket disconnection
         on large messages.
         """
+        meta = meta or {}
+        api_send = bool(meta.get("_api_send"))
+
         if not self.enabled or not self._connected:
-            logger.warning("XiaoYi: Cannot send - not connected")
+            self._handle_delivery_failure(
+                api_send,
+                "Cannot send because the channel is not connected",
+            )
             return
 
-        meta = meta or {}
-        session_id = meta.get("session_id") or to_handle
+        session_id = self._native_session_id(
+            meta.get("session_id") or to_handle,
+        )
         task_id = meta.get("task_id") or self._session_task_map.get(session_id)
 
         if not task_id:
-            logger.warning(f"XiaoYi: No task_id for session {session_id}")
+            self._handle_delivery_failure(
+                api_send,
+                f"No task_id for session {session_id}",
+            )
             return
 
         # Don't send empty text
@@ -1119,7 +1131,36 @@ class XiaoYiChannel(BaseChannel):
         chunks = self._chunk_text(text)
 
         for chunk in chunks:
-            await self._send_chunk(session_id, task_id, message_id, chunk)
+            sent = await self._send_chunk(
+                session_id,
+                task_id,
+                message_id,
+                chunk,
+            )
+            if not sent:
+                self._handle_delivery_failure(
+                    api_send,
+                    f"Failed to send message for session {session_id}",
+                )
+                return
+
+    @staticmethod
+    def _native_session_id(session_id: str) -> str:
+        """Return the XiaoYi-native session ID without its channel prefix."""
+        if session_id.startswith("xiaoyi:"):
+            return session_id.split(":", 1)[-1]
+        return session_id
+
+    @staticmethod
+    def _handle_delivery_failure(api_send: bool, message: str) -> None:
+        """Raise API delivery failures without breaking normal replies."""
+        if api_send:
+            logger.error(f"XiaoYi: {message}")
+            raise ChannelError(
+                channel_name="xiaoyi",
+                message=message,
+            )
+        logger.warning(f"XiaoYi: {message}")
 
     def _chunk_text(self, text: str) -> List[str]:
         """Split text into chunks of TEXT_CHUNK_LIMIT size."""
@@ -1199,17 +1240,17 @@ class XiaoYiChannel(BaseChannel):
         task_id: str,
         message_id: str,
         text: str,
-    ) -> None:
+    ) -> bool:
         """Send a single text chunk via WebSocket."""
         if not self._connected:
-            return
+            return False
         msg = self._build_artifact_msg(
             session_id,
             task_id,
             message_id,
             [{"kind": "text", "text": text}],
         )
-        await self._send_to_session_server(session_id, msg)
+        return await self._send_to_session_server(session_id, msg)
 
     async def _send_reasoning_chunk(
         self,
@@ -1658,7 +1699,7 @@ class XiaoYiChannel(BaseChannel):
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
         """Map dispatch target to channel-specific to_handle."""
         if session_id.startswith("xiaoyi:"):
-            return session_id.split(":", 1)[-1]
+            return self._native_session_id(session_id)
         return user_id
 
     async def _on_process_completed(

--- a/tests/unit/channels/test_xiaoyi.py
+++ b/tests/unit/channels/test_xiaoyi.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from qwenpaw.exceptions import ChannelError
+
 
 # =============================================================================
 # Fixtures
@@ -723,6 +725,116 @@ class TestXiaoYiChannelSend:
         xiaoyi_channel._connected = False
 
         await xiaoyi_channel.send("user123", "Hello")
+
+    async def test_api_send_raises_when_not_connected(self, xiaoyi_channel):
+        """API sends should report a disconnected channel as a failure."""
+        xiaoyi_channel.enabled = True
+        xiaoyi_channel._connected = False
+
+        with pytest.raises(ChannelError, match="not connected"):
+            await xiaoyi_channel.send(
+                "session_123",
+                "Hello",
+                meta={"_api_send": True},
+            )
+
+    async def test_api_send_normalizes_prefixed_session(self, xiaoyi_channel):
+        """API sends should resolve task IDs using the native session ID."""
+        from qwenpaw.schemas import ContentType, TextContent
+
+        xiaoyi_channel._connected = True
+        xiaoyi_channel._session_task_map["session_123"] = "task_123"
+
+        with patch.object(
+            xiaoyi_channel,
+            "_send_chunk",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_send:
+            await xiaoyi_channel.send_content_parts(
+                "session_123",
+                [TextContent(type=ContentType.TEXT, text="Hello")],
+                meta={
+                    "_api_send": True,
+                    "session_id": "xiaoyi:session_123",
+                },
+            )
+
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[:2] == (
+            "session_123",
+            "task_123",
+        )
+
+    async def test_api_send_raises_when_task_id_missing(
+        self,
+        xiaoyi_channel,
+    ):
+        """API sends should report a missing task mapping as a failure."""
+        xiaoyi_channel._connected = True
+
+        with pytest.raises(ChannelError, match="No task_id"):
+            await xiaoyi_channel.send(
+                "session_123",
+                "Hello",
+                meta={"_api_send": True},
+            )
+
+    async def test_normal_reply_keeps_missing_task_id_tolerant(
+        self,
+        xiaoyi_channel,
+    ):
+        """Normal conversation replies should retain warning-only behavior."""
+        xiaoyi_channel._connected = True
+
+        await xiaoyi_channel.send("session_123", "Hello")
+
+    async def test_api_send_raises_when_transport_fails(
+        self,
+        xiaoyi_channel,
+    ):
+        """API sends should report failure when both WebSockets reject it."""
+        from qwenpaw.app.channels.xiaoyi.channel import XiaoYiConnection
+
+        xiaoyi_channel._connected = True
+        xiaoyi_channel._session_task_map["session_123"] = "task_123"
+        primary = MagicMock(spec=XiaoYiConnection)
+        primary.send_json = AsyncMock(return_value=False)
+        backup = MagicMock(spec=XiaoYiConnection)
+        backup.send_json = AsyncMock(return_value=False)
+        xiaoyi_channel._conn_primary = primary
+        xiaoyi_channel._conn_backup = backup
+
+        with pytest.raises(ChannelError, match="Failed to send message"):
+            await xiaoyi_channel.send(
+                "session_123",
+                "Hello",
+                meta={"_api_send": True},
+            )
+
+        primary.send_json.assert_awaited_once()
+        backup.send_json.assert_awaited_once()
+
+    async def test_normal_reply_keeps_transport_failure_tolerant(
+        self,
+        xiaoyi_channel,
+    ):
+        """Normal replies should not raise when the transport send fails."""
+        from qwenpaw.app.channels.xiaoyi.channel import XiaoYiConnection
+
+        xiaoyi_channel._connected = True
+        xiaoyi_channel._session_task_map["session_123"] = "task_123"
+        primary = MagicMock(spec=XiaoYiConnection)
+        primary.send_json = AsyncMock(return_value=False)
+        backup = MagicMock(spec=XiaoYiConnection)
+        backup.send_json = AsyncMock(return_value=False)
+        xiaoyi_channel._conn_primary = primary
+        xiaoyi_channel._conn_backup = backup
+
+        await xiaoyi_channel.send("session_123", "Hello")
+
+        primary.send_json.assert_awaited_once()
+        backup.send_json.assert_awaited_once()
 
     async def test_send_skips_empty_text(self, xiaoyi_channel):
         """send() should skip empty text."""


### PR DESCRIPTION
## Summary

- Normalize `xiaoyi:`-prefixed session IDs before looking up XiaoYi task
  mappings.
- Propagate proactive-send failures when the channel is disconnected,
  no task mapping exists, or both WebSocket transports fail.
- Log API-initiated delivery failures at ERROR level.
- Preserve warning-only behavior for normal conversation replies.

## Root cause

`ChannelManager.send_text()` resolved the native XiaoYi handle but also
placed the original prefixed session ID into `meta`.

XiaoYi preferred `meta["session_id"]` when looking up the task mapping,
while `_session_task_map` was registered using the native session ID
without the `xiaoyi:` prefix.

As a result, the lookup returned no `task_id`, the message was skipped,
and the API still returned success because no exception propagated to
the caller.

## Fix

- Strip the `xiaoyi:` prefix before task-map lookup.
- Return the WebSocket send result from the XiaoYi transport helpers.
- Raise `ChannelError` for API-initiated sends when:
  - the channel is disconnected;
  - no `task_id` is available;
  - neither WebSocket connection accepts the message.
- Keep normal conversation delivery tolerant so transient channel
  failures do not interrupt the agent processing flow.

This follows the existing DingTalk and WeChat behavior: explicit
API/CLI sends propagate delivery failures, while normal conversation
replies remain best-effort.

## Testing

- `75 passed` across XiaoYi channel and messages-router unit tests.
- Pre-commit checks passed, including AST validation, mypy, Black,
  Flake8, and Pylint.
- `git diff --check` and Python compilation checks passed.
- XiaoYi WebSocket connection integration coverage passed.

The existing message round-trip integration case remains blocked locally
by a pre-existing dependency mismatch: the source requires AgentScope
`2.0.6`, while `uv.lock` and the local base environment contain
`2.0.4.post1`. This mismatch was not introduced by this change.