### PR TITLE
feat(dingtalk): support shared session context in group chats

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -37,6 +37,7 @@ export interface DingTalkConfig extends BaseChannelConfig {
   robot_code: string;
   at_sender_on_reply?: boolean;
   streaming_enabled?: boolean;
+  share_session_in_group?: boolean;
   endpoint?: string;
 }
 

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -515,6 +515,14 @@ export function ChannelDrawer({
             >
               <Switch />
             </Form.Item>
+            <Form.Item
+              name="share_session_in_group"
+              label={t("channels.shareSessionInGroup")}
+              valuePropName="checked"
+              tooltip={t("channels.shareSessionInGroupTooltip")}
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -77,6 +77,7 @@ from .constants import (
 from .content_utils import (
     parse_data_url,
     session_param_from_webhook_url,
+    shared_group_session_id_from_conversation_id,
     short_session_id_from_conversation_id,
 )
 from .handler import DingTalkChannelHandler
@@ -368,10 +369,13 @@ class DingTalkChannel(BaseChannel):
         sender_id: str,
         channel_meta: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Session_id = short suffix of conversation_id for cron lookup."""
+        """Resolve session_id from conversation metadata."""
         meta = channel_meta or {}
         cid = meta.get("conversation_id")
         if cid:
+            # Shared groups need full-ID entropy because user_id is "group".
+            if meta.get("is_group") and self.share_session_in_group:
+                return shared_group_session_id_from_conversation_id(cid)
             return short_session_id_from_conversation_id(cid)
         return f"{self.channel}:{sender_id}"
 
@@ -2503,12 +2507,12 @@ class DingTalkChannel(BaseChannel):
             payload = it if isinstance(it, dict) else {}
             merged_parts.extend(payload.get("content_parts") or [])
             m = payload.get("meta") or {}
+            # Keep first sender identity; refresh only delivery metadata.
             for k in (
                 "conversation_id",
                 "session_webhook",
                 "session_webhook_expired_time",
                 "conversation_type",
-                "sender_staff_id",
             ):
                 if k in m:
                     merged_meta[k] = m[k]

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -152,6 +152,7 @@ class DingTalkChannel(BaseChannel):
         access_control_dm: bool = False,
         access_control_group: bool = False,
         endpoint: str = "",
+        share_session_in_group: bool = False,
     ):
         # Streaming only makes sense for card mode (AI Card streaming updates).
         # For markdown mode, force streaming_enabled=False so base class
@@ -194,6 +195,7 @@ class DingTalkChannel(BaseChannel):
         self.robot_code = robot_code or self.client_id
         self.card_auto_layout = card_auto_layout
         self.at_sender_on_reply = at_sender_on_reply
+        self.share_session_in_group = share_session_in_group
         self.endpoint = (endpoint or "").strip().rstrip("/")
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
@@ -293,6 +295,9 @@ class DingTalkChannel(BaseChannel):
             )
             == "1",
             endpoint=os.getenv("DINGTALK_ENDPOINT", ""),
+            share_session_in_group=(
+                os.getenv("DINGTALK_SHARE_SESSION_IN_GROUP", "0") == "1"
+            ),
         )
 
     @classmethod
@@ -349,6 +354,9 @@ class DingTalkChannel(BaseChannel):
                 getattr(config, "access_control_group", False),
             ),
             endpoint=getattr(config, "endpoint", ""),
+            share_session_in_group=bool(
+                getattr(config, "share_session_in_group", False),
+            ),
         )
 
     # ---------------------------
@@ -373,9 +381,14 @@ class DingTalkChannel(BaseChannel):
         Appends sender_id to the base session key so that messages
         from different users whose conversation_id share the same
         suffix are routed to separate queues and never merged.
+        Skipped for shared group sessions so that one chat maps to
+        one queue and turns stay serialized.
         """
         base_key = super().get_debounce_key(payload)
         if isinstance(payload, dict):
+            meta = payload.get("meta") or {}
+            if meta.get("is_group") and self.share_session_in_group:
+                return base_key
             sender_id = payload.get("sender_id") or ""
             if sender_id:
                 return f"{base_key}:{sender_id}"
@@ -394,9 +407,16 @@ class DingTalkChannel(BaseChannel):
         if payload.get("session_webhook"):
             meta["session_webhook"] = payload["session_webhook"]
         session_id = self.resolve_session_id(sender_id, meta)
+        # Shared id must not contain "_": the webhook fallback key
+        # splits "dingtalk:sw:<user_id>_<session_id>" on the last one.
+        user_id = (
+            "group"
+            if (meta.get("is_group") and self.share_session_in_group)
+            else sender_id
+        )
         request = self.build_agent_request_from_user_content(
             channel_id=channel_id,
-            sender_id=sender_id,
+            sender_id=user_id,
             session_id=session_id,
             content_parts=content_parts,
             channel_meta=meta,

--- a/src/qwenpaw/app/channels/dingtalk/constants.py
+++ b/src/qwenpaw/app/channels/dingtalk/constants.py
@@ -7,6 +7,9 @@ DINGTALK_TOKEN_TTL_SECONDS = 3600
 # Short suffix length for session_id from conversation_id
 DINGTALK_SESSION_ID_SUFFIX_LEN = 8
 
+# Shared-group session IDs use 64 bits from SHA-256.
+DINGTALK_SHARED_SESSION_HASH_LEN = 16
+
 # DingTalk message type to runtime content type
 DINGTALK_TYPE_MAPPING = {
     "picture": "image",

--- a/src/qwenpaw/app/channels/dingtalk/content_utils.py
+++ b/src/qwenpaw/app/channels/dingtalk/content_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 import re
 from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
@@ -20,6 +21,7 @@ from ..base import ContentType
 
 from .constants import (
     DINGTALK_SESSION_ID_SUFFIX_LEN,
+    DINGTALK_SHARED_SESSION_HASH_LEN,
     DINGTALK_TYPE_MAPPING,
 )
 
@@ -124,6 +126,14 @@ def short_session_id_from_conversation_id(conversation_id: str) -> str:
     return (
         conversation_id[-n:] if len(conversation_id) >= n else conversation_id
     )
+
+
+def shared_group_session_id_from_conversation_id(
+    conversation_id: str,
+) -> str:
+    """Hash a group conversation ID into a short stable session ID."""
+    digest = hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()
+    return digest[:DINGTALK_SHARED_SESSION_HASH_LEN]
 
 
 def session_param_from_webhook_url(url: str) -> Optional[str]:

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -344,6 +344,7 @@ class DingTalkConfig(BaseChannelConfig):
     card_auto_layout: bool = False
     at_sender_on_reply: bool = False
     streaming_enabled: bool = False
+    share_session_in_group: bool = False
     endpoint: str = ""
 
 

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -100,6 +100,30 @@ def dingtalk_channel(
 
 
 @pytest.fixture
+def dingtalk_channel_shared_group(
+    mock_process_handler,
+    temp_media_dir,
+) -> Generator:
+    """Create a DingTalkChannel sharing one session per group."""
+    from qwenpaw.app.channels.dingtalk.channel import DingTalkChannel
+
+    channel = DingTalkChannel(
+        process=mock_process_handler,
+        enabled=True,
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        bot_prefix="[TestBot] ",
+        media_dir=str(temp_media_dir),
+        share_session_in_group=True,
+        display_config=ChannelDisplayConfig(
+            show_tool_calls=False,
+            show_tool_results=False,
+        ),
+    )
+    yield channel
+
+
+@pytest.fixture
 def dingtalk_channel_with_workspace(
     mock_process_handler,
     temp_workspace_dir,
@@ -954,6 +978,140 @@ class TestDingTalkResolveSession:
         result = dingtalk_channel._route_from_handle("")
 
         assert result == {}
+
+
+# =============================================================================
+# P2: Group session sharing (share_session_in_group)
+# =============================================================================
+
+
+class TestDingTalkShareSessionInGroup:
+    """Tests for per-user vs shared context in group chats."""
+
+    @staticmethod
+    def _group_payload() -> dict:
+        return {
+            "channel_id": "dingtalk",
+            "sender_id": "Alice#1234",
+            "acl_sender_id": "staff_alice",
+            "content_parts": [],
+            "meta": {
+                "conversation_id": "cidQWERTY7890XYZ",
+                "conversation_type": "group",
+                "is_group": True,
+            },
+        }
+
+    @staticmethod
+    def _dm_payload() -> dict:
+        return {
+            "channel_id": "dingtalk",
+            "sender_id": "Alice#1234",
+            "acl_sender_id": "staff_alice",
+            "content_parts": [],
+            "meta": {
+                "conversation_id": "cidDM0987654321",
+                "conversation_type": "dm",
+                "is_group": False,
+            },
+        }
+
+    def test_default_is_disabled(self, dingtalk_channel):
+        """Group members stay isolated unless sharing is enabled."""
+        assert dingtalk_channel.share_session_in_group is False
+
+    def test_group_isolated_keeps_sender_as_user_id(self, dingtalk_channel):
+        """Isolated mode keeps per-member user_id (own context)."""
+        request = dingtalk_channel.build_agent_request_from_native(
+            self._group_payload(),
+        )
+
+        assert request.user_id == "Alice#1234"
+        assert request.session_id == "Y7890XYZ"
+
+    def test_group_shared_collapses_user_id(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Shared mode collapses user_id so members share one context."""
+        channel = dingtalk_channel_shared_group
+        request = channel.build_agent_request_from_native(
+            self._group_payload(),
+        )
+
+        assert request.user_id == "group"
+        assert request.session_id == "Y7890XYZ"
+
+    def test_shared_user_id_has_no_underscore(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Shared user_id must stay splittable in the webhook key."""
+        channel = dingtalk_channel_shared_group
+        request = channel.build_agent_request_from_native(
+            self._group_payload(),
+        )
+        to_handle = channel.to_handle_from_target(
+            user_id=request.user_id,
+            session_id=request.session_id,
+        )
+
+        assert to_handle == "dingtalk:sw:group_Y7890XYZ"
+        fallback = channel._suffix_only_webhook_key(to_handle)
+        assert fallback == "dingtalk:sw:Y7890XYZ"
+
+    def test_dm_unaffected_by_sharing(self, dingtalk_channel_shared_group):
+        """Direct messages keep their own user_id when sharing is on."""
+        channel = dingtalk_channel_shared_group
+        request = channel.build_agent_request_from_native(self._dm_payload())
+
+        assert request.user_id == "Alice#1234"
+
+    def test_debounce_key_isolated_appends_sender(self, dingtalk_channel):
+        """Isolated mode routes each member to its own queue."""
+        key = dingtalk_channel.get_debounce_key(self._group_payload())
+
+        assert key == "Y7890XYZ:Alice#1234"
+
+    def test_debounce_key_shared_drops_sender(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Shared mode routes the whole group to one queue."""
+        key = dingtalk_channel_shared_group.get_debounce_key(
+            self._group_payload(),
+        )
+
+        assert key == "Y7890XYZ"
+
+    def test_debounce_key_shared_dm_keeps_sender(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """DM queues keep sender isolation when sharing is on."""
+        key = dingtalk_channel_shared_group.get_debounce_key(
+            self._dm_payload(),
+        )
+
+        assert key == "87654321:Alice#1234"
+
+    def test_from_config_passes_flag(self, mock_process_handler):
+        """from_config should forward share_session_in_group."""
+        from qwenpaw.app.channels.dingtalk.channel import DingTalkChannel
+        from qwenpaw.config.config import DingTalkConfig
+
+        config = DingTalkConfig(
+            enabled=True,
+            client_id="cid",
+            client_secret="secret",
+            share_session_in_group=True,
+        )
+        channel = DingTalkChannel.from_config(
+            process=mock_process_handler,
+            config=config,
+        )
+
+        assert channel.share_session_in_group is True
 
 
 # =============================================================================

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -985,6 +985,15 @@ class TestDingTalkResolveSession:
 # =============================================================================
 
 
+def _shared_sid(conversation_id: str) -> str:
+    """Expected shared-group session_id for a conversation_id."""
+    from qwenpaw.app.channels.dingtalk.content_utils import (
+        shared_group_session_id_from_conversation_id,
+    )
+
+    return shared_group_session_id_from_conversation_id(conversation_id)
+
+
 class TestDingTalkShareSessionInGroup:
     """Tests for per-user vs shared context in group chats."""
 
@@ -1040,7 +1049,8 @@ class TestDingTalkShareSessionInGroup:
         )
 
         assert request.user_id == "group"
-        assert request.session_id == "Y7890XYZ"
+        assert request.session_id == _shared_sid("cidQWERTY7890XYZ")
+        assert request.session_id != "Y7890XYZ"
 
     def test_shared_user_id_has_no_underscore(
         self,
@@ -1056,9 +1066,10 @@ class TestDingTalkShareSessionInGroup:
             session_id=request.session_id,
         )
 
-        assert to_handle == "dingtalk:sw:group_Y7890XYZ"
+        sid = _shared_sid("cidQWERTY7890XYZ")
+        assert to_handle == f"dingtalk:sw:group_{sid}"
         fallback = channel._suffix_only_webhook_key(to_handle)
-        assert fallback == "dingtalk:sw:Y7890XYZ"
+        assert fallback == f"dingtalk:sw:{sid}"
 
     def test_dm_unaffected_by_sharing(self, dingtalk_channel_shared_group):
         """Direct messages keep their own user_id when sharing is on."""
@@ -1082,7 +1093,7 @@ class TestDingTalkShareSessionInGroup:
             self._group_payload(),
         )
 
-        assert key == "Y7890XYZ"
+        assert key == _shared_sid("cidQWERTY7890XYZ")
 
     def test_debounce_key_shared_dm_keeps_sender(
         self,
@@ -1112,6 +1123,87 @@ class TestDingTalkShareSessionInGroup:
         )
 
         assert channel.share_session_in_group is True
+
+    def test_merge_two_members_keeps_first_sender_identity(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Merging members must not mix sender identity fields."""
+        channel = dingtalk_channel_shared_group
+        alice = self._group_payload()
+        alice["meta"]["sender_staff_id"] = "staff_alice"
+        alice["meta"]["user_name"] = "Alice"
+        bob = self._group_payload()
+        bob["sender_id"] = "Bob#5678"
+        bob["acl_sender_id"] = "staff_bob"
+        bob["meta"]["sender_staff_id"] = "staff_bob"
+        bob["meta"]["user_name"] = "Bob"
+
+        merged = channel.merge_native_items([alice, bob])
+
+        assert merged["sender_id"] == "Alice#1234"
+        assert merged["acl_sender_id"] == "staff_alice"
+        assert merged["meta"]["user_name"] == "Alice"
+        assert merged["meta"]["sender_staff_id"] == "staff_alice"
+
+    def test_merge_two_members_tracks_newest_session(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Conversation/webhook state still follows the newest item."""
+        channel = dingtalk_channel_shared_group
+        alice = self._group_payload()
+        alice["meta"]["session_webhook"] = "https://old.example"
+        bob = self._group_payload()
+        bob["sender_id"] = "Bob#5678"
+        bob["meta"]["session_webhook"] = "https://new.example"
+
+        merged = channel.merge_native_items([alice, bob])
+
+        assert merged["meta"]["session_webhook"] == "https://new.example"
+        assert merged["meta"]["batched_count"] == 2
+
+    def test_shared_groups_with_same_suffix_stay_separate(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Groups sharing an 8-char suffix stay isolated."""
+        channel = dingtalk_channel_shared_group
+        first = self._group_payload()
+        first["meta"]["conversation_id"] = "cidAAAASAME8888"
+        second = self._group_payload()
+        second["meta"]["conversation_id"] = "cidBBBBSAME8888"
+
+        req_a = channel.build_agent_request_from_native(first)
+        req_b = channel.build_agent_request_from_native(second)
+
+        assert first["meta"]["conversation_id"][-8:] == (
+            second["meta"]["conversation_id"][-8:]
+        )
+        assert req_a.session_id != req_b.session_id
+        assert channel.get_debounce_key(first) != channel.get_debounce_key(
+            second,
+        )
+
+    def test_shared_session_id_is_underscore_free(
+        self,
+        dingtalk_channel_shared_group,
+    ):
+        """Hash must stay "_"-free for the webhook fallback key split."""
+        channel = dingtalk_channel_shared_group
+        request = channel.build_agent_request_from_native(
+            self._group_payload(),
+        )
+
+        assert "_" not in request.session_id
+
+    def test_isolated_mode_keeps_short_suffix(self, dingtalk_channel):
+        """Isolated mode keeps the legacy suffix (no state migration)."""
+        request = dingtalk_channel.build_agent_request_from_native(
+            self._group_payload(),
+        )
+
+        assert request.session_id == "Y7890XYZ"
 
 
 # =============================================================================

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -77,6 +77,7 @@ In your agent's `agent.json` (e.g., `~/.qwenpaw/workspaces/default/agent.json`),
   "card_template_id": "",
   "card_template_key": "content",
   "robot_code": "",
+  "share_session_in_group": false,
   "show_tool_calls": true,
   "show_tool_results": true,
   "show_thinking": true,
@@ -87,15 +88,16 @@ In your agent's `agent.json` (e.g., `~/.qwenpaw/workspaces/default/agent.json`),
 
 **DingTalk-specific fields:**
 
-| Field               | Type   | Default         | Description                                                                                                      |
-| ------------------- | ------ | --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `client_id`         | string | `""` (required) | DingTalk app Client ID (AppKey)                                                                                  |
-| `client_secret`     | string | `""` (required) | DingTalk app Client Secret (AppSecret)                                                                           |
-| `message_type`      | string | `"markdown"`    | Message mode: `"markdown"` (default) or `"card"` (AI interactive card)                                           |
-| `card_template_id`  | string | `""`            | DingTalk AI Card template ID (required when `message_type` is `card`)                                            |
-| `card_template_key` | string | `"content"`     | AI Card variable key; must exactly match your template variable name                                             |
-| `robot_code`        | string | `""`            | Robot code (recommended explicit config for group card delivery scenarios; falls back to `client_id` when empty) |
-| `media_dir`         | string | `null`          | Media file download directory (leave empty to not save)                                                          |
+| Field                    | Type   | Default         | Description                                                                                                                |
+| ------------------------ | ------ | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `client_id`              | string | `""` (required) | DingTalk app Client ID (AppKey)                                                                                            |
+| `client_secret`          | string | `""` (required) | DingTalk app Client Secret (AppSecret)                                                                                     |
+| `message_type`           | string | `"markdown"`    | Message mode: `"markdown"` (default) or `"card"` (AI interactive card)                                                     |
+| `card_template_id`       | string | `""`            | DingTalk AI Card template ID (required when `message_type` is `card`)                                                      |
+| `card_template_key`      | string | `"content"`     | AI Card variable key; must exactly match your template variable name                                                       |
+| `robot_code`             | string | `""`            | Robot code (recommended explicit config for group card delivery scenarios; falls back to `client_id` when empty)           |
+| `share_session_in_group` | bool   | `false`         | If `true`, all group members share one conversation context; if `false` (default), each member gets an independent context |
+| `media_dir`              | string | `null`          | Media file download directory (leave empty to not save)                                                                    |
 
 > **Tips:**
 >
@@ -233,20 +235,22 @@ Find `channels.feishu` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspace
   "bot_prefix": "[BOT]",
   "app_id": "cli_xxxxx",
   "app_secret": "your App Secret",
-  "domain": "feishu"
+  "domain": "feishu",
+  "share_session_in_group": false
 }
 ```
 
 **Feishu-specific fields:**
 
-| Field                | Type   | Default         | Description                                    |
-| -------------------- | ------ | --------------- | ---------------------------------------------- |
-| `app_id`             | string | `""` (required) | Feishu App ID                                  |
-| `app_secret`         | string | `""` (required) | Feishu App Secret                              |
-| `domain`             | string | `"feishu"`      | `"feishu"` (China) or `"lark"` (International) |
-| `encrypt_key`        | string | `""`            | Event encryption key (optional)                |
-| `verification_token` | string | `""`            | Event verification token (optional)            |
-| `media_dir`          | string | `null`          | Directory for received media files             |
+| Field                    | Type   | Default         | Description                                                                                              |
+| ------------------------ | ------ | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `app_id`                 | string | `""` (required) | Feishu App ID                                                                                            |
+| `app_secret`             | string | `""` (required) | Feishu App Secret                                                                                        |
+| `domain`                 | string | `"feishu"`      | `"feishu"` (China) or `"lark"` (International)                                                           |
+| `encrypt_key`            | string | `""`            | Event encryption key (optional)                                                                          |
+| `verification_token`     | string | `""`            | Event verification token (optional)                                                                      |
+| `share_session_in_group` | bool   | `false`         | If `true`, all members in a group share one session; if `false`, each member gets an independent session |
+| `media_dir`              | string | `null`          | Directory for received media files                                                                       |
 
 > **Tip:** Other fields (encrypt_key, verification_token, media_dir) are optional; with WebSocket mode you can omit them (defaults apply).
 
@@ -627,18 +631,20 @@ Find `wecom` and fill in the corresponding information, for example:
   "bot_id": "your bot_id",
   "secret": "your secret",
   "media_dir": "~/.qwenpaw/media",
-  "max_reconnect_attempts": -1
+  "max_reconnect_attempts": -1,
+  "share_session_in_group": true
 }
 ```
 
 **WeCom-specific fields:**
 
-| Field                    | Type   | Default            | Description                                          |
-| ------------------------ | ------ | ------------------ | ---------------------------------------------------- |
-| `bot_id`                 | string | `""` (required)    | WeCom bot ID                                         |
-| `secret`                 | string | `""` (required)    | WeCom bot secret                                     |
-| `media_dir`              | string | `~/.qwenpaw/media` | Media files (images, files, etc.) download directory |
-| `max_reconnect_attempts` | int    | `-1`               | WebSocket max reconnect attempts (`-1` = unlimited)  |
+| Field                    | Type   | Default            | Description                                                                                              |
+| ------------------------ | ------ | ------------------ | -------------------------------------------------------------------------------------------------------- |
+| `bot_id`                 | string | `""` (required)    | WeCom bot ID                                                                                             |
+| `secret`                 | string | `""` (required)    | WeCom bot secret                                                                                         |
+| `media_dir`              | string | `~/.qwenpaw/media` | Media files (images, files, etc.) download directory                                                     |
+| `max_reconnect_attempts` | int    | `-1`               | WebSocket max reconnect attempts (`-1` = unlimited)                                                      |
+| `share_session_in_group` | bool   | `true`             | If `true`, all members in a group share one session; if `false`, each member gets an independent session |
 
 ### Start chatting with the bot in WeCom
 
@@ -1631,23 +1637,23 @@ Find `channels.slack` in your agent's `agent.json` (e.g., `~/.qwenpaw/workspaces
 
 ### Config overview
 
-| Channel    | Config key | Main fields                                                                                                |
-| ---------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| DingTalk   | dingtalk   | client_id, client_secret, message_type, card_template_id, card_template_key, robot_code                    |
-| Feishu     | feishu     | app_id, app_secret, domain; optional encrypt_key, verification_token, media_dir                            |
-| iMessage   | imessage   | db_path, poll_sec (macOS only)                                                                             |
-| Discord    | discord    | bot_token; optional http_proxy, http_proxy_auth                                                            |
-| QQ         | qq         | app_id, client_secret, markdown_enabled, max_reconnect_attempts                                            |
-| Telegram   | telegram   | bot_token; optional http_proxy, http_proxy_auth                                                            |
-| Mattermost | mattermost | url, bot_token; optional show_typing, thread_follow_without_mention                                        |
-| Matrix     | matrix     | homeserver, user_id, access_token                                                                          |
-| Slack      | slack      | bot_token, app_token; optional proxy, streaming_enabled                                                    |
-| WeCom      | wecom      | bot_id, secret; optional media_dir, max_reconnect_attempts                                                 |
-| WeChat     | wechat     | bot_token (or QR login); optional bot_token_file, base_url, media_dir                                      |
-| XiaoYi     | xiaoyi     | ak, sk, agent_id; optional ws_url                                                                          |
-| Yuanbao    | yuanbao    | app_id, app_secret; optional api_domain, media_dir                                                         |
-| Voice      | voice      | twilio_account_sid, twilio_auth_token, phone_number, phone_number_sid; optional tts_provider, stt_provider |
-| Azure Bot  | azure_bot  | app_id, app_password, tenant_id; optional http_port, media_dir, share_session_in_group                     |
+| Channel    | Config key | Main fields                                                                                                              |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| DingTalk   | dingtalk   | client_id, client_secret, message_type, card_template_id, card_template_key, robot_code; optional share_session_in_group |
+| Feishu     | feishu     | app_id, app_secret, domain; optional encrypt_key, verification_token, media_dir, share_session_in_group                  |
+| iMessage   | imessage   | db_path, poll_sec (macOS only)                                                                                           |
+| Discord    | discord    | bot_token; optional http_proxy, http_proxy_auth                                                                          |
+| QQ         | qq         | app_id, client_secret, markdown_enabled, max_reconnect_attempts                                                          |
+| Telegram   | telegram   | bot_token; optional http_proxy, http_proxy_auth                                                                          |
+| Mattermost | mattermost | url, bot_token; optional show_typing, thread_follow_without_mention                                                      |
+| Matrix     | matrix     | homeserver, user_id, access_token                                                                                        |
+| Slack      | slack      | bot_token, app_token; optional proxy, streaming_enabled                                                                  |
+| WeCom      | wecom      | bot_id, secret; optional media_dir, max_reconnect_attempts, share_session_in_group                                       |
+| WeChat     | wechat     | bot_token (or QR login); optional bot_token_file, base_url, media_dir                                                    |
+| XiaoYi     | xiaoyi     | ak, sk, agent_id; optional ws_url                                                                                        |
+| Yuanbao    | yuanbao    | app_id, app_secret; optional api_domain, media_dir                                                                       |
+| Voice      | voice      | twilio_account_sid, twilio_auth_token, phone_number, phone_number_sid; optional tts_provider, stt_provider               |
+| Azure Bot  | azure_bot  | app_id, app_password, tenant_id; optional http_port, media_dir, share_session_in_group                                   |
 
 All channels also support the common access control fields (`dm_policy`, `group_policy`, `allow_from`, `deny_message`, `require_mention`) documented in the common fields section below.
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -72,6 +72,7 @@
   "bot_prefix": "[BOT]",
   "client_id": "你的 Client ID",
   "client_secret": "你的 Client Secret",
+  "share_session_in_group": false,
   "show_tool_calls": true,
   "show_tool_results": true,
   "show_thinking": true,
@@ -82,15 +83,16 @@
 
 **钉钉专属字段说明：**
 
-| 字段                | 类型   | 默认值       | 说明                                                           |
-| ------------------- | ------ | ------------ | -------------------------------------------------------------- |
-| `client_id`         | string | `""`（必填） | 钉钉应用 Client ID（即 AppKey）                                |
-| `client_secret`     | string | `""`（必填） | 钉钉应用 Client Secret（即 AppSecret）                         |
-| `message_type`      | string | `"markdown"` | 消息类型：`"markdown"` 或 `"card"`（AI 卡片）                  |
-| `card_template_id`  | string | `""`         | AI 卡片模板 ID（当 `message_type` 为 `"card"` 时必填）         |
-| `card_template_key` | string | `"content"`  | AI 卡片模板变量名（必须与钉钉模板中的变量名完全一致）          |
-| `robot_code`        | string | `""`         | 机器人编码（群聊卡片场景建议配置，留空时回退使用 `client_id`） |
-| `media_dir`         | string | `null`       | 媒体文件下载目录（留空则不保存）                               |
+| 字段                     | 类型   | 默认值       | 说明                                                                                   |
+| ------------------------ | ------ | ------------ | -------------------------------------------------------------------------------------- |
+| `client_id`              | string | `""`（必填） | 钉钉应用 Client ID（即 AppKey）                                                        |
+| `client_secret`          | string | `""`（必填） | 钉钉应用 Client Secret（即 AppSecret）                                                 |
+| `message_type`           | string | `"markdown"` | 消息类型：`"markdown"` 或 `"card"`（AI 卡片）                                          |
+| `card_template_id`       | string | `""`         | AI 卡片模板 ID（当 `message_type` 为 `"card"` 时必填）                                 |
+| `card_template_key`      | string | `"content"`  | AI 卡片模板变量名（必须与钉钉模板中的变量名完全一致）                                  |
+| `robot_code`             | string | `""`         | 机器人编码（群聊卡片场景建议配置，留空时回退使用 `client_id`）                         |
+| `share_session_in_group` | bool   | `false`      | 为 `true` 时群内所有成员共享同一会话上下文；为 `false`（默认）时每位成员拥有独立上下文 |
+| `media_dir`              | string | `null`       | 媒体文件下载目录（留空则不保存）                                                       |
 
 > **提示：**
 >
@@ -226,20 +228,22 @@
   "bot_prefix": "[BOT]",
   "app_id": "cli_xxxxx",
   "app_secret": "你的 App Secret",
-  "domain": "feishu"
+  "domain": "feishu",
+  "share_session_in_group": false
 }
 ```
 
 **飞书专属字段说明：**
 
-| 字段                 | 类型   | 默认值       | 说明                                       |
-| -------------------- | ------ | ------------ | ------------------------------------------ |
-| `app_id`             | string | `""`（必填） | 飞书应用 App ID                            |
-| `app_secret`         | string | `""`（必填） | 飞书应用 App Secret                        |
-| `domain`             | string | `"feishu"`   | `"feishu"`（国内）或 `"lark"`（国际版）    |
-| `encrypt_key`        | string | `""`         | 消息加密密钥（可选，WebSocket 模式可不填） |
-| `verification_token` | string | `""`         | 验证 Token（可选，WebSocket 模式可不填）   |
-| `media_dir`          | string | `null`       | 媒体文件下载目录（留空则不保存）           |
+| 字段                     | 类型   | 默认值       | 说明                                                          |
+| ------------------------ | ------ | ------------ | ------------------------------------------------------------- |
+| `app_id`                 | string | `""`（必填） | 飞书应用 App ID                                               |
+| `app_secret`             | string | `""`（必填） | 飞书应用 App Secret                                           |
+| `domain`                 | string | `"feishu"`   | `"feishu"`（国内）或 `"lark"`（国际版）                       |
+| `encrypt_key`            | string | `""`         | 消息加密密钥（可选，WebSocket 模式可不填）                    |
+| `verification_token`     | string | `""`         | 验证 Token（可选，WebSocket 模式可不填）                      |
+| `share_session_in_group` | bool   | `false`      | 为 `true` 时群成员共享一个会话；为 `false` 时每个成员独立会话 |
+| `media_dir`              | string | `null`       | 媒体文件下载目录（留空则不保存）                              |
 
 > **提示：** 其他字段（encrypt_key、verification_token、media_dir）可选，WebSocket 模式可不填，有默认值。
 
@@ -609,18 +613,20 @@ NapCat  ──反向 WS──▶  QwenPaw (:6199/ws)
   "bot_id": "your bot_id",
   "secret": "your secret",
   "media_dir": "~/.qwenpaw/media",
-  "max_reconnect_attempts": -1
+  "max_reconnect_attempts": -1,
+  "share_session_in_group": true
 }
 ```
 
 **企业微信专属字段说明：**
 
-| 字段                     | 类型   | 默认值             | 说明                                      |
-| ------------------------ | ------ | ------------------ | ----------------------------------------- |
-| `bot_id`                 | string | `""`（必填）       | 企业微信机器人 Bot ID                     |
-| `secret`                 | string | `""`（必填）       | 企业微信机器人 Secret                     |
-| `media_dir`              | string | `~/.qwenpaw/media` | 媒体文件（图片、文件等）下载目录          |
-| `max_reconnect_attempts` | int    | `-1`               | WebSocket 最大重连次数（`-1` = 无限重连） |
+| 字段                     | 类型   | 默认值             | 说明                                                                    |
+| ------------------------ | ------ | ------------------ | ----------------------------------------------------------------------- |
+| `bot_id`                 | string | `""`（必填）       | 企业微信机器人 Bot ID                                                   |
+| `secret`                 | string | `""`（必填）       | 企业微信机器人 Secret                                                   |
+| `media_dir`              | string | `~/.qwenpaw/media` | 媒体文件（图片、文件等）下载目录                                        |
+| `max_reconnect_attempts` | int    | `-1`               | WebSocket 最大重连次数（`-1` = 无限重连）                               |
+| `share_session_in_group` | bool   | `true`             | 为 `true` 时群聊所有成员共享一个会话；为 `false` 时每位成员拥有独立会话 |
 
 ### 在企业微信开始与机器人聊天
 
@@ -1649,22 +1655,22 @@ https://xxxx.ngrok-free.app/api/messages
 
 ### 配置总览
 
-| 频道       | 配置键     | 必填/主要字段                                                                                          |
-| ---------- | ---------- | ------------------------------------------------------------------------------------------------------ |
-| 钉钉       | dingtalk   | client_id, client_secret, message_type, card_template_id, card_template_key, robot_code                |
-| 飞书       | feishu     | app_id, app_secret；可选 encrypt_key, verification_token, media_dir                                    |
-| iMessage   | imessage   | db_path, poll_sec（仅 macOS）                                                                          |
-| Discord    | discord    | bot_token；可选 http_proxy, http_proxy_auth                                                            |
-| QQ         | qq         | app_id, client_secret                                                                                  |
-| Telegram   | telegram   | bot_token；可选 http_proxy, http_proxy_auth                                                            |
-| Mattermost | mattermost | url, bot_token; 可选 show_typing, dm_policy, allow_from                                                |
-| Matrix     | matrix     | homeserver, user_id, access_token                                                                      |
-| 企业微信   | wecom      | bot_id, secret；可选 media_dir                                                                         |
-| 微信个人   | wechat     | bot_token（或扫码登录）；可选 bot_token_file, base_url, media_dir                                      |
-| 小艺       | xiaoyi     | ak, sk, agent_id；可选 ws_url                                                                          |
-| 元宝       | yuanbao    | app_id, app_secret；可选 api_domain, media_dir                                                         |
-| Voice      | voice      | twilio_account_sid, twilio_auth_token, phone_number, phone_number_sid；可选 tts_provider, stt_provider |
-| Azure Bot  | azure_bot  | app_id, app_password, tenant_id；可选 http_port, media_dir, share_session_in_group                     |
+| 频道       | 配置键     | 必填/主要字段                                                                                                        |
+| ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| 钉钉       | dingtalk   | client_id, client_secret, message_type, card_template_id, card_template_key, robot_code；可选 share_session_in_group |
+| 飞书       | feishu     | app_id, app_secret；可选 encrypt_key, verification_token, media_dir, share_session_in_group                          |
+| iMessage   | imessage   | db_path, poll_sec（仅 macOS）                                                                                        |
+| Discord    | discord    | bot_token；可选 http_proxy, http_proxy_auth                                                                          |
+| QQ         | qq         | app_id, client_secret                                                                                                |
+| Telegram   | telegram   | bot_token；可选 http_proxy, http_proxy_auth                                                                          |
+| Mattermost | mattermost | url, bot_token; 可选 show_typing, dm_policy, allow_from                                                              |
+| Matrix     | matrix     | homeserver, user_id, access_token                                                                                    |
+| 企业微信   | wecom      | bot_id, secret；可选 media_dir, share_session_in_group                                                               |
+| 微信个人   | wechat     | bot_token（或扫码登录）；可选 bot_token_file, base_url, media_dir                                                    |
+| 小艺       | xiaoyi     | ak, sk, agent_id；可选 ws_url                                                                                        |
+| 元宝       | yuanbao    | app_id, app_secret；可选 api_domain, media_dir                                                                       |
+| Voice      | voice      | twilio_account_sid, twilio_auth_token, phone_number, phone_number_sid；可选 tts_provider, stt_provider               |
+| Azure Bot  | azure_bot  | app_id, app_password, tenant_id；可选 http_port, media_dir, share_session_in_group                                   |
 
 所有频道均支持本页顶部「通用字段」中介绍的访问控制字段（`dm_policy`、`group_policy`、`allow_from`、`deny_message`、`require_mention`）。
 


### PR DESCRIPTION
## Description

DingTalk group chats previously always isolated context per member: `session_id`
is derived from the conversation id suffix, but `user_id` is the sender, and
session state is keyed by `(user_id, session_id)` — so every member got their
own context.

This PR adds a `share_session_in_group` toggle so group members can share one
conversation context, matching the existing option in Feishu / WeCom / OneBot /
Matrix.

**Defaults to `false`, preserving current behavior** — existing users see no change.

### Implementation (two call sites, both required)

1. `build_agent_request_from_native` — in a group with sharing on, `request.user_id`
   collapses to the constant `"group"` (same approach as WeCom). The raw
   `payload["sender_id"]` is left untouched, so logging, `acl_sender_id` and
   `meta["user_name"]` are unaffected.

2. `get_debounce_key` — stops appending `sender_id` when sharing is on. This one
   is easy to miss but necessary: the queue key is computed from the payload at
   enqueue time, *before* the `AgentRequest` exists, so it cannot see the
   collapsed `user_id`. Changing only (1) would route two members of the same
   group into two queues with two concurrent consumers, while their `chat.id` is
   now identical — `TaskTracker.attach_or_start` then returns `is_new=False`, the
   later message only receives a subscriber queue and its payload is never
   executed (log: `Message ignored (task already running)`). Feishu and WeCom
   don't hit this because their payloads carry `session_id`, so their queues are
   already per-conversation.

### Send path is unaffected

DingTalk resolves delivery targets through a stored sessionWebhook table.
Verified that changing `user_id` does not affect it:

- Live replies read the webhook straight from the current request's
  `meta["session_webhook"]` — no table lookup.
- The group webhook entry is already stored under `dingtalk:sw:<session_id>`
  (no `user_id` in the key).
- Proactive/cron sends resolve `dingtalk:sw:group_<session_id>` and fall back
  through `_suffix_only_webhook_key` to the group entry (covered by a test).
- The Open API fallback uses `conversation_id` / `sender_staff_id`, unrelated to
  `user_id`.

> The shared id must not contain `_`, otherwise the `rfind("_")` split in that
> fallback key breaks — noted in a code comment.

### Drive-by fix (missing docs)

Feishu and WeCom have supported `share_session_in_group` in code for a while, but
neither channel doc ever mentioned it (WeCom even defaults to `true`, so users had
no documented way to find or disable it). This PR adds the field to their JSON
examples, channel-specific field tables and the appendix config overview.

**Related Issue:** Closes #7158 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
