### PR TITLE
test(browser): bound sibling-session overlap span instead of fast-task latency

### DIFF
--- a/tests/integration/browser/test_execution_lifecycle_e2e.py
+++ b/tests/integration/browser/test_execution_lifecycle_e2e.py
@@ -47,24 +47,57 @@ async def test_worker_is_reused_then_reclaimed() -> None:
 
 
 async def test_sibling_sessions_run_without_serializing() -> None:
+    """Sibling sessions must run in parallel, not queue behind one lock.
+
+    Instead of timing a single fast request against a wall-clock budget
+    (flaky: worker-process spawn cost varies by runner), measure the
+    total span of two overlapping tasks:
+
+    - a long task sleeps 3.0 s in session A, started first;
+    - a short task sleeps 1.0 s in session B, started while A is still
+      running.
+
+    If the sessions run in parallel the span is ~3.0 s (the longer of
+    the two); if they are wrongly serialized it is ~4.0 s (3 + 1).  A
+    bound of 3.5 s sits in the middle with ~0.5 s margin on each side,
+    so normal runner jitter cannot flip the verdict.  Both workers are
+    warmed up first so subprocess spawn cost stays out of the timed
+    span.
+    """
     plane = SubprocessPlane()
     runtime = KernelRuntime(plane=plane)
-    slow = _request(
-        "slow",
-        "slow",
-        "import asyncio\nawait asyncio.sleep(1.0)\nreturn 'slow'",
+    long_request = _request(
+        "long",
+        "sibling-a",
+        "import asyncio\nawait asyncio.sleep(3.0)\nreturn 'long'",
     )
-    fast = _request("fast", "fast", "return 'fast'")
+    short_request = _request(
+        "short",
+        "sibling-b",
+        "import asyncio\nawait asyncio.sleep(1.0)\nreturn 'short'",
+    )
     try:
-        slow_task = asyncio.create_task(runtime.run(slow))
-        await asyncio.sleep(0.15)
-        started = time.monotonic()
-        fast_result = await runtime.run(fast)
+        # Warm up both workers so spawn cost is outside the timed span.
+        await runtime.run(_request("warm-a", "sibling-a", "return 'ok'"))
+        await runtime.run(_request("warm-b", "sibling-b", "return 'ok'"))
 
-        assert fast_result.value == "fast"
-        assert not slow_task.done()
-        assert time.monotonic() - started < 0.75
-        assert (await slow_task).value == "slow"
+        started = time.monotonic()
+        long_task = asyncio.create_task(runtime.run(long_request))
+        await asyncio.sleep(0.15)
+        short_result = await runtime.run(short_request)
+
+        assert short_result.value == "short"
+        # The long task is still running when the short one returns —
+        # direct proof the sessions did not queue behind each other.
+        assert not long_task.done()
+        long_result = await long_task
+        elapsed = time.monotonic() - started
+
+        assert long_result.value == "long"
+        # Parallel ≈ 3.0 s; a serialized implementation would need ≈ 4.0 s.
+        assert (
+            elapsed < 3.5
+        ), f"sibling sessions appear serialized: took {elapsed:.2f}s"
     finally:
         await plane.discard_all_workers()
 

--- a/tests/integration/browser/test_execution_lifecycle_e2e.py
+++ b/tests/integration/browser/test_execution_lifecycle_e2e.py
@@ -54,15 +54,16 @@ async def test_sibling_sessions_run_without_serializing() -> None:
     total span of two overlapping tasks:
 
     - a long task sleeps 3.0 s in session A, started first;
-    - a short task sleeps 1.0 s in session B, started while A is still
+    - a short task sleeps 2.0 s in session B, started while A is still
       running.
 
     If the sessions run in parallel the span is ~3.0 s (the longer of
-    the two); if they are wrongly serialized it is ~4.0 s (3 + 1).  A
-    bound of 3.5 s sits in the middle with ~0.5 s margin on each side,
-    so normal runner jitter cannot flip the verdict.  Both workers are
-    warmed up first so subprocess spawn cost stays out of the timed
-    span.
+    the two); if they are wrongly serialized it is ~5.0 s (3 + 2).  A
+    bound of 4.5 s leaves ~1.5 s of headroom for runner jitter on the
+    parallel side while the serialized case still overshoots it by
+    ~0.5 s, so normal runner jitter cannot flip the verdict.  Both
+    workers are warmed up first so subprocess spawn cost stays out of
+    the timed span.
     """
     plane = SubprocessPlane()
     runtime = KernelRuntime(plane=plane)
@@ -74,7 +75,7 @@ async def test_sibling_sessions_run_without_serializing() -> None:
     short_request = _request(
         "short",
         "sibling-b",
-        "import asyncio\nawait asyncio.sleep(1.0)\nreturn 'short'",
+        "import asyncio\nawait asyncio.sleep(2.0)\nreturn 'short'",
     )
     try:
         # Warm up both workers so spawn cost is outside the timed span.
@@ -94,9 +95,9 @@ async def test_sibling_sessions_run_without_serializing() -> None:
         elapsed = time.monotonic() - started
 
         assert long_result.value == "long"
-        # Parallel ≈ 3.0 s; a serialized implementation would need ≈ 4.0 s.
+        # Parallel ≈ 3.0 s; a serialized implementation would need ≈ 5.0 s.
         assert (
-            elapsed < 3.5
+            elapsed < 4.5
         ), f"sibling sessions appear serialized: took {elapsed:.2f}s"
     finally:
         await plane.discard_all_workers()


### PR DESCRIPTION
## Description

Rewrites the serialization assertion in
`test_sibling_sessions_run_without_serializing` so the test can no
longer flake under runner load.

**What the test checks:** each browser-execution session gets its own
worker process, and sibling sessions must run in parallel rather than
queueing behind a single lock.

**Why the old assertion was flaky:** it timed a single fast request
against a 0.75 s wall-clock budget and treated any overshoot as proof
of serialization. But that latency also includes spawning the session's
worker subprocess, which varies with runner load. Real failures were
observed at 0.81 s and 0.89 s on 2-core Windows runners — parallel
execution misreported as serialized, with only ~0.08 s of margin.

**New approach (overlap-span bound):** instead of timing one request,
measure the total span of two overlapping tasks:

- a long task sleeps 3.0 s in session A, started first;
- a short task sleeps 2.0 s in session B while A is still running.

Parallel execution finishes in ~3.0 s (the longer of the two); a
serialized implementation needs ~5.0 s (3 + 2). A 4.5 s bound leaves
~1.5 s of headroom for runner jitter on the parallel side while the
serialized case still overshoots it by ~0.5 s — the verdict now rests
on a 2 s gap that normal jitter cannot flip.

Both workers are warmed up before timing starts, so subprocess spawn
cost stays outside the timed span. The previous direct proof (the long
task is still running when the short one returns) is retained alongside
the span bound.

**Related Issue:** none; the flakes surfaced during #6764 CI validation
(0.81 s / 0.89 s vs the old 0.75 s budget) — a pre-existing flaky test.

**Security Considerations:** none, tests only.

## Type of Change

- [x] Refactoring

## Component(s) Affected

- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — not needed
- [x] Ready for review

## Testing

- Local: 20 consecutive runs pass in 4.40–4.42 s each (timed span
  ~3.0 s, 1.5 s below the bound; jitter 0.02 s).
- Local under CPU contention (4 busy-loop burners simulating a loaded
  runner): 6 consecutive runs pass in 4.40–4.43 s — the bound holds
  under load.
- Full file regression: 4 passed in 10.06 s.
- Fork full-integration CI (yutai78786/QwenPaw run 32350910561,
  four-platform matrix): all green; the Windows integration job — where
  the original flakes occurred — runs this test as PASSED; overall
  `820 passed, 7 skipped, 4 xpassed`.

## Evidence

```bash
$ pytest tests/integration/browser/test_execution_lifecycle_e2e.py::test_sibling_sessions_run_without_serializing -q
# 20 consecutive runs:
1 passed in 4.41s  # ... (4.40–4.42 s, jitter 0.02 s)

$ pytest tests/integration/browser/test_execution_lifecycle_e2e.py -q
4 passed in 10.06s

$ pre-commit run --files tests/integration/browser/test_execution_lifecycle_e2e.py
# black / flake8 / pylint / mypy all Passed
```

Fork CI: https://github.com/yutai78786/QwenPaw/actions/runs/32350910561

Old-assertion flake observations (fork CI logs): 0.89 s and 0.81 s
against the 0.75 s budget.

## Additional Notes

- Tests-only change: one test file, +46/-12; no production code is
  touched.
- Test name, intent, and location are unchanged — no gate or marker
  selection is affected.
- Task durations (2 s / 3 s) and the 4.5 s bound were settled in
  review: lengthening the short task to 2 s widens the parallel-vs-
  serialized gap from 1 s to 2 s for extra jitter resistance.
