### PR TITLE
fix(workspace): make startup failure cleanup cancellation-safe

### DIFF
--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -23,8 +23,9 @@ from ..constant import (
     CUSTOM_AGENT_STARTUP_CONCURRENCY,
 )
 from ..config.utils import load_config
-from ..utils.startup_display import AgentStartupDisplay
+from ..utils.io_utils import run_async_to_completion
 from ..utils.logging import sanitize_log_value
+from ..utils.startup_display import AgentStartupDisplay
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,29 @@ class MultiAgentManager:
         Overridden by WorkspaceRegistry.
         """
         return Workspace(agent_id=agent_id, workspace_dir=workspace_dir)
+
+    @staticmethod
+    async def _cleanup_failed_reload_candidate(
+        candidate: Workspace,
+        agent_id: str,
+        original_error: BaseException,
+    ) -> None:
+        """Stop an uncommitted candidate before propagating its failure."""
+        try:
+            await run_async_to_completion(
+                candidate.stop(final=True, preserve_reused=True),
+            )
+        except asyncio.CancelledError:
+            # A later cancellation was delayed until stop() completed. Keep
+            # the cancellation that originally aborted candidate startup.
+            if not isinstance(original_error, asyncio.CancelledError):
+                raise
+        except BaseException:
+            logger.warning(
+                "Failed to clean up uncommitted workspace candidate "
+                f"for {agent_id}",
+                exc_info=True,
+            )
 
     def get_loaded_agent(self, agent_id: str) -> Workspace | None:
         """Return an already loaded workspace without starting it."""
@@ -538,30 +562,36 @@ class MultiAgentManager:
             workspace_dir=agent_ref.workspace_dir,
         )
 
-        # Step 3.5: Set reusable components from old instance (if any)
-        async with self._lock:
-            old_instance = self.agents.get(agent_id)
-
+        # Until the atomic swap commits, this manager exclusively owns the
+        # candidate and must stop it on every exit path.
+        candidate_committed = False
         reusable = {}
-        if old_instance:
-            # TaskTracker is agent-scoped rather than workspace-scoped. Reuse
-            # it before startup so reconnect/status/stop requests arriving
-            # after the atomic swap can still reach in-flight runs.
-            new_instance.set_task_tracker(old_instance.task_tracker)
-
-            # Get all reusable services from old instance's ServiceManager
-            # pylint: disable=protected-access
-            reusable = old_instance._service_manager.get_reusable_services()
-            # pylint: enable=protected-access
-
-            if reusable:
-                await new_instance.set_reusable_components(reusable)
-                logger.info(
-                    f"Set reusable components for {agent_id}: "
-                    f"{list(reusable.keys())}",
-                )
-
         try:
+            # Step 3.5: Set reusable components from old instance (if any)
+            async with self._lock:
+                old_instance = self.agents.get(agent_id)
+
+            if old_instance:
+                # TaskTracker is agent-scoped rather than workspace-scoped.
+                # Reuse it before startup so reconnect/status/stop requests
+                # arriving after the atomic swap can still reach in-flight
+                # runs.
+                new_instance.set_task_tracker(old_instance.task_tracker)
+
+                # Get all reusable services from the old ServiceManager.
+                # pylint: disable=protected-access
+                reusable = (
+                    old_instance._service_manager.get_reusable_services()
+                )
+                # pylint: enable=protected-access
+
+                if reusable:
+                    await new_instance.set_reusable_components(reusable)
+                    logger.info(
+                        f"Set reusable components for {agent_id}: "
+                        f"{list(reusable.keys())}",
+                    )
+
             await new_instance.start()
             new_instance.set_manager(self)  # Set manager reference
             await self._setup_workspace_plugins(
@@ -569,47 +599,61 @@ class MultiAgentManager:
                 str(agent_ref.workspace_dir),
             )
             logger.info(f"New workspace instance started: {agent_id}")
-        except Exception as e:
-            logger.exception(
-                f"Failed to start new workspace instance for {agent_id}: {e}",
-            )
-            # Try to clean up the failed new instance
-            try:
-                await new_instance.stop(final=True, preserve_reused=True)
-            except Exception:
-                pass  # Best effort cleanup
-            # Old instance is still running and serving requests
-            return False
 
-        # Step 4: Atomic swap (minimal lock time)
-        # From this point, reload is considered successful
-        async with self._lock:
-            # Double-check agent still exists
-            if agent_id not in self.agents:
+            # Step 4: Atomic swap (minimal lock time). Do not await candidate
+            # cleanup while holding this lock.
+            discard_reason = None
+            async with self._lock:
+                if agent_id not in self.agents:
+                    discard_reason = "removed"
+                elif self._config_generations.get(agent_id, 0) != generation:
+                    discard_reason = "stale"
+                else:
+                    old_instance = self.agents[agent_id]
+                    self.agents[agent_id] = new_instance
+                    candidate_committed = True
+        except BaseException as error:
+            if candidate_committed:
+                raise
+
+            if isinstance(error, Exception):
+                logger.exception(
+                    "Failed to start new workspace instance for "
+                    f"{agent_id}: {error}",
+                )
+
+            await self._cleanup_failed_reload_candidate(
+                new_instance,
+                agent_id,
+                error,
+            )
+
+            if isinstance(error, asyncio.CancelledError):
+                raise
+            if isinstance(error, Exception):
+                # Old instance is still running and serving requests.
+                return False
+            raise
+
+        if not candidate_committed:
+            if discard_reason == "removed":
                 logger.warning(
                     f"Agent {agent_id} was removed during reload, "
-                    f"stopping new instance",
+                    "stopping new instance",
                 )
-                await new_instance.stop(final=True, preserve_reused=True)
-                return False
-
-            if self._config_generations.get(agent_id, 0) != generation:
-                # The configuration changed while this replacement was
-                # being built: installing it would revert the newer
-                # write. The writer's own reload delivers the fresh
-                # state; the current (already patched in memory)
-                # instance keeps serving until then.
+            else:
+                # Installing this candidate would revert a newer write. The
+                # writer's reload will deliver the fresh state.
                 logger.info(
                     f"Discarding stale reload for {agent_id}: "
-                    f"configuration changed during rebuild",
+                    "configuration changed during rebuild",
                 )
-                await new_instance.stop(final=True, preserve_reused=True)
-                return False
+            await run_async_to_completion(
+                new_instance.stop(final=True, preserve_reused=True),
+            )
+            return False
 
-            # Swap instances atomically
-            old_instance = self.agents[agent_id]
-            self.agents[agent_id] = new_instance
-            logger.info(f"Workspace instance replaced: {agent_id}")
+        logger.info(f"Workspace instance replaced: {agent_id}")
 
         # A reusable service can be rejected during startup when its class no
         # longer matches the newly loaded configuration (for example, after a

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -575,7 +575,7 @@ class MultiAgentManager:
             )
             # Try to clean up the failed new instance
             try:
-                await new_instance.stop()
+                await new_instance.stop(final=True, preserve_reused=True)
             except Exception:
                 pass  # Best effort cleanup
             # Old instance is still running and serving requests
@@ -590,7 +590,7 @@ class MultiAgentManager:
                     f"Agent {agent_id} was removed during reload, "
                     f"stopping new instance",
                 )
-                await new_instance.stop()
+                await new_instance.stop(final=True, preserve_reused=True)
                 return False
 
             if self._config_generations.get(agent_id, 0) != generation:
@@ -603,7 +603,7 @@ class MultiAgentManager:
                     f"Discarding stale reload for {agent_id}: "
                     f"configuration changed during rebuild",
                 )
-                await new_instance.stop()
+                await new_instance.stop(final=True, preserve_reused=True)
                 return False
 
             # Swap instances atomically

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -109,6 +109,58 @@ class MultiAgentManager:
                 exc_info=True,
             )
 
+    async def _prepare_reload_candidate(
+        self,
+        candidate: Workspace,
+        agent_id: str,
+        workspace_dir: str,
+    ) -> dict:
+        """Attach reusable state and fully start a reload candidate."""
+        async with self._lock:
+            old_instance = self.agents.get(agent_id)
+
+        reusable = {}
+        if old_instance:
+            # TaskTracker is agent-scoped rather than workspace-scoped.
+            candidate.set_task_tracker(old_instance.task_tracker)
+
+            # pylint: disable=protected-access
+            reusable = old_instance._service_manager.get_reusable_services()
+            # pylint: enable=protected-access
+            if reusable:
+                await candidate.set_reusable_components(reusable)
+                logger.info(
+                    f"Set reusable components for {agent_id}: "
+                    f"{list(reusable.keys())}",
+                )
+
+        await candidate.start()
+        candidate.set_manager(self)
+        await self._setup_workspace_plugins(candidate, str(workspace_dir))
+        logger.info(f"New workspace instance started: {agent_id}")
+        return reusable
+
+    @staticmethod
+    async def _discard_reload_candidate(
+        candidate: Workspace,
+        agent_id: str,
+        reason: str,
+    ) -> None:
+        """Log and stop a candidate rejected before the atomic swap."""
+        if reason == "removed":
+            logger.warning(
+                f"Agent {agent_id} was removed during reload, "
+                "stopping new instance",
+            )
+        else:
+            logger.info(
+                f"Discarding stale reload for {agent_id}: "
+                "configuration changed during rebuild",
+            )
+        await run_async_to_completion(
+            candidate.stop(final=True, preserve_reused=True),
+        )
+
     def get_loaded_agent(self, agent_id: str) -> Workspace | None:
         """Return an already loaded workspace without starting it."""
         return self.agents.get(agent_id)
@@ -565,40 +617,12 @@ class MultiAgentManager:
         # Until the atomic swap commits, this manager exclusively owns the
         # candidate and must stop it on every exit path.
         candidate_committed = False
-        reusable = {}
         try:
-            # Step 3.5: Set reusable components from old instance (if any)
-            async with self._lock:
-                old_instance = self.agents.get(agent_id)
-
-            if old_instance:
-                # TaskTracker is agent-scoped rather than workspace-scoped.
-                # Reuse it before startup so reconnect/status/stop requests
-                # arriving after the atomic swap can still reach in-flight
-                # runs.
-                new_instance.set_task_tracker(old_instance.task_tracker)
-
-                # Get all reusable services from the old ServiceManager.
-                # pylint: disable=protected-access
-                reusable = (
-                    old_instance._service_manager.get_reusable_services()
-                )
-                # pylint: enable=protected-access
-
-                if reusable:
-                    await new_instance.set_reusable_components(reusable)
-                    logger.info(
-                        f"Set reusable components for {agent_id}: "
-                        f"{list(reusable.keys())}",
-                    )
-
-            await new_instance.start()
-            new_instance.set_manager(self)  # Set manager reference
-            await self._setup_workspace_plugins(
+            reusable = await self._prepare_reload_candidate(
                 new_instance,
-                str(agent_ref.workspace_dir),
+                agent_id,
+                agent_ref.workspace_dir,
             )
-            logger.info(f"New workspace instance started: {agent_id}")
 
             # Step 4: Atomic swap (minimal lock time). Do not await candidate
             # cleanup while holding this lock.
@@ -636,20 +660,11 @@ class MultiAgentManager:
             raise
 
         if not candidate_committed:
-            if discard_reason == "removed":
-                logger.warning(
-                    f"Agent {agent_id} was removed during reload, "
-                    "stopping new instance",
-                )
-            else:
-                # Installing this candidate would revert a newer write. The
-                # writer's reload will deliver the fresh state.
-                logger.info(
-                    f"Discarding stale reload for {agent_id}: "
-                    "configuration changed during rebuild",
-                )
-            await run_async_to_completion(
-                new_instance.stop(final=True, preserve_reused=True),
+            assert discard_reason is not None
+            await self._discard_reload_candidate(
+                new_instance,
+                agent_id,
+                discard_reason,
             )
             return False
 

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -8,7 +8,7 @@ improve testability and code organization.
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from ...utils.io_utils import run_sync_io
 
@@ -18,25 +18,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _publish_service(
-    ws: "Workspace",
-    name: str,
-    service: Any,
-    publish: Optional[Callable[[Any], None]],
-) -> None:
-    """Publish ownership through ServiceManager, with direct-call fallback."""
-    if publish is not None:
-        publish(service)
-    else:
-        # Preserve direct factory calls used by focused unit tests and other
-        # internal callers outside ServiceManager.
-        getattr(ws, "_service_manager").services[name] = service
-
-
 async def create_driver_service(
     ws: "Workspace",
     _service,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create and initialize the per-workspace DriverManager.
 
@@ -96,7 +81,7 @@ async def create_driver_service(
     )
     # Publish immediately after construction and before migration/start can
     # suspend.  Cancellation can then always find and shut down the manager.
-    _publish_service(ws, "driver_manager", driver_manager, publish)
+    publish(driver_manager)
     # Future Driver protocols should be registered here together with their
     # endpoint validator and tests.  This PR intentionally keeps the concrete
     # runtime surface to MCP while leaving DriverManager protocol-neutral.
@@ -113,7 +98,7 @@ async def create_driver_service(
 async def create_driver_config_watcher(
     ws: "Workspace",
     _service,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create watcher for manual DriverCard edits.
 
@@ -132,7 +117,7 @@ async def create_driver_config_watcher(
         driver_manager,
         ws.workspace_dir / "drivers",
     )
-    _publish_service(ws, "driver_config_watcher", watcher, publish)
+    publish(watcher)
     return watcher
     # pylint: enable=protected-access
 
@@ -140,7 +125,7 @@ async def create_driver_config_watcher(
 async def create_chat_service(
     ws: "Workspace",
     service,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create chat manager, or reuse existing one.
 
@@ -171,7 +156,7 @@ async def create_chat_service(
             repo=chat_repo,
             on_session_closed=close_browser_session,
         )
-        _publish_service(ws, "chat_manager", cm, publish)
+        publish(cm)
         logger.info(f"ChatManager created: {chats_path}")
     cm.set_on_session_closed(close_browser_session)
 
@@ -196,7 +181,7 @@ async def create_chat_service(
 async def create_channel_service(
     ws: "Workspace",
     _,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create channel manager if configured.
 
@@ -238,7 +223,7 @@ async def create_channel_service(
         on_last_dispatch=on_last_dispatch,
         workspace_dir=ws.workspace_dir,
     )
-    _publish_service(ws, "channel_manager", cm, publish)
+    publish(cm)
 
     cm.set_workspace(ws)
     from ..approvals import get_approval_service
@@ -256,7 +241,7 @@ async def create_channel_service(
 async def create_mail_monitor_service(
     ws: "Workspace",
     _,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create the mail push monitor when enabled for this agent.
 
@@ -309,7 +294,7 @@ async def create_mail_monitor_service(
         workspace=ws,
         mail_config=mail,
     )
-    _publish_service(ws, "mail_monitor", monitor, publish)
+    publish(monitor)
     return monitor
     # pylint: enable=protected-access
 
@@ -317,7 +302,7 @@ async def create_mail_monitor_service(
 async def create_agent_config_watcher(
     ws: "Workspace",
     _,
-    publish: Optional[Callable[[Any], None]] = None,
+    publish: Callable[[Any], None],
 ):
     """Create agent config watcher if channel/cron exists.
 
@@ -348,6 +333,6 @@ async def create_agent_config_watcher(
         workspace_dir=ws.workspace_dir,
         workspace=ws,
     )
-    _publish_service(ws, "agent_config_watcher", watcher, publish)
+    publish(watcher)
     return watcher
     # pylint: enable=protected-access

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -8,7 +8,7 @@ improve testability and code organization.
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from ...utils.io_utils import run_sync_io
 
@@ -18,7 +18,26 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def create_driver_service(ws: "Workspace", _service):
+def _publish_service(
+    ws: "Workspace",
+    name: str,
+    service: Any,
+    publish: Optional[Callable[[Any], None]],
+) -> None:
+    """Publish ownership through ServiceManager, with direct-call fallback."""
+    if publish is not None:
+        publish(service)
+    else:
+        # Preserve direct factory calls used by focused unit tests and other
+        # internal callers outside ServiceManager.
+        getattr(ws, "_service_manager").services[name] = service
+
+
+async def create_driver_service(
+    ws: "Workspace",
+    _service,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create and initialize the per-workspace DriverManager.
 
     DriverManager is the runtime for external capabilities.  MCP is wired as
@@ -75,12 +94,14 @@ async def create_driver_service(ws: "Workspace", _service):
         MCPDriverHandler,
         endpoint_validator=validate_mcp_endpoint,
     )
+    # Publish immediately after construction and before migration/start can
+    # suspend.  Cancellation can then always find and shut down the manager.
+    _publish_service(ws, "driver_manager", driver_manager, publish)
     # Future Driver protocols should be registered here together with their
     # endpoint validator and tests.  This PR intentionally keeps the concrete
     # runtime surface to MCP while leaving DriverManager protocol-neutral.
     await migrate_legacy_mcp_if_needed(ws, driver_manager)
     await driver_manager.start()
-    ws._service_manager.services["driver_manager"] = driver_manager
     logger.debug(
         "DriverManager external capability runtime initialized for agent: %s",
         ws.agent_id,
@@ -89,7 +110,11 @@ async def create_driver_service(ws: "Workspace", _service):
     # pylint: enable=protected-access
 
 
-async def create_driver_config_watcher(ws: "Workspace", _service):
+async def create_driver_config_watcher(
+    ws: "Workspace",
+    _service,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create watcher for manual DriverCard edits.
 
     Console/API updates call ``DriverConfigService.reload_driver_best_effort``
@@ -107,12 +132,16 @@ async def create_driver_config_watcher(ws: "Workspace", _service):
         driver_manager,
         ws.workspace_dir / "drivers",
     )
-    ws._service_manager.services["driver_config_watcher"] = watcher
+    _publish_service(ws, "driver_config_watcher", watcher, publish)
     return watcher
     # pylint: enable=protected-access
 
 
-async def create_chat_service(ws: "Workspace", service):
+async def create_chat_service(
+    ws: "Workspace",
+    service,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create chat manager, or reuse existing one.
 
     Args:
@@ -142,7 +171,7 @@ async def create_chat_service(ws: "Workspace", service):
             repo=chat_repo,
             on_session_closed=close_browser_session,
         )
-        ws._service_manager.services["chat_manager"] = cm
+        _publish_service(ws, "chat_manager", cm, publish)
         logger.info(f"ChatManager created: {chats_path}")
     cm.set_on_session_closed(close_browser_session)
 
@@ -164,7 +193,11 @@ async def create_chat_service(ws: "Workspace", service):
     # pylint: enable=protected-access
 
 
-async def create_channel_service(ws: "Workspace", _):
+async def create_channel_service(
+    ws: "Workspace",
+    _,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create channel manager if configured.
 
     Args:
@@ -205,7 +238,7 @@ async def create_channel_service(ws: "Workspace", _):
         on_last_dispatch=on_last_dispatch,
         workspace_dir=ws.workspace_dir,
     )
-    ws._service_manager.services["channel_manager"] = cm
+    _publish_service(ws, "channel_manager", cm, publish)
 
     cm.set_workspace(ws)
     from ..approvals import get_approval_service
@@ -220,7 +253,11 @@ async def create_channel_service(ws: "Workspace", _):
     # pylint: enable=protected-access
 
 
-async def create_mail_monitor_service(ws: "Workspace", _):
+async def create_mail_monitor_service(
+    ws: "Workspace",
+    _,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create the mail push monitor when enabled for this agent.
 
     Started only when the agent has a personal mailbox with credentials
@@ -272,12 +309,16 @@ async def create_mail_monitor_service(ws: "Workspace", _):
         workspace=ws,
         mail_config=mail,
     )
-    ws._service_manager.services["mail_monitor"] = monitor
+    _publish_service(ws, "mail_monitor", monitor, publish)
     return monitor
     # pylint: enable=protected-access
 
 
-async def create_agent_config_watcher(ws: "Workspace", _):
+async def create_agent_config_watcher(
+    ws: "Workspace",
+    _,
+    publish: Optional[Callable[[Any], None]] = None,
+):
     """Create agent config watcher if channel/cron exists.
 
     The watcher only triggers reloads via ``MultiAgentManager`` and
@@ -307,6 +348,6 @@ async def create_agent_config_watcher(ws: "Workspace", _):
         workspace_dir=ws.workspace_dir,
         workspace=ws,
     )
-    ws._service_manager.services["agent_config_watcher"] = watcher
+    _publish_service(ws, "agent_config_watcher", watcher, publish)
     return watcher
     # pylint: enable=protected-access

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -204,9 +204,7 @@ class ServiceManager:
 
             # Start concurrent services in parallel
             if concurrent:
-                await asyncio.gather(
-                    *[self._start_service(desc) for desc in concurrent],
-                )
+                await self._start_concurrent_services(concurrent)
 
             # Start sequential services one by one
             for desc in sequential:
@@ -221,6 +219,34 @@ class ServiceManager:
             f"{sanitize_log_value(self.workspace.agent_id)} "
             f"in {elapsed:.3f}s",
         )
+
+    async def _start_concurrent_services(
+        self,
+        descriptors: List[ServiceDescriptor],
+    ) -> None:
+        """Start a priority group, cancelling siblings on first failure."""
+        tasks = [
+            asyncio.create_task(self._start_service(descriptor))
+            for descriptor in descriptors
+        ]
+        pending = set(tasks)
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                # Keep exception selection deterministic when several starts
+                # finish in the same event-loop iteration.
+                for task in tasks:
+                    if task in done:
+                        task.result()
+        except BaseException:
+            for task in pending:
+                task.cancel()
+            # Await every task so simultaneous failures are retrieved too.
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
     async def _start_service(self, descriptor: ServiceDescriptor) -> None:
         """Start a single service.
@@ -412,12 +438,21 @@ class ServiceManager:
             f"{sanitize_log_value(self.workspace.agent_id)}",
         )
 
-    async def stop_all(self, final: bool = False) -> None:
+    async def stop_all(
+        self,
+        final: bool = False,
+        preserve_reused: bool = False,
+    ) -> None:
         """Stop all services in reverse priority order.
 
         Args:
             final: If True, stop ALL services including reusable ones.
                    If False (default), skip reusable services (for reload).
+            preserve_reused: Keep services borrowed from another workspace
+                alive.  This is used when an uncommitted replacement
+                workspace must be discarded: its own services need final
+                cleanup, but entries in ``reused_services`` still belong to
+                the workspace that is serving requests.
 
         Reused services are skipped. Errors are logged while every service is
         attempted; failures from ``require_clean_stop`` services are then
@@ -438,7 +473,11 @@ class ServiceManager:
             # Stop all services in this priority group concurrently
             results = await asyncio.gather(
                 *[
-                    self._stop_service(desc, final=final)
+                    self._stop_service(
+                        desc,
+                        final=final,
+                        preserve_reused=preserve_reused,
+                    )
                     for desc in descriptors
                 ],
                 return_exceptions=True,
@@ -465,6 +504,7 @@ class ServiceManager:
         self,
         descriptor: ServiceDescriptor,
         final: bool = False,
+        preserve_reused: bool = False,
     ) -> None:
         """Stop a single service.
 
@@ -472,8 +512,17 @@ class ServiceManager:
             descriptor: Service descriptor
             final: If True, stop service even if reusable.
                    If False, skip reusable services (for reload).
+            preserve_reused: Skip a service borrowed from another workspace,
+                even during final cleanup of this workspace.
         """
         name = descriptor.name
+
+        if preserve_reused and name in self.reused_services:
+            logger.debug(
+                f"Preserved borrowed service '{name}' "
+                f"while stopping {self.workspace.agent_id}",
+            )
+            return
 
         # Skip reusable services UNLESS this is final shutdown
         # (may be transferred to new instance during reload)

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -366,13 +366,57 @@ class ServiceManager:
         if descriptor.init_args:
             init_kwargs = descriptor.init_args(self.workspace)
 
-        # Offload synchronous constructor to thread pool to avoid blocking
-        # the event loop during background startup.
-        service = await asyncio.to_thread(
+        def register_service(service: Any) -> None:
+            self.services[descriptor.name] = service
+
+        # A running thread cannot be cancelled.  Delay propagation of task
+        # cancellation until construction has finished, and register the
+        # resulting instance first so workspace cleanup retains ownership.
+        service = await self._run_sync_to_completion(
             partial(service_cls, **init_kwargs),
+            on_success=register_service,
         )
-        self.services[descriptor.name] = service
         return service
+
+    @staticmethod
+    async def _run_sync_to_completion(
+        func: Callable[[], Any],
+        on_success: Optional[Callable[[Any], None]] = None,
+    ) -> Any:
+        """Run synchronous lifecycle work without abandoning its thread.
+
+        Cancelling a task waiting on ``asyncio.to_thread`` does not stop a
+        thread that is already running.  Shield the worker and defer
+        cancellation until it completes.  ``on_success`` runs before the
+        cancellation is propagated, allowing a newly constructed service to
+        be registered for cleanup.
+        """
+        worker = asyncio.create_task(asyncio.to_thread(func))
+        cancellation: Optional[asyncio.CancelledError] = None
+
+        while True:
+            try:
+                result = await asyncio.shield(worker)
+                break
+            except asyncio.CancelledError as error:
+                if worker.cancelled():
+                    if cancellation is not None:
+                        raise cancellation from error
+                    raise
+                if cancellation is None:
+                    cancellation = error
+            except BaseException as error:
+                if cancellation is not None:
+                    raise cancellation from error
+                raise
+
+        if on_success is not None:
+            on_success(result)
+
+        if cancellation is not None:
+            raise cancellation
+
+        return result
 
     async def _run_post_init(
         self,
@@ -431,7 +475,7 @@ class ServiceManager:
         if asyncio.iscoroutinefunction(start_fn):
             await start_fn()
         else:
-            await asyncio.to_thread(start_fn)
+            await self._run_sync_to_completion(start_fn)
 
         logger.debug(
             f"Service '{descriptor.name}' started for "

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -639,7 +639,7 @@ class ServiceManager:
                     if asyncio.iscoroutinefunction(stop_fn):
                         await stop_fn()
                     else:
-                        stop_fn()
+                        await self._run_sync_to_completion(stop_fn)
                     logger.debug(
                         f"Service '{name}' stopped "
                         f"for {self.workspace.agent_id}",

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -100,6 +100,7 @@ class ServiceManager:
         self.services: Dict[str, Any] = {}
         self.descriptors: Dict[str, ServiceDescriptor] = {}
         self.reused_services: Set[str] = set()
+        self._required_cleanup_services: Set[str] = set()
 
     def register(self, descriptor: ServiceDescriptor) -> None:
         """Register a service descriptor.
@@ -307,6 +308,7 @@ class ServiceManager:
                     )
                     cleanup_succeeded = True
                 except Exception as cleanup_error:
+                    self._required_cleanup_services.add(name)
                     logger.warning(
                         "Failed to clean up optional service '%s'; "
                         "aborting workspace startup",
@@ -533,8 +535,9 @@ class ServiceManager:
                 the workspace that is serving requests.
 
         Reused services are skipped. Errors are logged while every service is
-        attempted; failures from ``require_clean_stop`` services are then
-        propagated so the workspace cannot commit a false stopped state.
+        attempted; failures from ``require_clean_stop`` services and services
+        whose startup cleanup already failed are then propagated so the
+        workspace cannot commit a false stopped state.
         """
         logger.debug(
             f"Stopping {len(self.services)} services "
@@ -567,7 +570,10 @@ class ServiceManager:
                     logger.warning(
                         f"Error stopping service '{desc.name}': {result}",
                     )
-                    if desc.require_clean_stop:
+                    if (
+                        desc.require_clean_stop
+                        or desc.name in self._required_cleanup_services
+                    ):
                         clean_stop_errors.append((desc.name, result))
 
         if clean_stop_errors:
@@ -623,6 +629,7 @@ class ServiceManager:
 
         service = self.services.get(name)
         if not service:
+            self._required_cleanup_services.discard(name)
             return
 
         try:
@@ -637,6 +644,7 @@ class ServiceManager:
                         f"Service '{name}' stopped "
                         f"for {self.workspace.agent_id}",
                     )
+            self._required_cleanup_services.discard(name)
         except Exception as e:
             logger.warning(
                 f"Error stopping service '{name}' "

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -7,6 +7,7 @@ for all workspace services (MemoryManager, ChatManager, etc.).
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 from dataclasses import dataclass, field
@@ -42,7 +43,10 @@ class ServiceDescriptor:
         name: Unique service identifier (e.g., 'memory_manager')
         service_class: Class to instantiate (e.g., MemoryManager)
         init_args: Callable that returns init kwargs for the service
-        post_init: Optional hook called after creation (for setup logic)
+        post_init: Optional hook called after creation (for setup logic).
+            Hooks that create a service before awaiting must call the supplied
+            publisher before that first cancellable await so the manager owns
+            the instance and can clean it up.
         start_method: Name of method to call after creation (e.g., 'start')
         stop_method: Name of method to call during shutdown (e.g., 'stop')
         reusable: Whether this service can be reused across reloads
@@ -61,10 +65,7 @@ class ServiceDescriptor:
     service_class: Optional[Union[type, Callable[["Workspace"], type]]] = None
     init_args: Optional[Callable[[Workspace], dict]] = None
     post_init: Optional[
-        Union[
-            Callable[[Workspace, Any], None],
-            Callable[[Workspace, Any], Awaitable[Any]],
-        ]
+        Callable[[Workspace, Any, Callable[[Any], None]], Any]
     ] = None
     start_method: Optional[str] = None
     stop_method: Optional[str] = None
@@ -146,7 +147,7 @@ class ServiceManager:
         if descriptor.reload_func is not None:
             try:
                 result = descriptor.reload_func(self.workspace, instance)
-                if asyncio.iscoroutine(result):
+                if inspect.isawaitable(result):
                     await result
                 logger.debug(f"Called reload_func for service '{name}'")
             except Exception as e:
@@ -297,8 +298,29 @@ class ServiceManager:
                     f"{sanitize_log_value(self.workspace.agent_id)} "
                     f"(continuing without it): {sanitize_log_value(e)}",
                 )
-                self.reused_services.discard(name)
-                self.services.pop(name, None)
+                # A post_init hook may already have published a partially
+                # initialized service.  Keep ownership until cleanup has
+                # completed; otherwise pop() would make it unreachable by
+                # the workspace's later stop_all().  Borrowed services still
+                # belong to the workspace currently serving requests.
+                cleanup_succeeded = False
+                try:
+                    await self._stop_service(
+                        descriptor,
+                        final=True,
+                        preserve_reused=True,
+                    )
+                    cleanup_succeeded = True
+                except Exception:
+                    logger.warning(
+                        "Failed to clean up optional service '%s'",
+                        name,
+                        exc_info=True,
+                    )
+                finally:
+                    self.reused_services.discard(name)
+                    if cleanup_succeeded:
+                        self.services.pop(name, None)
                 return
             logger.exception(
                 f"Failed to start service '{name}' "
@@ -437,8 +459,15 @@ class ServiceManager:
         if not descriptor.post_init:
             return service
 
-        result = descriptor.post_init(self.workspace, service)
-        if asyncio.iscoroutine(result):
+        def publish_service(instance: Any) -> None:
+            self.services[name] = instance
+
+        result = descriptor.post_init(
+            self.workspace,
+            service,
+            publish_service,
+        )
+        if inspect.isawaitable(result):
             result = await result
 
         # Capture service from post_init return value or self.services

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -11,7 +11,6 @@ import inspect
 import logging
 import time
 from dataclasses import dataclass, field
-from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,6 +23,7 @@ from typing import (
     Union,
 )
 
+from ...utils.io_utils import run_sync_io
 from ...utils.logging import sanitize_log_value
 
 if TYPE_CHECKING:
@@ -100,7 +100,6 @@ class ServiceManager:
         self.services: Dict[str, Any] = {}
         self.descriptors: Dict[str, ServiceDescriptor] = {}
         self.reused_services: Set[str] = set()
-        self._required_cleanup_services: Set[str] = set()
 
     def register(self, descriptor: ServiceDescriptor) -> None:
         """Register a service descriptor.
@@ -294,35 +293,23 @@ class ServiceManager:
 
         except Exception as e:
             if descriptor.optional:
-                # A post_init hook may already have published a partially
-                # initialized service.  Keep ownership until cleanup has
-                # completed; otherwise pop() would make it unreachable by
-                # the workspace's later stop_all().  Borrowed services still
-                # belong to the workspace currently serving requests.
-                cleanup_succeeded = False
                 try:
                     await self._stop_service(
                         descriptor,
                         final=True,
                         preserve_reused=True,
                     )
-                    cleanup_succeeded = True
                 except Exception as cleanup_error:
-                    self._required_cleanup_services.add(name)
+                    descriptor.require_clean_stop = True
                     logger.warning(
                         "Failed to clean up optional service '%s'; "
                         "aborting workspace startup",
                         name,
                         exc_info=True,
                     )
-                    # Keep the instance registered so Workspace.start() can
-                    # retry cleanup, but do not expose it through a workspace
-                    # that was reported as successfully started.
                     raise cleanup_error from e
-                finally:
-                    self.reused_services.discard(name)
-                    if cleanup_succeeded:
-                        self.services.pop(name, None)
+                self.reused_services.discard(name)
+                self.services.pop(name, None)
                 logger.warning(
                     f"Optional service '{name}' failed to start for "
                     f"{sanitize_log_value(self.workspace.agent_id)} "
@@ -395,57 +382,14 @@ class ServiceManager:
         if descriptor.init_args:
             init_kwargs = descriptor.init_args(self.workspace)
 
-        def register_service(service: Any) -> None:
+        def create_and_register() -> Any:
+            service = service_cls(**init_kwargs)
             self.services[descriptor.name] = service
+            return service
 
-        # A running thread cannot be cancelled.  Delay propagation of task
-        # cancellation until construction has finished, and register the
-        # resulting instance first so workspace cleanup retains ownership.
-        service = await self._run_sync_to_completion(
-            partial(service_cls, **init_kwargs),
-            on_success=register_service,
-        )
-        return service
-
-    @staticmethod
-    async def _run_sync_to_completion(
-        func: Callable[[], Any],
-        on_success: Optional[Callable[[Any], None]] = None,
-    ) -> Any:
-        """Run synchronous lifecycle work without abandoning its thread.
-
-        Cancelling a task waiting on ``asyncio.to_thread`` does not stop a
-        thread that is already running.  Shield the worker and defer
-        cancellation until it completes.  ``on_success`` runs before the
-        cancellation is propagated, allowing a newly constructed service to
-        be registered for cleanup.
-        """
-        worker = asyncio.create_task(asyncio.to_thread(func))
-        cancellation: Optional[asyncio.CancelledError] = None
-
-        while True:
-            try:
-                result = await asyncio.shield(worker)
-                break
-            except asyncio.CancelledError as error:
-                if worker.cancelled():
-                    if cancellation is not None:
-                        raise cancellation from error
-                    raise
-                if cancellation is None:
-                    cancellation = error
-            except BaseException as error:
-                if cancellation is not None:
-                    raise cancellation from error
-                raise
-
-        if on_success is not None:
-            on_success(result)
-
-        if cancellation is not None:
-            raise cancellation
-
-        return result
+        # Register inside the worker before it completes so cancellation can
+        # never leave a successfully constructed service unowned.
+        return await run_sync_io(create_and_register)
 
     async def _run_post_init(
         self,
@@ -511,7 +455,7 @@ class ServiceManager:
         if asyncio.iscoroutinefunction(start_fn):
             await start_fn()
         else:
-            await self._run_sync_to_completion(start_fn)
+            await run_sync_io(start_fn)
 
         logger.debug(
             f"Service '{descriptor.name}' started for "
@@ -570,10 +514,7 @@ class ServiceManager:
                     logger.warning(
                         f"Error stopping service '{desc.name}': {result}",
                     )
-                    if (
-                        desc.require_clean_stop
-                        or desc.name in self._required_cleanup_services
-                    ):
+                    if desc.require_clean_stop:
                         clean_stop_errors.append((desc.name, result))
 
         if clean_stop_errors:
@@ -629,7 +570,6 @@ class ServiceManager:
 
         service = self.services.get(name)
         if not service:
-            self._required_cleanup_services.discard(name)
             return
 
         try:
@@ -639,12 +579,11 @@ class ServiceManager:
                     if asyncio.iscoroutinefunction(stop_fn):
                         await stop_fn()
                     else:
-                        await self._run_sync_to_completion(stop_fn)
+                        await run_sync_io(stop_fn)
                     logger.debug(
                         f"Service '{name}' stopped "
                         f"for {self.workspace.agent_id}",
                     )
-            self._required_cleanup_services.discard(name)
         except Exception as e:
             logger.warning(
                 f"Error stopping service '{name}' "

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -293,11 +293,6 @@ class ServiceManager:
 
         except Exception as e:
             if descriptor.optional:
-                logger.warning(
-                    f"Optional service '{name}' failed to start for "
-                    f"{sanitize_log_value(self.workspace.agent_id)} "
-                    f"(continuing without it): {sanitize_log_value(e)}",
-                )
                 # A post_init hook may already have published a partially
                 # initialized service.  Keep ownership until cleanup has
                 # completed; otherwise pop() would make it unreachable by
@@ -311,16 +306,26 @@ class ServiceManager:
                         preserve_reused=True,
                     )
                     cleanup_succeeded = True
-                except Exception:
+                except Exception as cleanup_error:
                     logger.warning(
-                        "Failed to clean up optional service '%s'",
+                        "Failed to clean up optional service '%s'; "
+                        "aborting workspace startup",
                         name,
                         exc_info=True,
                     )
+                    # Keep the instance registered so Workspace.start() can
+                    # retry cleanup, but do not expose it through a workspace
+                    # that was reported as successfully started.
+                    raise cleanup_error from e
                 finally:
                     self.reused_services.discard(name)
                     if cleanup_succeeded:
                         self.services.pop(name, None)
+                logger.warning(
+                    f"Optional service '{name}' failed to start for "
+                    f"{sanitize_log_value(self.workspace.agent_id)} "
+                    f"(continuing without it): {sanitize_log_value(e)}",
+                )
                 return
             logger.exception(
                 f"Failed to start service '{name}' "
@@ -593,7 +598,8 @@ class ServiceManager:
         if preserve_reused and name in self.reused_services:
             logger.debug(
                 f"Preserved borrowed service '{name}' "
-                f"while stopping {self.workspace.agent_id}",
+                "while stopping "
+                f"{sanitize_log_value(self.workspace.agent_id)}",
             )
             return
 

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -10,6 +10,7 @@ Each Workspace represents a standalone agent workspace with its own:
 
 Request processing is handled by ``Runtime`` (see ``stream_query``).
 """
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any, AsyncGenerator, Iterable, Optional
@@ -80,6 +81,7 @@ class Workspace:
         self._config = None  # Loaded before start()
         self._config_mtime: float | None = None
         self._started = False
+        self._start_attempted = False
         self._manager = None  # Reference to MultiAgentManager
         self._task_tracker = TaskTracker()
         self._app_services: Any = None
@@ -570,6 +572,8 @@ class Workspace:
             )
             return
 
+        self._start_attempted = True
+
         logger.info(
             f"Starting workspace: {sanitize_log_value(self.agent_id)}",
         )
@@ -606,14 +610,22 @@ class Workspace:
                 f"{sanitize_log_value(self.agent_id)}",
             )
 
-        except Exception as e:
-            logger.error(
-                "Failed to start agent instance "
-                f"{sanitize_log_value(self.agent_id)}: "
-                f"{sanitize_log_value(e)}",
-            )
+        except BaseException as error:
+            if not isinstance(error, asyncio.CancelledError):
+                logger.error(
+                    "Failed to start agent instance "
+                    f"{sanitize_log_value(self.agent_id)}: "
+                    f"{sanitize_log_value(error)}",
+                )
             # Clean up partially started components
-            await self.stop()
+            try:
+                await self.stop(final=True, preserve_reused=True)
+            except BaseException as cleanup_error:
+                logger.warning(
+                    "Failed to clean up partially started workspace "
+                    f"{sanitize_log_value(self.agent_id)}: "
+                    f"{sanitize_log_value(cleanup_error)}",
+                )
             raise
 
     def _migrate_legacy_weixin_data(self) -> None:
@@ -675,14 +687,20 @@ class Workspace:
                 sanitize_log_value(exc),
             )
 
-    async def stop(self, final: bool = True):
+    async def stop(
+        self,
+        final: bool = True,
+        preserve_reused: bool = False,
+    ):
         """Stop agent instance and clean up all resources.
 
         Args:
             final: If True (default), stop ALL services including reusable.
                    If False, skip reusable services (for reload scenario).
+            preserve_reused: Keep services borrowed from another workspace
+                alive while cleaning up this workspace.
         """
-        if not self._started:
+        if not self._started and not self._start_attempted:
             logger.debug(
                 f"Workspace not started: {sanitize_log_value(self.agent_id)}",
             )
@@ -694,13 +712,17 @@ class Workspace:
         )
 
         # Stop all services via ServiceManager (handles reuse automatically)
-        await self._service_manager.stop_all(final=final)
+        await self._service_manager.stop_all(
+            final=final,
+            preserve_reused=preserve_reused,
+        )
 
         if self._harness_runtime is not None:
             await self._harness_runtime.stop()
             self._harness_runtime = None
 
         self._started = False
+        self._start_attempted = False
         logger.info(
             f"Workspace stopped: {sanitize_log_value(self.agent_id)}",
         )

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -17,6 +17,7 @@ from typing import Any, AsyncGenerator, Callable, Iterable, Optional
 
 from ...config.timezone import normalize_tz
 from ...config.utils import load_config
+from ...utils.io_utils import run_async_to_completion
 
 from .service_manager import ServiceDescriptor, ServiceManager
 from .workspace_plugins import WorkspacePlugins
@@ -620,7 +621,14 @@ class Workspace:
                 )
             # Clean up partially started components
             try:
-                await self.stop(final=True, preserve_reused=True)
+                await run_async_to_completion(
+                    self.stop(final=True, preserve_reused=True),
+                )
+            except asyncio.CancelledError:
+                # A later cancellation request was delayed until cleanup
+                # completed. Preserve the original startup cancellation.
+                if not isinstance(error, asyncio.CancelledError):
+                    raise
             except BaseException as cleanup_error:
                 logger.warning(
                     "Failed to clean up partially started workspace "

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -13,7 +13,7 @@ Request processing is handled by ``Runtime`` (see ``stream_query``).
 import asyncio
 import logging
 from pathlib import Path
-from typing import Any, AsyncGenerator, Iterable, Optional
+from typing import Any, AsyncGenerator, Callable, Iterable, Optional
 
 from ...config.timezone import normalize_tz
 from ...config.utils import load_config
@@ -378,6 +378,7 @@ class Workspace:
         def _init_local_workspace(
             ws: "Workspace",
             _service: Any,
+            _publish: Callable[[Any], None],
         ) -> "QwenPawLocalWorkspace":
             return ws._local_workspace  # pylint: disable=protected-access
 

--- a/tests/unit/app/mail/test_service_factories_guard.py
+++ b/tests/unit/app/mail/test_service_factories_guard.py
@@ -39,15 +39,23 @@ def _fake_workspace(backend: str, tmp_path) -> SimpleNamespace:
     )
 
 
+def _create_monitor(ws):
+    published = []
+    monitor = asyncio.run(
+        create_mail_monitor_service(ws, None, published.append),
+    )
+    return monitor, published
+
+
 def test_third_party_backend_never_starts_monitor(tmp_path):
     ws = _fake_workspace("claude_code", tmp_path)
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, published = _create_monitor(ws)
     assert monitor is None
-    assert "mail_monitor" not in ws._service_manager.services
+    assert published == []
 
 
 def test_qwenpaw_backend_still_starts_monitor(tmp_path):
     ws = _fake_workspace("qwenpaw", tmp_path)
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, published = _create_monitor(ws)
     assert monitor is not None
-    assert ws._service_manager.services["mail_monitor"] is monitor
+    assert published == [monitor]

--- a/tests/unit/app/mail/test_service_factories_guard.py
+++ b/tests/unit/app/mail/test_service_factories_guard.py
@@ -51,7 +51,7 @@ def test_third_party_backend_never_starts_monitor(tmp_path):
     ws = _fake_workspace("claude_code", tmp_path)
     monitor, published = _create_monitor(ws)
     assert monitor is None
-    assert published == []
+    assert not published
 
 
 def test_qwenpaw_backend_still_starts_monitor(tmp_path):

--- a/tests/unit/app/mail/test_service_factories_seed_files.py
+++ b/tests/unit/app/mail/test_service_factories_seed_files.py
@@ -62,10 +62,19 @@ def _fake_workspace(
     )
 
 
+def _create_monitor(ws):
+    published = []
+    monitor = asyncio.run(
+        create_mail_monitor_service(ws, None, published.append),
+    )
+    return monitor, published
+
+
 def test_monitor_start_seeds_missing_mail_files(tmp_path):
     ws = _fake_workspace("qwenpaw", tmp_path)
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, published = _create_monitor(ws)
     assert monitor is not None
+    assert published == [monitor]
     triage = tmp_path / "MAIL_TRIAGE.md"
     contacts = tmp_path / "CONTACTS.md"
     assert triage.is_file()
@@ -80,14 +89,14 @@ def test_monitor_start_keeps_existing_files(tmp_path):
     existing = tmp_path / "MAIL_TRIAGE.md"
     existing.write_text("user edited triage tree", encoding="utf-8")
     ws = _fake_workspace("qwenpaw", tmp_path)
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, _published = _create_monitor(ws)
     assert monitor is not None
     assert existing.read_text(encoding="utf-8") == "user edited triage tree"
 
 
 def test_monitor_start_falls_back_to_en_for_unknown_language(tmp_path):
     ws = _fake_workspace("qwenpaw", tmp_path, language="fr")
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, _published = _create_monitor(ws)
     assert monitor is not None
     triage = tmp_path / "MAIL_TRIAGE.md"
     assert triage.is_file()
@@ -99,7 +108,8 @@ def test_monitor_start_falls_back_to_en_for_unknown_language(tmp_path):
 
 def test_guarded_backend_does_not_seed_files(tmp_path):
     ws = _fake_workspace("claude_code", tmp_path)
-    monitor = asyncio.run(create_mail_monitor_service(ws, None))
+    monitor, published = _create_monitor(ws)
     assert monitor is None
+    assert published == []
     assert not (tmp_path / "MAIL_TRIAGE.md").exists()
     assert not (tmp_path / "CONTACTS.md").exists()

--- a/tests/unit/app/mail/test_service_factories_seed_files.py
+++ b/tests/unit/app/mail/test_service_factories_seed_files.py
@@ -110,6 +110,6 @@ def test_guarded_backend_does_not_seed_files(tmp_path):
     ws = _fake_workspace("claude_code", tmp_path)
     monitor, published = _create_monitor(ws)
     assert monitor is None
-    assert published == []
+    assert not published
     assert not (tmp_path / "MAIL_TRIAGE.md").exists()
     assert not (tmp_path / "CONTACTS.md").exists()

--- a/tests/unit/app/test_multi_agent_reload_guard.py
+++ b/tests/unit/app/test_multi_agent_reload_guard.py
@@ -88,7 +88,10 @@ async def test_stale_reload_aborts_when_config_changes_mid_build(manager):
 
     assert await reload_task is False
     assert mgr.agents["agent"] is old_instance
-    new_instance.stop.assert_awaited()
+    new_instance.stop.assert_awaited_once_with(
+        final=True,
+        preserve_reused=True,
+    )
 
 
 async def test_reload_swaps_when_no_write_intervenes(manager):

--- a/tests/unit/app/test_multi_agent_reload_guard.py
+++ b/tests/unit/app/test_multi_agent_reload_guard.py
@@ -104,6 +104,32 @@ async def test_reload_swaps_when_no_write_intervenes(manager):
     assert mgr.agents["agent"] is not old_instance
 
 
+async def test_cancelled_plugin_setup_cleans_uncommitted_candidate(manager):
+    mgr, old_instance = manager
+    new_instance = _fake_workspace()
+    plugin_setup_entered = asyncio.Event()
+    mgr._create_workspace = lambda agent_id, workspace_dir: new_instance
+
+    async def blocking_plugin_setup(*_args) -> None:
+        plugin_setup_entered.set()
+        await asyncio.Event().wait()
+
+    mgr._setup_workspace_plugins = blocking_plugin_setup
+
+    reload_task = asyncio.create_task(mgr.reload_agent("agent"))
+    await plugin_setup_entered.wait()
+    reload_task.cancel("reload cancelled")
+
+    with pytest.raises(asyncio.CancelledError, match="reload cancelled"):
+        await reload_task
+
+    new_instance.stop.assert_awaited_once_with(
+        final=True,
+        preserve_reused=True,
+    )
+    assert mgr.agents["agent"] is old_instance
+
+
 async def test_writers_reload_lands_after_stale_abort(manager):
     """The bumping writer's own reload installs the fresh workspace."""
     mgr, _old_instance = manager

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -614,3 +614,85 @@ async def test_workspace_cleans_up_when_start_is_cancelled(
     closed.assert_awaited_once_with()
     assert workspace._started is False
     assert workspace._start_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_workspace_cleanup_survives_repeated_cancellation(
+    monkeypatch,
+    tmp_path,
+):
+    start_entered = asyncio.Event()
+    close_entered = asyncio.Event()
+    release_close = asyncio.Event()
+    close_finished = asyncio.Event()
+
+    class _BlockingService:
+        async def start(self) -> None:
+            start_entered.set()
+            await asyncio.Event().wait()
+
+        async def close(self) -> None:
+            close_entered.set()
+            await release_close.wait()
+            close_finished.set()
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="blocking",
+            service_class=_BlockingService,
+            start_method="start",
+            stop_method="close",
+            concurrent_init=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await start_entered.wait()
+    start_task.cancel("initial cancellation")
+    await close_entered.wait()
+    start_task.cancel("repeated cancellation")
+    await asyncio.sleep(0)
+
+    assert not start_task.done()
+    release_close.set()
+    with pytest.raises(asyncio.CancelledError, match="initial cancellation"):
+        await start_task
+
+    assert close_finished.is_set()
+    assert workspace._started is False
+    assert workspace._start_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_synchronous_stop_does_not_block_event_loop():
+    close_entered = threading.Event()
+    release_close = threading.Event()
+    state = SimpleNamespace(released_by_event_loop=False)
+
+    class _BlockingSyncService:
+        def close(self) -> None:
+            close_entered.set()
+            state.released_by_event_loop = release_close.wait(timeout=0.25)
+
+    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
+    manager.register(ServiceDescriptor(name="sync", stop_method="close"))
+    manager.services["sync"] = _BlockingSyncService()
+
+    async def release_from_event_loop() -> None:
+        while not close_entered.is_set():
+            await asyncio.sleep(0)
+        release_close.set()
+
+    await asyncio.gather(
+        manager.stop_all(final=True),
+        release_from_event_loop(),
+    )
+
+    assert state.released_by_event_loop is True

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """Strict-stop lifecycle tests for workspace services."""
+# pylint: disable=protected-access
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -10,6 +13,7 @@ from qwenpaw.app.workspace.service_manager import (
     ServiceDescriptor,
     ServiceManager,
 )
+from qwenpaw.app.workspace.workspace import Workspace
 
 
 @pytest.mark.asyncio
@@ -30,3 +34,217 @@ async def test_required_clean_stop_failure_is_propagated():
 
     with pytest.raises(RuntimeError, match="worker is still alive"):
         await manager.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_cleanup_preserves_only_borrowed_services():
+    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
+    borrowed = SimpleNamespace(close=AsyncMock())
+    candidate_owned = SimpleNamespace(close=AsyncMock())
+    ordinary = SimpleNamespace(close=AsyncMock())
+
+    for name, service, reusable in (
+        ("borrowed", borrowed, True),
+        ("candidate_owned", candidate_owned, True),
+        ("ordinary", ordinary, False),
+    ):
+        manager.register(
+            ServiceDescriptor(
+                name=name,
+                stop_method="close",
+                reusable=reusable,
+            ),
+        )
+        manager.services[name] = service
+
+    manager.reused_services.add("borrowed")
+
+    await manager.stop_all(final=True, preserve_reused=True)
+
+    borrowed.close.assert_not_awaited()
+    candidate_owned.close.assert_awaited_once_with()
+    ordinary.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_workspace_cleans_up_services_after_partial_start_failure(
+    monkeypatch,
+    tmp_path,
+):
+    closed = AsyncMock()
+
+    class _StartedService:
+        async def start(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            await closed()
+
+    class _FailingService:
+        async def start(self) -> None:
+            raise RuntimeError("later service failed")
+
+        async def close(self) -> None:
+            return None
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="started",
+            service_class=_StartedService,
+            start_method="start",
+            stop_method="close",
+            reusable=True,
+            priority=1,
+            concurrent_init=False,
+        ),
+    )
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="failing",
+            service_class=_FailingService,
+            start_method="start",
+            stop_method="close",
+            priority=2,
+            concurrent_init=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    with pytest.raises(RuntimeError, match="later service failed"):
+        await workspace.start()
+
+    closed.assert_awaited_once_with()
+    assert workspace._started is False
+    assert workspace._start_attempted is False
+
+    # A second stop remains a no-op after the partial cleanup completed.
+    await workspace.stop()
+    closed.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_workspace_cancels_concurrent_starts_before_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    slow_start_entered = asyncio.Event()
+    failure_raised = asyncio.Event()
+    slow_start_cancelled = asyncio.Event()
+    state = SimpleNamespace(active=False, closed=False)
+
+    class _SlowService:
+        async def start(self) -> None:
+            slow_start_entered.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                slow_start_cancelled.set()
+                raise
+
+        async def close(self) -> None:
+            state.active = False
+            state.closed = True
+
+    class _FailingService:
+        async def start(self) -> None:
+            await slow_start_entered.wait()
+            failure_raised.set()
+            raise RuntimeError("concurrent service failed")
+
+        async def close(self) -> None:
+            return None
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    for name, service_class in (
+        ("slow", _SlowService),
+        ("failing", _FailingService),
+    ):
+        workspace._service_manager.register(
+            ServiceDescriptor(
+                name=name,
+                service_class=service_class,
+                start_method="start",
+                stop_method="close",
+                priority=1,
+                concurrent_init=True,
+            ),
+        )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await failure_raised.wait()
+
+    with pytest.raises(RuntimeError, match="concurrent service failed"):
+        await asyncio.wait_for(start_task, timeout=0.5)
+
+    assert slow_start_cancelled.is_set()
+    assert state.closed is True
+    assert state.active is False
+
+
+@pytest.mark.asyncio
+async def test_workspace_cleans_up_when_start_is_cancelled(
+    monkeypatch,
+    tmp_path,
+):
+    blocking_start_entered = asyncio.Event()
+    closed = AsyncMock()
+
+    class _StartedService:
+        async def start(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            await closed()
+
+    class _BlockingService:
+        async def start(self) -> None:
+            blocking_start_entered.set()
+            await asyncio.Event().wait()
+
+        async def close(self) -> None:
+            return None
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    for priority, name, service_class in (
+        (1, "started", _StartedService),
+        (2, "blocking", _BlockingService),
+    ):
+        workspace._service_manager.register(
+            ServiceDescriptor(
+                name=name,
+                service_class=service_class,
+                start_method="start",
+                stop_method="close",
+                priority=priority,
+                concurrent_init=False,
+            ),
+        )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await blocking_start_entered.wait()
+    start_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    closed.assert_awaited_once_with()
+    assert workspace._started is False
+    assert workspace._start_attempted is False

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -14,6 +15,11 @@ from qwenpaw.app.workspace.service_manager import (
     ServiceManager,
 )
 from qwenpaw.app.workspace.workspace import Workspace
+
+
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    while not event.is_set():
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -191,6 +197,141 @@ async def test_workspace_cancels_concurrent_starts_before_cleanup(
     assert slow_start_cancelled.is_set()
     assert state.closed is True
     assert state.active is False
+
+
+@pytest.mark.asyncio
+async def test_workspace_waits_for_sync_constructor_before_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    constructor_entered = threading.Event()
+    release_constructor = threading.Event()
+    failure_raised = asyncio.Event()
+    state = SimpleNamespace(constructed=0, closed=0)
+
+    class _SlowConstructorService:
+        def __init__(self) -> None:
+            constructor_entered.set()
+            release_constructor.wait()
+            state.constructed += 1
+
+        def close(self) -> None:
+            state.closed += 1
+
+    class _FailingService:
+        async def start(self) -> None:
+            await _wait_for_thread_event(constructor_entered)
+            failure_raised.set()
+            raise RuntimeError("concurrent service failed")
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    for name, service_class, start_method, stop_method in (
+        ("slow", _SlowConstructorService, None, "close"),
+        ("failing", _FailingService, "start", None),
+    ):
+        workspace._service_manager.register(
+            ServiceDescriptor(
+                name=name,
+                service_class=service_class,
+                start_method=start_method,
+                stop_method=stop_method,
+                priority=1,
+                concurrent_init=True,
+            ),
+        )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await failure_raised.wait()
+    await asyncio.sleep(0)
+
+    try:
+        assert not start_task.done()
+        assert "slow" not in workspace._service_manager.services
+    finally:
+        release_constructor.set()
+
+    with pytest.raises(RuntimeError, match="concurrent service failed"):
+        await asyncio.wait_for(start_task, timeout=0.5)
+
+    assert state.constructed == 1
+    assert state.closed == 1
+    assert "slow" in workspace._service_manager.services
+
+
+@pytest.mark.asyncio
+async def test_workspace_waits_for_sync_start_before_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    start_entered = threading.Event()
+    release_start = threading.Event()
+    failure_raised = asyncio.Event()
+    state = SimpleNamespace(
+        start_finished=False,
+        stop_called=False,
+        start_stop_overlapped=False,
+    )
+
+    class _SlowStartService:
+        def start(self) -> None:
+            start_entered.set()
+            release_start.wait()
+            state.start_finished = True
+
+        def close(self) -> None:
+            state.stop_called = True
+            state.start_stop_overlapped = not state.start_finished
+
+    class _FailingService:
+        async def start(self) -> None:
+            await _wait_for_thread_event(start_entered)
+            failure_raised.set()
+            raise RuntimeError("concurrent service failed")
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    for name, service_class in (
+        ("slow", _SlowStartService),
+        ("failing", _FailingService),
+    ):
+        workspace._service_manager.register(
+            ServiceDescriptor(
+                name=name,
+                service_class=service_class,
+                start_method="start",
+                stop_method="close",
+                priority=1,
+                concurrent_init=True,
+            ),
+        )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await failure_raised.wait()
+    await asyncio.sleep(0)
+
+    try:
+        assert not start_task.done()
+        assert state.stop_called is False
+    finally:
+        release_start.set()
+
+    with pytest.raises(RuntimeError, match="concurrent service failed"):
+        await asyncio.wait_for(start_task, timeout=0.5)
+
+    assert state.start_finished is True
+    assert state.stop_called is True
+    assert state.start_stop_overlapped is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -500,9 +500,63 @@ async def test_optional_cleanup_failure_aborts_workspace_start(
 
     assert not workspace._started
     assert close_attempts == 2
+    assert not workspace._service_manager._required_cleanup_services
     # The failed instance remains owned for cleanup, but the workspace never
     # becomes a successfully started candidate that can serve requests.
     assert workspace._service_manager.services["optional"] is service
+
+
+@pytest.mark.asyncio
+async def test_repeated_optional_cleanup_failure_keeps_workspace_retryable(
+    monkeypatch,
+    tmp_path,
+):
+    close_attempts = 0
+
+    class _PartiallyStartedService:
+        async def close(self) -> None:
+            nonlocal close_attempts
+            close_attempts += 1
+            raise RuntimeError("optional cleanup still failing")
+
+    service = _PartiallyStartedService()
+
+    async def failing_factory(_workspace, _service, publish):
+        publish(service)
+        raise RuntimeError("optional startup failed")
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="optional",
+            post_init=failing_factory,
+            stop_method="close",
+            optional=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    with pytest.raises(RuntimeError, match="optional cleanup still failing"):
+        await workspace.start()
+
+    assert close_attempts == 2
+    assert workspace._start_attempted
+    assert workspace._service_manager.services["optional"] is service
+
+    with pytest.raises(RuntimeError, match="optional cleanup still failing"):
+        await workspace.stop(final=True, preserve_reused=True)
+
+    assert close_attempts == 3
+    assert workspace._start_attempted
+    assert workspace._service_manager.services["optional"] is service
+    assert workspace._service_manager._required_cleanup_services == {
+        "optional",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -460,6 +460,52 @@ async def test_optional_service_is_cleaned_before_removal():
 
 
 @pytest.mark.asyncio
+async def test_optional_cleanup_failure_aborts_workspace_start(
+    monkeypatch,
+    tmp_path,
+):
+    close_attempts = 0
+
+    class _PartiallyStartedService:
+        async def close(self) -> None:
+            nonlocal close_attempts
+            close_attempts += 1
+            if close_attempts == 1:
+                raise RuntimeError("optional cleanup failed")
+
+    service = _PartiallyStartedService()
+
+    async def failing_factory(_workspace, _service, publish):
+        publish(service)
+        raise RuntimeError("optional startup failed")
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="optional",
+            post_init=failing_factory,
+            stop_method="close",
+            optional=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    with pytest.raises(RuntimeError, match="optional cleanup failed"):
+        await workspace.start()
+
+    assert not workspace._started
+    assert close_attempts == 2
+    # The failed instance remains owned for cleanup, but the workspace never
+    # becomes a successfully started candidate that can serve requests.
+    assert workspace._service_manager.services["optional"] is service
+
+
+@pytest.mark.asyncio
 async def test_workspace_cleans_up_when_start_is_cancelled(
     monkeypatch,
     tmp_path,

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -335,6 +335,131 @@ async def test_workspace_waits_for_sync_start_before_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_workspace_cleans_up_published_async_factory_on_sibling_failure(
+    monkeypatch,
+    tmp_path,
+):
+    factory_created = asyncio.Event()
+    closed = AsyncMock()
+
+    class _FactoryResource:
+        async def close(self) -> None:
+            await closed()
+
+    async def slow_factory(_workspace, _service, publish):
+        resource = _FactoryResource()
+        publish(resource)
+        factory_created.set()
+        await asyncio.Event().wait()
+        return resource
+
+    async def failing_factory(_workspace, _service, _publish):
+        await factory_created.wait()
+        raise RuntimeError("concurrent factory failed")
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    for name, factory, stop_method in (
+        ("slow", slow_factory, "close"),
+        ("failing", failing_factory, None),
+    ):
+        workspace._service_manager.register(
+            ServiceDescriptor(
+                name=name,
+                post_init=factory,
+                stop_method=stop_method,
+                priority=1,
+                concurrent_init=True,
+            ),
+        )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    with pytest.raises(RuntimeError, match="concurrent factory failed"):
+        await workspace.start()
+
+    assert "slow" in workspace._service_manager.services
+    closed.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_workspace_cleans_up_published_async_factory_when_cancelled(
+    monkeypatch,
+    tmp_path,
+):
+    factory_created = asyncio.Event()
+    closed = AsyncMock()
+
+    class _FactoryResource:
+        async def close(self) -> None:
+            await closed()
+
+    async def blocking_factory(_workspace, _service, publish):
+        resource = _FactoryResource()
+        publish(resource)
+        factory_created.set()
+        await asyncio.Event().wait()
+        return resource
+
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager = ServiceManager(workspace)
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name="blocking",
+            post_init=blocking_factory,
+            stop_method="close",
+            concurrent_init=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
+
+    start_task = asyncio.create_task(workspace.start())
+    await factory_created.wait()
+    start_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    assert "blocking" in workspace._service_manager.services
+    closed.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_optional_service_is_cleaned_before_removal():
+    closed = AsyncMock()
+
+    class _PartiallyStartedService:
+        async def close(self) -> None:
+            await closed()
+
+    async def failing_factory(_workspace, _service, publish):
+        publish(_PartiallyStartedService())
+        raise RuntimeError("optional startup failed")
+
+    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
+    manager.register(
+        ServiceDescriptor(
+            name="optional",
+            post_init=failing_factory,
+            stop_method="close",
+            optional=True,
+        ),
+    )
+
+    await manager.start_all()
+
+    closed.assert_awaited_once_with()
+    assert "optional" not in manager.services
+
+
+@pytest.mark.asyncio
 async def test_workspace_cleans_up_when_start_is_cancelled(
     monkeypatch,
     tmp_path,

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Strict-stop lifecycle tests for workspace services."""
-# pylint: disable=protected-access
+"""Cancellation-safe workspace service lifecycle tests."""
+# pylint: disable=protected-access,redefined-outer-name
 from __future__ import annotations
 
 import asyncio
@@ -17,26 +17,51 @@ from qwenpaw.app.workspace.service_manager import (
 from qwenpaw.app.workspace.workspace import Workspace
 
 
-async def _wait_for_thread_event(event: threading.Event) -> None:
+async def _wait_for(event: threading.Event) -> None:
     while not event.is_set():
         await asyncio.sleep(0)
+
+
+@pytest.fixture
+def workspace(monkeypatch, tmp_path) -> Workspace:
+    instance = Workspace("agent-1", str(tmp_path))
+    instance._service_manager = ServiceManager(instance)
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.load_agent_config",
+        lambda _agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(instance, "_migrate_legacy_weixin_data", lambda: None)
+    return instance
+
+
+def _register(
+    workspace: Workspace,
+    name: str,
+    service_class=None,
+    **kwargs,
+) -> None:
+    workspace._service_manager.register(
+        ServiceDescriptor(
+            name=name,
+            service_class=service_class,
+            **kwargs,
+        ),
+    )
 
 
 @pytest.mark.asyncio
 async def test_required_clean_stop_failure_is_propagated():
     manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
-
-    class _StuckService:
-        async def stop(self) -> None:
-            raise RuntimeError("worker is still alive")
-
+    service = SimpleNamespace(
+        stop=AsyncMock(side_effect=RuntimeError("worker is still alive")),
+    )
     descriptor = ServiceDescriptor(
         name="mail_monitor",
         stop_method="stop",
         require_clean_stop=True,
     )
     manager.register(descriptor)
-    manager.services[descriptor.name] = _StuckService()
+    manager.services[descriptor.name] = service
 
     with pytest.raises(RuntimeError, match="worker is still alive"):
         await manager.stop_all()
@@ -45,405 +70,220 @@ async def test_required_clean_stop_failure_is_propagated():
 @pytest.mark.asyncio
 async def test_candidate_cleanup_preserves_only_borrowed_services():
     manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
-    borrowed = SimpleNamespace(close=AsyncMock())
-    candidate_owned = SimpleNamespace(close=AsyncMock())
-    ordinary = SimpleNamespace(close=AsyncMock())
-
-    for name, service, reusable in (
-        ("borrowed", borrowed, True),
-        ("candidate_owned", candidate_owned, True),
-        ("ordinary", ordinary, False),
-    ):
+    services = {
+        name: SimpleNamespace(close=AsyncMock())
+        for name in ("borrowed", "candidate_owned", "ordinary")
+    }
+    for name, service in services.items():
         manager.register(
             ServiceDescriptor(
                 name=name,
                 stop_method="close",
-                reusable=reusable,
+                reusable=name != "ordinary",
             ),
         )
         manager.services[name] = service
-
     manager.reused_services.add("borrowed")
 
     await manager.stop_all(final=True, preserve_reused=True)
 
-    borrowed.close.assert_not_awaited()
-    candidate_owned.close.assert_awaited_once_with()
-    ordinary.close.assert_awaited_once_with()
+    services["borrowed"].close.assert_not_awaited()
+    services["candidate_owned"].close.assert_awaited_once_with()
+    services["ordinary"].close.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_workspace_cleans_up_services_after_partial_start_failure(
-    monkeypatch,
-    tmp_path,
-):
+async def test_workspace_cleans_up_after_partial_start_failure(workspace):
     closed = AsyncMock()
 
-    class _StartedService:
-        async def start(self) -> None:
+    class Started:
+        async def start(self):
             return None
 
-        async def close(self) -> None:
+        async def close(self):
             await closed()
 
-    class _FailingService:
-        async def start(self) -> None:
+    class Failing:
+        async def start(self):
             raise RuntimeError("later service failed")
 
-        async def close(self) -> None:
-            return None
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="started",
-            service_class=_StartedService,
-            start_method="start",
-            stop_method="close",
-            reusable=True,
-            priority=1,
-            concurrent_init=False,
-        ),
+    _register(
+        workspace,
+        "started",
+        Started,
+        start_method="start",
+        stop_method="close",
+        priority=1,
+        concurrent_init=False,
     )
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="failing",
-            service_class=_FailingService,
-            start_method="start",
-            stop_method="close",
-            priority=2,
-            concurrent_init=False,
-        ),
+    _register(
+        workspace,
+        "failing",
+        Failing,
+        start_method="start",
+        priority=2,
+        concurrent_init=False,
     )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
 
     with pytest.raises(RuntimeError, match="later service failed"):
         await workspace.start()
 
     closed.assert_awaited_once_with()
-    assert workspace._started is False
-    assert workspace._start_attempted is False
+    assert not workspace._started
+    assert not workspace._start_attempted
 
-    # A second stop remains a no-op after the partial cleanup completed.
-    await workspace.stop()
+
+@pytest.mark.asyncio
+async def test_concurrent_failure_cancels_sibling_before_cleanup(workspace):
+    slow_entered = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    closed = AsyncMock()
+
+    class Slow:
+        async def start(self):
+            slow_entered.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                slow_cancelled.set()
+                raise
+
+        async def close(self):
+            await closed()
+
+    class Failing:
+        async def start(self):
+            await slow_entered.wait()
+            raise RuntimeError("concurrent service failed")
+
+    for name, service_class, stop_method in (
+        ("slow", Slow, "close"),
+        ("failing", Failing, None),
+    ):
+        _register(
+            workspace,
+            name,
+            service_class,
+            start_method="start",
+            stop_method=stop_method,
+            priority=1,
+        )
+
+    with pytest.raises(RuntimeError, match="concurrent service failed"):
+        await workspace.start()
+
+    assert slow_cancelled.is_set()
     closed.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_workspace_cancels_concurrent_starts_before_cleanup(
-    monkeypatch,
-    tmp_path,
+@pytest.mark.parametrize("blocking_phase", ["constructor", "start"])
+async def test_cleanup_waits_for_sync_lifecycle_work(
+    workspace,
+    blocking_phase,
 ):
-    slow_start_entered = asyncio.Event()
-    failure_raised = asyncio.Event()
-    slow_start_cancelled = asyncio.Event()
-    state = SimpleNamespace(active=False, closed=False)
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    closed = threading.Event()
 
-    class _SlowService:
-        async def start(self) -> None:
-            slow_start_entered.set()
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                slow_start_cancelled.set()
-                raise
+    class Slow:
+        def __init__(self):
+            if blocking_phase == "constructor":
+                entered.set()
+                release.wait()
+                finished.set()
 
-        async def close(self) -> None:
-            state.active = False
-            state.closed = True
+        def start(self):
+            if blocking_phase == "start":
+                entered.set()
+                release.wait()
+                finished.set()
 
-    class _FailingService:
-        async def start(self) -> None:
-            await slow_start_entered.wait()
-            failure_raised.set()
+        def close(self):
+            assert finished.is_set()
+            closed.set()
+
+    class Failing:
+        async def start(self):
+            await _wait_for(entered)
             raise RuntimeError("concurrent service failed")
 
-        async def close(self) -> None:
-            return None
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    for name, service_class in (
-        ("slow", _SlowService),
-        ("failing", _FailingService),
-    ):
-        workspace._service_manager.register(
-            ServiceDescriptor(
-                name=name,
-                service_class=service_class,
-                start_method="start",
-                stop_method="close",
-                priority=1,
-                concurrent_init=True,
-            ),
-        )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
+    _register(
+        workspace,
+        "slow",
+        Slow,
+        start_method="start",
+        stop_method="close",
+        priority=1,
     )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
-
-    start_task = asyncio.create_task(workspace.start())
-    await failure_raised.wait()
-
-    with pytest.raises(RuntimeError, match="concurrent service failed"):
-        await asyncio.wait_for(start_task, timeout=0.5)
-
-    assert slow_start_cancelled.is_set()
-    assert state.closed is True
-    assert state.active is False
-
-
-@pytest.mark.asyncio
-async def test_workspace_waits_for_sync_constructor_before_cleanup(
-    monkeypatch,
-    tmp_path,
-):
-    constructor_entered = threading.Event()
-    release_constructor = threading.Event()
-    failure_raised = asyncio.Event()
-    state = SimpleNamespace(constructed=0, closed=0)
-
-    class _SlowConstructorService:
-        def __init__(self) -> None:
-            constructor_entered.set()
-            release_constructor.wait()
-            state.constructed += 1
-
-        def close(self) -> None:
-            state.closed += 1
-
-    class _FailingService:
-        async def start(self) -> None:
-            await _wait_for_thread_event(constructor_entered)
-            failure_raised.set()
-            raise RuntimeError("concurrent service failed")
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    for name, service_class, start_method, stop_method in (
-        ("slow", _SlowConstructorService, None, "close"),
-        ("failing", _FailingService, "start", None),
-    ):
-        workspace._service_manager.register(
-            ServiceDescriptor(
-                name=name,
-                service_class=service_class,
-                start_method=start_method,
-                stop_method=stop_method,
-                priority=1,
-                concurrent_init=True,
-            ),
-        )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
+    _register(
+        workspace,
+        "failing",
+        Failing,
+        start_method="start",
+        priority=1,
     )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
 
-    start_task = asyncio.create_task(workspace.start())
-    await failure_raised.wait()
+    task = asyncio.create_task(workspace.start())
+    await _wait_for(entered)
     await asyncio.sleep(0)
-
     try:
-        assert not start_task.done()
-        assert "slow" not in workspace._service_manager.services
+        assert not task.done()
+        assert not closed.is_set()
     finally:
-        release_constructor.set()
+        release.set()
 
     with pytest.raises(RuntimeError, match="concurrent service failed"):
-        await asyncio.wait_for(start_task, timeout=0.5)
-
-    assert state.constructed == 1
-    assert state.closed == 1
+        await task
+    assert finished.is_set()
+    assert closed.is_set()
     assert "slow" in workspace._service_manager.services
 
 
 @pytest.mark.asyncio
-async def test_workspace_waits_for_sync_start_before_cleanup(
-    monkeypatch,
-    tmp_path,
+async def test_published_async_factory_is_cleaned_on_sibling_failure(
+    workspace,
 ):
-    start_entered = threading.Event()
-    release_start = threading.Event()
-    failure_raised = asyncio.Event()
-    state = SimpleNamespace(
-        start_finished=False,
-        stop_called=False,
-        start_stop_overlapped=False,
-    )
-
-    class _SlowStartService:
-        def start(self) -> None:
-            start_entered.set()
-            release_start.wait()
-            state.start_finished = True
-
-        def close(self) -> None:
-            state.stop_called = True
-            state.start_stop_overlapped = not state.start_finished
-
-    class _FailingService:
-        async def start(self) -> None:
-            await _wait_for_thread_event(start_entered)
-            failure_raised.set()
-            raise RuntimeError("concurrent service failed")
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    for name, service_class in (
-        ("slow", _SlowStartService),
-        ("failing", _FailingService),
-    ):
-        workspace._service_manager.register(
-            ServiceDescriptor(
-                name=name,
-                service_class=service_class,
-                start_method="start",
-                stop_method="close",
-                priority=1,
-                concurrent_init=True,
-            ),
-        )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
-
-    start_task = asyncio.create_task(workspace.start())
-    await failure_raised.wait()
-    await asyncio.sleep(0)
-
-    try:
-        assert not start_task.done()
-        assert state.stop_called is False
-    finally:
-        release_start.set()
-
-    with pytest.raises(RuntimeError, match="concurrent service failed"):
-        await asyncio.wait_for(start_task, timeout=0.5)
-
-    assert state.start_finished is True
-    assert state.stop_called is True
-    assert state.start_stop_overlapped is False
-
-
-@pytest.mark.asyncio
-async def test_workspace_cleans_up_published_async_factory_on_sibling_failure(
-    monkeypatch,
-    tmp_path,
-):
-    factory_created = asyncio.Event()
+    published = asyncio.Event()
     closed = AsyncMock()
 
-    class _FactoryResource:
-        async def close(self) -> None:
-            await closed()
-
     async def slow_factory(_workspace, _service, publish):
-        resource = _FactoryResource()
-        publish(resource)
-        factory_created.set()
+        publish(SimpleNamespace(close=closed))
+        published.set()
         await asyncio.Event().wait()
-        return resource
 
     async def failing_factory(_workspace, _service, _publish):
-        await factory_created.wait()
-        raise RuntimeError("concurrent factory failed")
+        await published.wait()
+        raise RuntimeError("factory failed")
 
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
     for name, factory, stop_method in (
         ("slow", slow_factory, "close"),
         ("failing", failing_factory, None),
     ):
-        workspace._service_manager.register(
-            ServiceDescriptor(
-                name=name,
-                post_init=factory,
-                stop_method=stop_method,
-                priority=1,
-                concurrent_init=True,
-            ),
+        _register(
+            workspace,
+            name,
+            post_init=factory,
+            stop_method=stop_method,
+            priority=1,
         )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
 
-    with pytest.raises(RuntimeError, match="concurrent factory failed"):
+    with pytest.raises(RuntimeError, match="factory failed"):
         await workspace.start()
 
-    assert "slow" in workspace._service_manager.services
-    closed.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_workspace_cleans_up_published_async_factory_when_cancelled(
-    monkeypatch,
-    tmp_path,
-):
-    factory_created = asyncio.Event()
-    closed = AsyncMock()
-
-    class _FactoryResource:
-        async def close(self) -> None:
-            await closed()
-
-    async def blocking_factory(_workspace, _service, publish):
-        resource = _FactoryResource()
-        publish(resource)
-        factory_created.set()
-        await asyncio.Event().wait()
-        return resource
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="blocking",
-            post_init=blocking_factory,
-            stop_method="close",
-            concurrent_init=False,
-        ),
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
-
-    start_task = asyncio.create_task(workspace.start())
-    await factory_created.wait()
-    start_task.cancel()
-
-    with pytest.raises(asyncio.CancelledError):
-        await start_task
-
-    assert "blocking" in workspace._service_manager.services
     closed.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
 async def test_optional_service_is_cleaned_before_removal():
+    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
     closed = AsyncMock()
 
-    class _PartiallyStartedService:
-        async def close(self) -> None:
-            await closed()
-
     async def failing_factory(_workspace, _service, publish):
-        publish(_PartiallyStartedService())
+        publish(SimpleNamespace(close=closed))
         raise RuntimeError("optional startup failed")
 
-    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
     manager.register(
         ServiceDescriptor(
             name="optional",
@@ -460,239 +300,77 @@ async def test_optional_service_is_cleaned_before_removal():
 
 
 @pytest.mark.asyncio
-async def test_optional_cleanup_failure_aborts_workspace_start(
-    monkeypatch,
-    tmp_path,
-):
+async def test_optional_cleanup_failure_remains_retryable(workspace):
     close_attempts = 0
 
-    class _PartiallyStartedService:
-        async def close(self) -> None:
-            nonlocal close_attempts
-            close_attempts += 1
-            if close_attempts == 1:
-                raise RuntimeError("optional cleanup failed")
+    async def close():
+        nonlocal close_attempts
+        close_attempts += 1
+        raise RuntimeError("optional cleanup failed")
 
-    service = _PartiallyStartedService()
+    service = SimpleNamespace(close=close)
 
     async def failing_factory(_workspace, _service, publish):
         publish(service)
         raise RuntimeError("optional startup failed")
 
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="optional",
-            post_init=failing_factory,
-            stop_method="close",
-            optional=True,
-        ),
+    _register(
+        workspace,
+        "optional",
+        post_init=failing_factory,
+        stop_method="close",
+        optional=True,
     )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
 
     with pytest.raises(RuntimeError, match="optional cleanup failed"):
         await workspace.start()
-
-    assert not workspace._started
-    assert close_attempts == 2
-    assert not workspace._service_manager._required_cleanup_services
-    # The failed instance remains owned for cleanup, but the workspace never
-    # becomes a successfully started candidate that can serve requests.
-    assert workspace._service_manager.services["optional"] is service
-
-
-@pytest.mark.asyncio
-async def test_repeated_optional_cleanup_failure_keeps_workspace_retryable(
-    monkeypatch,
-    tmp_path,
-):
-    close_attempts = 0
-
-    class _PartiallyStartedService:
-        async def close(self) -> None:
-            nonlocal close_attempts
-            close_attempts += 1
-            raise RuntimeError("optional cleanup still failing")
-
-    service = _PartiallyStartedService()
-
-    async def failing_factory(_workspace, _service, publish):
-        publish(service)
-        raise RuntimeError("optional startup failed")
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="optional",
-            post_init=failing_factory,
-            stop_method="close",
-            optional=True,
-        ),
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
-
-    with pytest.raises(RuntimeError, match="optional cleanup still failing"):
-        await workspace.start()
-
     assert close_attempts == 2
     assert workspace._start_attempted
     assert workspace._service_manager.services["optional"] is service
 
-    with pytest.raises(RuntimeError, match="optional cleanup still failing"):
+    with pytest.raises(RuntimeError, match="optional cleanup failed"):
         await workspace.stop(final=True, preserve_reused=True)
-
     assert close_attempts == 3
     assert workspace._start_attempted
-    assert workspace._service_manager.services["optional"] is service
-    assert workspace._service_manager._required_cleanup_services == {
-        "optional",
-    }
 
 
 @pytest.mark.asyncio
-async def test_workspace_cleans_up_when_start_is_cancelled(
-    monkeypatch,
-    tmp_path,
-):
-    blocking_start_entered = asyncio.Event()
-    closed = AsyncMock()
-
-    class _StartedService:
-        async def start(self) -> None:
-            return None
-
-        async def close(self) -> None:
-            await closed()
-
-    class _BlockingService:
-        async def start(self) -> None:
-            blocking_start_entered.set()
-            await asyncio.Event().wait()
-
-        async def close(self) -> None:
-            return None
-
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    for priority, name, service_class in (
-        (1, "started", _StartedService),
-        (2, "blocking", _BlockingService),
-    ):
-        workspace._service_manager.register(
-            ServiceDescriptor(
-                name=name,
-                service_class=service_class,
-                start_method="start",
-                stop_method="close",
-                priority=priority,
-                concurrent_init=False,
-            ),
-        )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
-
-    start_task = asyncio.create_task(workspace.start())
-    await blocking_start_entered.wait()
-    start_task.cancel()
-
-    with pytest.raises(asyncio.CancelledError):
-        await start_task
-
-    closed.assert_awaited_once_with()
-    assert workspace._started is False
-    assert workspace._start_attempted is False
-
-
-@pytest.mark.asyncio
-async def test_workspace_cleanup_survives_repeated_cancellation(
-    monkeypatch,
-    tmp_path,
-):
+async def test_workspace_cleanup_survives_repeated_cancellation(workspace):
     start_entered = asyncio.Event()
     close_entered = asyncio.Event()
     release_close = asyncio.Event()
     close_finished = asyncio.Event()
 
-    class _BlockingService:
-        async def start(self) -> None:
+    class Blocking:
+        async def start(self):
             start_entered.set()
             await asyncio.Event().wait()
 
-        async def close(self) -> None:
+        async def close(self):
             close_entered.set()
             await release_close.wait()
             close_finished.set()
 
-    workspace = Workspace("agent-1", str(tmp_path))
-    workspace._service_manager = ServiceManager(workspace)
-    workspace._service_manager.register(
-        ServiceDescriptor(
-            name="blocking",
-            service_class=_BlockingService,
-            start_method="start",
-            stop_method="close",
-            concurrent_init=False,
-        ),
+    _register(
+        workspace,
+        "blocking",
+        Blocking,
+        start_method="start",
+        stop_method="close",
+        concurrent_init=False,
     )
-    monkeypatch.setattr(
-        "qwenpaw.app.workspace.workspace.load_agent_config",
-        lambda _agent_id: SimpleNamespace(),
-    )
-    monkeypatch.setattr(workspace, "_migrate_legacy_weixin_data", lambda: None)
 
-    start_task = asyncio.create_task(workspace.start())
+    task = asyncio.create_task(workspace.start())
     await start_entered.wait()
-    start_task.cancel("initial cancellation")
+    task.cancel("initial cancellation")
     await close_entered.wait()
-    start_task.cancel("repeated cancellation")
+    task.cancel("repeated cancellation")
     await asyncio.sleep(0)
 
-    assert not start_task.done()
+    assert not task.done()
     release_close.set()
     with pytest.raises(asyncio.CancelledError, match="initial cancellation"):
-        await start_task
-
+        await task
     assert close_finished.is_set()
-    assert workspace._started is False
-    assert workspace._start_attempted is False
-
-
-@pytest.mark.asyncio
-async def test_synchronous_stop_does_not_block_event_loop():
-    close_entered = threading.Event()
-    release_close = threading.Event()
-    state = SimpleNamespace(released_by_event_loop=False)
-
-    class _BlockingSyncService:
-        def close(self) -> None:
-            close_entered.set()
-            state.released_by_event_loop = release_close.wait(timeout=0.25)
-
-    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
-    manager.register(ServiceDescriptor(name="sync", stop_method="close"))
-    manager.services["sync"] = _BlockingSyncService()
-
-    async def release_from_event_loop() -> None:
-        while not close_entered.is_set():
-            await asyncio.sleep(0)
-        release_close.set()
-
-    await asyncio.gather(
-        manager.stop_all(final=True),
-        release_from_event_loop(),
-    )
-
-    assert state.released_by_event_loop is True
+    assert not workspace._started
+    assert not workspace._start_attempted


### PR DESCRIPTION
## Description

Make workspace startup and reload-candidate cleanup cancellation-safe without leaving partially constructed, started, or borrowed services behind.

The lifecycle rules are now:

- an uncommitted reload candidate receives final cleanup while preserving reusable services borrowed from the active workspace;
- workspace startup cleans up after ordinary failures and cancellation, even before `_started` becomes true;
- concurrent startup cancels and joins sibling tasks on the first failure;
- synchronous constructors, `start()`, and `stop()` finish their worker-thread work before cancellation propagates;
- async factories publish ownership before their first cancellable await;
- an optional service is removed only after cleanup succeeds; cleanup failures abort startup and remain retryable;
- strict stop failures propagate, preventing a workspace from reporting a false stopped state;
- generic awaitables are recognized with `inspect.isawaitable()`;
- the borrowed-service cleanup log sanitizes `agent_id`.

## Scope after review cleanup

The implementation reuses the existing cancellation-safe `run_sync_io()` helper instead of maintaining a second local implementation. Repeated workspace setup and lifecycle cases in the tests were consolidated with fixtures and parametrization.

Relative to the PR base:

- production: `+306 / -115` (net `+191`);
- tests: `+407 / -16` (net `+391`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend
- [x] Tests

## Testing

Focused lifecycle, reload, startup, and cancellation-helper suite:

```bash
pytest -q tests/unit/app/workspace \
  tests/unit/app/test_multi_agent_reload_guard.py \
  tests/unit/app/test_multi_agent_manager_startup.py \
  tests/unit/utils/test_io_utils.py
```

```text
60 passed in 2.29s
```

Mail factory compatibility tests:

```bash
PYTHONPATH=packages/qwenpawmail-mcp/src pytest -q \
  tests/unit/app/mail/test_service_factories_guard.py \
  tests/unit/app/mail/test_service_factories_seed_files.py
```

```text
6 passed in 0.34s
```

All pre-commit hooks on the eight changed files pass, including mypy, Black, Flake8, and Pylint. `git diff --check` also passes.

## Security Considerations

The configurable `agent_id` is sanitized before interpolation in the new borrowed-service cleanup log.

## Checklist

- [x] Focused tests pass
- [x] Pre-commit checks on changed files pass
- [x] Documentation not needed for this internal lifecycle fix
- [x] Ready for review
