### PR TITLE
test(coverage): fix Windows integration coverage always reading 0

### DIFF
--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -365,6 +365,23 @@ jobs:
               # tolerate that — the combined value is what matters.
               coverage xml --data-file=.coverage.integration \
                 -o coverage.integration.xml || [ "$?" -eq 2 ]
+              # Fail-closed guard: a collection that ran but recorded
+              # zero executed lines is a silent failure, not coverage.
+              # Historically the Windows data file uploaded fine while
+              # holding 752 file entries and 0 executed lines, masked
+              # by the combined report. Make that loud.
+              # Fail-closed guard: a collection that ran but recorded
+              # zero executed lines is a silent failure, not coverage.
+              # Historically the Windows data file uploaded fine while
+              # holding 752 file entries and 0 executed lines, masked
+              # by the combined report. Make that loud: the line_bits
+              # table holds every executed line, so an empty table
+              # means the flush path dropped all data. Any anomaly
+              # (missing table, corrupt file) also fails loud here.
+              if ! python -c "import sqlite3, sys; conn = sqlite3.connect('.coverage.integration'); n = conn.execute('SELECT COUNT(*) FROM line_bits').fetchone()[0]; conn.close(); print(f'[coverage guard] {n} executed-line rows recorded'); sys.exit(0 if n > 0 else 1)"; then
+                echo "::error::Integration coverage collection ran but recorded 0 executed lines - the flush path is silently dropping data"
+                PYTEST_RC=1
+              fi
             else
               echo "::warning::Integration coverage data file missing despite QWENPAW_INTEGRATION_COVERAGE=1 (session may have crashed before coverage flush)"
             fi

--- a/tests/integration/_coverage_app_main.py
+++ b/tests/integration/_coverage_app_main.py
@@ -39,7 +39,9 @@ def _sigbreak_to_keyboard_interrupt(signum, frame):
 if hasattr(signal, "SIGBREAK"):
     signal.signal(signal.SIGBREAK, _sigbreak_to_keyboard_interrupt)
 
-# Emulate ``python -m qwenpaw app <args...>``: argv[0] is the program
-# name, the rest is passed through untouched.
-sys.argv = ["qwenpaw", "app", *sys.argv[1:]]
+# Emulate ``python -m qwenpaw app <args...>``.  The fixture invokes this
+# wrapper as ``python _coverage_app_main.py app --host ...``, so the
+# subcommand and its flags are already in sys.argv[1:]; only argv[0]
+# (the wrapper path) needs replacing with the program name.
+sys.argv = ["qwenpaw", *sys.argv[1:]]
 runpy.run_module("qwenpaw", run_name="__main__")

--- a/tests/integration/_coverage_app_main.py
+++ b/tests/integration/_coverage_app_main.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Coverage-mode app launcher for Windows integration tests.
+
+Launches the same server as ``python -m qwenpaw app`` (same CLI entry,
+same argv layout), but first maps SIGBREAK to KeyboardInterrupt.
+
+Why this wrapper exists (Windows-only, coverage mode only):
+
+The integration fixture stops the app subprocess with CTRL_BREAK_EVENT
+so the child can run its atexit handlers and flush subprocess coverage
+data.  But CPython only installs a Python-level handler for SIGINT
+(see ``Modules/signalmodule.c`` init: ``set_handler(SIGINT, ...)``);
+SIGBREAK keeps the CRT default action, and neither uvicorn (handles
+SIGINT/SIGTERM only) nor QwenPaw registers a SIGBREAK handler.  The
+default action terminates the process immediately -- atexit never runs,
+so coverage's save never happens and all recorded data is dropped.
+Forensics proof (fork run 31671241854): every app's tracer was active
+(per-app debug logs with ``Tracing '...qwenpaw...'`` dispositions), yet
+main-process saves never materialized and the combined data held 752
+files with 0 executed lines, while the identical mechanism on
+ubuntu/macos recorded ~53k lines.
+
+Raising KeyboardInterrupt instead puts the shutdown on the exact same
+graceful path POSIX enjoys with SIGINT: uvicorn unwinds, the interpreter
+exits normally, atexit runs, coverage flushes.
+
+This file is only used when ``QWENPAW_INTEGRATION_COVERAGE`` is enabled
+on ``win32``; the normal (non-coverage) launch command is unchanged.
+"""
+import runpy
+import signal
+import sys
+
+
+def _sigbreak_to_keyboard_interrupt(signum, frame):
+    raise KeyboardInterrupt
+
+
+if hasattr(signal, "SIGBREAK"):
+    signal.signal(signal.SIGBREAK, _sigbreak_to_keyboard_interrupt)
+
+# Emulate ``python -m qwenpaw app <args...>``: argv[0] is the program
+# name, the rest is passed through untouched.
+sys.argv = ["qwenpaw", "app", *sys.argv[1:]]
+runpy.run_module("qwenpaw", run_name="__main__")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -427,6 +427,25 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     # another process (e.g. a mock server in a parallel test) can steal
     # it while the app is still starting. Retry the whole launch on a
     # fresh port instead of serving requests from the wrong process.
+    # On Windows with subprocess coverage enabled, launch the app through
+    # a wrapper that maps SIGBREAK to KeyboardInterrupt.  CPython installs
+    # a Python-level handler only for SIGINT (Modules/signalmodule.c);
+    # SIGBREAK keeps the CRT default action, and neither uvicorn nor
+    # QwenPaw registers a SIGBREAK handler, so the CTRL_BREAK_EVENT sent
+    # by _shutdown_app would terminate the process without running
+    # atexit -- coverage's save never happens and all recorded data is
+    # dropped (forensics: fork runs 31666657171 / 31671241854, tracer
+    # active yet 752 files with 0 executed lines).  Raising
+    # KeyboardInterrupt instead puts shutdown on the same graceful path
+    # POSIX enjoys with SIGINT, so atexit runs and coverage flushes.
+    # Non-coverage launches are unchanged.
+    app_launcher = [sys.executable, "-m", "qwenpaw"]
+    if sys.platform == "win32" and _integration_coverage_requested():
+        app_launcher = [
+            sys.executable,
+            str(Path(__file__).parent / "_coverage_app_main.py"),
+        ]
+
     max_attempts = 3
     port = _find_free_port(host)
     while True:
@@ -435,9 +454,7 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
         # teardown below.
         process = subprocess.Popen(  # pylint: disable=consider-using-with
             [
-                sys.executable,
-                "-m",
-                "qwenpaw",
+                *app_launcher,
                 "app",
                 "--host",
                 host,


### PR DESCRIPTION
## Description

Fixes Windows integration coverage reading **0 executed lines every
night** and adds a fail-closed guard so a silently empty collection can
never upload unnoticed again.

**How silent this was:** since multi-platform integration coverage
landed (#5531, June 26), the Windows nightly integration coverage has
been 0 every night while the same mechanism records ~35% on
ubuntu/macos the same evening. It never errored: the data file was
produced and uploaded nightly (752 file entries), and the combined
three-platform report stayed healthy because the other two platforms
carried the total — no existing monitor ever tripped. Windows is
historically the accident-prone platform (#6727: 66 cases silently
skipped via path separators), yet its coverage was a blind spot.

**Root cause (CPython source-level proof):** teardown stops the app
subprocess with CTRL_BREAK_EVENT, expecting a graceful exit that flushes
coverage data. But CPython (Modules/signalmodule.c, v3.11.9) installs a
Python-level handler only for SIGINT; SIGBREAK keeps the CRT default
action. uvicorn handles SIGINT/SIGTERM only and QwenPaw registers no
SIGBREAK handler, so the default action terminates the process
immediately — atexit never runs, coverage's save never happens, and all
main-process data is dropped. ubuntu/macos go SIGINT → graceful
shutdown → flush (~53k lines). Two forensics rounds (fork runs
31666657171 / 31671241854) ruled out the other suspects: per-app debug
logs show the tracer was active in every app, yet the combined data
held 752 files with 0 executed lines.

**Fix (test infrastructure only, no production change):**
1. **New wrapper** `tests/integration/_coverage_app_main.py`: in
   coverage mode on win32 the app is launched through it — it maps
   SIGBREAK to KeyboardInterrupt, then runs the exact same `qwenpaw
   app` entry. CTRL_BREAK then follows the same graceful path POSIX
   enjoys with SIGINT, so coverage flushes. Non-coverage launches are
   byte-for-byte unchanged.
2. **Fail-closed guard in the nightly workflow:** after the integration
   coverage export, the data file's executed-line rows are checked; a
   collection that ran but recorded 0 rows fails loudly (the exact
   silent shape that hid here for 8 weeks). A real run lands near 35%,
   so this trips only on a broken flush path.

**Related Issue:** none; independent root cause from #6743 (upload on
failure); touches the same nightly workflow as #6764 but no conflict.

**Security Considerations:** none, tests only.

## Type of Change

- [x] Refactoring

## Component(s) Affected

- [x] Tests
- [x] CI/CD

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — not needed
- [x] Ready for review

## Testing

- Lock-version pre-commit on changed files: black / flake8 / pylint /
  mypy / yaml / workflow lint all pass.
- Non-coverage smoke: app_server fixture test passes, launch command
  unchanged.
- Linux coverage-mode smoke: passes (Linux uses the SIGINT path and is
  unaffected — zero behavior spread).
- Guard exercised both ways against real coverage data files: empty
  data fails (rc=1), populated data passes (rc=0).
- Wrapper equivalence: `wrapper.py app --help` output matches
  `python -m qwenpaw app --help` (an argv-doubling bug found in v1 —
  the wrapper re-injected the already-passed "app" subcommand — was
  fixed and verified this way).
- Fork Windows-specific CI run 32454291949
  (full-tests-nightly dispatch, coverage_platforms=windows): see
  Evidence.

## Evidence

Windows coverage data file, read-only SQLite inspection:

| metric | before (Aug-12 nightly, win) | after (Aug-21 fork run 32454291949) |
|---|---|---|
| file entries | 752 | 791 |
| files with executed lines | **0** | **675** |
| total executed lines | **0** | **68,394** |

Same-evening reference: ubuntu 53,037 lines, macOS 52,816 lines — the
Windows numbers are now on the same scale (slightly higher: the Windows
integration sweep runs more cases).

Fork run: https://github.com/yutai78786/QwenPaw/actions/runs/32454291949
(the run-level "cancelled" is the pre-existing E2E 45-minute timeout
issue, unrelated; the Windows integrated-tests job is success).

```bash
$ pre-commit run --files tests/integration/conftest.py \
    tests/integration/_coverage_app_main.py \
    .github/workflows/full-tests-nightly.yml
# black / flake8 / pylint / mypy / yaml / workflow lint all Passed
```

## Additional Notes

- Tests-only change; the non-coverage launch command is unchanged.
- Root cause pinned at CPython source level; two forensics rounds ruled
  out shutdown-timeout and source-matching suspects first.
- A more thorough product-side fix would be graceful SIGBREAK shutdown
  in `qwenpaw app` itself (today CTRL_BREAK kills the process and skips
  all cleanup), but that is a product change and intentionally not
  included here.
- Platform-dimension gap detection on the metrics side belongs to the
  data-collection owner and is being evaluated separately; it does not
  block this PR.
