### PR TITLE
fix(chat): exclude reasoning from generated titles

### DIFF
--- a/src/qwenpaw/app/chats/title_generator.py
+++ b/src/qwenpaw/app/chats/title_generator.py
@@ -42,21 +42,23 @@ TITLE_PROMPT = (
 
 MAX_INPUT_CHARS = 500
 MAX_TITLE_CHARS = 60
-_INLINE_REASONING_BLOCK_RE = re.compile(
-    r"<(?P<tag>think(?:ing)?|analysis|reasoning)\b[^>]*>"
+_LEADING_REASONING_BLOCK_RE = re.compile(
+    r"\A\s*<(?P<tag>think(?:ing)?|analysis|reasoning)\b[^>]*>"
     + r".*?</(?P=tag)\s*>",
     flags=re.IGNORECASE | re.DOTALL,
 )
-_UNTERMINATED_REASONING_BLOCK_RE = re.compile(
-    r"<(?:think(?:ing)?|analysis|reasoning)\b[^>]*>.*\Z",
+_LEADING_REASONING_TAG_RE = re.compile(
+    r"\A\s*<(?:think(?:ing)?|analysis|reasoning)\b[^>]*>",
     flags=re.IGNORECASE | re.DOTALL,
 )
 
 
 def _clean_title(raw: str) -> str:
     """Normalize model output into a single-line title."""
-    answer = _INLINE_REASONING_BLOCK_RE.sub("", raw).strip()
-    if _UNTERMINATED_REASONING_BLOCK_RE.search(answer):
+    answer = raw.strip()
+    while match := _LEADING_REASONING_BLOCK_RE.match(answer):
+        answer = answer[match.end() :].lstrip()
+    if _LEADING_REASONING_TAG_RE.match(answer):
         return ""
     title = answer.splitlines()[0] if answer else ""
     title = title.strip().strip("\"'`“”‘’")

--- a/src/qwenpaw/app/chats/title_generator.py
+++ b/src/qwenpaw/app/chats/title_generator.py
@@ -137,7 +137,11 @@ async def generate_and_update_title(
             ]
 
             raw_title = await asyncio.wait_for(
-                consume_model_response(model, messages),
+                consume_model_response(
+                    model,
+                    messages,
+                    disable_thinking=True,
+                ),
                 timeout=timeout,
             )
             title = _clean_title(raw_title)

--- a/src/qwenpaw/app/chats/title_generator.py
+++ b/src/qwenpaw/app/chats/title_generator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from qwenpaw.exceptions import AppBaseException
@@ -41,11 +42,23 @@ TITLE_PROMPT = (
 
 MAX_INPUT_CHARS = 500
 MAX_TITLE_CHARS = 60
+_INLINE_REASONING_BLOCK_RE = re.compile(
+    r"<(?P<tag>think(?:ing)?|analysis|reasoning)\b[^>]*>"
+    + r".*?</(?P=tag)\s*>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_UNTERMINATED_REASONING_BLOCK_RE = re.compile(
+    r"<(?:think(?:ing)?|analysis|reasoning)\b[^>]*>.*\Z",
+    flags=re.IGNORECASE | re.DOTALL,
+)
 
 
 def _clean_title(raw: str) -> str:
     """Normalize model output into a single-line title."""
-    title = raw.strip().splitlines()[0] if raw.strip() else ""
+    answer = _INLINE_REASONING_BLOCK_RE.sub("", raw).strip()
+    if _UNTERMINATED_REASONING_BLOCK_RE.search(answer):
+        return ""
+    title = answer.splitlines()[0] if answer else ""
     title = title.strip().strip("\"'`“”‘’")
     while title and title[-1] in ".,;:!?":
         title = title[:-1].rstrip()
@@ -137,11 +150,7 @@ async def generate_and_update_title(
             ]
 
             raw_title = await asyncio.wait_for(
-                consume_model_response(
-                    model,
-                    messages,
-                    disable_thinking=True,
-                ),
+                consume_model_response(model, messages),
                 timeout=timeout,
             )
             title = _clean_title(raw_title)

--- a/src/qwenpaw/utils/model_response.py
+++ b/src/qwenpaw/utils/model_response.py
@@ -12,6 +12,15 @@ from __future__ import annotations
 from collections.abc import AsyncIterable
 from typing import Any
 
+_REASONING_BLOCK_TYPES = frozenset(
+    {
+        "analysis",
+        "reasoning",
+        "reasoning_content",
+        "thinking",
+    },
+)
+
 
 def safe_attr(obj: Any, name: str) -> Any:
     """``getattr(obj, name, None)`` that also returns ``None`` for dict-like
@@ -26,8 +35,14 @@ def safe_attr(obj: Any, name: str) -> Any:
 
 
 def _first_text_in_list(items: list) -> str:
-    """First text fragment from a list-of-blocks ``content``."""
+    """First answer text from block content, excluding reasoning blocks."""
     for item in items:
+        block_type = safe_attr(item, "type")
+        if (
+            isinstance(block_type, str)
+            and block_type.lower() in _REASONING_BLOCK_TYPES
+        ):
+            continue
         got = (
             item.get("text")
             if isinstance(item, dict)
@@ -42,20 +57,24 @@ def extract_response_text(response: Any) -> str:
     """Pull text out of a ``ChatResponse``-like object or a stream chunk.
 
     Handles the ``.text`` scalar, a ``.content`` string, and the
-    list-of-text-blocks shape some providers return.
+    list-of-text-blocks shape some providers return. Explicit reasoning and
+    thinking blocks are never treated as answer text, including non-standard
+    compatible-provider blocks that store their payload under ``text``.
     """
     if response is None:
         return ""
     if isinstance(response, str):
         return response
-    text = safe_attr(response, "text")
-    if isinstance(text, str) and text:
-        return text
     content = safe_attr(response, "content")
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        return _first_text_in_list(content)
+        answer = _first_text_in_list(content)
+        if answer:
+            return answer
+    text = safe_attr(response, "text")
+    if isinstance(text, str) and text:
+        return text
     return ""
 
 

--- a/src/qwenpaw/utils/model_response.py
+++ b/src/qwenpaw/utils/model_response.py
@@ -57,9 +57,11 @@ def extract_response_text(response: Any) -> str:
     """Pull text out of a ``ChatResponse``-like object or a stream chunk.
 
     Handles the ``.text`` scalar, a ``.content`` string, and the
-    list-of-text-blocks shape some providers return. Explicit reasoning and
-    thinking blocks are never treated as answer text, including non-standard
-    compatible-provider blocks that store their payload under ``text``.
+    list-of-text-blocks shape some providers return. A non-empty structured
+    ``content`` list is authoritative over an aggregate ``.text`` value.
+    Explicit reasoning and thinking blocks are never treated as answer text,
+    including non-standard compatible-provider blocks that store their
+    payload under ``text``.
     """
     if response is None:
         return ""
@@ -68,10 +70,11 @@ def extract_response_text(response: Any) -> str:
     content = safe_attr(response, "content")
     if isinstance(content, str):
         return content
-    if isinstance(content, list):
-        answer = _first_text_in_list(content)
-        if answer:
-            return answer
+    if isinstance(content, list) and content:
+        # A non-empty structured response is authoritative. Falling back to
+        # an aggregate ``.text`` value when it contains only thinking blocks
+        # can re-introduce the reasoning text that was deliberately skipped.
+        return _first_text_in_list(content)
     text = safe_attr(response, "text")
     if isinstance(text, str) and text:
         return text

--- a/tests/unit/app/chats/test_title_generator.py
+++ b/tests/unit/app/chats/test_title_generator.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Tests for asynchronous chat-title generation."""
 
 from types import SimpleNamespace
+
+import pytest
 
 from qwenpaw.app.chats import title_generator
 
@@ -20,8 +23,10 @@ class _ChatManager:
         return SimpleNamespace(id=chat_id, name=patch.name)
 
 
-async def test_title_generation_disables_thinking(monkeypatch):
-    """Utility title calls should not ask reasoning models to think."""
+async def test_title_generation_keeps_thinking_out_of_persisted_title(
+    monkeypatch,
+):
+    """Reasoning may run, but only the final answer becomes the title."""
     seen_kwargs = {}
     chat_manager = _ChatManager()
     workspace = SimpleNamespace(
@@ -52,7 +57,10 @@ async def test_title_generation_disables_thinking(monkeypatch):
         assert received_model is model
         assert messages[-1].content[0].text == "How do I deploy QwenPaw?"
         seen_kwargs.update(kwargs)
-        return "Deploying QwenPaw"
+        return (
+            "<think>Here's a thinking process about the request.</think>\n"
+            "Deploying QwenPaw"
+        )
 
     monkeypatch.setattr(title_generator, "run_sync_io", fake_run_sync_io)
     monkeypatch.setattr(
@@ -72,5 +80,28 @@ async def test_title_generation_disables_thinking(monkeypatch):
         placeholder_name="How do I d",
     )
 
-    assert seen_kwargs == {"disable_thinking": True}
+    assert not seen_kwargs
     assert chat_manager.updated_title == "Deploying QwenPaw"
+
+
+def test_clean_title_rejects_unterminated_inline_reasoning():
+    assert (
+        title_generator._clean_title(
+            "<think>Here's a thinking process without a final answer",
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "<think>reasoning</think>\nDeploying QwenPaw",
+        "<thinking>reasoning</thinking>\nDeploying QwenPaw",
+        "<analysis>reasoning</analysis>\nDeploying QwenPaw",
+        "<reasoning>reasoning</reasoning>\nDeploying QwenPaw",
+        "<THINK mode='deep'>reasoning</THINK>\nDeploying QwenPaw",
+    ],
+)
+def test_clean_title_strips_common_inline_reasoning_formats(raw):
+    assert title_generator._clean_title(raw) == "Deploying QwenPaw"

--- a/tests/unit/app/chats/test_title_generator.py
+++ b/tests/unit/app/chats/test_title_generator.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Tests for asynchronous chat-title generation."""
+
+from types import SimpleNamespace
+
+from qwenpaw.app.chats import title_generator
+
+
+class _ChatManager:
+    def __init__(self) -> None:
+        self.updated_title: str | None = None
+
+    async def patch_chat_if_name_matches(
+        self,
+        chat_id,
+        _placeholder_name,
+        patch,
+    ):
+        self.updated_title = patch.name
+        return SimpleNamespace(id=chat_id, name=patch.name)
+
+
+async def test_title_generation_disables_thinking(monkeypatch):
+    """Utility title calls should not ask reasoning models to think."""
+    seen_kwargs = {}
+    chat_manager = _ChatManager()
+    workspace = SimpleNamespace(
+        agent_id="agent-1",
+        chat_manager=chat_manager,
+    )
+    config = SimpleNamespace(
+        running=SimpleNamespace(
+            auto_title_config=SimpleNamespace(
+                enabled=True,
+                timeout_seconds=5,
+            ),
+        ),
+    )
+    model = object()
+
+    async def fake_run_sync_io(_func, *_args):
+        return config
+
+    async def fake_create_model_and_formatter_async(**_kwargs):
+        return model, object()
+
+    async def fake_consume_model_response(
+        received_model,
+        messages,
+        **kwargs,
+    ):
+        assert received_model is model
+        assert messages[-1].content[0].text == "How do I deploy QwenPaw?"
+        seen_kwargs.update(kwargs)
+        return "Deploying QwenPaw"
+
+    monkeypatch.setattr(title_generator, "run_sync_io", fake_run_sync_io)
+    monkeypatch.setattr(
+        title_generator,
+        "consume_model_response",
+        fake_consume_model_response,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.model_factory.create_model_and_formatter_async",
+        fake_create_model_and_formatter_async,
+    )
+
+    await title_generator.generate_and_update_title(
+        workspace=workspace,
+        chat_id="chat-1",
+        user_message="How do I deploy QwenPaw?",
+        placeholder_name="How do I d",
+    )
+
+    assert seen_kwargs == {"disable_thinking": True}
+    assert chat_manager.updated_title == "Deploying QwenPaw"

--- a/tests/unit/app/chats/test_title_generator.py
+++ b/tests/unit/app/chats/test_title_generator.py
@@ -84,13 +84,35 @@ async def test_title_generation_keeps_thinking_out_of_persisted_title(
     assert chat_manager.updated_title == "Deploying QwenPaw"
 
 
-def test_clean_title_rejects_unterminated_inline_reasoning():
+def test_clean_title_rejects_unterminated_leading_reasoning():
     assert (
         title_generator._clean_title(
             "<think>Here's a thinking process without a final answer",
         )
         == ""
     )
+
+
+def test_clean_title_keeps_answer_before_unterminated_reasoning():
+    assert (
+        title_generator._clean_title(
+            "Deploying QwenPaw\n<think>truncated reasoning",
+        )
+        == "Deploying QwenPaw"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Understanding <think> Tags",
+        "Meaning of <think>foo</think>",
+        "Escaping <analysis> in XML",
+        "Use <reasoning> safely",
+    ],
+)
+def test_clean_title_preserves_reasoning_tags_in_answer(raw):
+    assert title_generator._clean_title(raw) == raw
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_model_response.py
+++ b/tests/unit/utils/test_model_response.py
@@ -92,6 +92,23 @@ def test_extract_response_text_prefers_typed_answer_over_combined_text():
     assert extract_response_text(response) == "Deploying QwenPaw"
 
 
+def test_extract_response_text_does_not_fall_back_from_thinking_only_content():
+    response = SimpleNamespace(
+        text="Here's a thinking process",
+        content=[
+            {"type": "thinking", "text": "Here's a thinking process"},
+        ],
+    )
+
+    assert extract_response_text(response) == ""
+
+
+def test_extract_response_text_falls_back_from_empty_content_list():
+    response = SimpleNamespace(text="Deploying QwenPaw", content=[])
+
+    assert extract_response_text(response) == "Deploying QwenPaw"
+
+
 async def test_consume_non_streaming():
     async def model(messages, **kw):
         return SimpleNamespace(text="done")

--- a/tests/unit/utils/test_model_response.py
+++ b/tests/unit/utils/test_model_response.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from agentscope.model import ChatResponse
+from agentscope.message import TextBlock, ThinkingBlock
 
 from qwenpaw.utils.model_response import (
     consume_model_response,
@@ -53,6 +54,44 @@ def test_extract_response_text(response, expected):
     assert extract_response_text(response) == expected
 
 
+def test_extract_response_text_skips_typed_thinking_block():
+    response = ChatResponse(
+        content=[
+            ThinkingBlock(thinking="Here's a thinking process"),
+            TextBlock(text="Deploying QwenPaw"),
+        ],
+        is_last=True,
+    )
+
+    assert extract_response_text(response) == "Deploying QwenPaw"
+
+
+def test_extract_response_text_skips_compatible_reasoning_text_block():
+    response = {
+        "content": [
+            {
+                "type": "reasoning",
+                "text": "Here's a thinking process",
+            },
+            {"type": "text", "text": "Deploying QwenPaw"},
+        ],
+    }
+
+    assert extract_response_text(response) == "Deploying QwenPaw"
+
+
+def test_extract_response_text_prefers_typed_answer_over_combined_text():
+    response = SimpleNamespace(
+        text="Here's a thinking process\nDeploying QwenPaw",
+        content=[
+            {"type": "thinking", "text": "Here's a thinking process"},
+            {"type": "text", "text": "Deploying QwenPaw"},
+        ],
+    )
+
+    assert extract_response_text(response) == "Deploying QwenPaw"
+
+
 async def test_consume_non_streaming():
     async def model(messages, **kw):
         return SimpleNamespace(text="done")
@@ -68,6 +107,26 @@ async def test_consume_agentscope_chat_response():
         )
 
     assert await consume_model_response(model, []) == "done"
+
+
+async def test_consume_agentscope_stream_ignores_thinking_chunks():
+    async def model(messages, **kw):
+        async def gen():
+            yield ChatResponse(
+                content=[ThinkingBlock(thinking="Analyze the request")],
+                is_last=False,
+            )
+            yield ChatResponse(
+                content=[
+                    ThinkingBlock(thinking="Analyze the request"),
+                    TextBlock(text="Deploying QwenPaw"),
+                ],
+                is_last=True,
+            )
+
+        return gen()
+
+    assert await consume_model_response(model, []) == "Deploying QwenPaw"
 
 
 async def test_consume_streaming_takes_last_non_empty_chunk():


### PR DESCRIPTION
## Summary

Prevent model reasoning content from being persisted as automatically generated chat titles.

This keeps thinking enabled according to the user's model configuration. It only separates reasoning from the final answer when consuming model responses.

Fixes #6979.

## Changes

- Treat non-empty structured `content` blocks as authoritative over aggregated `.text`.
- Exclude `thinking`, `reasoning`, `reasoning_content`, and `analysis` blocks from extracted answer text.
- Prevent thinking-only structured responses from falling back to `.text` and leaking reasoning.
- Preserve `.text` compatibility when structured `content` is absent or empty.
- Strip leading `<think>`, `<thinking>`, `<analysis>`, and `<reasoning>` blocks from generated titles.
- Reject unterminated leading reasoning blocks while preserving:
  - a valid title emitted before truncated reasoning;
  - legitimate reasoning tags used inside the title text.
- Leave the existing placeholder unchanged when no safe title can be extracted.

## Scope and compatibility

`extract_response_text()` is a shared helper used by:

- automatic title generation;
- governance rule generalization.

The structured-content precedence therefore applies to both call paths. Normal Agent conversation streaming does not use this helper and is unchanged.

This PR does not:

- disable model thinking;
- send provider-specific reasoning parameters;
- change normal Agent responses;
- read compressed conversation history when generating a title.

## Tests

Added coverage for:

- AgentScope `ThinkingBlock` followed by a final `TextBlock`;
- compatible-provider reasoning blocks whose payload is stored under `text`;
- responses containing both structured content and aggregated `.text`;
- thinking-only structured responses;
- empty structured content falling back to `.text`;
- streaming responses containing thinking chunks;
- common inline reasoning tag formats;
- unterminated leading reasoning;
- valid titles followed by truncated reasoning;
- legitimate reasoning tags inside title text.

Validation:

- `172 passed`
- pre-commit checks passed, including mypy, black, flake8, and pylint