### PR TITLE
feat(os): auto-hide Dock for maximized windows

### DIFF
--- a/console/src/os/DesktopOS.tsx
+++ b/console/src/os/DesktopOS.tsx
@@ -34,7 +34,7 @@ import { baseFromRoutePath } from "./osRouteMap";
 import MenuBar from "./MenuBar";
 import Dock from "./Dock";
 import SpacesPanel from "./SpacesPanel";
-import { useEdgeReveal } from "./useEdgeReveal";
+import { shouldRevealDock, useEdgeReveal } from "./useEdgeReveal";
 import { useOsIcons, defaultIconPos } from "./osIconStore";
 import { useOsDock } from "./osDockStore";
 import { useIconDrag } from "./useIconDrag";
@@ -220,9 +220,18 @@ export default function DesktopOS() {
     .map((id) => windows[id])
     .filter((w): w is NonNullable<typeof w> => Boolean(w));
 
-  // Desktop keeps the menu bar visible above maximized windows. Mobile uses
-  // full-screen windows and keeps the menu bar hidden.
-  const { topHot } = useEdgeReveal();
+  // Desktop keeps the menu bar visible. A maximized active window hides the
+  // Dock until the pointer reaches the bottom edge; mobile keeps it visible.
+  const { topHot, bottomHot } = useEdgeReveal();
+  const activeWindow = activeId ? windows[activeId] : undefined;
+  const activeWindowMaximized = Boolean(
+    activeWindow?.maximized && !activeWindow.minimized,
+  );
+  const dockRevealed = shouldRevealDock(
+    isMobile,
+    activeWindowMaximized,
+    bottomHot,
+  );
 
   // Persisted desktop icon positions + transient drag handlers. While a
   // drag is in flight the position lives in the DOM only (rAF-coalesced);
@@ -503,7 +512,7 @@ export default function DesktopOS() {
 
       <SpacesPanel visible={topHot} />
       <MenuBar hidden={isMobile} />
-      <Dock />
+      <Dock revealed={dockRevealed} />
 
       {ctxMenu && (
         <Dropdown

--- a/console/src/os/useEdgeReveal.test.ts
+++ b/console/src/os/useEdgeReveal.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveEdges, type EdgeState } from "./useEdgeReveal";
+import {
+  resolveEdges,
+  shouldRevealDock,
+  type EdgeState,
+} from "./useEdgeReveal";
 
 const OPTS = { threshold: 6, topBand: 120, bottomBand: 96 };
 const OFF: EdgeState = { topHot: false, bottomHot: false };
@@ -31,5 +35,23 @@ describe("resolveEdges", () => {
   it("releases bottom once pointer leaves the band", () => {
     const prev = { topHot: false, bottomHot: true };
     expect(resolveEdges(700, 800, prev, OPTS).bottomHot).toBe(false);
+  });
+});
+
+describe("shouldRevealDock", () => {
+  it("keeps the Dock visible without a maximized active window", () => {
+    expect(shouldRevealDock(false, false, false)).toBe(true);
+  });
+
+  it("hides the Dock for a maximized active window", () => {
+    expect(shouldRevealDock(false, true, false)).toBe(false);
+  });
+
+  it("reveals the Dock when the pointer reaches the bottom edge", () => {
+    expect(shouldRevealDock(false, true, true)).toBe(true);
+  });
+
+  it("keeps the Dock visible on mobile", () => {
+    expect(shouldRevealDock(true, true, false)).toBe(true);
   });
 });

--- a/console/src/os/useEdgeReveal.ts
+++ b/console/src/os/useEdgeReveal.ts
@@ -19,6 +19,15 @@ export interface EdgeOptions {
   bottomBand?: number;
 }
 
+/** Resolve Dock visibility from device, window and pointer-edge state. */
+export function shouldRevealDock(
+  isMobile: boolean,
+  activeWindowMaximized: boolean,
+  bottomHot: boolean,
+): boolean {
+  return isMobile || !activeWindowMaximized || bottomHot;
+}
+
 interface ResolvedOpts {
   threshold: number;
   topBand: number;


### PR DESCRIPTION
## Summary

- Auto-hide the Dock when the active OS window is maximized.
- Reveal it when the pointer reaches the bottom edge.
- Keep it visible for normal windows and on mobile.

## Validation

- 13 related tests passed.
- TypeScript, ESLint, and Prettier checks passed.

Fixes #7195