### PR TITLE
fix(release): bundle qwenpawmail MCP as a standalone sidecar

### DIFF
--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -169,6 +169,7 @@ Write-Host ""
 $BACKEND_DIR = Join-Path $DIST "pyinstaller\qwenpaw-backend"
 $BACKEND_EXE = Join-Path $BACKEND_DIR "qwenpaw-backend.exe"
 $CLI_EXE = Join-Path $BACKEND_DIR "qwenpaw.exe"
+$MAIL_MCP_EXE = Join-Path $BACKEND_DIR "qwenpawmail-mcp.exe"
 $MODEL_CATALOG = Join-Path $BACKEND_DIR `
     "_internal\qwenpaw\providers\data\model_catalog.json"
 if (-not (Test-Path $BACKEND_DIR)) {
@@ -181,6 +182,11 @@ if (-not (Test-Path $BACKEND_EXE)) {
 }
 if (-not (Test-Path $CLI_EXE)) {
     Write-Host "ERROR: CLI executable not found at $CLI_EXE" -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $MAIL_MCP_EXE)) {
+    Write-Host "ERROR: Mail MCP executable not found at $MAIL_MCP_EXE" `
+        -ForegroundColor Red
     exit 1
 }
 if (-not (Test-Path $MODEL_CATALOG)) {

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -103,6 +103,7 @@ echo ""
 BACKEND_DIR="${DIST}/pyinstaller/qwenpaw-backend"
 BACKEND_EXE="${BACKEND_DIR}/qwenpaw-backend"
 CLI_EXE="${BACKEND_DIR}/qwenpaw"
+MAIL_MCP_EXE="${BACKEND_DIR}/qwenpawmail-mcp"
 MODEL_CATALOG="${BACKEND_DIR}/_internal/qwenpaw/providers/data/model_catalog.json"
 if [ ! -d "${BACKEND_DIR}" ]; then
     echo "ERROR: Backend bundle directory not found at ${BACKEND_DIR}"
@@ -114,6 +115,10 @@ if [ ! -f "${BACKEND_EXE}" ]; then
 fi
 if [ ! -f "${CLI_EXE}" ]; then
     echo "ERROR: CLI executable not found at ${CLI_EXE}"
+    exit 1
+fi
+if [ ! -f "${MAIL_MCP_EXE}" ]; then
+    echo "ERROR: Mail MCP executable not found at ${MAIL_MCP_EXE}"
     exit 1
 fi
 if [ ! -f "${MODEL_CATALOG}" ]; then
@@ -139,6 +144,7 @@ mkdir -p "${DEST}"
 cp -R "${BACKEND_DIR}/." "${DEST}/"
 chmod +x "${DEST}/qwenpaw-backend"
 chmod +x "${DEST}/qwenpaw"
+chmod +x "${DEST}/qwenpawmail-mcp"
 echo "Copied to: ${DEST}"
 echo ""
 

--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -22,6 +22,7 @@ from PyInstaller.utils.hooks import (
 REPO_ROOT = Path(SPECPATH).parent.parent
 
 SRC = REPO_ROOT / "src" / "qwenpaw"
+QWENPAWMAIL_SRC = REPO_ROOT / "packages" / "qwenpawmail-mcp" / "src"
 if sys.platform == "darwin":
     codesign_identity = os.environ.get(
         "PYINSTALLER_CODESIGN_IDENTITY"
@@ -164,8 +165,13 @@ a = Analysis(
     [
         str(SRC / "tauri" / "entry.py"),
         str(SRC / "tauri" / "cli_entry.py"),
+        str(SRC / "tauri" / "mail_mcp_entry.py"),
     ],
-    pathex=[str(REPO_ROOT), str(REPO_ROOT / "src")],
+    pathex=[
+        str(REPO_ROOT),
+        str(REPO_ROOT / "src"),
+        str(QWENPAWMAIL_SRC),
+    ],
     binaries=[*qoder_binaries, *codex_binaries],
     datas=datas,
     hiddenimports=[
@@ -189,6 +195,9 @@ a = Analysis(
         *collect_submodules("qwenpaw.agents.acp"),
         # PawApp SDK modules are imported by installed app plugins at runtime.
         *collect_submodules("qwenpaw.pawapp"),
+        # Mail support lives in a second source root and also ships as its own
+        # stdio sidecar so the frozen backend is never used as an interpreter.
+        *collect_submodules("qwenpawmail_mcp"),
         # ASGI app entry points
         "qwenpaw.app._app",
         "qwenpaw.app.multi_agent_manager",
@@ -268,9 +277,27 @@ cli_exe = EXE(
     exclude_binaries=True,
 )
 
+mail_mcp_exe = EXE(
+    pyz,
+    script_entry("mail_mcp_entry.py"),
+    [],
+    name="qwenpawmail-mcp",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=codesign_identity,
+    exclude_binaries=True,
+)
+
 coll = COLLECT(
     backend_exe,
     cli_exe,
+    mail_mcp_exe,
     a.binaries,
     a.datas,
     strip=False,

--- a/src/qwenpaw/app/mail/driver_config.py
+++ b/src/qwenpaw/app/mail/driver_config.py
@@ -55,6 +55,15 @@ def resolve_qwenpawmail_command() -> str:
     override = os.environ.get("QWENPAWMAIL_PYTHON", "").strip()
     if override:
         return override
+    if getattr(sys, "frozen", False):
+        executable_name = (
+            "qwenpawmail-mcp.exe"
+            if sys.platform == "win32"
+            else "qwenpawmail-mcp"
+        )
+        bundled = Path(sys.executable).with_name(executable_name)
+        if bundled.is_file():
+            return str(bundled)
     try:
         if importlib.util.find_spec("qwenpawmail_mcp") is not None:
             return sys.executable

--- a/src/qwenpaw/tauri/mail_mcp_entry.py
+++ b/src/qwenpaw/tauri/mail_mcp_entry.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""PyInstaller entry point for the bundled qwenpawmail MCP server."""
+
+from __future__ import annotations
+
+from qwenpawmail_mcp.__main__ import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/routers/test_agents_mail_validation.py
+++ b/tests/unit/routers/test_agents_mail_validation.py
@@ -466,8 +466,29 @@ def test_resolve_qwenpawmail_command_env_override(monkeypatch):
     assert _resolve_qwenpawmail_command() == "/custom/bin/python"
 
 
+def test_resolve_qwenpawmail_command_uses_bundled_sidecar(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("QWENPAWMAIL_PYTHON", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    backend = tmp_path / (
+        "qwenpaw-backend.exe" if sys.platform == "win32" else "qwenpaw-backend"
+    )
+    mail_mcp = backend.with_name(
+        "qwenpawmail-mcp.exe"
+        if sys.platform == "win32"
+        else "qwenpawmail-mcp",
+    )
+    mail_mcp.touch()
+    monkeypatch.setattr(sys, "executable", str(backend))
+
+    assert _resolve_qwenpawmail_command() == str(mail_mcp)
+
+
 def test_resolve_qwenpawmail_command_uses_current_env(monkeypatch):
     monkeypatch.delenv("QWENPAWMAIL_PYTHON", raising=False)
+    monkeypatch.delattr(sys, "frozen", raising=False)
     with patch(
         "importlib.util.find_spec",
         return_value=object(),
@@ -477,6 +498,7 @@ def test_resolve_qwenpawmail_command_uses_current_env(monkeypatch):
 
 def test_resolve_qwenpawmail_command_falls_back_to_path(monkeypatch):
     monkeypatch.delenv("QWENPAWMAIL_PYTHON", raising=False)
+    monkeypatch.delattr(sys, "frozen", raising=False)
     with patch(
         "importlib.util.find_spec",
         return_value=None,

--- a/tests/unit/tauri/test_pyinstaller_spec.py
+++ b/tests/unit/tauri/test_pyinstaller_spec.py
@@ -60,3 +60,12 @@ def test_desktop_spec_collects_provider_catalog_data():
         "providers/data",
         "qwenpaw/providers/data",
     ) in _data_directories()
+
+
+def test_desktop_spec_bundles_qwenpawmail_mcp_sidecar():
+    source = SPEC_PATH.read_text(encoding="utf-8")
+
+    assert "qwenpawmail_mcp" in _collected_submodule_packages()
+    assert "str(QWENPAWMAIL_SRC)" in source
+    assert 'script_entry("mail_mcp_entry.py")' in source
+    assert 'name="qwenpawmail-mcp"' in source


### PR DESCRIPTION
## Description

Adopt a standalone qwenpawmail-mcp sidecar:

- Add the mail source path, hidden imports, and standalone executable to qwenpaw.spec.
- Add a minimal PyInstaller entry point for the bundled mail MCP server.
- Prefer the sibling sidecar only in frozen builds while preserving development behavior and environment-variable overrides.
- Verify the sidecar output in both macOS and Windows build scripts to prevent silent packaging omissions.
- Add tests for command resolution and the PyInstaller spec.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
