### PR TITLE
fix(qq): isolate conversation sessions and preserve reply routes

### DIFF
--- a/src/qwenpaw/app/channels/qq/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/qq/cards/tool_guard.py
@@ -473,7 +473,7 @@ async def _send_resolved_message(
     guild_id = str(session_ctx.get("gid") or "")
     msg_id = str(session_ctx.get("mid") or "")
 
-    if not sender_id and not group_openid and not channel_id:
+    if not any((sender_id, group_openid, channel_id, guild_id)):
         logger.warning("qq resolved message: no target to send to")
         return
 
@@ -525,7 +525,9 @@ def _enqueue_approval_command(
     session_id = str(session_ctx.get("sid") or "")
     message_type = str(session_ctx.get("mt") or "c2c")
     group_openid = str(session_ctx.get("goid") or "")
-    is_group = message_type == "group"
+    channel_id = str(session_ctx.get("cid") or "")
+    guild_id = str(session_ctx.get("gid") or "")
+    is_group = message_type in ("group", "guild")
 
     command_text = f"/approval {action} {request_id}"
     payload = {
@@ -540,6 +542,8 @@ def _enqueue_approval_command(
             "message_type": message_type,
             "sender_id": sender_id,
             "group_openid": group_openid,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
             "is_group": is_group,
             "from_card_action": True,
         },

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -857,29 +857,122 @@ class QQChannel(BaseChannel):
         guild_id: Optional[str] = None,
     ) -> tuple[str, bool, str]:
         """Return (api_path, use_msg_seq, seq_key)."""
-        if message_type == "dm" and guild_id:
+        if message_type == "dm":
+            if not guild_id:
+                raise ValueError("QQ guild DM route requires guild_id")
             return (
                 f"/dms/{guild_id}/messages",
                 False,
                 "",
             )
-        if message_type == "group" and group_openid:
+        if message_type == "group":
+            if not group_openid:
+                raise ValueError("QQ group route requires group_openid")
             return (
                 f"/v2/groups/{group_openid}/messages",
                 True,
                 "group",
             )
-        if message_type == "guild" and channel_id:
+        if message_type == "guild":
+            if not channel_id:
+                raise ValueError("QQ guild route requires channel_id")
             return (
                 f"/channels/{channel_id}/messages",
                 False,
                 "",
             )
-        # c2c or fallback
+        if message_type == "c2c":
+            if not sender_id:
+                raise ValueError("QQ C2C route requires user_openid")
+            return (
+                f"/v2/users/{sender_id}/messages",
+                True,
+                "c2c",
+            )
+        raise ValueError(f"Unsupported QQ message_type: {message_type}")
+
+    # ------------------------------------------------------------------
+    # Session / route helpers
+    # ------------------------------------------------------------------
+
+    def resolve_session_id(
+        self,
+        sender_id: str,
+        channel_meta: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Return a session ID scoped to one QQ conversation."""
+        meta = channel_meta or {}
+        message_type = str(meta.get("message_type") or "c2c")
+        if message_type == "group":
+            group_openid = str(meta.get("group_openid") or "unknown")
+            return f"qq:group:{group_openid}"
+        if message_type == "guild":
+            channel_id = str(meta.get("channel_id") or "unknown")
+            return f"qq:guild:{channel_id}"
+        if message_type == "dm":
+            guild_id = str(meta.get("guild_id") or "unknown")
+            return f"qq:dm:{guild_id}"
+        return f"qq:c2c:{sender_id or 'unknown'}"
+
+    @staticmethod
+    def _route_meta_from_handle(to_handle: str) -> Dict[str, str]:
+        """Decode a QQ session ID or direct handle into routing metadata."""
+        handle = (to_handle or "").strip()
+        routes = (
+            ("qq:c2c:", "c2c", "sender_id"),
+            ("qq:group:", "group", "group_openid"),
+            ("qq:guild:", "guild", "channel_id"),
+            ("qq:dm:", "dm", "guild_id"),
+            ("qq:", "c2c", "sender_id"),
+            ("group:", "group", "group_openid"),
+            ("channel:", "guild", "channel_id"),
+        )
+        for prefix, message_type, target_key in routes:
+            if handle.startswith(prefix):
+                target = handle.removeprefix(prefix)
+                if target == "unknown":
+                    return {"message_type": message_type}
+                return {
+                    "message_type": message_type,
+                    target_key: target,
+                }
+        return {}
+
+    def _normalize_route_meta(
+        self,
+        to_handle: str,
+        meta: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Merge durable route data encoded in ``to_handle`` into metadata."""
+        route_meta = dict(meta or {})
+        encoded_route = self._route_meta_from_handle(to_handle)
+        if encoded_route:
+            route_meta.update(encoded_route)
+        else:
+            route_meta.setdefault("message_type", "c2c")
+            if to_handle:
+                route_meta.setdefault("sender_id", to_handle)
+        return route_meta
+
+    def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
+        """Return a durable QQ session handle for proactive sends."""
+        return session_id or f"qq:c2c:{user_id}"
+
+    def get_to_handle_from_request(self, request: Any) -> str:
+        """Return the request session ID so replies retain their route."""
+        session_id = getattr(request, "session_id", "") or ""
+        user_id = getattr(request, "user_id", "") or ""
+        return session_id or f"qq:c2c:{user_id}"
+
+    def get_on_reply_sent_args(
+        self,
+        request: Any,
+        to_handle: str,
+    ) -> tuple:
+        """Report the original QQ user and isolated session to the callback."""
         return (
-            f"/v2/users/{sender_id}/messages",
-            True,
-            "c2c",
+            getattr(request, "user_id", "") or "",
+            getattr(request, "session_id", "") or "",
         )
 
     async def _dispatch_text(
@@ -1093,12 +1186,12 @@ class QQChannel(BaseChannel):
         meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Send one text via QQ HTTP API.
-        Routes by meta or to_handle (group:/channel:/openid).
+        Routes by metadata or a conversation-scoped QQ session handle.
         """
         if not self.enabled or not text.strip():
             return
         text = text.strip()
-        meta = meta or {}
+        meta = self._normalize_route_meta(to_handle, meta)
         use_markdown = _as_bool(
             meta.get("markdown_enabled", self._markdown_enabled),
         )
@@ -1108,21 +1201,12 @@ class QQChannel(BaseChannel):
                 logger.info(
                     "qq send: stripped URL content for API compatibility",
                 )
-        message_type = meta.get("message_type")
+        message_type = str(meta.get("message_type") or "c2c")
         msg_id = meta.get("message_id")
         sender_id = meta.get("sender_id") or to_handle
         channel_id = meta.get("channel_id")
         group_openid = meta.get("group_openid")
         guild_id = meta.get("guild_id")
-        if message_type is None:
-            if to_handle.startswith("group:"):
-                message_type = "group"
-                group_openid = to_handle[6:]
-            elif to_handle.startswith("channel:"):
-                message_type = "guild"
-                channel_id = to_handle[8:]
-            else:
-                message_type = "c2c"
         try:
             token = await self._get_access_token_async()
         except Exception:
@@ -1326,14 +1410,19 @@ class QQChannel(BaseChannel):
         if attachments:
             media_parts = self._parse_qq_attachments(attachments)
             content_parts = list(content_parts) + media_parts
-        session_id = self.resolve_session_id(sender_id, meta)
-        return self.build_agent_request_from_user_content(
+        session_id = payload.get("session_id") or self.resolve_session_id(
+            sender_id,
+            meta,
+        )
+        request = self.build_agent_request_from_user_content(
             channel_id=channel_id,
             sender_id=sender_id,
             session_id=session_id,
             content_parts=content_parts,
             channel_meta=meta,
         )
+        request.channel_meta = meta
+        return request
 
     # ------------------------------------------------------------------
     # Instant acknowledgment
@@ -1573,6 +1662,7 @@ class QQChannel(BaseChannel):
         send_meta: Dict[str, Any],
     ) -> None:
         """Render card-flagged events via the card handler; else default."""
+        send_meta = self._normalize_route_meta(to_handle, send_meta)
         if await self._card_handler.try_send_card_for_event(
             to_handle,
             event,
@@ -2041,7 +2131,7 @@ class QQChannel(BaseChannel):
 
         body = "\n".join(text_parts).strip() if text_parts else ""
 
-        meta = meta or {}
+        meta = self._normalize_route_meta(to_handle, meta)
         message_type = meta.get("message_type", "c2c")
         msg_id = meta.get("message_id")
 
@@ -2105,7 +2195,7 @@ class QQChannel(BaseChannel):
         if not self.enabled:
             return
 
-        meta = meta or {}
+        meta = self._normalize_route_meta(to_handle, meta)
         (
             message_type,
             sender_id,

--- a/tests/unit/channels/test_qq.py
+++ b/tests/unit/channels/test_qq.py
@@ -641,6 +641,295 @@ class TestResolveSendPath:
         assert use_seq is True
         assert seq_key == "c2c"
 
+    @pytest.mark.parametrize(
+        ("message_type", "channel_id", "group_openid", "guild_id"),
+        [
+            ("dm", None, None, None),
+            ("group", None, None, None),
+            ("guild", None, None, None),
+        ],
+    )
+    def test_missing_target_does_not_fall_back_to_c2c(
+        self,
+        qq_channel,
+        message_type,
+        channel_id,
+        group_openid,
+        guild_id,
+    ):
+        """Known non-C2C routes must reject a missing target."""
+        with pytest.raises(ValueError):
+            qq_channel._resolve_send_path(
+                message_type=message_type,
+                sender_id="user123",
+                channel_id=channel_id,
+                group_openid=group_openid,
+                guild_id=guild_id,
+            )
+
+
+class TestSessionRouting:
+    """Tests for QQ conversation-scoped sessions and send handles."""
+
+    @pytest.mark.parametrize(
+        ("meta", "expected"),
+        [
+            ({"message_type": "c2c"}, "qq:c2c:user_1"),
+            (
+                {"message_type": "group", "group_openid": "group_1"},
+                "qq:group:group_1",
+            ),
+            (
+                {"message_type": "guild", "channel_id": "channel_1"},
+                "qq:guild:channel_1",
+            ),
+            (
+                {"message_type": "dm", "guild_id": "guild_1"},
+                "qq:dm:guild_1",
+            ),
+        ],
+    )
+    def test_resolve_session_id_by_conversation(
+        self,
+        qq_channel,
+        meta,
+        expected,
+    ):
+        """Each QQ source uses its own conversation identifier."""
+        assert qq_channel.resolve_session_id("user_1", meta) == expected
+
+    def test_same_sender_uses_four_distinct_sessions(self, qq_channel):
+        """The same sender cannot share context across QQ sources."""
+        sessions = {
+            qq_channel.resolve_session_id("user_1", {"message_type": "c2c"}),
+            qq_channel.resolve_session_id(
+                "user_1",
+                {"message_type": "group", "group_openid": "group_1"},
+            ),
+            qq_channel.resolve_session_id(
+                "user_1",
+                {"message_type": "guild", "channel_id": "channel_1"},
+            ),
+            qq_channel.resolve_session_id(
+                "user_1",
+                {"message_type": "dm", "guild_id": "guild_1"},
+            ),
+        }
+        assert len(sessions) == 4
+
+    def test_missing_non_c2c_target_never_uses_c2c_session(self, qq_channel):
+        """Malformed non-C2C metadata stays outside private conversations."""
+        assert (
+            qq_channel.resolve_session_id(
+                "user_1",
+                {"message_type": "group"},
+            )
+            == "qq:group:unknown"
+        )
+
+    @pytest.mark.parametrize(
+        ("session_id", "user_id", "expected"),
+        [
+            ("qq:c2c:user_1", "other", "qq:c2c:user_1"),
+            ("qq:group:group_1", "other", "qq:group:group_1"),
+            ("qq:guild:channel_1", "other", "qq:guild:channel_1"),
+            ("qq:dm:guild_1", "other", "qq:dm:guild_1"),
+            ("qq:user_1", "other", "qq:user_1"),
+            ("", "user_1", "qq:c2c:user_1"),
+        ],
+    )
+    def test_to_handle_from_target(
+        self,
+        qq_channel,
+        session_id,
+        user_id,
+        expected,
+    ):
+        """Cron uses the session handle and old IDs remain C2C handles."""
+        assert (
+            qq_channel.to_handle_from_target(
+                user_id=user_id,
+                session_id=session_id,
+            )
+            == expected
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("to_handle", "expected_type", "expected_target"),
+        [
+            ("qq:c2c:user_1", "c2c", "user_1"),
+            ("qq:group:group_1", "group", "group_1"),
+            ("qq:guild:channel_1", "guild", "channel_1"),
+            ("qq:dm:guild_1", "dm", "guild_1"),
+        ],
+    )
+    async def test_send_content_parts_recovers_route_from_session(
+        self,
+        qq_channel,
+        to_handle,
+        expected_type,
+        expected_target,
+    ):
+        """Scheduled sends route correctly when dispatch metadata is empty."""
+        from qwenpaw.schemas import TextContent
+
+        qq_channel._get_access_token_async = AsyncMock(return_value="token")
+        qq_channel._send_text_with_fallback = AsyncMock(return_value=True)
+        await qq_channel.send_content_parts(
+            to_handle,
+            [TextContent(type="text", text="scheduled message")],
+            {},
+        )
+
+        args = qq_channel._send_text_with_fallback.call_args.args
+        kwargs = qq_channel._send_text_with_fallback.call_args.kwargs
+        assert args[0] == expected_type
+        if expected_type == "c2c":
+            assert args[1] == expected_target
+        elif expected_type == "group":
+            assert args[3] == expected_target
+        elif expected_type == "guild":
+            assert args[2] == expected_target
+        else:
+            assert kwargs["guild_id"] == expected_target
+
+    @pytest.mark.asyncio
+    async def test_card_route_uses_session_when_meta_is_empty(
+        self,
+        qq_channel,
+    ):
+        """Approval cards receive the route decoded from their session."""
+        event = MagicMock()
+        qq_channel._card_handler.try_send_card_for_event = AsyncMock(
+            return_value=True,
+        )
+
+        await qq_channel.on_event_message_completed(
+            MagicMock(),
+            "qq:group:group_1",
+            event,
+            {},
+        )
+
+        send_meta = (
+            qq_channel._card_handler.try_send_card_for_event.call_args.args[2]
+        )
+        assert send_meta["message_type"] == "group"
+        assert send_meta["group_openid"] == "group_1"
+
+    @pytest.mark.asyncio
+    async def test_guild_dm_card_resolved_message_uses_guild_id(
+        self,
+        qq_channel,
+    ):
+        """Guild DM approval results accept guild_id as the route target."""
+        from qwenpaw.app.channels.qq.cards.tool_guard import (
+            _send_resolved_message,
+        )
+
+        qq_channel._get_access_token_async = AsyncMock(return_value="token")
+        qq_channel._send_text_with_fallback = AsyncMock(return_value=True)
+
+        await _send_resolved_message(
+            qq_channel,
+            session_ctx={"mt": "dm", "gid": "guild_1"},
+            tool_name="example_tool",
+            action="approve",
+            operator_display="user_1",
+        )
+
+        call = qq_channel._send_text_with_fallback.call_args
+        assert call.args[0] == "dm"
+        assert call.kwargs["guild_id"] == "guild_1"
+
+    def test_card_action_preserves_guild_dm_route_metadata(
+        self,
+        qq_channel,
+    ):
+        """Card actions retain Guild DM metadata for access-control replies."""
+        from qwenpaw.app.channels.qq.cards.tool_guard import (
+            _enqueue_approval_command,
+        )
+
+        enqueued = []
+        qq_channel._enqueue = enqueued.append
+
+        _enqueue_approval_command(
+            qq_channel,
+            action="approve",
+            request_id="request_1",
+            session_ctx={
+                "sid": "qq:dm:guild_1",
+                "mt": "dm",
+                "cid": "channel_1",
+                "gid": "guild_1",
+            },
+            user_id="user_1",
+        )
+
+        meta = enqueued[0]["meta"]
+        assert meta["channel_id"] == "channel_1"
+        assert meta["guild_id"] == "guild_1"
+        assert meta["is_group"] is False
+
+    def test_card_action_treats_guild_messages_as_group_access(
+        self,
+        qq_channel,
+    ):
+        """Guild-channel card actions use the group access-control policy."""
+        from qwenpaw.app.channels.qq.cards.tool_guard import (
+            _enqueue_approval_command,
+        )
+
+        enqueued = []
+        qq_channel._enqueue = enqueued.append
+
+        _enqueue_approval_command(
+            qq_channel,
+            action="approve",
+            request_id="request_1",
+            session_ctx={
+                "sid": "qq:guild:channel_1",
+                "mt": "guild",
+                "cid": "channel_1",
+                "gid": "guild_1",
+            },
+            user_id="user_1",
+        )
+
+        assert enqueued[0]["meta"]["is_group"] is True
+
+    @pytest.mark.asyncio
+    @patch("qwenpaw.app.channels.qq.channel._api_request_async")
+    async def test_guild_dm_approval_card_uses_dms_path(
+        self,
+        mock_api,
+        qq_channel,
+    ):
+        """Guild DM approval cards use the DMS endpoint with a keyboard."""
+        from qwenpaw.app.channels.qq.cards.tool_guard import (
+            _send_keyboard_message,
+        )
+
+        keyboard = {"content": {"rows": []}}
+        await _send_keyboard_message(
+            qq_channel,
+            token="token",
+            message_type="dm",
+            sender_id="",
+            group_openid="",
+            channel_id="",
+            guild_id="guild_1",
+            msg_id="message_1",
+            markdown_content="Approval required",
+            keyboard=keyboard,
+        )
+
+        call = mock_api.call_args
+        assert call.args[3] == "/dms/guild_1/messages"
+        assert call.args[4]["keyboard"] == keyboard
+
 
 class TestSend:
     """Tests for send method."""
@@ -1857,6 +2146,7 @@ class TestHandleMsgEvent:
         req = enqueued[0]
         assert req.channel_meta["message_type"] == "c2c"
         assert req.channel_meta["sender_id"] == "sender_1"
+        assert req.session_id == "qq:c2c:sender_1"
 
     def test_guild_message_has_extra_meta(self, qq_channel):
         """Guild message should have extra metadata."""
@@ -1875,6 +2165,7 @@ class TestHandleMsgEvent:
         assert meta["message_type"] == "guild"
         assert meta["channel_id"] == "ch_100"
         assert meta["guild_id"] == "g_200"
+        assert enqueued[0].session_id == "qq:guild:ch_100"
 
     def test_group_message(self, qq_channel):
         """Group message should work correctly."""
@@ -1891,6 +2182,24 @@ class TestHandleMsgEvent:
         meta = enqueued[0].channel_meta
         assert meta["message_type"] == "group"
         assert meta["group_openid"] == "grp_300"
+        assert enqueued[0].session_id == "qq:group:grp_300"
+
+    def test_guild_direct_message_uses_guild_session(self, qq_channel):
+        """Guild DMs use the DMS guild ID rather than the sender ID."""
+        enqueued = []
+        qq_channel._enqueue = enqueued.append
+        d = {
+            "author": {"id": "author_1"},
+            "content": "hello DM",
+            "id": "msg_004",
+            "channel_id": "ch_100",
+            "guild_id": "g_200",
+        }
+
+        qq_channel._handle_msg_event("DIRECT_MESSAGE_CREATE", d)
+
+        assert len(enqueued) == 1
+        assert enqueued[0].session_id == "qq:dm:g_200"
 
     def test_empty_text_no_attachments_skipped(self, qq_channel):
         """Empty text with no attachments should be skipped."""
@@ -2085,6 +2394,23 @@ class TestBuildAgentRequestFromNative:
         }
         req = qq_channel.build_agent_request_from_native(native)
         assert req.user_id == "user_1"
+
+    def test_explicit_session_id_is_preserved(self, qq_channel):
+        """Card actions retain the session encoded in the button."""
+        from qwenpaw.schemas import TextContent
+
+        native = {
+            "channel_id": "qq",
+            "sender_id": "user_1",
+            "session_id": "qq:group:group_1",
+            "content_parts": [TextContent(type="text", text="/approval")],
+            "meta": {"message_type": "group"},
+        }
+
+        req = qq_channel.build_agent_request_from_native(native)
+
+        assert req.session_id == "qq:group:group_1"
+        assert req.channel_meta == {"message_type": "group"}
 
     def test_non_dict_payload(self, qq_channel):
         """Should handle non-dict payload gracefully."""


### PR DESCRIPTION
## Description

- isolate QQ C2C, group, guild channel, and guild DM sessions by their
  conversation identifiers
- preserve the session-derived route for replies, scheduled sends, media,
  and tool-guard approval cards
- fail closed when a non-C2C route is missing its required target
- complete guild DM approval-card routing and preserve callback metadata
  for access-control responses

**Related Issue:** Fixes #7159 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
