### PR TITLE
fix(console): hide grep badge for no matches

### DIFF
--- a/console/src/components/Chat/ToolCards/cards/GrepSearchCard.test.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GrepSearchCard.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      key === "tool.lineBadge.matches" ? `${options?.count} matches` : key,
+  }),
+}));
+
+vi.mock("../shared", () => ({
+  ToolCardShell: ({
+    badges,
+    children,
+  }: {
+    badges?: React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      {badges}
+      {children}
+    </div>
+  ),
+  DefaultBlock: ({ content }: { content: string }) => <pre>{content}</pre>,
+}));
+
+vi.mock("../shared/utils", () => ({
+  countLines: (text: unknown) =>
+    typeof text === "string" && text ? text.split("\n").length : 0,
+  stringifyResult: (result: unknown) =>
+    typeof result === "string" ? result : "",
+}));
+
+import GrepSearchCard from "./GrepSearchCard";
+
+const createContent = (result: string) => ({
+  type: "tool_call" as const,
+  id: "grep-1",
+  name: "grep_search",
+  status: "done" as const,
+  params: { pattern: "needle" },
+  result,
+});
+
+describe("GrepSearchCard", () => {
+  it("does not show a match badge for the no-match result message", () => {
+    render(
+      <GrepSearchCard
+        content={createContent("No matches found for pattern: needle")}
+      />,
+    );
+
+    expect(screen.queryByText("1 matches")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No matches found for pattern: needle"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the line count for actual matches", () => {
+    render(
+      <GrepSearchCard content={createContent("src/example.ts:1: needle")} />,
+    );
+
+    expect(screen.getByText("1 matches")).toBeInTheDocument();
+  });
+});

--- a/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
@@ -34,7 +34,10 @@ const GrepSearchCard: React.FC<GrepSearchCardProps> = ({
   }
 
   const resultText = stringifyResult(content.result);
-  const lineCount = countLines(resultText);
+  const hasNoMatches = resultText
+    .trim()
+    .startsWith("No matches found for pattern:");
+  const lineCount = hasNoMatches ? 0 : countLines(resultText);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (


### PR DESCRIPTION
## Issue

When `grep_search` yields no results, the backend returns:

No matches found for pattern: ...

Previously, the frontend calculated the match count based on the number of text lines in the results, incorrectly displaying "1 match."

## Modification

Detect the "no match" message from `grep_search` and set the match count to 0.

Hide the match count badge when there are no matches.

Retain the existing logic for counting actual search result lines.

Add regression tests for scenarios involving no matches and single-line matches.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
