### PR TITLE
fix(providers): refresh DeepSeek catalog per vendor retirement and docs

### DIFF
--- a/src/qwenpaw/providers/data/model_catalog.json
+++ b/src/qwenpaw/providers/data/model_catalog.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "catalog_version": "2026.07.29",
-  "published_at": "2026-07-29T00:00:00Z",
+  "catalog_version": "2026.08.23",
+  "published_at": "2026-08-23T00:00:00Z",
   "providers": {
     "MODELSCOPE_MODELS": [
       {
@@ -1477,41 +1477,6 @@
     ],
     "DEEPSEEK_MODELS": [
       {
-        "id": "deepseek-chat",
-        "name": "DeepSeek Chat",
-        "supports_image": false,
-        "supports_video": false,
-        "probe_source": "documentation",
-        "is_free": false,
-        "is_recommended": true,
-        "source": "builtin",
-        "availability_status": "unverified",
-        "availability_retryable": true,
-        "config_overrides": [],
-        "max_tokens": 8192,
-        "max_input_length": 131072,
-        "max_input_length_configured": false,
-        "generate_kwargs": {},
-        "relay_reasoning": true
-      },
-      {
-        "id": "deepseek-reasoner",
-        "name": "DeepSeek Reasoner",
-        "supports_image": false,
-        "supports_video": false,
-        "probe_source": "documentation",
-        "is_free": false,
-        "source": "builtin",
-        "availability_status": "unverified",
-        "availability_retryable": true,
-        "config_overrides": [],
-        "max_tokens": 8192,
-        "max_input_length": 131072,
-        "max_input_length_configured": false,
-        "generate_kwargs": {},
-        "relay_reasoning": true
-      },
-      {
         "id": "deepseek-v4-flash",
         "name": "DeepSeek V4 Flash",
         "supports_image": false,
@@ -1523,7 +1488,7 @@
         "availability_retryable": true,
         "config_overrides": [],
         "max_tokens": 8192,
-        "max_input_length": 131072,
+        "max_input_length": 1000000,
         "max_input_length_configured": false,
         "generate_kwargs": {},
         "relay_reasoning": true
@@ -1540,7 +1505,24 @@
         "availability_retryable": true,
         "config_overrides": [],
         "max_tokens": 8192,
-        "max_input_length": 131072,
+        "max_input_length": 1000000,
+        "max_input_length_configured": false,
+        "generate_kwargs": {},
+        "relay_reasoning": true
+      },
+      {
+        "id": "deepseek-v4-flash-vision-exp",
+        "name": "DeepSeek V4 Flash Vision Exp",
+        "supports_image": true,
+        "supports_video": false,
+        "probe_source": "documentation",
+        "is_free": false,
+        "source": "builtin",
+        "availability_status": "unverified",
+        "availability_retryable": true,
+        "config_overrides": [],
+        "max_tokens": 8192,
+        "max_input_length": 1000000,
         "max_input_length_configured": false,
         "generate_kwargs": {},
         "relay_reasoning": true


### PR DESCRIPTION
Verified against the live vendor API (GET api.deepseek.com/models) and the official Models & Pricing table (api-docs.deepseek.com):

- remove deepseek-chat / deepseek-reasoner — retired by vendor, no longer served (live /models returns only the v4 family)
- deepseek-v4-flash / deepseek-v4-pro: correct context window 128k -> 1M (pricing table: CONTEXT LENGTH 1M, MAX OUTPUT 384K)
- add deepseek-v4-flash-vision-exp — live-served, 1M context, image input
- bump catalog_version to 2026.08.23

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
