### PR TITLE
fix(release): exclude datapaw from the main plugin pack step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,13 +233,19 @@ jobs:
           python-version: "3.11"
 
       - name: Pack plugins and build index
+        # qwenpaw-creator and datapaw are released through their own
+        # version-driven pipelines (creator-release.yml,
+        # datapaw-release.yml pending); datapaw additionally needs its
+        # vendored context console staged before packing, so packing it
+        # here fails pack_requires validation by design.
         run: |
           python scripts/pack/generate_plugin_metadata.py \
             --plugins-root plugins \
             --dist dist/plugins \
             --metadata-out dist/plugins/index.json \
             --cdn-prefix /files/plugins \
-            --exclude qwenpaw-creator
+            --exclude qwenpaw-creator \
+            --exclude datapaw
 
       - name: Upload plugins dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Unblocks the failing main release: the `build-plugins` job in `release.yml`
still packs **all** plugins and was missed when datapaw was routed to its own
release pipeline, so datapaw's `pack_requires` validation fails the whole run
(https://github.com/agentscope-ai/QwenPaw/actions/runs/32331354353):

```
ERROR: datapaw: refusing to pack - required file(s) missing:
  - ui/dist/index.js
  - ui/dist/context-console/index.html
  - ui/dist/app/logo-mark-v4.png
```

That validation is working as designed — datapaw's frontend embeds a vendored
context console that cannot be staged in this job, so packing it here would
ship a broken artifact. The fix mirrors what `plugins-release.yml` already
does: `--exclude datapaw` (alongside the existing `--exclude qwenpaw-creator`),
with a comment pointing at the dedicated pipelines. datapaw publishing is
handled by its own version-driven workflow (#7089).

**Related Issue:** Follow-up to #6940; complements #7089.

**Security Considerations:** None — workflow arg change only.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] CI/CD

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Re-ran the exact failing command locally with the added exclude:

```bash
python scripts/pack/generate_plugin_metadata.py \
  --plugins-root plugins --dist dist/plugins \
  --metadata-out dist/plugins/index.json \
  --cdn-prefix /files/plugins \
  --exclude qwenpaw-creator --exclude datapaw
```

## Evidence

```
$ python scripts/pack/generate_plugin_metadata.py ... --exclude qwenpaw-creator --exclude datapaw
  + pack bundle/chrome -> chrome/chrome-0.1.0.zip
  ... (9 plugins, same set as the failing run minus the datapaw error)
Wrote index: dist/plugins/index.json
  9 plugin(s) across 3 kind(s)
exit=0

$ pre-commit run --files .github/workflows/release.yml
check yaml...............................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
```

## Additional Notes

Once #7089 lands, all three packer call sites (`release.yml`,
`plugins-release.yml`, `datapaw-release.yml`) will be mutually consistent.
