### PR TITLE
fix(e2e): dismiss Try Desktop Mode onboarding overlay before tests

### DIFF
--- a/e2e/fixtures/__init__.py
+++ b/e2e/fixtures/__init__.py
@@ -156,7 +156,19 @@ def browser_context(browser: Browser, request: pytest.FixtureRequest) -> Generat
             "height": config.browser.viewport_height,
         } if video_dir else None,
     )
-    
+
+    # Pre-dismiss the "Try Desktop Mode" onboarding tour (v2.1.0-beta+).
+    # The tour renders a transparent spotlight overlay that intercepts all
+    # pointer events on first visit, breaking every click-driven test.
+    # Same pattern as the last-used-agent localStorage pinning in gotchas.
+    context.add_init_script(
+        """
+        try {
+            localStorage.setItem('qwenpaw.desktop-mode-hint.dismissed', '1');
+        } catch (e) {}
+        """
+    )
+
     yield context
     
     logger.info(f"Closing browser context for test: {test_name}")


### PR DESCRIPTION
> **Submitted by**: Li Shizhen·E2E@QPQAT

## Problem

Since #6645 (v2.1.0-beta) introduced the **Try Desktop Mode** onboarding overlay, the nightly E2E job has been red for **8 consecutive days** (runs #71–#78). The overlay renders a transparent full-screen SVG that intercepts every pointer event on first visit, so all click-based test cases systematically time out at 60s and the job hits the 45-minute cap.

Evidence from CI logs: **72** `intercepts pointer events` occurrences per run; only ~19% of cases pass. Control run on 8-04 (before #6645): 0 interceptions, 137 passed.

## Fix

Preset the localStorage dismissal flag before tests so each browser context starts from a clean interactive state (1 file, +13/-1 in `e2e/fixtures/__init__.py`).

## Verification

- Local: `test_agents.py` 11 passed / 1 skipped / 0 failed (skip = drag-reorder case needing ≥2 sortable agents in env, unrelated)
- Fork CI after fix: **0** overlay interceptions (vs 72 before), **0** click timeouts, job completes in ~15 min instead of being killed at the 45-min cap

The remaining 3 failures observed on fork CI are unrelated to this overlay (selector/endpoint issues tracked separately).

---
*This is the overlay-fix half of fix/e2e-agents-action-cell, split into a dedicated branch for a fast nightly recovery, as discussed.*