### PR TITLE
fix(desktop): launch bundled qwenpawmail MCP

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -22,6 +22,7 @@ from PyInstaller.utils.hooks import (
 REPO_ROOT = Path(SPECPATH).parent.parent
 
 SRC = REPO_ROOT / "src" / "qwenpaw"
+MAIL_MCP_SRC = REPO_ROOT / "packages" / "qwenpawmail-mcp" / "src"
 if sys.platform == "darwin":
     codesign_identity = os.environ.get(
         "PYINSTALLER_CODESIGN_IDENTITY"
@@ -165,7 +166,7 @@ a = Analysis(
         str(SRC / "tauri" / "entry.py"),
         str(SRC / "tauri" / "cli_entry.py"),
     ],
-    pathex=[str(REPO_ROOT), str(REPO_ROOT / "src")],
+    pathex=[str(REPO_ROOT), str(REPO_ROOT / "src"), str(MAIL_MCP_SRC)],
     binaries=[*qoder_binaries, *codex_binaries],
     datas=datas,
     hiddenimports=[
@@ -183,6 +184,8 @@ a = Analysis(
         "uvicorn.lifespan.on",
         # All CLI sub-commands (dynamically loaded by Click)
         *collect_submodules("qwenpaw.cli"),
+        # The mail MCP package lives under a second setuptools source root.
+        *collect_submodules("qwenpawmail_mcp"),
         # All channel adapters (imported on-demand at runtime)
         *collect_submodules("qwenpaw.app.channels"),
         # ACP runner support is lazily imported by delegate_external_agent.

--- a/src/qwenpaw/app/mail/driver_config.py
+++ b/src/qwenpaw/app/mail/driver_config.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 # Compatibility alias used by the agent router for provider validation.
 ENTERPRISE_MAIL_PROVIDERS = ENTERPRISE_PROVIDERS
 
+_MAIL_MCP_MODULE_ARGS = ["-m", "qwenpawmail_mcp"]
+_INTERNAL_MAIL_MCP_ARGS = ["--internal-mail-mcp"]
+
 
 def is_managed_qwenpawmail_card(path: Path) -> bool:
     """Return whether *path* is a QwenPaw-generated mail DriverCard."""
@@ -50,17 +53,26 @@ def is_managed_qwenpawmail_card(path: Path) -> bool:
     )
 
 
-def resolve_qwenpawmail_command() -> str:
-    """Resolve the interpreter used to launch the qwenpawmail MCP server."""
+def resolve_qwenpawmail_endpoint() -> tuple[str, list[str]]:
+    """Resolve the command and arguments for the qwenpawmail MCP server."""
     override = os.environ.get("QWENPAWMAIL_PYTHON", "").strip()
     if override:
-        return override
+        return override, list(_MAIL_MCP_MODULE_ARGS)
+    if getattr(sys, "frozen", False):
+        executable = Path(sys.executable)
+        cli_executable = executable.with_name(f"qwenpaw{executable.suffix}")
+        return str(cli_executable), list(_INTERNAL_MAIL_MCP_ARGS)
     try:
         if importlib.util.find_spec("qwenpawmail_mcp") is not None:
-            return sys.executable
+            return sys.executable, list(_MAIL_MCP_MODULE_ARGS)
     except (ImportError, ValueError):
         pass
-    return "python"
+    return "python", list(_MAIL_MCP_MODULE_ARGS)
+
+
+def resolve_qwenpawmail_command() -> str:
+    """Resolve the executable used to launch the qwenpawmail MCP server."""
+    return resolve_qwenpawmail_endpoint()[0]
 
 
 def _load_managed_qwenpawmail_card(path: Path) -> DriverCard | None:
@@ -126,6 +138,7 @@ def generate_qwenpawmail_driver_card(
         (workspace_dir / "mail_state").mkdir(parents=True, exist_ok=True)
         save_agent_mail_credentials(workspace_dir, mail)
         env = build_qwenpawmail_env(mail, workspace_dir)
+        command, args = resolve_qwenpawmail_endpoint()
         has_runtime_mail_credential = bool(
             mail is not None
             and not mail.is_new_account
@@ -137,8 +150,8 @@ def generate_qwenpawmail_driver_card(
             protocol="mcp",
             endpoint={
                 "transport": "stdio",
-                "command": resolve_qwenpawmail_command(),
-                "args": ["-m", "qwenpawmail_mcp"],
+                "command": command,
+                "args": args,
                 "env": env,
             },
             credentials=(

--- a/src/qwenpaw/tauri/cli_entry.py
+++ b/src/qwenpaw/tauri/cli_entry.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import sys
 
-from qwenpaw.cli.main import cli
+
+_INTERNAL_MAIL_MCP_ARG = "--internal-mail-mcp"
+
+
+def main() -> None:
+    """Dispatch bundled internal services or the public Click CLI."""
+    mp.freeze_support()
+    if sys.argv[1:] == [_INTERNAL_MAIL_MCP_ARG]:
+        from qwenpawmail_mcp.__main__ import main as mail_mcp_main
+
+        mail_mcp_main()
+        return
+
+    from qwenpaw.cli.main import cli
+
+    cli()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    mp.freeze_support()
-    cli()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tests/unit/app/mail/test_driver_config.py
+++ b/tests/unit/app/mail/test_driver_config.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+
+import pytest
+import yaml
+
+from qwenpaw.app.mail import driver_config
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "cli_name"),
+    [
+        ("qwenpaw-backend", "qwenpaw"),
+        ("qwenpaw-backend.exe", "qwenpaw.exe"),
+    ],
+)
+def test_driver_card_uses_bundled_cli_when_frozen(
+    tmp_path,
+    monkeypatch,
+    backend_name,
+    cli_name,
+):
+    monkeypatch.delenv("QWENPAWMAIL_PYTHON", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / backend_name))
+
+    assert driver_config.generate_qwenpawmail_driver_card(tmp_path)
+
+    card_path = tmp_path / "drivers" / "mcp" / "qwenpawmail.yaml"
+    card = yaml.safe_load(card_path.read_text(encoding="utf-8"))
+    assert card["endpoint"]["command"] == str(tmp_path / cli_name)
+    assert card["endpoint"]["args"] == ["--internal-mail-mcp"]
+
+
+def test_frozen_driver_card_preserves_python_override(monkeypatch):
+    monkeypatch.setenv("QWENPAWMAIL_PYTHON", "/custom/bin/python")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+
+    command, args = driver_config.resolve_qwenpawmail_endpoint()
+
+    assert command == "/custom/bin/python"
+    assert args == ["-m", "qwenpawmail_mcp"]

--- a/tests/unit/tauri/test_cli_entry.py
+++ b/tests/unit/tauri/test_cli_entry.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from qwenpaw.tauri import cli_entry
+
+
+def test_internal_mail_mcp_dispatch_does_not_start_click(monkeypatch):
+    monkeypatch.setattr(
+        cli_entry.sys,
+        "argv",
+        ["qwenpaw", "--internal-mail-mcp"],
+    )
+    monkeypatch.delitem(sys.modules, "qwenpaw.cli.main", raising=False)
+
+    with patch("qwenpawmail_mcp.__main__.main") as mail_mcp_main:
+        cli_entry.main()
+
+    mail_mcp_main.assert_called_once_with()
+    assert "qwenpaw.cli.main" not in sys.modules
+
+
+def test_other_arguments_start_click(monkeypatch):
+    monkeypatch.setattr(cli_entry.sys, "argv", ["qwenpaw", "--version"])
+
+    with patch("qwenpaw.cli.main.cli") as cli:
+        cli_entry.main()
+
+    cli.assert_called_once_with()

--- a/tests/unit/tauri/test_pyinstaller_spec.py
+++ b/tests/unit/tauri/test_pyinstaller_spec.py
@@ -51,8 +51,30 @@ def _data_directories() -> set[tuple[str, str]]:
     return set()
 
 
+def _analysis_path_names() -> set[str]:
+    tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
+    analysis = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Analysis"
+    )
+    pathex = next(
+        keyword.value
+        for keyword in analysis.keywords
+        if keyword.arg == "pathex"
+    )
+    return {node.id for node in ast.walk(pathex) if isinstance(node, ast.Name)}
+
+
 def test_desktop_spec_collects_pawapp_sdk_for_runtime_loaded_plugins():
     assert "qwenpaw.pawapp" in _collected_submodule_packages()
+
+
+def test_desktop_spec_collects_qwenpawmail_from_nested_source_root():
+    assert "qwenpawmail_mcp" in _collected_submodule_packages()
+    assert "MAIL_MCP_SRC" in _analysis_path_names()
 
 
 def test_desktop_spec_collects_provider_catalog_data():


### PR DESCRIPTION
## Description

Fix desktop packaging and runtime startup for the `qwenpawmail` MCP server:

- collect the nested `qwenpawmail_mcp` package in the shared PyInstaller bundle;
- launch it through the existing sibling `qwenpaw` executable in frozen Windows/macOS builds;
- preserve `QWENPAWMAIL_PYTHON` and `python -m qwenpawmail_mcp` behavior outside the default frozen path.

This addresses the packaged import failure observed in [Actions run 32343783023](https://github.com/jinglinpeng/CoPaw/actions/runs/32343783023).

**Related Issue:** No linked issue; regression from the mailbox desktop integration.

**Security Considerations:** Mail credentials remain resolved through the existing credential binding and child-process environment. The packaged-only entry requires an exact internal argument and does not add a public Click command.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the focused tests with both repository source roots on `PYTHONPATH`:

```powershell
python -m pytest --confcutdir=tests/unit/tauri tests/unit/tauri/test_cli_entry.py tests/unit/tauri/test_pyinstaller_spec.py -q
python -m pytest --confcutdir=tests/unit/app/mail tests/unit/app/mail/test_driver_config.py -q
```

The non-publishing Windows/macOS desktop workflow passed at [Actions run 32350211975](https://github.com/jinglinpeng/CoPaw/actions/runs/32350211975).

## Evidence

```text
.....                                                                    [100%]
5 passed in 2.23s

...                                                                      [100%]
3 passed in 2.63s

PyInstaller collect_submodules('qwenpawmail_mcp'):
collected=10
missing=

Black 23.3.0:
5 files would be left unchanged.

Origin desktop package/verify:
macOS   success  25m23s
Windows success  37m57s
```

## Additional Notes

The broader local suite was not claimed: the available shared environment has AgentScope 1.0.19, while this source revision imports AgentScope 2.0.6 APIs. The remote desktop build installs the revision's declared dependencies and passed the authoritative frozen-runtime checks on both platforms.