### PR TITLE
perf(drivers): initialize persistent drivers concurrently

### DIFF
--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -94,33 +94,14 @@ class DriverManager:
     async def build_drivers(self) -> None:
         """Scan cards_dir and build enabled handlers."""
         built: dict[str, DriverHandler] = {}
-        for path in await self._card_store.list_paths():
-            try:
-                card = await self._card_store.load_path(path)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to build Driver from %s: %s",
-                    path,
-                    exc,
-                    exc_info=True,
-                )
-                continue
-            try:
-                if not card.enabled:
-                    logger.debug(
-                        "Driver '%s' is disabled; skipping",
-                        card.name,
-                    )
-                    continue
-                handler = await self._build_and_init_handler(card)
-                built[card.name] = handler
-            except Exception as exc:
-                logger.warning(
-                    "Failed to build Driver '%s': %s",
-                    card.name,
-                    exc,
-                    exc_info=True,
-                )
+        paths = await self._card_store.list_paths()
+        results = await asyncio.gather(
+            *(self._load_and_build_driver(path) for path in paths),
+        )
+        for result in results:
+            if result is not None:
+                name, handler = result
+                built[name] = handler
 
         collisions: set[str] = set()
         old_handlers: list[DriverHandler] = []
@@ -148,6 +129,40 @@ class DriverManager:
             )
 
         await self._shutdown_handlers(old_handlers)
+
+    async def _load_and_build_driver(
+        self,
+        path: Path,
+    ) -> tuple[str, DriverHandler] | None:
+        """Load and initialize one enabled persistent Driver."""
+        try:
+            card = await self._card_store.load_path(path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build Driver from %s: %s",
+                path,
+                exc,
+                exc_info=True,
+            )
+            return None
+
+        try:
+            if not card.enabled:
+                logger.debug(
+                    "Driver '%s' is disabled; skipping",
+                    card.name,
+                )
+                return None
+            handler = await self._build_and_init_handler(card)
+            return card.name, handler
+        except Exception as exc:
+            logger.warning(
+                "Failed to build Driver '%s': %s",
+                card.name,
+                exc,
+                exc_info=True,
+            )
+            return None
 
     async def upsert_driver(
         self,


### PR DESCRIPTION
## Summary

- Load and initialize enabled persistent Drivers concurrently during workspace startup.
- Preserve the existing behavior for disabled cards, per-card failure isolation, transient-name collision checks, atomic publication, and old-handler cleanup.

## What this improves

This reduces cold workspace startup and reload latency when two or more persistent Drivers are enabled. MCP is currently the concrete Driver protocol, so the practical target is users with multiple enabled MCP servers.

Previously, initialization latency approached the sum of all Driver connection times. With this change, it approaches the slowest individual connection time. In a controlled Driver-only benchmark with two healthy local MCP servers and a fixed 500 ms startup delay, 10 repeated samples improved from 1628 +/- 50 ms to 796 +/- 17 ms (51.1%).

## Scope and limitations

- Zero or one enabled Driver: no expected latency improvement.
- Warm requests and model inference: unchanged.
- End-to-end first-token latency improves only when Driver initialization is on the workspace critical path; memory, plugin, and model latency may dominate some configurations.
- The implementation still waits for every enabled Driver to initialize. It does not skip MCP startup or expose an incomplete tool set.

## Validation

- 195 existing focused unit and MCP integration tests passed.
- pre-commit passed for the changed file.