### PR TITLE
[DO NOT MERGE] fix(memory): restore periodic ReMe index compaction

### DIFF
--- a/scripts/reproduce_reme_index_growth.py
+++ b/scripts/reproduce_reme_index_growth.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Reproduce retained ReMe index growth from repeated Markdown updates."""
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import gc
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import psutil
+from reme import ReMe
+from reme.enumeration import ComponentEnum
+
+from qwenpaw.agents.memory.reme_config import _base_config
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=120)
+    parser.add_argument("--directory-count", type=int, default=980)
+    parser.add_argument("--lines-per-update", type=int, default=40)
+    parser.add_argument("--compact-every", type=int, default=0)
+    return parser.parse_args()
+
+
+def _application(workspace: Path) -> ReMe:
+    config = _base_config()
+    config["components"]["file_store"]["default"]["embedding_store"] = ""
+    config["components"].pop("embedding_store")
+    config["components"].pop("as_embedding")
+    config.update(
+        workspace_dir=str(workspace),
+        metadata_dir=".reme",
+        session_dir="sessions",
+        mem_session_dir="mem_session",
+        resource_dir="resource",
+        daily_dir="memory",
+        digest_dir="digest",
+        language="zh",
+        timezone="Asia/Shanghai",
+        enable_logo=False,
+        log_to_console=False,
+    )
+    return ReMe(**config)
+
+
+def _component(app: ReMe, kind: ComponentEnum) -> Any:
+    return app.context.components[kind]["default"]
+
+
+def _index_bytes(index: Any) -> int:
+    arrays = [index._doc_lens, index._deleted]
+    arrays.extend(index._doc_token_ids)
+    arrays.extend(index._posting_doc_idxs.values())
+    arrays.extend(index._posting_tfs.values())
+    return sum(array.nbytes for array in arrays)
+
+
+def _report(label: str, index: Any, baseline_rss: int) -> None:
+    rss = psutil.Process(os.getpid()).memory_info().rss
+    deleted = int(index._deleted.sum())
+    print(
+        f"{label}: rss_delta_mib={(rss - baseline_rss) / 2**20:.1f} "
+        f"live_docs={index.n_docs} allocated_docs={len(index._doc_ids)} "
+        f"deleted_docs={deleted} arrays_mib={_index_bytes(index) / 2**20:.1f}",
+    )
+
+
+async def _run(args: argparse.Namespace) -> None:
+    logging.disable(logging.CRITICAL)
+    with tempfile.TemporaryDirectory(prefix="qwenpaw-reme-memory-") as root:
+        workspace = Path(root)
+        memory_dir = workspace / "memory"
+        memory_dir.mkdir()
+        note = memory_dir / "2026-08-22.md"
+        paths = [
+            f"D:/HuaweiFamilyArchive/category-{idx:04d}/document.md"
+            for idx in range(args.directory_count)
+        ]
+        content = ["# 2026-08-22", "", "## Directory inventory", *paths]
+
+        app = _application(workspace)
+        tokenizer = _component(app, ComponentEnum.TOKENIZER)
+        graph = _component(app, ComponentEnum.FILE_GRAPH)
+        keyword = _component(app, ComponentEnum.KEYWORD_INDEX)
+        store = _component(app, ComponentEnum.FILE_STORE)
+        chunker = app.context.components[ComponentEnum.FILE_CHUNKER][
+            "markdown"
+        ]
+        for component in (tokenizer, graph, keyword, store):
+            await component.start()
+
+        process = psutil.Process(os.getpid())
+        baseline_rss = process.memory_info().rss
+        _report("start", keyword, baseline_rss)
+        for iteration in range(1, args.iterations + 1):
+            content.append(f"\n## Completed turn {iteration}")
+            content.extend(
+                f"- archived item {iteration:04d}-{line:04d}"
+                for line in range(args.lines_per_update)
+            )
+            note.write_text("\n".join(content), encoding="utf-8")
+            await store.upsert([await chunker.chunk(note)])
+            if args.compact_every > 0 and iteration % args.compact_every == 0:
+                await store.optimize_index()
+            if iteration in {1, args.iterations // 2, args.iterations}:
+                gc.collect()
+                _report(f"update-{iteration}", keyword, baseline_rss)
+
+        await store.optimize_index()
+        gc.collect()
+        _report("after-final-compact", keyword, baseline_rss)
+        await store.close()
+
+
+def main() -> None:
+    asyncio.run(_run(_arguments()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qwenpaw/agents/memory/reme_config.py
+++ b/src/qwenpaw/agents/memory/reme_config.py
@@ -84,6 +84,11 @@ def _base_config() -> dict[str, Any]:
                     },
                 ],
             },
+            "optimize_index_cron": {
+                "backend": "cron",
+                "cron": "0 2 * * *",
+                "steps": [{"backend": "optimize_index_step"}],
+            },
             "version": {
                 "backend": "base",
                 "description": "return reme package version",

--- a/tests/unit/agents/memory/test_reme_config.py
+++ b/tests/unit/agents/memory/test_reme_config.py
@@ -42,6 +42,16 @@ def test_reme_file_processing_is_limited_to_10_mb() -> None:
         assert cfg["jobs"][job_name]["max_file_bytes"] == 10 * 1024 * 1024
 
 
+def test_reme_compacts_deferred_index_deletions_daily() -> None:
+    cfg = _config_for_embedding(EmbeddingModelConfig())
+
+    assert cfg["jobs"]["optimize_index_cron"] == {
+        "backend": "cron",
+        "cron": "0 2 * * *",
+        "steps": [{"backend": "optimize_index_step"}],
+    }
+
+
 def test_daily_paper_replaces_auto_resource_without_removing_resource_dir():
     cfg = _config_for_embedding(EmbeddingModelConfig())
 


### PR DESCRIPTION
## Summary

Restore the `optimize_index_cron` job that exists in the upstream ReMe default configuration but was omitted from the embedded QwenPaw configuration.

ReMe replaces indexed Markdown chunks with lazy deletion. Without this maintenance job, old BM25 document slots and posting entries remain resident for the entire backend lifetime. This affects completed work as well as active work, so it does not require a large number of unfinished tasks.

Related to #7222.

## Incident investigation

The reported failure ended at `console/channel.py` while allocating the SSE string, but that line is the final failed allocation rather than evidence that SSE serialization caused the buildup. The preceding blank `Event JSON serialization failed` warnings are consistent with `MemoryError`, whose string representation is empty.

I checked the other suspected paths before changing code:

- Shell execution returns one final `ToolChunk`; the 980-directory workload does not create one chunk per directory.
- Tool results are capped before entering context (50 KB by default; Markdown exemption retains this recent limit rather than disabling pruning).
- A representative five-command, 980-directory SSE run was only about 3.7 MB, so the proposed per-tool O(n^2) streaming explanation did not reproduce.
- ReMe `BM25Index`, however, marks replaced chunks deleted and retains their document arrays and posting entries until `optimize_index()` runs.
- ReMe ships a daily `optimize_index_cron` at 02:00. QwenPaw copied the embedded job configuration without this job, so a desktop backend running for days never reclaimed that deferred index state.

This PR fixes the confirmed unbounded long-running accumulator. Without a heap dump from the affected Windows process, it does not claim that this mechanism alone accounts for every byte of the reported 20 GB peak.

## Reproduction

The included script uses the actual ReMe `MarkdownFileChunker`, `LocalFileStore`, and `BM25Index`. It starts a daily memory Markdown document with 980 directory entries, then repeatedly appends completed-turn notes and reindexes the same file.

```bash
PYTHONPATH=src conda run -n QwenPaw python \
  scripts/reproduce_reme_index_growth.py \
  --iterations 600 \
  --directory-count 980 \
  --lines-per-update 40

PYTHONPATH=src conda run -n QwenPaw python \
  scripts/reproduce_reme_index_growth.py \
  --iterations 600 \
  --directory-count 980 \
  --lines-per-update 40 \
  --compact-every 300
```

`--compact-every 300` models a maintenance boundary between two equal activity periods. The production fix uses the same ReMe `optimize_index_step` on its daily 02:00 schedule.

## Before / after

Measured on macOS, Python 3.12, ReMe 0.4.1.5, embeddings disabled. Values are process RSS deltas from the initialized store; enabled embeddings add their own bounded cache cost.

| 600 updates | RSS delta | live docs | allocated docs | deleted docs | tracked index arrays |
|---|---:|---:|---:|---:|---:|
| Before: no maintenance | 108.7 MiB | 70 | 22,784 | 22,714 | 21.5 MiB |
| After: one maintenance boundary | 79.6 MiB | 70 | 70 | 0 | 0.1 MiB |

The scheduled maintenance reduced peak RSS by 29.1 MiB (26.8%) in this run and removed 99.7% of allocated document slots. RSS does not immediately return all freed arenas to the OS, but subsequent updates reuse them instead of retaining every historical chunk version.

No tool output or current index document is dropped; only already deleted index entries are compacted.

## Tests

```text
180 passed in 0.84s
```

Also passed all pre-commit hooks for the three changed files.