### PR TITLE
fix(console): preserve non-ASCII file card names

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -111,6 +111,15 @@ describe("getMediaInfo", () => {
     ...overrides,
   });
 
+  const dataBlockResult = (url: string, name?: string): string =>
+    JSON.stringify([
+      {
+        type: "data",
+        source: { type: "url", url, media_type: "text/markdown" },
+        ...(name ? { name } : {}),
+      },
+    ]);
+
   it("does not fall back to a relative param path (backend cannot preview it)", () => {
     const media = getMediaInfo(
       baseToolCall({ params: { file_path: "file1.txt" } }),
@@ -149,6 +158,58 @@ describe("getMediaInfo", () => {
     );
     expect(media?.url).toBe("/api/files/preview/abs/path/file1.txt");
     expect(media?.name).toBe("file1.txt");
+  });
+
+  it("prefers a DataBlock name over its percent-encoded URL basename", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        status: "done",
+        result: dataBlockResult(
+          "file:///abs/path/QA%E6%B5%8B%E8%AF%95.md",
+          "QA测试.md",
+        ),
+      }),
+    );
+
+    expect(media).toEqual({
+      url: "/api/files/preview/abs/path/QA%E6%B5%8B%E8%AF%95.md",
+      name: "QA测试.md",
+      type: "file",
+    });
+  });
+
+  it("decodes a percent-encoded URL basename when no name is provided", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        status: "done",
+        result: dataBlockResult("file:///abs/path/QA%E6%B5%8B%E8%AF%95.md"),
+      }),
+    );
+
+    expect(media?.name).toBe("QA测试.md");
+  });
+
+  it("preserves a malformed URL basename instead of throwing", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        status: "done",
+        result: dataBlockResult("file:///abs/path/report%ZZ.md"),
+      }),
+    );
+
+    expect(media?.name).toBe("report%ZZ.md");
+  });
+
+  it("falls back to the param filename when the result URL has no basename", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        params: { file_path: "/abs/path/report.md" },
+        status: "done",
+        result: dataBlockResult("file:///abs/path/"),
+      }),
+    );
+
+    expect(media?.name).toBe("report.md");
   });
 
   it("only auto-expands multimedia file previews", () => {

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -30,6 +30,16 @@ export function shortFileName(filePath: string): string {
   return parts[parts.length - 1] || filePath;
 }
 
+function filenameFromUrl(url: string): string {
+  const path = url.split(/[?#]/, 1)[0];
+  const filename = path.replace(/\\/g, "/").split("/").pop() || "";
+  try {
+    return decodeURIComponent(filename);
+  } catch {
+    return filename;
+  }
+}
+
 /** Count lines in a string */
 export function countLines(text: unknown): number {
   if (typeof text !== "string" || !text) return 0;
@@ -165,6 +175,9 @@ function extractUrlFromResultBlocks(
   for (const block of arr) {
     if (!block || typeof block !== "object") continue;
     const b = block as Record<string, unknown>;
+    const filename = [b.filename, b.file_name, b.name].find(
+      (value): value is string => typeof value === "string" && Boolean(value),
+    );
 
     // Content blocks with source.url (file / image / video / audio types)
     if (b.source && typeof b.source === "object") {
@@ -172,7 +185,7 @@ function extractUrlFromResultBlocks(
       if (typeof src.url === "string" && src.url) {
         return {
           url: src.url,
-          filename: typeof b.filename === "string" ? b.filename : undefined,
+          filename,
         };
       }
     }
@@ -181,13 +194,13 @@ function extractUrlFromResultBlocks(
     if (typeof b.url === "string" && b.url) {
       return {
         url: b.url,
-        filename: typeof b.filename === "string" ? b.filename : undefined,
+        filename,
       };
     }
     if (typeof b.path === "string" && b.path) {
       return {
         url: b.path,
-        filename: typeof b.filename === "string" ? b.filename : undefined,
+        filename,
       };
     }
   }
@@ -243,7 +256,7 @@ export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
 
   const name =
     fromResult?.filename ||
-    rawUrl.split("/").pop() ||
+    filenameFromUrl(rawUrl) ||
     paramPath.split("/").pop() ||
     "file";
   const ext = getFileExtFromPath(name);


### PR DESCRIPTION
## Description

Fixes #7136.

AgentScope 2.0 serializes a `DataBlock` display filename as `name`, while the
shared Console tool-card parser only read `filename`. `URLSource` correctly
percent-encodes non-ASCII path segments, so the parser then fell back to an
encoded URL basename such as `QA%E6%B5%8B%E8%AF%95.md`.

This change:

- normalizes `filename`, `file_name`, and `name` in the shared result-block
  parser;
- safely decodes a URL basename only when no structured name is available;
- preserves malformed escapes and the existing basename-less URL fallback;
- leaves preview URLs, backend paths, and provider formatting unchanged.

The shared parser is used by send-file, image, video, screenshot, and generic
attachment cards, so the fix applies at their common display boundary.

**Related Issue:** Fixes #7136

**Security Considerations:** Decoding is limited to the React-rendered display
name. The preview URL and file target remain unchanged, malformed encodings are
kept verbatim, and React continues to escape rendered text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable: this changes only shared Console card display parsing and does
not modify a channel implementation or contract.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Verification matrix:

| Surface | Result |
| --- | --- |
| Structured `DataBlock.name` | Preferred and rendered unchanged |
| Legacy `filename` | Existing behavior preserved |
| Percent-encoded URL fallback | Decoded for display |
| Malformed percent escape | Preserved without throwing |
| URL without basename | Falls back to the parameter filename |
| Preview URL | Remains percent-encoded and unchanged |
| Backend/provider paths | Not modified |

## Evidence

The regression test failed on `main` with the reported display value:

```text
Expected: "QA测试.md"
Received: "QA%E6%B5%8B%E8%AF%95.md"
```

After the fix:

```bash
npm run test:run -- \
  src/components/Chat/ToolCards/cards/GrepSearchCard.test.tsx \
  src/components/Chat/ToolCards/cards/SendFileCard.test.tsx \
  src/components/Chat/ToolCards/shared/DefaultBlock.test.tsx \
  src/components/Chat/ToolCards/shared/FileAttachmentPreview.test.tsx \
  src/components/Chat/ToolCards/shared/MediaPreview.test.tsx \
  src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx \
  src/components/Chat/ToolCards/shared/toolCards.module.test.ts \
  src/components/Chat/ToolCards/shared/utils.test.ts
# Test Files  8 passed (8)
# Tests       47 passed (47)

npm exec eslint -- \
  src/components/Chat/ToolCards/shared/utils.ts \
  src/components/Chat/ToolCards/shared/utils.test.ts
# passed

npm exec prettier -- --check \
  src/components/Chat/ToolCards/shared/utils.ts \
  src/components/Chat/ToolCards/shared/utils.test.ts
# All matched files use Prettier code style!

pre-commit run --files \
  console/src/components/Chat/ToolCards/shared/utils.ts \
  console/src/components/Chat/ToolCards/shared/utils.test.ts
# all applicable hooks passed

npm run build
# TypeScript and Vite build completed; Monaco stylesheet verification passed.
```

## Additional Notes

No screenshot is included because this is a display-value parsing fix with no
layout change. The regression asserts the exact readable name and the unchanged
percent-encoded preview URL returned to the card.
