### PR TITLE
fix(runtime): prevent cumulative heartbeat memory growth

### DIFF
--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -764,7 +764,15 @@ class Envelope:
     # ------------------------------------------------------------------
 
     async def heartbeat(self) -> AsyncGenerator[Any, None]:
-        yield self._tag_seq(self._response)
+        from ..schemas import Event
+
+        # Heartbeats only keep the transport alive. Re-emitting the mutable
+        # response would serialize every completed tool result and media block
+        # again, and TaskTracker retains each SSE event for reconnect replay.
+        # A long idle period after several screenshots could therefore retain
+        # gigabytes of duplicate response snapshots.
+        heartbeat = Event(object="message", type="heartbeat")
+        yield self._tag_seq(heartbeat)
 
     # ------------------------------------------------------------------
     # Command short-circuit

--- a/tests/unit/runtime/test_envelope_heartbeat.py
+++ b/tests/unit/runtime/test_envelope_heartbeat.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""Tests for lightweight runtime heartbeat events."""
+
+import pytest
+
+from qwenpaw.runtime.envelope import Envelope
+from qwenpaw.schemas import (
+    ContentType,
+    Message,
+    Role,
+    RunStatus,
+    TextContent,
+)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_does_not_repeat_accumulated_response() -> None:
+    envelope = Envelope(session_id="session-with-large-output")
+    large_output = "x" * (1024 * 1024)
+    envelope._response.output.append(  # pylint: disable=protected-access
+        Message(
+            role=Role.TOOL,
+            status=RunStatus.Completed,
+            content=[
+                TextContent(
+                    type=ContentType.TEXT,
+                    text=large_output,
+                ),
+            ],
+        ),
+    )
+
+    events = [event async for event in envelope.heartbeat()]
+
+    assert len(events) == 1
+    heartbeat = events[0]
+    assert heartbeat.object == "message"
+    assert heartbeat.type == "heartbeat"
+    assert large_output not in heartbeat.model_dump_json()
+    assert len(heartbeat.model_dump_json()) < 256
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_keeps_accumulated_response_unchanged() -> None:
+    envelope = Envelope(session_id="session")
+    message = Message(
+        role=Role.ASSISTANT,
+        status=RunStatus.Completed,
+        content=[TextContent(type=ContentType.TEXT, text="finished")],
+    )
+    envelope._response.output.append(  # pylint: disable=protected-access
+        message,
+    )
+
+    _ = [event async for event in envelope.heartbeat()]
+
+    assert envelope._response.output == [  # pylint: disable=protected-access
+        message,
+    ]


### PR DESCRIPTION
## Description

Fix unbounded backend memory growth while a long-running Console turn is
idle after accumulating large tool results, especially screenshot-heavy
desktop automation turns.

### Root cause

This is a multiplier that requires both a large current-turn response and an
idle/stalled upstream stream:

1. `Envelope._response.output` accumulates completed messages and tool
   results from the current turn. Frozen screenshots can be close to 2 MiB
   before Base64 encoding.
2. `AgentExecutor` emits a heartbeat every 25 seconds while AgentScope is not
   yielding an event (for example, while a SiliconFlow DeepSeek stream is
   stalled in Thinking).
3. `Envelope.heartbeat()` previously yielded the entire mutable
   `AgentResponse`.
4. The Console serialized that cumulative response into a new SSE string on
   every heartbeat.
5. `TaskTracker._RunState.buffer` retains every SSE string until the run ends
   so reconnecting clients can replay it.

The retained size is therefore approximately:

`serialized current-turn response size × heartbeat count`

As the turn itself also grows, the total can become super-linear over the
whole run. This matches reports where the backend remains in Thinking,
repeated event serialization warnings appear, and the process eventually
raises `MemoryError`.

QwenPaw 2.1.0 had no semantic stalled-stream watchdog, so the multiplier
could run indefinitely. 2.1.1b1 contains the stream watchdog from #7150,
but an OpenAI-compatible provider can still wait before returning the stream
object (the OpenAI SDK default read timeout is 600 seconds and retries may
apply). The upstream stall is the trigger; the cumulative heartbeat is the
unbounded memory multiplier fixed here.

### Fix

Emit the frontend's existing lightweight heartbeat event:

```json
{"object":"message","type":"heartbeat"}
```

instead of re-emitting `_response`.

No model delta, thinking block, ToolChunk/tool result, completed message, or
final `AgentResponse` is dropped. Only redundant full-response snapshots used
as transport keepalives are replaced. The Console already treats this event
as a no-op, and reconnect replay still retains all real stream events.

### Reproduction

Two complementary reproductions were used.

#### 1. Local SiliconFlow/DeepSeek-compatible stalled API

A local `/v1/chat/completions` endpoint emitted OpenAI-compatible DeepSeek
reasoning chunks and then deliberately kept the SSE connection open:

```python
@app.post("/v1/chat/completions")
async def chat_completions(request: Request) -> StreamingResponse:
    await request.json()

    async def generate():
        for _ in range(5_000):
            chunk = {
                "id": "mock-deepseek-stall",
                "object": "chat.completion.chunk",
                "model": "deepseek-ai/DeepSeek-V4",
                "choices": [{
                    "index": 0,
                    "delta": {"reasoning_content": "思" * 16},
                    "finish_reason": None,
                }],
            }
            yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
            await asyncio.sleep(0)

        while not await request.is_disconnected():
            await asyncio.sleep(0.1)

    return StreamingResponse(generate(), media_type="text/event-stream")
```

The harness used the real OpenAI SDK, AgentScope `Agent`, QwenPaw
`OpenAIChatModelCompat`, `RetryChatModel`, `AgentExecutor`, `Envelope`, SSE
serialization, and `TaskTracker`. Eight 2 MiB screenshot-shaped tool results
were accumulated in the same Envelope before the stalled model step.

For test speed, the heartbeat interval was reduced from 25 seconds to 0.25
seconds. The object serialized and retained on each tick was unchanged.
Twenty-four ticks correspond to ten minutes at the production interval.

| macOS full-chain result | Before | After |
| --- | ---: | ---: |
| Heartbeat SSE size | 21.337 MiB | < 1 KiB |
| RSS increase after 24 heartbeats | 537.7 MiB | 11.4 MiB |
| Stop completion at this load | 0.019 s | 0.001 s |

This also shows that stop works when the process is healthy. At multi-GB
memory pressure, repeated large JSON serialization and allocation can make
both the UI and backend appear unresponsive before cancellation is handled.

#### 2. Windows process-memory benchmark

The Windows benchmark uses the real QwenPaw schema and Envelope, six frozen
screenshot-shaped outputs at the 2 MiB raw-image limit, and the same SSE
strings retained by `TaskTracker`. It serializes 160 heartbeat events, equal
to 66 minutes 40 seconds at the production interval.

Reproduction script and successful `windows-latest` run:

- Script: https://github.com/rayrayraykk/CoPaw/blob/1157caf06cda40359d6176ce28d1bbf387824ca9/.github/scripts/windows_heartbeat_memory.py
- Run: https://github.com/rayrayraykk/CoPaw/actions/runs/32704108253

Environment: Windows Server 2025, CPython 3.12.10.

| 160 heartbeat events | Before | After |
| --- | ---: | ---: |
| SSE event size | 16.0025 MiB | ~0.0001 MiB |
| Retained SSE buffer | 2.5004 GiB | < 0.0001 GiB |
| Working Set delta | 2560.6 MiB | 0.0 MiB |
| Private Bytes delta | 2565.7 MiB | 0.0 MiB |
| Serialization time | 2.090 s | < 0.001 s |

The issue is cross-platform Python retention, not a WebView leak. Windows
Task Manager reports `qwenpaw-backend.exe` and WebView2 as separate rows;
Windows was used here because it matches the reported environment and exposes
both Working Set and Private Bytes.

## Evidence

The commit contains only the runtime fix and its regression tests. Benchmark
and mock-service files are intentionally not part of the PR.

```text
PYTHONPATH=src:packages/qwenpawmail-mcp/src conda run -n QwenPaw pytest -q \
  tests/unit/runtime tests/unit/app/test_task_tracker.py \
  tests/unit/app/channels/test_console_channel.py \
  tests/unit/channels/test_console.py

169 passed in 21.82s
```

```text
PYTHONPATH=src conda run -n QwenPaw pre-commit run --files \
  src/qwenpaw/runtime/envelope.py \
  tests/unit/runtime/test_envelope_heartbeat.py

All checks passed
```

The regression test verifies that a heartbeat does not contain a 1 MiB
accumulated output, stays below 256 bytes, and does not mutate the accumulated
response that is emitted normally at finalization.
