### PR TITLE
fix(console): include custom channels in MCP rules

### DIFF
--- a/console/src/pages/Agent/MCP/accessPolicy.test.ts
+++ b/console/src/pages/Agent/MCP/accessPolicy.test.ts
@@ -4,6 +4,7 @@ import {
   addClientRule,
   addToolRule,
   buildMCPAccessToolGroups,
+  getMCPChannelSourceValues,
   removeClientRule,
   removeToolRule,
   upsertClientRule,
@@ -102,6 +103,30 @@ describe("MCP access policy helpers", () => {
         ],
       }),
     ]);
+  });
+
+  it("merges dynamic and saved custom channel source values", () => {
+    const values = getMCPChannelSourceValues(
+      {
+        ...policy,
+        client_overrides: [
+          ...policy.client_overrides,
+          {
+            source_type: "channel",
+            source_value: "saved-channel",
+            subject_type: "all",
+            subject_value: "",
+            effect: "allow",
+          },
+        ],
+      },
+      ["plugin-channel", "console", "*"],
+    );
+
+    expect(values).toContain("plugin-channel");
+    expect(values).toContain("saved-channel");
+    expect(values.filter((value) => value === "console")).toHaveLength(1);
+    expect(values).not.toContain("*");
   });
 
   it("adds and updates MCP-wide client rules independently from tool rules", () => {

--- a/console/src/pages/Agent/MCP/accessPolicy.ts
+++ b/console/src/pages/Agent/MCP/accessPolicy.ts
@@ -64,6 +64,30 @@ export const MCP_CHANNEL_SOURCE_VALUES = [
   "xiaoyi",
 ] as const;
 
+export function getMCPChannelSourceValues(
+  policy: MCPAccessPolicy,
+  availableValues: readonly string[] = [],
+): string[] {
+  const savedValues = [
+    ...policy.client_overrides,
+    ...policy.tool_overrides,
+  ].flatMap((rule) =>
+    rule.source_type === "channel" ? [rule.source_value] : [],
+  );
+  const values = new Set<string>();
+  for (const value of [
+    ...MCP_CHANNEL_SOURCE_VALUES,
+    ...availableValues,
+    ...savedValues,
+  ]) {
+    const normalized = (value || "").trim();
+    if (normalized && normalized !== "*") {
+      values.add(normalized);
+    }
+  }
+  return Array.from(values);
+}
+
 export function normalizeMCPAccessPolicy(
   policy: MCPAccessPolicy,
 ): MCPAccessPolicy {

--- a/console/src/pages/Agent/MCP/components/MCPAccessClientPanel.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPAccessClientPanel.tsx
@@ -16,6 +16,7 @@ import { MCPAccessRuleRows } from "./MCPAccessRuleRows";
 interface MCPAccessClientPanelProps {
   policy: MCPAccessPolicy;
   principalOptions: MCPAccessPrincipalOption[];
+  channelSourceValues: readonly string[];
   setDefaultEffect: (effect: MCPAccessEffect) => void;
   addClientAccessRule: () => void;
   updateClientRule: (
@@ -30,6 +31,7 @@ interface MCPAccessClientPanelProps {
 export const MCPAccessClientPanel: React.FC<MCPAccessClientPanelProps> = ({
   policy,
   principalOptions,
+  channelSourceValues,
   setDefaultEffect,
   addClientAccessRule,
   updateClientRule,
@@ -68,6 +70,7 @@ export const MCPAccessClientPanel: React.FC<MCPAccessClientPanelProps> = ({
       <MCPAccessRuleRows
         rules={policy.client_overrides}
         principalOptions={principalOptions}
+        channelSourceValues={channelSourceValues}
         getKey={accessRuleIdentityKey}
         updateRule={updateClientRule}
         setRuleEffect={setClientRuleEffect}

--- a/console/src/pages/Agent/MCP/components/MCPAccessModal.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPAccessModal.tsx
@@ -18,6 +18,8 @@ import {
   addToolRule,
   buildMCPAccessToolGroups,
   findMCPAccessPolicyWarning,
+  getMCPChannelSourceValues,
+  MCP_CHANNEL_SOURCE_VALUES,
   normalizeMCPAccessPolicy,
   removeClientRule,
   removeToolRule,
@@ -50,6 +52,9 @@ export const MCPAccessModal: React.FC<MCPAccessModalProps> = ({
   const [principalOptions, setPrincipalOptions] = useState<
     MCPAccessPrincipalOption[]
   >([]);
+  const [channelSourceValues, setChannelSourceValues] = useState<string[]>([
+    ...MCP_CHANNEL_SOURCE_VALUES,
+  ]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [toolsError, setToolsError] = useState("");
@@ -62,13 +67,20 @@ export const MCPAccessModal: React.FC<MCPAccessModalProps> = ({
       setLoading(true);
       setTools([]);
       setPrincipalOptions([]);
+      setChannelSourceValues([...MCP_CHANNEL_SOURCE_VALUES]);
       setToolsError("");
       try {
-        const savedPolicy = await api.getMCPPolicy(client.key);
+        const [savedPolicy, availableChannelValues] = await Promise.all([
+          api.getMCPPolicy(client.key),
+          api.listChannelTypes().catch(() => []),
+        ]);
         if (!cancelled) {
           const normalized = normalizeMCPAccessPolicy(savedPolicy);
           setPolicy(normalized);
           setInitialPolicySignature(policySignature(normalized));
+          setChannelSourceValues(
+            getMCPChannelSourceValues(normalized, availableChannelValues),
+          );
         }
 
         try {
@@ -246,6 +258,7 @@ export const MCPAccessModal: React.FC<MCPAccessModalProps> = ({
           <MCPAccessClientPanel
             policy={policy}
             principalOptions={principalOptions}
+            channelSourceValues={channelSourceValues}
             setDefaultEffect={setDefaultEffect}
             addClientAccessRule={() =>
               setPolicy((prev) => (prev ? addClientRule(prev) : prev))
@@ -270,6 +283,7 @@ export const MCPAccessModal: React.FC<MCPAccessModalProps> = ({
             <MCPAccessToolPanel
               groups={groups}
               principalOptions={principalOptions}
+              channelSourceValues={channelSourceValues}
               setToolDefaultEffect={(toolName, effect) =>
                 setPolicy((prev) =>
                   prev ? upsertToolDefault(prev, toolName, effect) : prev,

--- a/console/src/pages/Agent/MCP/components/MCPAccessRuleRows.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPAccessRuleRows.tsx
@@ -12,7 +12,6 @@ import type {
 } from "../../../../api/types";
 import {
   buildSubjectValueOptions,
-  MCP_CHANNEL_SOURCE_VALUES,
   ruleHasAmbiguousUserSource,
   ruleHasUnknownUserValue,
 } from "../accessPolicy";
@@ -121,13 +120,14 @@ const CHANNEL_SOURCE_FALLBACK_LABELS: Record<string, string> = {
 function channelSourceOptions(
   allChannelsLabel: string,
   channelLabel: (value: string) => string,
+  channelSourceValues: readonly string[],
 ): { label: string; value: string }[] {
   return [
     {
       label: allChannelsLabel,
       value: "*",
     },
-    ...MCP_CHANNEL_SOURCE_VALUES.map((value) => ({
+    ...channelSourceValues.map((value) => ({
       label: channelLabel(value),
       value,
     })),
@@ -160,6 +160,7 @@ function sourceValueSelectValue(sourceValue: string): string {
 interface MCPAccessRuleRowsProps<Rule extends MCPAccessRule> {
   rules: Rule[];
   principalOptions?: MCPAccessPrincipalOption[];
+  channelSourceValues: readonly string[];
   getKey: (rule: Rule) => string;
   updateRule: (rule: Rule, patch: Partial<MCPAccessRule>) => void;
   setRuleEffect: (rule: Rule, effect: MCPAccessEffect) => void;
@@ -171,6 +172,7 @@ interface MCPAccessRuleRowsProps<Rule extends MCPAccessRule> {
 export function MCPAccessRuleRows<Rule extends MCPAccessRule>({
   rules,
   principalOptions = [],
+  channelSourceValues,
   getKey,
   updateRule,
   setRuleEffect,
@@ -186,6 +188,7 @@ export function MCPAccessRuleRows<Rule extends MCPAccessRule>({
   const sourceValueOptions = channelSourceOptions(
     t("mcp.access.sourceValueAllChannels"),
     channelLabel,
+    channelSourceValues,
   );
   const channelSourceTypeLabel = t("mcp.access.source.channel");
   const subjectTypeOptions = [

--- a/console/src/pages/Agent/MCP/components/MCPAccessToolPanel.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPAccessToolPanel.tsx
@@ -17,6 +17,7 @@ import { MCPAccessRuleRows } from "./MCPAccessRuleRows";
 interface MCPAccessToolPanelProps {
   groups: MCPAccessToolGroup[];
   principalOptions: MCPAccessPrincipalOption[];
+  channelSourceValues: readonly string[];
   setToolDefaultEffect: (toolName: string, effect: MCPAccessEffect) => void;
   addRule: (toolName: string) => void;
   updateRule: (
@@ -31,6 +32,7 @@ interface MCPAccessToolPanelProps {
 export const MCPAccessToolPanel: React.FC<MCPAccessToolPanelProps> = ({
   groups,
   principalOptions,
+  channelSourceValues,
   setToolDefaultEffect,
   addRule,
   updateRule,
@@ -104,6 +106,7 @@ export const MCPAccessToolPanel: React.FC<MCPAccessToolPanelProps> = ({
             <MCPAccessRuleRows
               rules={group.rules}
               principalOptions={principalOptions}
+              channelSourceValues={channelSourceValues}
               getKey={toolRuleIdentityKey}
               updateRule={updateRule}
               setRuleEffect={setRuleEffect}


### PR DESCRIPTION
## Summary

Fixes #7197.

Custom plugin channels were missing from the MCP access-rule source selector because the Console only used a hard-coded list of built-in channels.

## Changes

Load available channel types from /config/channels/types.

Include plugin-registered channels in MCP access-rule selectors.

Preserve channel values from existing policies, even when a plugin is temporarily unavailable.

Fall back to the built-in channel list if dynamic channel loading fails.

Deduplicate and filter invalid channel values.

Add regression coverage for dynamic and saved custom channels.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
