### PR TITLE
fix(console): decode non-ASCII file card names from DataBlock

### DIFF
--- a/console/src/components/Chat/ToolCards/cards/RunToolBatchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/RunToolBatchCard.tsx
@@ -8,7 +8,6 @@ import {
   stringifyResult,
   toDisplayUrl,
   getFileExtFromPath,
-  fileNameFromUrl,
 } from "../shared/utils";
 import type { DefaultBlockProps } from "../shared";
 
@@ -252,7 +251,6 @@ function extractMediaFromBlocks(result: unknown): MediaInfo[] {
       (typeof item.file_name === "string" && item.file_name) ||
       (typeof item.name === "string" && item.name) ||
       (typeof item.title === "string" && item.title) ||
-      fileNameFromUrl(rawUrl) ||
       shortFileName(rawUrl);
     const ext = getFileExtFromPath(rawUrl);
     const type =

--- a/console/src/components/Chat/ToolCards/cards/RunToolBatchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/RunToolBatchCard.tsx
@@ -8,6 +8,7 @@ import {
   stringifyResult,
   toDisplayUrl,
   getFileExtFromPath,
+  fileNameFromUrl,
 } from "../shared/utils";
 import type { DefaultBlockProps } from "../shared";
 
@@ -251,6 +252,7 @@ function extractMediaFromBlocks(result: unknown): MediaInfo[] {
       (typeof item.file_name === "string" && item.file_name) ||
       (typeof item.name === "string" && item.name) ||
       (typeof item.title === "string" && item.title) ||
+      fileNameFromUrl(rawUrl) ||
       shortFileName(rawUrl);
     const ext = getFileExtFromPath(rawUrl);
     const type =

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -13,6 +13,7 @@ import {
   formatMemorySearch,
   getMediaInfo,
   hasMultimediaPreview,
+  shortFileName,
 } from "./utils";
 import type { ToolCallContent } from "./types";
 
@@ -30,6 +31,33 @@ const translate = ((key: string) => {
 
   return translations[key] ?? key;
 }) as TFunction;
+
+describe("shortFileName", () => {
+  it("extracts a filename from a POSIX path", () => {
+    expect(shortFileName("/tmp/report.txt")).toBe("report.txt");
+  });
+
+  it("extracts a filename from a Windows path", () => {
+    expect(shortFileName("C:\\Users\\test\\report.txt")).toBe("report.txt");
+  });
+
+  it("strips URL query and hash and decodes the filename", () => {
+    expect(
+      shortFileName(
+        "https://example.com/QA%E6%B5%8B%E8%AF%95.md?download=1#preview",
+      ),
+    ).toBe("QA测试.md");
+  });
+
+  it("keeps malformed percent sequences verbatim", () => {
+    expect(shortFileName("file:///tmp/100%_done.md")).toBe("100%_done.md");
+  });
+
+  it("returns no filename for inline data and blob URLs", () => {
+    expect(shortFileName("data:text/plain;base64,abc")).toBe("");
+    expect(shortFileName("blob:https://example.com/id")).toBe("");
+  });
+});
 
 describe("formatMemorySearch", () => {
   it("renders memory search results as readable markdown cards", () => {

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -151,6 +151,64 @@ describe("getMediaInfo", () => {
     expect(media?.name).toBe("file1.txt");
   });
 
+  it("uses the DataBlock `name` for a non-ASCII filename", () => {
+    // agentscope types URLSource.url as a pydantic AnyUrl, so the URL always
+    // arrives percent-encoded while the readable name rides along on `name`.
+    const media = getMediaInfo(
+      baseToolCall({
+        params: { file_path: "/media/QA测试_示例.md" },
+        status: "done",
+        result: JSON.stringify([
+          {
+            type: "data",
+            source: {
+              type: "url",
+              url: "file:///media/QA%E6%B5%8B%E8%AF%95_%E7%A4%BA%E4%BE%8B.md",
+              media_type: "text/markdown",
+            },
+            name: "QA测试_示例.md",
+          },
+          { type: "text", text: "File sent successfully." },
+        ]),
+      }),
+    );
+    expect(media?.name).toBe("QA测试_示例.md");
+  });
+
+  it("decodes a percent-encoded URL when no block name is present", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        status: "done",
+        result: JSON.stringify([
+          {
+            type: "data",
+            source: {
+              type: "url",
+              url: "file:///media/QA%E6%B5%8B%E8%AF%95_%E7%A4%BA%E4%BE%8B.md",
+              media_type: "text/markdown",
+            },
+          },
+        ]),
+      }),
+    );
+    expect(media?.name).toBe("QA测试_示例.md");
+  });
+
+  it("keeps a malformed percent sequence verbatim instead of throwing", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        status: "done",
+        result: JSON.stringify([
+          {
+            type: "data",
+            source: { type: "url", url: "file:///media/100%_done.md" },
+          },
+        ]),
+      }),
+    );
+    expect(media?.name).toBe("100%_done.md");
+  });
+
   it("only auto-expands multimedia file previews", () => {
     expect(
       hasMultimediaPreview(

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -5,6 +5,7 @@
 
 import type { TFunction } from "i18next";
 import type { ToolCallContent } from "./types";
+import { mediaFilenameFromUrl } from "../../MediaDownload/utils";
 import { chatApi } from "@/api/modules/chat";
 
 // ---------------------------------------------------------------------------
@@ -28,6 +29,17 @@ export function toDisplayUrl(url: string): string {
 export function shortFileName(filePath: string): string {
   const parts = filePath.replace(/\\/g, "/").split("/");
   return parts[parts.length - 1] || filePath;
+}
+
+/**
+ * Last path segment of a URL, percent-decoded for display.
+ *
+ * Non-ASCII names reach the frontend percent-encoded because agentscope
+ * types `URLSource.url` as a pydantic `AnyUrl`, which encodes them on
+ * serialization. Returns "" when no segment can be derived (data:/blob:).
+ */
+export function fileNameFromUrl(url: string): string {
+  return mediaFilenameFromUrl(url, "");
 }
 
 /** Count lines in a string */
@@ -136,6 +148,17 @@ function classifyMediaType(ext: string): MediaType {
 }
 
 /**
+ * Display filename carried by a content block. agentscope 2.x `DataBlock`
+ * stores it as `name`, MCP-style blocks as `filename` / `file_name`.
+ */
+function blockFilename(b: Record<string, unknown>): string | undefined {
+  for (const value of [b.filename, b.file_name, b.name]) {
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+/**
  * Extract a URL and filename from a result that uses the MCP content-block
  * array format, e.g.:
  * `[{"type":"file","source":{"type":"url","url":"file:///..."},"filename":"a.txt"},
@@ -170,25 +193,16 @@ function extractUrlFromResultBlocks(
     if (b.source && typeof b.source === "object") {
       const src = b.source as Record<string, unknown>;
       if (typeof src.url === "string" && src.url) {
-        return {
-          url: src.url,
-          filename: typeof b.filename === "string" ? b.filename : undefined,
-        };
+        return { url: src.url, filename: blockFilename(b) };
       }
     }
 
     // Flat blocks: { url: "..." } or { path: "..." }
     if (typeof b.url === "string" && b.url) {
-      return {
-        url: b.url,
-        filename: typeof b.filename === "string" ? b.filename : undefined,
-      };
+      return { url: b.url, filename: blockFilename(b) };
     }
     if (typeof b.path === "string" && b.path) {
-      return {
-        url: b.path,
-        filename: typeof b.filename === "string" ? b.filename : undefined,
-      };
+      return { url: b.path, filename: blockFilename(b) };
     }
   }
 
@@ -243,7 +257,7 @@ export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
 
   const name =
     fromResult?.filename ||
-    rawUrl.split("/").pop() ||
+    fileNameFromUrl(rawUrl) ||
     paramPath.split("/").pop() ||
     "file";
   const ext = getFileExtFromPath(name);

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -27,19 +27,11 @@ export function toDisplayUrl(url: string): string {
 
 /** Extract short file name from a path */
 export function shortFileName(filePath: string): string {
-  const parts = filePath.replace(/\\/g, "/").split("/");
-  return parts[parts.length - 1] || filePath;
-}
-
-/**
- * Last path segment of a URL, percent-decoded for display.
- *
- * Non-ASCII names reach the frontend percent-encoded because agentscope
- * types `URLSource.url` as a pydantic `AnyUrl`, which encodes them on
- * serialization. Returns "" when no segment can be derived (data:/blob:).
- */
-export function fileNameFromUrl(url: string): string {
-  return mediaFilenameFromUrl(url, "");
+  const filename = mediaFilenameFromUrl(filePath, "");
+  if (filename) return filename;
+  return filePath.startsWith("data:") || filePath.startsWith("blob:")
+    ? ""
+    : filePath;
 }
 
 /** Count lines in a string */
@@ -257,8 +249,8 @@ export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
 
   const name =
     fromResult?.filename ||
-    fileNameFromUrl(rawUrl) ||
-    paramPath.split("/").pop() ||
+    shortFileName(rawUrl) ||
+    shortFileName(paramPath) ||
     "file";
   const ext = getFileExtFromPath(name);
   const mediaType = classifyMediaType(ext);


### PR DESCRIPTION
File cards from send_file_to_user showed percent-encoded mojibake for non-ASCII (e.g. Chinese) filenames. agentscope types URLSource.url as a pydantic AnyUrl that encodes non-ASCII on serialization, so the readable name only survives on the block's name field.

- Prefer filename/file_name/name from result blocks (covers DataBlock)
- decodeURIComponent the URL last segment when falling back
- Apply same fallback in run_tool_batch aggregate

Fixes #7136

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
