### PR TITLE
fix(cli): bootstrap workspace runtime for headless tasks

### DIFF
--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -52,6 +52,8 @@ class ServiceDescriptor:
         concurrent_init: Whether this can be initialized concurrently
         optional: If True, a failure during start logs but does not abort
             the workspace; the service is simply absent.
+        enabled_in_headless: Whether one-shot headless runtimes should start
+            this service. Disable for long-lived background integrations.
         require_clean_stop: If True, a stop failure is propagated after the
             manager has attempted to stop every service.  Use for services
             whose live worker would conflict with a replacement workspace.
@@ -79,6 +81,7 @@ class ServiceDescriptor:
     priority: int = 100
     concurrent_init: bool = True
     optional: bool = False
+    enabled_in_headless: bool = True
     require_clean_stop: bool = False
 
 
@@ -179,10 +182,11 @@ class ServiceManager:
             groups[descriptor.priority].append(descriptor)
         return groups
 
-    async def start_all(self) -> None:
+    async def start_all(self, *, headless: bool = False) -> None:
         """Start all registered services in priority order.
 
         Services with same priority are started concurrently if allowed.
+        Headless startup skips long-lived background integrations.
         Reused services are skipped.  Between priority groups and after each
         sequential service, the event loop is yielded so HTTP requests can
         be served during background startup.
@@ -196,7 +200,11 @@ class ServiceManager:
         priority_groups = self._group_by_priority()
 
         for priority in sorted(priority_groups.keys()):
-            descriptors = priority_groups[priority]
+            descriptors = [
+                descriptor
+                for descriptor in priority_groups[priority]
+                if not headless or descriptor.enabled_in_headless
+            ]
 
             # Separate concurrent and sequential services
             concurrent = [d for d in descriptors if d.concurrent_init]

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -460,6 +460,7 @@ class Workspace:
                 stop_method="stop_all",
                 priority=30,
                 concurrent_init=False,
+                enabled_in_headless=False,
             ),
         )
 
@@ -486,6 +487,7 @@ class Workspace:
                 stop_method="stop",
                 priority=40,
                 concurrent_init=False,
+                enabled_in_headless=False,
             ),
         )
 
@@ -499,6 +501,7 @@ class Workspace:
                 stop_method="stop",
                 priority=45,
                 concurrent_init=False,
+                enabled_in_headless=False,
                 require_clean_stop=True,
             ),
         )
@@ -513,6 +516,7 @@ class Workspace:
                 stop_method="stop",
                 priority=50,
                 concurrent_init=False,
+                enabled_in_headless=False,
             ),
         )
 
@@ -526,6 +530,7 @@ class Workspace:
                 stop_method="stop",
                 priority=51,
                 concurrent_init=False,
+                enabled_in_headless=False,
             ),
         )
 
@@ -561,8 +566,8 @@ class Workspace:
         for name, component in components.items():
             await self._service_manager.set_reusable(name, component)
 
-    async def start(self):
-        """Start workspace and initialize all components."""
+    async def start(self, *, headless: bool = False):
+        """Start workspace components needed for the selected runtime mode."""
         if self._started:
             logger.debug(
                 "Workspace already started: "
@@ -598,7 +603,7 @@ class Workspace:
             self._migrate_legacy_weixin_data()
 
             # 3. Start all services via ServiceManager
-            await self._service_manager.start_all()
+            await self._service_manager.start_all(headless=headless)
 
             self._started = True
             logger.info(

--- a/src/qwenpaw/cli/task_cmd.py
+++ b/src/qwenpaw/cli/task_cmd.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator
 
 import click
 
@@ -84,29 +84,71 @@ def _read_instruction(raw: str) -> str:
     return raw
 
 
-async def _run_task(
+def _response_text(response: Any) -> str:
+    """Extract the final assistant text from a runtime response."""
+    output = getattr(response, "output", None) or []
+    if not output:
+        return ""
+    content = getattr(output[-1], "content", None) or []
+    text_parts = []
+    for item in content:
+        item_type = getattr(item, "type", None)
+        if getattr(item_type, "value", item_type) != "text":
+            continue
+        if text := getattr(item, "text", ""):
+            text_parts.append(text)
+    return "\n".join(text_parts).strip()
+
+
+def _response_usage(response: Any) -> dict:
+    """Return the runtime's token usage as a plain dictionary."""
+    usage = getattr(response, "usage", None)
+    if isinstance(usage, dict):
+        return dict(usage)
+    if hasattr(usage, "model_dump"):
+        return usage.model_dump()
+    return {}
+
+
+async def _run_task(  # pylint: disable=too-many-statements
     instruction: str,
     agent_config,
-    request_context: dict[str, str],
+    request_context: dict[str, Any],
     max_iters: int,
     timeout: int,
     output_dir: str | None,
     skills_dir: str | None = None,
 ) -> dict:
-    from types import SimpleNamespace
+    from ..agents.acp.meta import ACP_EPHEMERAL_META_KEY
+    from ..app.app_services import AppServiceManager
+    from ..app.workspace.bootstrap_factory import WorkspaceBootstrapFactory
+    from ..app.workspace.workspace import Workspace
+    from ..constant import WORKING_DIR
+    from ..runtime import Runtime
+    from ..schemas import AgentRequest, AgentResponse, RunStatus
 
-    from agentscope.message import UserMsg
-
-    from ..runtime.builder import AgentBuilder
-    from ..schemas import AgentRequest
-
-    agent_config.running.max_iters = max_iters
+    runtime_config = agent_config.model_copy(deep=True)
+    runtime_config.running.max_iters = max_iters
+    runtime_config.running.loop.iteration.max_iterations = max_iters
 
     base_workspace: Path | None = None
     if agent_config.workspace_dir:
         base_workspace = Path(agent_config.workspace_dir).expanduser()
 
-    with _isolated_skills_workspace(skills_dir, base_workspace) as workspace:
+    app_services = None
+    workspace_instance = None
+    app_services_started = False
+    workspace_started = False
+    t0 = time.monotonic()
+
+    with _isolated_skills_workspace(
+        skills_dir,
+        base_workspace,
+    ) as workspace_dir:
+        resolved_workspace_dir = workspace_dir or base_workspace or WORKING_DIR
+        runtime_request_context = dict(request_context)
+        runtime_request_context[ACP_EPHEMERAL_META_KEY] = True
+
         req = AgentRequest(
             input=[
                 {
@@ -117,35 +159,57 @@ async def _run_task(
             session_id=request_context.get("session_id", "headless-task"),
             user_id=request_context.get("user_id", "headless"),
             channel=request_context.get("channel", "console"),
-        )
-        ctx = SimpleNamespace(
-            request=req,
-            session_id=req.session_id,
             agent_id=request_context.get("agent_id", "default"),
-            root_session_id=req.session_id,
-            root_agent_id=request_context.get("agent_id", "default"),
-            workspace_dir=workspace,
-            workspace=None,
-            app_services=None,
-            agent_config=None,
-            session_state=None,
+            request_context=runtime_request_context,
         )
-        builder = AgentBuilder()
-        agent = await builder.build(ctx)
-
-        t0 = time.monotonic()
         try:
-            response = await asyncio.wait_for(
-                agent.reply(
-                    [UserMsg(name="user", content=instruction)],
+            app_services = AppServiceManager()
+            await app_services.start()
+            app_services_started = True
+
+            workspace_instance = Workspace(
+                agent_id=request_context.get("agent_id", "default"),
+                workspace_dir=str(resolved_workspace_dir),
+            )
+            workspace_instance.bootstrap_plugins(
+                **WorkspaceBootstrapFactory.build_bootstrap_kwargs(
+                    app_services,
                 ),
+            )
+            workspace_instance.set_app_services(app_services)
+            await workspace_instance.start(headless=True)
+            workspace_started = True
+
+            runtime = Runtime(
+                workspace=workspace_instance,
+                app_services=app_services,
+                agent_config_override=runtime_config,
+            )
+
+            async def _consume_response() -> AgentResponse:
+                final_response = None
+                async for event in runtime.run(req):
+                    if isinstance(event, AgentResponse) and event.status in {
+                        RunStatus.Completed,
+                        RunStatus.Failed,
+                    }:
+                        final_response = event
+                if final_response is None:
+                    raise RuntimeError(
+                        "Task runtime produced no final response",
+                    )
+                return final_response
+
+            response = await asyncio.wait_for(
+                _consume_response(),
                 timeout=timeout,
             )
             elapsed = time.monotonic() - t0
             result: dict = {
                 "status": "success",
                 "elapsed_seconds": round(elapsed, 2),
-                "response": (response.get_text_content() if response else ""),
+                "response": _response_text(response),
+                "usage": _response_usage(response),
             }
         except asyncio.TimeoutError:
             elapsed = time.monotonic() - t0
@@ -163,24 +227,25 @@ async def _run_task(
                 "error": str(exc),
                 "response": "",
             }
+        finally:
+            if workspace_started and workspace_instance is not None:
+                try:
+                    await workspace_instance.stop(final=True)
+                except Exception:
+                    logger.warning(
+                        "Failed to stop headless task workspace",
+                        exc_info=True,
+                    )
+            if app_services_started and app_services is not None:
+                try:
+                    await app_services.stop()
+                except Exception:
+                    logger.warning(
+                        "Failed to stop headless task services",
+                        exc_info=True,
+                    )
 
-    usage: dict = {}
-    try:
-        model = getattr(agent, "model", None)
-        if model is not None:
-            monitor = getattr(model, "monitor", None)
-            if monitor is not None:
-                metrics = (
-                    monitor.get_metrics()
-                    if callable(getattr(monitor, "get_metrics", None))
-                    else {}
-                )
-                usage["input_tokens"] = metrics.get("prompt_tokens", 0)
-                usage["output_tokens"] = metrics.get("completion_tokens", 0)
-                usage["cost_usd"] = metrics.get("cost_usd")
-    except Exception:
-        logger.debug("Failed to extract token usage", exc_info=True)
-    result["usage"] = usage
+    result.setdefault("usage", {})
 
     if output_dir:
         out = Path(output_dir)
@@ -287,14 +352,14 @@ def task_cmd(
                 model=model,
             )
 
-    request_context: dict[str, str] = {
+    request_context: dict[str, Any] = {
         "session_id": "headless-task",
         "user_id": "headless",
         "channel": "console",
         "agent_id": agent_id,
     }
     if no_guard:
-        request_context["_headless_tool_guard"] = "false"
+        request_context["approval_level"] = "off"
 
     result = asyncio.run(
         _run_task(

--- a/src/qwenpaw/hooks/session/session_hook.py
+++ b/src/qwenpaw/hooks/session/session_hook.py
@@ -11,26 +11,13 @@ from __future__ import annotations
 import logging
 
 from ..base import LifecycleHook
-from ...agents.acp.meta import ACP_EPHEMERAL_META_KEY
 from ...runtime._state_utils import StateProxy
 from ...runtime.hooks import HookContext, HookResult
 from ...runtime.phases import Phase
+from ...runtime.request_context import is_ephemeral_request
 from .signals import SESSION_SAVE_SUCCEEDED_KEY
 
 logger = logging.getLogger(__name__)
-
-
-def is_ephemeral_request(ctx: HookContext) -> bool:
-    """Return whether a request must avoid persisted session state."""
-    request = ctx.request
-    request_context = getattr(request, "request_context", None)
-    if isinstance(request_context, dict):
-        value = request_context.get(ACP_EPHEMERAL_META_KEY)
-        if value is True:
-            return True
-        if isinstance(value, str) and value.lower() in {"1", "true", "yes"}:
-            return True
-    return False
 
 
 class SessionLoadHook(LifecycleHook):

--- a/src/qwenpaw/hooks/session/session_hook.py
+++ b/src/qwenpaw/hooks/session/session_hook.py
@@ -20,7 +20,8 @@ from .signals import SESSION_SAVE_SUCCEEDED_KEY
 logger = logging.getLogger(__name__)
 
 
-def _is_ephemeral_request(ctx: HookContext) -> bool:
+def is_ephemeral_request(ctx: HookContext) -> bool:
+    """Return whether a request must avoid persisted session state."""
     request = ctx.request
     request_context = getattr(request, "request_context", None)
     if isinstance(request_context, dict):
@@ -40,7 +41,7 @@ class SessionLoadHook(LifecycleHook):
     priority = 10
 
     async def run(self, ctx: HookContext) -> HookResult:
-        if _is_ephemeral_request(ctx):
+        if is_ephemeral_request(ctx):
             return HookResult()
         if ctx.workspace is None:
             return HookResult()
@@ -85,7 +86,7 @@ class SessionSaveHook(LifecycleHook):
 
     async def run(self, ctx: HookContext) -> HookResult:
         ctx.extras[SESSION_SAVE_SUCCEEDED_KEY] = False
-        if _is_ephemeral_request(ctx):
+        if is_ephemeral_request(ctx):
             return HookResult()
         if ctx.workspace is None or ctx.agent is None:
             return HookResult()
@@ -112,4 +113,4 @@ class SessionSaveHook(LifecycleHook):
         return HookResult()
 
 
-__all__ = ["SessionLoadHook", "SessionSaveHook"]
+__all__ = ["SessionLoadHook", "SessionSaveHook", "is_ephemeral_request"]

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Iterable
 from ..agents.acp.meta import ACP_PROJECT_DIR_META_KEY
 from ..utils.io_utils import run_sync_io
 from ..utils.logging import sanitize_log_value
+from .request_context import is_ephemeral_request
 
 if TYPE_CHECKING:
     from ..agents.context.visual_compression.runtime.recovery import (
@@ -997,11 +998,15 @@ class AgentBuilder:
     ) -> Any:
         """Build the scroll context strategy, or None when not selected.
 
-        Returns ``None`` for the native strategy (the default) so nothing
-        changes unless ``light_context_config.strategy == "scroll"``. The
-        shared ``offloader`` is forwarded so scroll can archive evicted turns
-        to ``dialog/*.jsonl`` (``offload_dialog``, on by default).
+        Returns ``None`` for ephemeral requests. For other requests, the
+        underlying factory returns ``None`` unless the scroll strategy is
+        selected. The shared ``offloader`` lets scroll archive evicted turns
+        to ``dialog/*.jsonl`` when ``offload_dialog`` is enabled.
         """
+        if is_ephemeral_request(ctx):
+            _logger.debug("scroll: disabled for ephemeral request")
+            return None
+
         workspace = getattr(ctx, "workspace", None)
         workspace_dir = (
             str(getattr(workspace, "workspace_dir", ""))

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -274,7 +274,9 @@ class AgentBuilder:
         from ..providers.provider_manager import ProviderManager
 
         agent_id = getattr(ctx, "agent_id", None) or "default"
-        agent_config = await run_sync_io(load_agent_config, agent_id)
+        agent_config = getattr(ctx, "agent_config", None)
+        if agent_config is None:
+            agent_config = await run_sync_io(load_agent_config, agent_id)
         request_context = self._build_request_context(ctx)
         agent_config = self._apply_request_project(
             agent_config,

--- a/src/qwenpaw/runtime/request_context.py
+++ b/src/qwenpaw/runtime/request_context.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Helpers for interpreting per-request runtime metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..agents.acp.meta import ACP_EPHEMERAL_META_KEY
+
+_TRUTHY_VALUES = {"1", "true", "yes"}
+
+
+def is_ephemeral_request_context(
+    request_context: Mapping[str, Any] | None,
+) -> bool:
+    """Return whether request metadata opts out of resumable state."""
+    if not isinstance(request_context, Mapping):
+        return False
+    value = request_context.get(ACP_EPHEMERAL_META_KEY)
+    if value is True:
+        return True
+    return isinstance(value, str) and value.lower() in _TRUTHY_VALUES
+
+
+def is_ephemeral_request(ctx: Any) -> bool:
+    """Return whether a runtime context opts out of resumable state."""
+    request = getattr(ctx, "request", None)
+    request_context = getattr(request, "request_context", None)
+    return is_ephemeral_request_context(request_context)
+
+
+__all__ = ["is_ephemeral_request", "is_ephemeral_request_context"]

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -26,6 +26,7 @@ from .executor import AgentExecutor
 from .hooks import HookAction, HookContext
 from .message_convert import _get_last_user_text, _request_input_to_msgs
 from .phases import Phase
+from .request_context import is_ephemeral_request
 
 logger = logging.getLogger(__name__)
 
@@ -269,8 +270,6 @@ class Runtime:
          participate in the cancel lifecycle.  ``ctx._envelope`` should
          also be promoted to a first-class ``HookContext`` field.
         """
-        from ..hooks.session.session_hook import is_ephemeral_request
-
         if is_ephemeral_request(ctx):
             return
 

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -43,9 +43,11 @@ class Runtime:
         *,
         workspace: Any,
         app_services: Any,
+        agent_config_override: Any = None,
     ) -> None:
         self.workspace = workspace
         self.app_services = app_services
+        self.agent_config_override = agent_config_override
 
     async def run(  # pylint: disable=too-many-branches,too-many-statements
         self,
@@ -267,6 +269,11 @@ class Runtime:
          participate in the cancel lifecycle.  ``ctx._envelope`` should
          also be promoted to a first-class ``HookContext`` field.
         """
+        from ..hooks.session.session_hook import is_ephemeral_request
+
+        if is_ephemeral_request(ctx):
+            return
+
         agent = getattr(ctx, "agent", None)
         if agent is None:
             return
@@ -500,6 +507,7 @@ class Runtime:
             workspace=self.workspace,
             app_services=self.app_services,
             input_msgs=_request_input_to_msgs(request.input),
+            agent_config=self.agent_config_override,
         )
 
     @staticmethod

--- a/tests/unit/agents/hooks/test_session_hook.py
+++ b/tests/unit/agents/hooks/test_session_hook.py
@@ -10,6 +10,7 @@ import pytest
 from qwenpaw.agents.acp.meta import ACP_EPHEMERAL_META_KEY
 from qwenpaw.hooks.session.session_hook import SessionLoadHook, SessionSaveHook
 from qwenpaw.hooks.session.signals import SESSION_SAVE_SUCCEEDED_KEY
+from qwenpaw.runtime.runtime import Runtime
 
 pytestmark = [pytest.mark.unit, pytest.mark.p1]
 
@@ -60,6 +61,18 @@ async def test_ephemeral_request_skips_session_load_and_save():
     assert session.loaded is False
     assert session.saved is False
     assert ctx.extras[SESSION_SAVE_SUCCEEDED_KEY] is False
+
+
+async def test_ephemeral_request_skips_cancel_path_session_save():
+    session = _FakeSession()
+    ctx = _ctx(session, ephemeral=True)
+
+    await Runtime._try_save_on_cancel(  # pylint: disable=protected-access
+        SimpleNamespace(),
+        ctx,
+    )
+
+    assert session.saved is False
 
 
 async def test_normal_request_loads_and_saves_session_state():

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -13,6 +13,41 @@ from qwenpaw.app.workspace.service_manager import (
 
 
 @pytest.mark.asyncio
+async def test_headless_start_skips_background_services():
+    manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
+    started: list[str] = []
+
+    class _Service:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def start(self) -> None:
+            started.append(self.name)
+
+    manager.register(
+        ServiceDescriptor(
+            name="core",
+            post_init=lambda _workspace, _service: _Service("core"),
+            start_method="start",
+        ),
+    )
+    manager.register(
+        ServiceDescriptor(
+            name="background",
+            post_init=lambda _workspace, _service: _Service("background"),
+            start_method="start",
+            enabled_in_headless=False,
+        ),
+    )
+
+    await manager.start_all(headless=True)
+
+    assert started == ["core"]
+    assert "core" in manager.services
+    assert "background" not in manager.services
+
+
+@pytest.mark.asyncio
 async def test_required_clean_stop_failure_is_propagated():
     manager = ServiceManager(SimpleNamespace(agent_id="agent-1"))
 

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -253,7 +253,7 @@ def test_stdout_json_and_default_context(monkeypatch) -> None:
     assert data["status"] == "success"
     assert "usage" in data
     assert "elapsed_seconds" in data
-    assert "_headless_tool_guard" not in captured_ctx
+    assert "approval_level" not in captured_ctx
     assert "_headless_skills_dir" not in captured_ctx
 
 
@@ -298,9 +298,7 @@ def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
             "QWENPAW_TOOL_GUARD_ENABLED",
         )
         captured["env_skills_dir"] = os.environ.get("QWENPAW_SKILLS_DIR")
-        captured["guard_bypassed"] = (
-            ctx.get("_headless_tool_guard", "true").lower() == "false"
-        )
+        captured["guard_bypassed"] = ctx.get("approval_level") == "off"
         return {
             "status": "success",
             "response": "ok",
@@ -327,7 +325,7 @@ def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
     assert result.exit_code == 0, result.output
 
     ctx = captured["request_context"]
-    assert ctx["_headless_tool_guard"] == "false"
+    assert ctx["approval_level"] == "off"
     assert "_headless_skills_dir" not in ctx
     assert ctx["session_id"] == "headless-task"
     assert ctx["agent_id"] == "e2e"
@@ -417,49 +415,152 @@ def test_isolated_workspace_does_not_pollute_real_workspace(tmp_path):
 # ── _run_task ────────────────────────────────────────────────────────
 
 
-async def test_run_task_sends_a_valid_user_message(monkeypatch) -> None:
-    """``_run_task`` must build a message AgentScope 2.0 accepts.
-
-    ``Msg.content`` is typed ``list[ContentBlock]``, so a bare string
-    raises a pydantic ``ValidationError`` that the surrounding
-    ``except Exception`` turns into ``status="error"`` — the task never
-    reaches the agent.
-    """
-    from qwenpaw.config.config import AgentProfileConfig
+async def test_run_task_uses_bootstrapped_workspace_runtime(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Headless tasks must use the same workspace-backed runtime contract."""
+    from qwenpaw.agents.acp.meta import ACP_EPHEMERAL_META_KEY
+    from qwenpaw.config.config import AgentProfileConfig, ModelSlotConfig
     from qwenpaw.cli.task_cmd import _run_task
-
-    captured: dict = {}
-
-    class _FakeAgent:
-        model = None
-
-        async def reply(self, msgs):
-            captured["msgs"] = list(msgs)
-            reply = MagicMock()
-            reply.get_text_content.return_value = "done"
-            return reply
-
-    class _FakeBuilder:
-        async def build(self, _ctx):
-            return _FakeAgent()
-
-    monkeypatch.setattr(
-        "qwenpaw.runtime.builder.AgentBuilder",
-        _FakeBuilder,
+    from qwenpaw.schemas import (
+        AgentResponse,
+        Message,
+        Role,
+        RunStatus,
+        TextContent,
     )
 
+    calls: list[str] = []
+    captured: dict = {}
+
+    class _FakeAppServices:
+        async def start(self):
+            calls.append("app.start")
+
+        async def stop(self):
+            calls.append("app.stop")
+
+    class _FakeWorkspace:
+        def __init__(self, *, agent_id, workspace_dir):
+            captured["agent_id"] = agent_id
+            captured["workspace_dir"] = workspace_dir
+
+        def bootstrap_plugins(self, **kwargs):
+            captured["bootstrap"] = kwargs
+
+        def set_app_services(self, app_services):
+            captured["workspace_app_services"] = app_services
+
+        async def start(self, *, headless=False):
+            captured["workspace_headless"] = headless
+            calls.append("workspace.start")
+
+        async def stop(self, final=True):
+            captured["workspace_stop_final"] = final
+            calls.append("workspace.stop")
+
+    class _FakeBootstrapFactory:
+        @staticmethod
+        def build_bootstrap_kwargs(app_services):
+            captured["bootstrap_app_services"] = app_services
+            return {"builtin_tool_funcs": ["tool"]}
+
+    class _FakeRuntime:
+        def __init__(
+            self,
+            *,
+            workspace,
+            app_services,
+            agent_config_override,
+        ):
+            captured["runtime_workspace"] = workspace
+            captured["runtime_app_services"] = app_services
+            captured["runtime_config"] = agent_config_override
+
+        async def run(self, request):
+            captured["request"] = request
+            yield AgentResponse(
+                output=[
+                    Message(
+                        role=Role.ASSISTANT,
+                        content=[TextContent(text="done")],
+                        status=RunStatus.Completed,
+                    ),
+                ],
+                status=RunStatus.Completed,
+                usage={"input_tokens": 2, "output_tokens": 1},
+            )
+
+    class _ForbiddenLegacyBuilder:
+        async def build(self, _ctx):
+            raise AssertionError("_run_task bypassed the workspace runtime")
+
+    monkeypatch.setattr(
+        "qwenpaw.app.app_services.AppServiceManager",
+        _FakeAppServices,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.workspace.Workspace",
+        _FakeWorkspace,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.workspace.bootstrap_factory.WorkspaceBootstrapFactory",
+        _FakeBootstrapFactory,
+    )
+    monkeypatch.setattr("qwenpaw.runtime.Runtime", _FakeRuntime)
+    monkeypatch.setattr(
+        "qwenpaw.runtime.builder.AgentBuilder",
+        _ForbiddenLegacyBuilder,
+    )
+
+    config = AgentProfileConfig(
+        id="default",
+        name="Default",
+        workspace_dir=str(tmp_path),
+        active_model=ModelSlotConfig(provider_id="test", model="model"),
+    )
     result = await _run_task(
         instruction="do the thing",
-        agent_config=AgentProfileConfig(id="default", name="Default"),
-        request_context={},
-        max_iters=1,
+        agent_config=config,
+        request_context={
+            "agent_id": "default",
+            "approval_level": "off",
+        },
+        max_iters=7,
         timeout=30,
         output_dir=None,
     )
 
-    assert result["status"] == "success"
-    assert result["response"] == "done"
-    msg = captured["msgs"][0]
-    assert msg.role == "user"
-    assert msg.content[0].type == "text"
-    assert msg.content[0].text == "do the thing"
+    assert result == {
+        "status": "success",
+        "elapsed_seconds": result["elapsed_seconds"],
+        "response": "done",
+        "usage": {"input_tokens": 2, "output_tokens": 1},
+    }
+    assert calls == [
+        "app.start",
+        "workspace.start",
+        "workspace.stop",
+        "app.stop",
+    ]
+    assert captured["bootstrap"] == {"builtin_tool_funcs": ["tool"]}
+    assert (
+        captured["bootstrap_app_services"] is captured["runtime_app_services"]
+    )
+    assert (
+        captured["workspace_app_services"] is captured["runtime_app_services"]
+    )
+    assert captured["runtime_workspace"] is not None
+    assert captured["workspace_headless"] is True
+    assert captured["workspace_stop_final"] is True
+    assert captured["runtime_config"].running.max_iters == 7
+    assert (
+        captured["runtime_config"].running.loop.iteration.max_iterations == 7
+    )
+    request = captured["request"]
+    assert request.input[0].role == Role.USER
+    assert request.input[0].content[0].type.value == "text"
+    assert request.input[0].content[0].text == "do the thing"
+    assert request.request_context["approval_level"] == "off"
+    assert request.request_context[ACP_EPHEMERAL_META_KEY] is True

--- a/tests/unit/runtime/test_agent_config_io.py
+++ b/tests/unit/runtime/test_agent_config_io.py
@@ -57,6 +57,44 @@ async def test_build_loads_agent_config_once_in_worker_thread(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_uses_preloaded_request_config(monkeypatch):
+    """A standalone runtime may seed a request-scoped config copy."""
+    config = SimpleNamespace(
+        id="agent-1",
+        active_model=None,
+        coding_mode=None,
+    )
+
+    def unexpected_load(_agent_id):
+        raise AssertionError("preloaded config was ignored")
+
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        unexpected_load,
+    )
+    monkeypatch.setattr(
+        provider_manager,
+        "ProviderManager",
+        SimpleNamespace(
+            get_instance=lambda: SimpleNamespace(
+                get_active_model=lambda: None,
+            ),
+        ),
+    )
+
+    ctx = SimpleNamespace(agent_id="agent-1", agent_config=config)
+
+    with pytest.raises(
+        ConfigurationException,
+        match="No active model configured",
+    ):
+        await AgentBuilder.__new__(AgentBuilder).build(ctx)
+
+    assert ctx.agent_config is config
+
+
+@pytest.mark.asyncio
 async def test_build_constructs_model_in_worker_thread(monkeypatch):
     """The async builder must offload the complete model factory call."""
     caller_thread = threading.get_ident()

--- a/tests/unit/runtime/test_builder_scroll_migration.py
+++ b/tests/unit/runtime/test_builder_scroll_migration.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 import qwenpaw.agents.context as context_mod
+from qwenpaw.agents.acp.meta import ACP_EPHEMERAL_META_KEY
 from qwenpaw.runtime.builder import AgentBuilder
 
 
@@ -34,6 +35,7 @@ async def test_scroll_component_build_runs_in_worker_thread(
         blocking_build,
     )
     ctx = SimpleNamespace(
+        request=SimpleNamespace(request_context={}),
         workspace=SimpleNamespace(workspace_dir=tmp_path),
         session_id="session",
         agent_id="agent",
@@ -57,3 +59,36 @@ async def test_scroll_component_build_runs_in_worker_thread(
         release.set()
 
     assert await asyncio.wait_for(task, timeout=1) is result
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_request_skips_scroll_component_build(
+    tmp_path,
+    monkeypatch,
+):
+    def unexpected_build(**_kwargs):
+        pytest.fail("ephemeral requests must not create scroll persistence")
+
+    monkeypatch.setattr(
+        context_mod,
+        "build_scroll_components",
+        unexpected_build,
+    )
+    ctx = SimpleNamespace(
+        request=SimpleNamespace(
+            request_context={ACP_EPHEMERAL_META_KEY: True},
+        ),
+        workspace=SimpleNamespace(workspace_dir=tmp_path),
+        session_id="headless-task",
+        agent_id="agent",
+    )
+    config = SimpleNamespace(id="agent")
+
+    result = await AgentBuilder._build_scroll_components(
+        ctx,
+        config,
+        model=object(),
+    )
+
+    assert result is None
+    assert not (tmp_path / "history.db").exists()


### PR DESCRIPTION
## Description

`qwenpaw task` built `AgentBuilder` with `ctx.workspace=None`, so the builder could not access `QwenPawLocalWorkspace`. As a result, headless tasks started with no registered tools and could not execute tool calls.

Closes #7240.

## Changes

- Run headless tasks through the standard bootstrapped `Workspace` and `Runtime` pipeline.
- Add a headless workspace startup mode that initializes required runtime services while skipping long-lived channel, cron, mail, and configuration-watcher services.
- Pass CLI model and iteration overrides through a request-scoped configuration copy.
- Map `--no-guard` to the effective `approval_level=off` governance setting.
- Mark task requests as ephemeral to prevent one-shot tasks, including cancelled or timed-out tasks, from persisting session state.
- Ensure workspace and application services are shut down reliably after execution.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
