### PR TITLE
perf(runtime): avoid quadratic long-thinking accumulation

### DIFF
--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -224,7 +224,10 @@ class Envelope:
                 self._message_started = True
             block_id = event.block_id
             index = len(self._text_blocks)
-            self._text_blocks[block_id] = {"index": index, "text": ""}
+            self._text_blocks[block_id] = {
+                "index": index,
+                "text_fragments": [],
+            }
 
         elif evt_type == EventType.TEXT_BLOCK_DELTA.value:
             if not self._message_started:
@@ -234,9 +237,12 @@ class Envelope:
             delta = event.delta or ""
             state = self._text_blocks.setdefault(
                 block_id,
-                {"index": len(self._text_blocks), "text": ""},
+                {
+                    "index": len(self._text_blocks),
+                    "text_fragments": [],
+                },
             )
-            state["text"] += delta
+            state["text_fragments"].append(delta)
             chunk = TextContent(
                 type=ContentType.TEXT,
                 text=delta,
@@ -251,9 +257,10 @@ class Envelope:
             state = self._text_blocks.get(block_id)
             if state is None:
                 return
+            text = "".join(state["text_fragments"])
             final_chunk = TextContent(
                 type=ContentType.TEXT,
-                text=state["text"],
+                text=text,
                 delta=False,
                 index=state["index"],
             )
@@ -262,11 +269,12 @@ class Envelope:
             self._completed_message.content.append(
                 TextContent(
                     type=ContentType.TEXT,
-                    text=state["text"],
+                    text=text,
                     delta=False,
                     index=state["index"],
                 ),
             )
+            state.pop("text_fragments", None)
 
         # === THINKING BLOCK ===
         elif evt_type == EventType.THINKING_BLOCK_START.value:
@@ -296,7 +304,7 @@ class Envelope:
             self._reasoning_blocks[block_id] = {
                 "msg_id": r_msg_id,
                 "envelope": r_envelope,
-                "text": "",
+                "text_fragments": [],
             }
             yield self._tag_seq(r_envelope)
 
@@ -324,11 +332,11 @@ class Envelope:
                 state = {
                     "msg_id": r_msg_id,
                     "envelope": r_envelope,
-                    "text": "",
+                    "text_fragments": [],
                 }
                 self._reasoning_blocks[block_id] = state
                 yield self._tag_seq(r_envelope)
-            state["text"] += delta
+            state["text_fragments"].append(delta)
             r_chunk = TextContent(
                 type=ContentType.TEXT,
                 text=delta,
@@ -343,9 +351,10 @@ class Envelope:
             state = self._reasoning_blocks.get(block_id)
             if state is None:
                 return
+            text = "".join(state["text_fragments"])
             r_final = TextContent(
                 type=ContentType.TEXT,
-                text=state["text"],
+                text=text,
                 delta=False,
                 index=0,
             )
@@ -354,13 +363,14 @@ class Envelope:
             state["envelope"].content.append(
                 TextContent(
                     type=ContentType.TEXT,
-                    text=state["text"],
+                    text=text,
                     delta=False,
                     index=0,
                 ),
             )
             state["envelope"].status = RunStatus.Completed
             self._response.output.append(state["envelope"])
+            state.pop("text_fragments", None)
             yield self._tag_seq(state["envelope"])
 
         # === TOOL CALL ===
@@ -401,7 +411,7 @@ class Envelope:
                 "name": event.tool_call_name,
                 "argument_fragments": [],
                 "message": plugin_call_message,
-                "output_text_acc": "",
+                "output_text_fragments": [],
                 "output_data_blocks": {},
             }
 
@@ -456,7 +466,7 @@ class Envelope:
                 state = {
                     "name": event.tool_call_name,
                     "argument_fragments": [],
-                    "output_text_acc": "",
+                    "output_text_fragments": [],
                     "output_data_blocks": {},
                 }
                 self._tool_calls[call_id] = state
@@ -488,7 +498,7 @@ class Envelope:
             yield self._tag_seq(stub_content.in_progress())
 
             state["output_message"] = out_message
-            state["output_text_acc"] = ""
+            state["output_text_fragments"] = []
             state["output_data_blocks"] = {}
 
         elif evt_type == EventType.TOOL_RESULT_TEXT_DELTA.value:
@@ -496,7 +506,7 @@ class Envelope:
             state = self._tool_calls.get(call_id)
             if state is None:
                 return
-            state["output_text_acc"] += event.delta or ""
+            state["output_text_fragments"].append(event.delta or "")
 
             delta_content = self._build_tool_result_content(
                 call_id,
@@ -588,6 +598,7 @@ class Envelope:
             out_message.add_content(new_content=final_content)
             yield self._tag_seq(final_content.completed())
             self._response.output.append(out_message)
+            state.pop("output_text_fragments", None)
             yield self._tag_seq(out_message.completed())
 
         # === DATA BLOCK ===
@@ -729,7 +740,7 @@ class Envelope:
         from ..schemas import DataContent
 
         blocks_dict: dict = state.get("output_data_blocks", {})
-        text_acc: str = state.get("output_text_acc", "")
+        text_acc = "".join(state.get("output_text_fragments", []))
 
         if blocks_dict:
             output_blocks: list[dict[str, Any]] = list(
@@ -845,7 +856,7 @@ class Envelope:
             # not finalized (TEXT_BLOCK_END never fired, e.g. on cancel).
             if not self._completed_message.content:
                 for state in self._text_blocks.values():
-                    text = state.get("text", "")
+                    text = "".join(state.get("text_fragments", []))
                     if text:
                         self._completed_message.content.append(
                             TextContent(
@@ -900,12 +911,12 @@ class Envelope:
             env = state.get("envelope")
             if env is not None and env.status == RunStatus.Completed:
                 continue
-            text = state.get("text", "")
+            text = "".join(state.get("text_fragments", []))
             if text:
                 result.append(("thinking", text))
 
         for state in self._text_blocks.values():
-            text = state.get("text", "")
+            text = "".join(state.get("text_fragments", []))
             if text:
                 result.append(("text", text))
 
@@ -915,11 +926,11 @@ class Envelope:
         """Return ``{call_id: accumulated_output}`` for tool calls that
         received partial results before the stream was interrupted.
 
-        Only includes entries where ``output_text_acc`` is non-empty.
+        Only includes entries where ``output_text_fragments`` is non-empty.
         """
         result: dict[str, str] = {}
         for call_id, state in self._tool_calls.items():
-            output = state.get("output_text_acc", "")
+            output = "".join(state.get("output_text_fragments", []))
             if output:
                 result[call_id] = output
         return result


### PR DESCRIPTION
## Description

This PR removes quadratic string concatenation from QwenPaw's streamed
reasoning and text accumulation. It applies the fragment-list approach already
used for tool-call arguments in #6346.

`Envelope` previously executed `state["text"] += delta` for every reasoning
and answer delta. A long Thinking block therefore repeatedly copied all text
received so far. The retained content was only O(n), but cumulative copying was
O(n²), creating allocator pressure and event-loop stalls before the stream
finished.

The runtime now:

- appends reasoning, answer, and tool-result text to fragment lists;
- joins reasoning and answer fragments only at block end or cancel-save;
- preserves every incremental SSE delta and every final payload;
- preserves cumulative tool-result payloads (`first`, `first-`,
  `first-second`) for frontend compatibility.

No chunks are sampled or discarded.

**Follow-up to:** #6346

**Security Considerations:** No security behavior or validation is changed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Performance improvement

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Investigation report

### Reported behavior

A Windows 2.1.1b1 user reported that a long-running Thinking turn stalled while
`qwenpaw-backend.exe` grew from about 3.1 GiB to 6.6 GiB, eventually reaching a
reported peak near 20 GiB. The log then showed repeated `Event JSON
serialization failed` warnings and a `MemoryError` in the console stream.

The application had been open for two days; this was not a single two-day
task. We did not have the user's heap profile or complete logs.

### Findings

1. **Confirmed:** reasoning and answer text used repeated immutable-string
   concatenation in `Envelope`. This is O(n²) cumulative copy work and aligns
   with the UI stalling during Thinking.
2. **Not confirmed as the cause:** ReMe auto-memory runs outside the per-token
   Envelope accumulation path. Its session state and configured caches did not
   account for the observed multi-GiB short-term rise in this investigation.
3. **Contributing retained memory, but linear:** task replay and subscriber
   buffers retain serialized SSE events. The reproduction deliberately keeps
   both buffers. Their size follows transmitted bytes rather than the square of
   accumulated Thinking text.
4. **Important limitation:** the reported multi-GiB Windows peak was not
   reproduced on macOS. The confirmed O(n²) defect can amplify transient memory
   and CPU pressure, but this PR does not claim that it alone fully explains or
   resolves the reported 20 GiB peak. A Windows heap trace from an affected run
   is still required for that conclusion.

### Local deterministic reproduction

The local investigation harness (not included in this PR) drives the real
`Envelope -> console SSE serialization` path and retains the same serialized
event objects in a replay buffer and one live subscriber queue.

Measured on macOS 26.3.2 arm64 with Python 3.12.13. Each delta contains four
bytes; the run retains 384,001 events in each of the two buffers.

| 384,000 Thinking deltas | Before | After | Change |
| --- | ---: | ---: | ---: |
| Final reasoning text | 1.465 MiB | 1.465 MiB | unchanged |
| Serialized SSE wire data | 66.178 MiB | 66.178 MiB | unchanged |
| Process RSS delta | 135.203 MiB | 93.094 MiB | -31.1% |
| Elapsed time | 9.489 s | 5.503 s | -42.0% |
| Accumulator | repeated string concatenation | fragments + final join | O(n²) copying removed |

The remaining approximately 93 MiB is primarily the deliberately retained SSE
replay/subscriber data and Python object overhead; it is not the final 1.465 MiB
reasoning string. This PR does not change those queues.

### Real DashScope long-Thinking check

The same combinatorics prompt was run through DashScope
`deepseek-v4-pro`, the real `AgentExecutor`, `Envelope`, and console SSE
serializer with `thinking_level=high`. Model output varies between calls, so
this is a scenario validation rather than a strict performance benchmark.

| Revision | Duration | Thinking chars | SSE events | SSE wire | Peak RSS delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `upstream/main` | 145.314 s | 23,851 | 4,363 | 0.821 MiB | +10.719 MiB |
| This PR | 142.798 s | 27,876 | 4,372 | 0.838 MiB | +12.672 MiB |

Neither macOS run reproduced GiB-scale growth. This prevents us from presenting
the synthetic improvement as proof that the complete Windows report is fixed.

## Testing

```bash
PYTHONPATH=src:packages/qwenpawmail-mcp/src \
  conda run --no-capture-output -n QwenPaw \
  pytest tests/unit/runtime -q

conda run --no-capture-output -n QwenPaw pre-commit run --files \
  src/qwenpaw/runtime/envelope.py
```

Results:

- `82 passed`
- all selected pre-commit hooks passed, including mypy, black, flake8, and
  pylint
- local scenario checks verified that each reasoning/text delta is unchanged,
  final and cancel-save content is complete, and cumulative tool-result output
  is unchanged

## Checklist

- [x] The confirmed failure mode was reproduced locally.
- [x] Runtime tests pass.
- [x] Pre-commit checks pass for every changed file.
- [x] No stream chunks are dropped or sampled.
- [x] The reproduction limits and remaining uncertainty are documented.
- [x] Ready for review.
