### PR TITLE
fix(console): retain embedding verification across navigation

### DIFF
--- a/console/src/pages/Agent/Config/components/EmbeddingModelCard.tsx
+++ b/console/src/pages/Agent/Config/components/EmbeddingModelCard.tsx
@@ -31,7 +31,7 @@ export function EmbeddingModelCard() {
   const { t } = useTranslation();
   const { modal } = useAppMessage();
   const form = Form.useFormInstance();
-  const { needsReindex, reindexing, openMemorySettings, configRevision } =
+  const { needsReindex, reindexing, openMemorySettings } =
     useMemoryMaintenance();
 
   const embeddingConfig = Form.useWatch(
@@ -57,11 +57,7 @@ export function EmbeddingModelCard() {
     testedEmbeddingIsCurrent,
     markVerified,
     clearVerification,
-  } = useEmbeddingVerification(
-    embeddingConfig,
-    embeddingEnabled,
-    configRevision,
-  );
+  } = useEmbeddingVerification(embeddingConfig, embeddingEnabled);
   const embeddingCacheEnabled = embeddingConfig?.enable_cache ?? true;
 
   const testEmbedding = async () => {

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
@@ -11,6 +11,7 @@ import { useState, type ReactNode } from "react";
 
 import { agentsApi, api } from "@/api";
 import { useAgentStore } from "@/stores/agentStore";
+import { useEmbeddingVerificationStore } from "@/stores/embeddingVerificationStore";
 import { renderWithProviders } from "@/test/common_setup";
 import {
   isValidDreamCronShape,
@@ -78,7 +79,6 @@ function RuntimeProvider({ children }: { children: ReactNode }) {
         runtimeStatus,
         diagnosticsStatus,
         checkMemoryStatus,
-        configRevision: 0,
       }}
     >
       {children}
@@ -98,7 +98,6 @@ function StaticMemoryProvider({ children }: { children: ReactNode }) {
         runtimeStatus: unknownRuntime,
         diagnosticsStatus: unknownDiagnostics,
         checkMemoryStatus: noopStatusCheck,
-        configRevision: 0,
       }}
     >
       {children}
@@ -146,7 +145,11 @@ function EmbeddingForm() {
   );
 }
 
-function ConfiguredEmbeddingForm() {
+function ConfiguredEmbeddingForm({
+  modelName = "text-embedding-v4",
+}: {
+  modelName?: string;
+}) {
   const [form] = Form.useForm();
   return (
     <Form
@@ -155,7 +158,7 @@ function ConfiguredEmbeddingForm() {
         reme_light_memory_config: {
           embedding_model_config: {
             backend: "openai",
-            model_name: "text-embedding-v4",
+            model_name: modelName,
             api_key: "secret",
             dimensions: 1024,
             enable_cache: true,
@@ -180,7 +183,6 @@ function ReindexingEmbeddingForm() {
         runtimeStatus: unknownRuntime,
         diagnosticsStatus: unknownDiagnostics,
         checkMemoryStatus: noopStatusCheck,
-        configRevision: 0,
       }}
     >
       <ConfiguredEmbeddingForm />
@@ -201,7 +203,6 @@ function NeedsReindexEmbeddingForm({ onOpen = vi.fn() }) {
         runtimeStatus: unknownRuntime,
         diagnosticsStatus: unknownDiagnostics,
         checkMemoryStatus: noopStatusCheck,
-        configRevision: 0,
       }}
     >
       <ConfiguredEmbeddingForm />
@@ -228,7 +229,6 @@ function MemoryAndEmbeddingForm() {
         runtimeStatus,
         diagnosticsStatus,
         checkMemoryStatus,
-        configRevision: 0,
       }}
     >
       <Form
@@ -255,6 +255,7 @@ function MemoryAndEmbeddingForm() {
 afterEach(() => {
   vi.restoreAllMocks();
   useAgentStore.setState({ selectedAgent: "default" });
+  useEmbeddingVerificationStore.setState({ verificationByAgent: {} });
 });
 
 describe("ReMe runtime status", () => {
@@ -631,7 +632,78 @@ describe("embedding card separation", () => {
     ).toBeInTheDocument();
   });
 
-  it("clears verification when the selected agent changes", async () => {
+  it("keeps a successful verification after the embedding card remounts", async () => {
+    vi.spyOn(api, "testEmbedding").mockResolvedValue({
+      success: true,
+      configured_dimensions: 1024,
+      actual_dimensions: 1024,
+      latency_ms: 86,
+      message: "ok",
+    });
+
+    const view = renderWithProviders(<ConfiguredEmbeddingForm />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "agentConfig.embeddingTestConnection",
+      }),
+    );
+    expect(
+      await screen.findByText("agentConfig.embeddingVerified"),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "agentConfig.embeddingTestConnection",
+        }),
+      ).toHaveAttribute("aria-busy", "false"),
+    );
+
+    view.unmount();
+    renderWithProviders(<ConfiguredEmbeddingForm />);
+
+    expect(
+      screen.getByText("agentConfig.embeddingVerified"),
+    ).toBeInTheDocument();
+    expect(api.testEmbedding).toHaveBeenCalledOnce();
+  });
+
+  it("does not reuse verification for different service settings", async () => {
+    vi.spyOn(api, "testEmbedding").mockResolvedValue({
+      success: true,
+      configured_dimensions: 1024,
+      actual_dimensions: 1024,
+      latency_ms: 86,
+      message: "ok",
+    });
+
+    const view = renderWithProviders(<ConfiguredEmbeddingForm />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "agentConfig.embeddingTestConnection",
+      }),
+    );
+    expect(
+      await screen.findByText("agentConfig.embeddingVerified"),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "agentConfig.embeddingTestConnection",
+        }),
+      ).toHaveAttribute("aria-busy", "false"),
+    );
+
+    view.unmount();
+    renderWithProviders(
+      <ConfiguredEmbeddingForm modelName="text-embedding-v5" />,
+    );
+
+    expect(
+      screen.getByText("agentConfig.embeddingNotVerified"),
+    ).toBeInTheDocument();
+  });
+
+  it("isolates verification by selected agent", async () => {
     vi.spyOn(api, "testEmbedding").mockResolvedValue({
       success: true,
       configured_dimensions: 1024,
@@ -653,6 +725,12 @@ describe("embedding card separation", () => {
 
     expect(
       await screen.findByText("agentConfig.embeddingNotVerified"),
+    ).toBeInTheDocument();
+
+    act(() => useAgentStore.setState({ selectedAgent: "default" }));
+
+    expect(
+      await screen.findByText("agentConfig.embeddingVerified"),
     ).toBeInTheDocument();
   });
 

--- a/console/src/pages/Agent/Config/components/useEmbeddingVerification.ts
+++ b/console/src/pages/Agent/Config/components/useEmbeddingVerification.ts
@@ -2,47 +2,48 @@ import { useCallback, useEffect, useState } from "react";
 
 import type { EmbeddingModelConfig } from "@/api/types/agent";
 import { useAgentStore } from "@/stores/agentStore";
+import { useEmbeddingVerificationStore } from "@/stores/embeddingVerificationStore";
 import { getEmbeddingServiceFingerprint } from "./embeddingUtils";
-
-interface VerifiedEmbedding {
-  agentId: string;
-  fingerprint: string;
-  dimensions: number;
-  latency: number;
-}
 
 export function useEmbeddingVerification(
   config: EmbeddingModelConfig | undefined,
   enabled: boolean,
-  configRevision: number,
 ) {
   const { selectedAgent } = useAgentStore();
   const agentId = selectedAgent || "default";
   const [testingEmbedding, setTestingEmbedding] = useState(false);
-  const [testedEmbedding, setTestedEmbedding] =
-    useState<VerifiedEmbedding | null>(null);
+  const testedEmbedding = useEmbeddingVerificationStore(
+    (state) => state.verificationByAgent[agentId] ?? null,
+  );
+  const setVerification = useEmbeddingVerificationStore(
+    (state) => state.setVerification,
+  );
+  const clearStoredVerification = useEmbeddingVerificationStore(
+    (state) => state.clearVerification,
+  );
 
-  const clearVerification = useCallback(() => setTestedEmbedding(null), []);
+  const clearVerification = useCallback(
+    () => clearStoredVerification(agentId),
+    [agentId, clearStoredVerification],
+  );
   const markVerified = useCallback(
     (dimensions: number, latency: number) => {
-      setTestedEmbedding({
-        agentId,
+      setVerification(agentId, {
         fingerprint: getEmbeddingServiceFingerprint(config),
         dimensions,
         latency,
+        verifiedAt: Date.now(),
       });
     },
-    [agentId, config],
+    [agentId, config, setVerification],
   );
 
-  useEffect(clearVerification, [agentId, configRevision, clearVerification]);
   useEffect(() => {
-    if (!enabled) clearVerification();
-  }, [clearVerification, enabled]);
+    if (config !== undefined && !enabled) clearVerification();
+  }, [clearVerification, config, enabled]);
 
   const testedEmbeddingIsCurrent =
-    testedEmbedding?.agentId === agentId &&
-    testedEmbedding.fingerprint === getEmbeddingServiceFingerprint(config);
+    testedEmbedding?.fingerprint === getEmbeddingServiceFingerprint(config);
 
   return {
     testingEmbedding,

--- a/console/src/pages/Agent/Config/index.tsx
+++ b/console/src/pages/Agent/Config/index.tsx
@@ -30,11 +30,9 @@ function AgentConfigPage() {
   );
   const [needsReindex, setNeedsReindex] = useState(false);
   const [localReindexing, setLocalReindexing] = useState(false);
-  const [configRevision, setConfigRevision] = useState(0);
   const syncReindexRequirement = useCallback(
     (config: { reme_light_memory_config?: { needs_reindex?: boolean } }) => {
       setNeedsReindex(config.reme_light_memory_config?.needs_reindex === true);
-      setConfigRevision((revision) => revision + 1);
     },
     [],
   );
@@ -313,7 +311,6 @@ function AgentConfigPage() {
             runtimeStatus,
             diagnosticsStatus,
             checkMemoryStatus,
-            configRevision,
           }}
         >
           <Form form={form} layout="vertical" className={styles.form}>

--- a/console/src/pages/Agent/Config/memoryMaintenanceContext.ts
+++ b/console/src/pages/Agent/Config/memoryMaintenanceContext.ts
@@ -13,7 +13,6 @@ export interface MemoryMaintenanceState {
   runtimeStatus: ReMeRuntimeStatus;
   diagnosticsStatus: ReMeDiagnosticsStatus;
   checkMemoryStatus: (includeDiagnostics?: boolean) => Promise<void>;
-  configRevision: number;
 }
 
 export const MemoryMaintenanceContext = createContext<MemoryMaintenanceState>({
@@ -25,7 +24,6 @@ export const MemoryMaintenanceContext = createContext<MemoryMaintenanceState>({
   runtimeStatus: { type: "unknown" },
   diagnosticsStatus: { type: "unknown" },
   checkMemoryStatus: async () => {},
-  configRevision: 0,
 });
 
 export function useMemoryMaintenance() {

--- a/console/src/stores/embeddingVerificationStore.ts
+++ b/console/src/stores/embeddingVerificationStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+
+export interface VerifiedEmbedding {
+  fingerprint: string;
+  dimensions: number;
+  latency: number;
+  verifiedAt: number;
+}
+
+interface EmbeddingVerificationStore {
+  verificationByAgent: Record<string, VerifiedEmbedding>;
+  setVerification: (agentId: string, verification: VerifiedEmbedding) => void;
+  clearVerification: (agentId: string) => void;
+}
+
+/**
+ * Keep successful embedding checks for the lifetime of the Console session.
+ *
+ * This state deliberately is not persisted to browser storage: a successful
+ * connectivity check is a point-in-time observation and should not survive an
+ * application restart. The service fingerprint makes the result valid only
+ * for the exact settings that were tested.
+ */
+export const useEmbeddingVerificationStore = create<EmbeddingVerificationStore>(
+  (set) => ({
+    verificationByAgent: {},
+    setVerification: (agentId, verification) =>
+      set((state) => ({
+        verificationByAgent: {
+          ...state.verificationByAgent,
+          [agentId]: verification,
+        },
+      })),
+    clearVerification: (agentId) =>
+      set((state) => {
+        if (!(agentId in state.verificationByAgent)) return state;
+        const verificationByAgent = { ...state.verificationByAgent };
+        delete verificationByAgent[agentId];
+        return { verificationByAgent };
+      }),
+  }),
+);


### PR DESCRIPTION
## Description

Keep successful Embedding service verification results in a session-scoped Zustand store instead of component-local state. Results are isolated by agent and matched against the exact service fingerprint, so navigating away and returning preserves a valid result while changed settings remain unverified.

This also removes the config revision behavior that cleared verification after saving unchanged settings, and guards against the form watcher's transient `undefined` value during remount.

**Related Issue:** Fixes #7226

**Security Considerations:** Verification fingerprints include credentials for exact matching but remain only in process memory. They are not written to localStorage, sessionStorage, configuration, or logs, and are discarded when the Console application restarts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Verify an Embedding service, leave the configuration page, and return: the exact configuration remains verified.
- Change the model/service settings: the previous result is not reused.
- Switch agents: verification status is isolated per agent and restored when switching back.

## Evidence

```text
npm test -- --run src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
Test Files  1 passed (1)
Tests       26 passed (26)

npm run test:run
Test Files  263 passed (263)
Tests       1977 passed (1977)

npm run format:check
All matched files use Prettier code style!

npx eslint <changed console files>
Passed with no errors.
```

## Additional Notes

The verification record intentionally does not survive an application restart because connectivity verification is a point-in-time observation rather than durable configuration state.
