### PR TITLE
test(integration): fix spawn recursion and port-race startup flakes

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -330,7 +330,6 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     """
     tmp_path = tmp_path_factory.mktemp("app_server")
     host = "127.0.0.1"
-    port = _find_free_port(host)
 
     working_dir = tmp_path / "working"
     secret_dir = tmp_path / "working.secret"
@@ -389,31 +388,73 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     popen_kwargs: dict[str, Any] = {}
     if sys.platform == "win32" and _integration_coverage_requested():
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
-    with subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "qwenpaw",
-            "app",
-            "--host",
-            host,
-            "--port",
-            str(port),
-            "--log-level",
-            "info",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        # Decode subprocess output as UTF-8 in the parent. Without this,
-        # Popen falls back to locale.getpreferredencoding(False) which
-        # is cp1252 on Windows CI runners and crashes _tee_stream.
-        encoding="utf-8",
-        errors="replace",
-        env=env,
-        **popen_kwargs,
-    ) as process:
+
+    def _shutdown_app(proc, tee_thread) -> None:
+        """Stop a launched app process; SIGINT on POSIX flushes coverage."""
+        if proc.poll() is None:
+            # On POSIX, SIGINT lets uvicorn shut down cleanly so
+            # subprocess coverage data flushes (SIGTERM often skips
+            # atexit / data-file write). On Windows, SIGINT is not
+            # delivered reliably to subprocesses; when subprocess
+            # coverage is enabled we create the child with
+            # CREATE_NEW_PROCESS_GROUP and send CTRL_BREAK_EVENT so
+            # the child can run atexit / flush coverage data.
+            # Without coverage we use terminate() for fast shutdown.
+            try:
+                if sys.platform == "win32":
+                    if _integration_coverage_requested():
+                        proc.send_signal(signal.CTRL_BREAK_EVENT)
+                    else:
+                        proc.terminate()
+                else:
+                    proc.send_signal(signal.SIGINT)
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        tee_thread.join(timeout=2)
+
+    # 15s default lets cold-start endpoints (ACP getter, heartbeat)
+    # finish without hiding real deadlocks; 30s in coverage mode
+    # for tracer overhead.
+    http_timeout = 30.0 if _integration_coverage_requested() else 15.0
+
+    # The port is probed free and released before the child binds it, so
+    # another process (e.g. a mock server in a parallel test) can steal
+    # it while the app is still starting. Retry the whole launch on a
+    # fresh port instead of serving requests from the wrong process.
+    max_attempts = 3
+    port = _find_free_port(host)
+    while True:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "qwenpaw",
+                "app",
+                "--host",
+                host,
+                "--port",
+                str(port),
+                "--log-level",
+                "info",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            # Decode subprocess output as UTF-8 in the parent. Without this,
+            # Popen falls back to locale.getpreferredencoding(False) which
+            # is cp1252 on Windows CI runners and crashes _tee_stream.
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+            **popen_kwargs,
+        )
         assert process.stdout is not None
 
         log_thread = threading.Thread(
@@ -422,73 +463,70 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
             daemon=True,
         )
         log_thread.start()
-
-        # 15s default lets cold-start endpoints (ACP getter, heartbeat)
-        # finish without hiding real deadlocks; 30s in coverage mode
-        # for tracer overhead.
-        http_timeout = 30.0 if _integration_coverage_requested() else 15.0
         client = httpx.Client(timeout=http_timeout, trust_env=False)
 
-        try:
-            max_wait_seconds = app_startup_wait_timeout()
-            start_at = time.time()
-            last_error: str | None = None
-            while time.time() - start_at < max_wait_seconds:
-                if process.poll() is not None:
-                    raise AssertionError(
-                        "qwenpaw app exited during startup.\n"
-                        f"exit_code={process.returncode}\n"
-                        f"logs:\n{''.join(logs)[-4000:]}",
-                    )
-
-                try:
-                    resp = client.get(f"http://{host}:{port}/api/healthz")
-                    if resp.status_code == 200:
-                        break
-                except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                    last_error = str(exc)
-                time.sleep(0.5)
-            else:
-                raise AssertionError(
-                    "qwenpaw core agents did not become ready in time.\n"
-                    f"last_error={last_error}\n"
-                    f"logs:\n{''.join(logs)[-4000:]}",
-                )
-
-            yield AppServer(
-                host=host,
-                port=port,
-                process=process,
-                client=client,
-                logs=logs,
-                log_thread=log_thread,
-                working_dir=working_dir,
-            )
-        finally:
-            client.close()
-            if process.poll() is None:
-                # On POSIX, SIGINT lets uvicorn shut down cleanly so
-                # subprocess coverage data flushes (SIGTERM often skips
-                # atexit / data-file write). On Windows, SIGINT is not
-                # delivered reliably to subprocesses; when subprocess
-                # coverage is enabled we create the child with
-                # CREATE_NEW_PROCESS_GROUP and send CTRL_BREAK_EVENT so
-                # the child can run atexit / flush coverage data.
-                # Without coverage we use terminate() for fast shutdown.
-                try:
-                    if sys.platform == "win32":
-                        if _integration_coverage_requested():
-                            process.send_signal(signal.CTRL_BREAK_EVENT)
-                        else:
-                            process.terminate()
-                    else:
-                        process.send_signal(signal.SIGINT)
-                    process.wait(timeout=15)
-                except subprocess.TimeoutExpired:
-                    process.terminate()
+        start_at = time.time()
+        last_error: str | None = None
+        ready = False
+        while time.time() - start_at < app_startup_wait_timeout():
+            if process.poll() is not None:
+                break
+            try:
+                resp = client.get(f"http://{host}:{port}/api/healthz")
+                if resp.status_code == 200:
                     try:
-                        process.wait(timeout=5)
-                    except subprocess.TimeoutExpired:
-                        process.kill()
-                        process.wait(timeout=5)
-            log_thread.join(timeout=2)
+                        payload = resp.json()
+                    except ValueError:
+                        payload = None
+                    # Identity check: only the real app answers
+                    # {"status": "ok", ...}. A foreign process that
+                    # grabbed the port would otherwise fool the
+                    # readiness loop with any 200 response.
+                    if (
+                        isinstance(payload, dict)
+                        and payload.get("status") == "ok"
+                    ):
+                        ready = True
+                        break
+                    last_error = (
+                        f"port {port} answered by a foreign server: "
+                        f"{payload!r}"
+                    )
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                last_error = str(exc)
+            time.sleep(0.5)
+
+        if ready:
+            break
+
+        client.close()
+        exit_note = (
+            f"exit_code={process.returncode}"
+            if process.poll() is not None
+            else f"last_error={last_error}"
+        )
+        logs_tail = "".join(logs)[-4000:]
+        _shutdown_app(process, log_thread)
+        max_attempts -= 1
+        if max_attempts <= 0:
+            raise AssertionError(
+                "qwenpaw core agents did not become ready in time.\n"
+                f"{exit_note}\n"
+                f"logs:\n{logs_tail}",
+            )
+        # Stolen port or slow start: retry on a freshly allocated port.
+        port = _find_free_port(host)
+
+    try:
+        yield AppServer(
+            host=host,
+            port=port,
+            process=process,
+            client=client,
+            logs=logs,
+            log_thread=log_thread,
+            working_dir=working_dir,
+        )
+    finally:
+        client.close()
+        _shutdown_app(process, log_thread)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -430,7 +430,10 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     max_attempts = 3
     port = _find_free_port(host)
     while True:
-        process = subprocess.Popen(
+        # Not a ``with`` block: the retry loop owns the process lifetime
+        # across attempts and hands the surviving process to the fixture
+        # teardown below.
+        process = subprocess.Popen(  # pylint: disable=consider-using-with
             [
                 sys.executable,
                 "-m",

--- a/tests/integration/test_agent_management_tools.py
+++ b/tests/integration/test_agent_management_tools.py
@@ -383,14 +383,23 @@ def test_spawn_subagent_batch(
 
 @pytest.mark.integration
 @pytest.mark.p2
-def test_spawn_subagent_empty_batch_rejected(
+def test_spawn_subagent_empty_batch_runs_single_task(
     app_server,
     mock_llm,  # pylint: disable=redefined-outer-name
 ):
-    """An empty batch list is rejected with a clear error.
+    """An empty ``batch`` placeholder falls back to single-task mode.
 
     Test purpose:
-      - Cover _spawn_batch's validation branch.
+      - Cover the ``_normalize_batch`` compatibility branch where an
+        empty list is treated as "field not supplied", so a tool call
+        carrying ``task`` + ``batch=[]`` spawns one subagent for
+        ``task`` instead of erroring.
+
+    Note:
+      ``batch=[]`` never reaches ``_spawn_batch`` validation because
+      empty placeholders are normalised to ``None`` first (see
+      ``_normalize_batch``).  Asserting a rejection here would recurse
+      into a forced tool call and time out.
     """
     srv, mock_url = mock_llm
     srv.force_tool_call = True
@@ -398,17 +407,23 @@ def test_spawn_subagent_empty_batch_rejected(
     srv.tool_call_arguments = json.dumps(
         {"task": "parent", "batch": []},
     )
+    # The spawned subagent's own turn also reaches the mock LLM; without
+    # this gate it would be forced to spawn again and recurse until the
+    # request times out. Only the parent prompt carries the marker.
+    marker = "INTEG-SPAWN-EMPTY-BATCH"
+    srv.force_tool_call_user_marker = marker
     unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
     provider_id = register_mock_provider(app_server, mock_url)
     try:
         final = _chat_once(
             app_server,
             "integ-tools-spawn-empty",
-            "spawn an empty batch",
+            f"{marker} spawn an empty batch",
         )
         assert final.get("status") == "finished", final
     finally:
         srv.force_tool_call = False
+        srv.force_tool_call_user_marker = None
         unregister_mock_provider(app_server, provider_id)
 
 
@@ -433,15 +448,20 @@ def test_spawn_subagent_with_allowed_tools(
             "timeout": 60,
         },
     )
+    # Without this gate the spawned subagent's own turn is forced to
+    # spawn again and the chat task never finishes (recursion → timeout).
+    marker = "INTEG-SPAWN-ALLOWED"
+    srv.force_tool_call_user_marker = marker
     unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
     provider_id = register_mock_provider(app_server, mock_url)
     try:
         final = _chat_once(
             app_server,
             "integ-tools-spawn-allowed",
-            "spawn with restricted tools",
+            f"{marker} spawn with restricted tools",
         )
         assert final.get("status") == "finished", final
     finally:
         srv.force_tool_call = False
+        srv.force_tool_call_user_marker = None
         unregister_mock_provider(app_server, provider_id)


### PR DESCRIPTION
> **Submitted by**: 秦琼·CIOps@QPQAT

## Description

Fix two flaky integration-test failures:

1. **Subagent recursion**: `test_spawn_subagent_empty_batch_rejected` and
   `test_spawn_subagent_with_allowed_tools` hung until the 240 s poll timeout.
   The mock LLM is forced to emit the same `spawn_subagent` tool call on every
   request, so the spawned subagent's own turn was forced to spawn again and
   recurse until timeout. Add the `force_tool_call_user_marker` gate already
   used by the passing spawn tests so only the parent turn carries the forced
   call. Rename the empty-batch case to `..._runs_single_task` to reflect real
   behaviour: `batch=[]` is normalised to `None` (placeholder) and falls back
   to single-task mode, it is not rejected.

2. **Port-race startup**: `test_api_version_ok` and
   `test_console_entry_or_fallback_ok` failed on py3.13 ubuntu. The fixture
   probes a free port then releases it before the child binds, so another
   process (a mock IM server in a parallel test) can steal it while the app is
   still starting. The readiness loop only checked for HTTP 200, so the foreign
   server fooled it and later `/api/version` & `/console/` requests hit the
   wrong process. Now the loop verifies the healthz payload identity
   (`{"status": "ok"}`) and retries the whole launch on a fresh port up to 3
   times.

**Related Issue:** Relates to #6764 (CI gate exposed these failures)

**Security Considerations:** None — pure test-side changes, no product code,
no auth/config/env handling.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

```bash
pytest tests/integration/test_agent_management_tools.py -q   # 10 passed
pytest tests/integration/test_app_startup.py -q              # 2 passed
```

To reproduce the pre-fix behaviour: remove the `force_tool_call_user_marker`
gate and re-run — both cases return to the 240 s timeout.

## Evidence

```
# Local (post-fix)
tests/integration/test_agent_management_tools.py  10 passed in 11.63s
tests/integration/test_app_startup.py             2 passed in 6.70s
tests/integration/test_spawn_subagent_args.py     12 passed in 13.68s

# Fork CI (PR #48, head 5f340b81)
Tests workflow 16/16 jobs green (unit 4-platform 7408/7348 passed,
zero abnormal skips; integration 4-platform 146/146/145+1 known skip/146 passed)
Pre-commit Checks green
```

CI run: https://github.com/yutai78786/QwenPaw/pull/48

## Additional Notes

- Only test-side defects fixed (missing gate + fixture race), zero product code touched.
- The two spawn cases are marked p2; PR gate only runs p0 — a manual p2 dispatch
  was run to verify (all 4 platforms PASSED, not skipped).
