### PR TITLE
fix(e2e): re-anchor agents action cells and follow project-directory API rename

### DIFF
--- a/e2e/pages/agents_page.py
+++ b/e2e/pages/agents_page.py
@@ -46,13 +46,17 @@ class AgentsPage(BasePage):
     AGENT_TABLE = '.qwenpaw-table'
     AGENT_LIST = '.qwenpaw-table-tbody'
     AGENT_ITEM = '.qwenpaw-table-tbody tr.qwenpaw-table-row'
-    # Table column order: drag handle (1) | Name (2) | ID (3) | Description (4) | Workspace (5) | Model (6) | Actions (7)
+    # Column order: drag handle (1) | Name (2) | ID (3) | Backend (4) |
+    # Description (5) | Workspace (6) | Model (7) | Actions (8). Upstream
+    # #6397 inserted the Backend column after ID, shifting everything to
+    # its right. Actions is declared ``fixed: "right"``, so anchor it on
+    # the fixed-column class instead of a position that keeps drifting.
     AGENT_NAME_CELL = 'td.qwenpaw-table-cell:nth-child(2)'
     AGENT_ID_CELL = 'td.qwenpaw-table-cell:nth-child(3)'
-    AGENT_DESC_CELL = 'td.qwenpaw-table-cell:nth-child(4)'
-    AGENT_WORKSPACE_CELL = 'td.qwenpaw-table-cell:nth-child(5)'
-    AGENT_MODEL_CELL = 'td.qwenpaw-table-cell:nth-child(6)'
-    AGENT_ACTIONS_CELL = 'td.qwenpaw-table-cell:nth-child(7)'
+    AGENT_DESC_CELL = 'td.qwenpaw-table-cell:nth-child(5)'
+    AGENT_WORKSPACE_CELL = 'td.qwenpaw-table-cell:nth-child(6)'
+    AGENT_MODEL_CELL = 'td.qwenpaw-table-cell:nth-child(7)'
+    AGENT_ACTIONS_CELL = 'td.qwenpaw-table-cell-fix-right'
     # Post-#6198 the name cell shows an AgentStatusIndicator dot exposing a
     # ``data-status`` attribute (disabled/pending/starting/running/failed)
     # instead of a "Disabled" Tag.

--- a/e2e/pages/coding_page.py
+++ b/e2e/pages/coding_page.py
@@ -324,9 +324,9 @@ class CodingPage(BasePage):
         return {"X-Agent-Id": self.AGENT_ID_DEFAULT}
 
     def api_create_project(self, api_context, name: str) -> dict:
-        """POST /api/workspace/coding-project/create."""
+        """POST /api/workspace/project-directory/create."""
         resp = api_context.post(
-            "/api/workspace/coding-project/create",
+            "/api/workspace/project-directory/create",
             data={"name": name},
             headers=self._agent_headers(),
         )
@@ -338,9 +338,9 @@ class CodingPage(BasePage):
         return body
 
     def api_activate_project(self, api_context, path: str) -> dict:
-        """PUT /api/workspace/coding-project — set the active project."""
+        """PUT /api/workspace/project-directory — set the active project."""
         resp = api_context.put(
-            "/api/workspace/coding-project",
+            "/api/workspace/project-directory",
             data={"path": path},
             headers=self._agent_headers(),
         )
@@ -362,9 +362,9 @@ class CodingPage(BasePage):
         return resp.json()
 
     def api_get_coding_project(self, api_context) -> dict:
-        """GET /api/workspace/coding-project — current bound project."""
+        """GET /api/workspace/project-directory — current bound project."""
         resp = api_context.get(
-            "/api/workspace/coding-project",
+            "/api/workspace/project-directory",
             headers=self._agent_headers(),
         )
         assert resp.ok, (

--- a/e2e/tests/test_coding.py
+++ b/e2e/tests/test_coding.py
@@ -152,7 +152,7 @@ class TestOpenExistingDirectory:
     The native folder-picker UI flow can't be driven from Playwright
     reliably, so we exercise the equivalent backend path: create a
     project (which lives at a real on-disk path), then re-bind the
-    agent to that path with PUT /api/workspace/coding-project.
+    agent to that path with PUT /api/workspace/project-directory.
     """
 
     @pytest.mark.test_id("CODE-003")


### PR DESCRIPTION
> **Submitted by**: Li Shizhen·E2E@QPQAT

## Problem

Two independent upstream changes broke e2e test cases; both are test-side fixes, no product code touched:

1. **#6397 added a Backend column** to the agents table, shifting every column to its right by one. The positional action-cell selectors (`nth-child(7)`) in `test_agents.py` landed on the wrong cell, so edit/toggle clicks timed out at 60s.
2. **#6504 renamed the workspace project routes** from `/api/workspace/coding-project` to `/api/workspace/project-directory`, but the e2e helpers were not updated. Project creation hit a dead path and failed with **405 Method Not Allowed**.

## Fix

- Re-anchor `AGENT_DESC/WORKSPACE/MODEL/ACTIONS` cells one column to the right (1 file, +9/-5 in `e2e/tests/test_agents.py`)
- Re-point the three coding-project helpers (create/activate/read) to the new `project-directory` routes (request/response shapes unchanged)

## Verification (fork CI, p0 marker)

| Run | Failed | Passed | Notes |
|---|---|---|---|
| before (baseline) | 8 | 61 | includes agents edit/toggle timeouts + coding create 405 |
| with fix ① only | 6 | 63 | agents edit/toggle turned green |
| with fix ①+② | **5** | **64** | coding create turned green |

The remaining 5 failures are pre-existing on main and unrelated to this PR (backup import entry, session pin marker, coding-mode entry selector, files download button, MCP toggle text); triage in progress separately.

---
*Companion of #7157 (overlay dismissal fix, merged); together they clear the nightly E2E blockers introduced by #6645 / #6397 / #6504.*