### PR TITLE
【DO NOT MERGE】fix(providers): stop sending media to SiliconFlow DeepSeek V4

### DIFF
--- a/src/qwenpaw/providers/data/model_capabilities.json
+++ b/src/qwenpaw/providers/data/model_capabilities.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "catalog_version": "2026.07.29",
-  "published_at": "2026-07-29T00:00:00Z",
+  "catalog_version": "2026.08.24",
+  "published_at": "2026-08-24T00:00:00Z",
   "capabilities": [
     {
       "provider_id": "modelscope",
@@ -570,6 +570,38 @@
       "expected_video": false,
       "doc_url": "https://api-docs.deepseek.com/",
       "note": "DeepSeek-V4 Pro reasoning model: no multimodal"
+    },
+    {
+      "provider_id": "siliconflow-cn",
+      "model_id": "deepseek-ai/DeepSeek-V4-Flash",
+      "expected_image": false,
+      "expected_video": false,
+      "doc_url": "https://www.siliconflow.cn/models",
+      "note": "DeepSeek-V4 Flash supports tools but not visual input"
+    },
+    {
+      "provider_id": "siliconflow-cn",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "expected_image": false,
+      "expected_video": false,
+      "doc_url": "https://www.siliconflow.cn/models",
+      "note": "DeepSeek-V4 Pro supports tools but not visual input"
+    },
+    {
+      "provider_id": "siliconflow-intl",
+      "model_id": "deepseek-ai/DeepSeek-V4-Flash",
+      "expected_image": false,
+      "expected_video": false,
+      "doc_url": "https://www.siliconflow.cn/models",
+      "note": "DeepSeek-V4 Flash supports tools but not visual input"
+    },
+    {
+      "provider_id": "siliconflow-intl",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "expected_image": false,
+      "expected_video": false,
+      "doc_url": "https://www.siliconflow.cn/models",
+      "note": "DeepSeek-V4 Pro supports tools but not visual input"
     },
     {
       "provider_id": "gemini",

--- a/src/qwenpaw/providers/provider_annotations.py
+++ b/src/qwenpaw/providers/provider_annotations.py
@@ -23,7 +23,11 @@ class ProviderAnnotationService:
     ) -> None:
         """Apply expected capabilities without overwriting probe results."""
         for provider in providers:
-            for model in provider.all_models():
+            candidates = [
+                *provider.all_models(),
+                *provider.discovered_models,
+            ]
+            for model in candidates:
                 if model.probe_source == "probed":
                     continue
                 if not refresh and model.supports_multimodal is not None:

--- a/src/qwenpaw/providers/provider_manager_discovery.py
+++ b/src/qwenpaw/providers/provider_manager_discovery.py
@@ -22,6 +22,7 @@ from .provider import (
     ProviderInfo,
 )
 from .provider_catalog import BUILTIN_PROVIDER_CATALOG_KEYS
+from .provider_annotations import ProviderAnnotationService
 from .provider_manager_host import ProviderManagerHost
 from .provider_discovery import (
     ProviderModelDiscoveryResult,
@@ -197,6 +198,9 @@ class ProviderManagerDiscoveryMixin(
             candidate.discovered_models = [
                 model.model_copy(deep=True) for model in models or []
             ]
+            ProviderAnnotationService(self._capability_registry).apply(
+                [candidate],
+            )
             candidate.models_last_synced_at = synced_at
             candidate.models_last_sync_error = None
         else:

--- a/tests/unit/providers/test_siliconflow_provider.py
+++ b/tests/unit/providers/test_siliconflow_provider.py
@@ -10,6 +10,7 @@ import pytest
 
 import qwenpaw.providers.provider_manager as provider_manager_module
 from qwenpaw.providers.openai_provider import OpenAIProvider
+from qwenpaw.providers.provider import ModelInfo
 from qwenpaw.providers.provider_manager import (
     PROVIDER_SILICONFLOW_CN,
     PROVIDER_SILICONFLOW_INTL,
@@ -70,6 +71,50 @@ def test_siliconflow_registered_in_provider_manager(
     assert provider_intl is not None
     assert isinstance(provider_intl, OpenAIProvider)
     assert provider_intl.base_url == "https://api.siliconflow.com/v1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_id",
+    ["siliconflow-cn", "siliconflow-intl"],
+)
+async def test_discovered_deepseek_v4_models_are_text_only(
+    isolated_secret_dir,
+    monkeypatch,
+    provider_id,
+) -> None:
+    """Apply packaged capabilities during the discovery transaction."""
+    manager = ProviderManager()
+    provider = manager.get_provider(provider_id)
+    assert provider is not None
+
+    async def fetch_models(_self, timeout=5):
+        return [
+            ModelInfo(
+                id="deepseek-ai/DeepSeek-V4-Flash",
+                name="DeepSeek V4 Flash",
+            ),
+            ModelInfo(
+                id="deepseek-ai/DeepSeek-V4-Pro",
+                name="DeepSeek V4 Pro",
+            ),
+        ]
+
+    monkeypatch.setattr(OpenAIProvider, "fetch_models", fetch_models)
+
+    result = await manager.discover_provider_models(provider_id)
+
+    assert result.success is True
+    for model_id in (
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "deepseek-ai/DeepSeek-V4-Pro",
+    ):
+        model = provider.get_discovered_model_info(model_id)
+        assert model is not None
+        assert model.supports_image is False
+        assert model.supports_video is False
+        assert model.supports_multimodal is False
+        assert model.probe_source == "documentation"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

SiliconFlow discovers models dynamically with namespaced IDs such as `deepseek-ai/DeepSeek-V4-Flash`. The packaged text-only annotations only covered the separate `deepseek` provider and unnamespaced IDs, so the SiliconFlow models remained `supports_multimodal=None`.

Unknown capability intentionally fails open. As a result, every new model call cloned, formatted, JSON-encoded, and uploaded every historical screenshot in the session even though SiliconFlow's DeepSeek V4 Pro/Flash models are text-only. The current response does not need to contain an image: old tool-result images in the live session are enough to make a new request large before/while the UI shows `Thinking`.

This PR:

- marks `deepseek-ai/DeepSeek-V4-Flash` and `deepseek-ai/DeepSeek-V4-Pro` as text-only for both `siliconflow-cn` and `siliconflow-intl`;
- applies documentation annotations to dynamically discovered models, including during the discovery transaction, rather than only to configured models on a later restart;
- preserves probed and user-configured capability values.

SiliconFlow's model catalog lists tool calling for these two models but does not list visual input; its visual models carry a separate visual-input capability: https://www.siliconflow.cn/models

## User-visible failure chain

1. One session accumulates screenshot `DataBlock`s across long agent/tool loops.
2. SiliconFlow DeepSeek V4 remains capability-unknown because the dynamic namespaced ID does not match the existing baseline.
3. Unknown fails open, so the OpenAI-compatible formatter retains all historical images.
4. Each subsequent turn rebuilds and uploads the growing full-media request. Temporary formatter/JSON/HTTP allocations raise the process high-water RSS; CPython does not promptly return all arenas to the OS.
5. A slow provider keeps the large request and streaming call alive longer. The UI can show only an unfinished `Thinking` block while the backend is under memory pressure.

This is independent of the two streaming fixes already merged today:

- #7239 removes quadratic `+=` accumulation for long text/reasoning deltas.
- #7244 stops cumulative response serialization in heartbeats.

Both are valid, but neither prevents historical screenshots from entering a text-only SiliconFlow request. This PR does not drop tool chunks or change the SSE/frontend protocol.

## Reproduction

The benchmark used the real QwenPaw OpenAI formatter, AgentScope `OpenAIChatModel`, and the OpenAI Python SDK against a local OpenAI-compatible streaming server. The server read the request without retaining it and returned reasoning deltas. Each simulated screenshot was a 1 MiB image in a historical `ToolResultBlock`; the same process made 15 calls while history grew from 4 to 60 images.

macOS, Python 3.12; values are backend RSS measured from the initialized model/session:

| 15-turn growing session | Capability state | Request body at 60 images | RSS after turn 1 | RSS after turn 15 | Retained delta after GC | Total elapsed |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Before | unknown → fail-open media | 80.0 MiB | 194.6 MiB | 751.9 MiB | +583.1 MiB | 6.42 s |
| After | documented text-only | 24.5 KiB | 177.5 MiB | 180.0 MiB | +10.7 MiB | 4.14 s |

A separate single-call boundary test with 130 historical images at 1.95 MiB each produced a 338.1 MiB request and +463.4 MiB client peak RSS before the fix. With media stripping, request size stays approximately constant (about 53 KiB for 130 history entries).

The mock is intentionally shaped like the reported workload: one session, historical screenshots/tool results, a new response that emits only reasoning, and an OpenAI-compatible DeepSeek endpoint. It does not rely on impossible concurrent unfinished tasks or cumulative provider deltas.

### Scope of the 12 GiB observation

I reproduced the monotonic per-turn RSS growth mechanism and the text-only control removes it. I did not reproduce exactly 12 GiB on macOS, and no Windows heap dump is available, so this PR does not claim this is the only allocation source in that specific process. Reaching 12 GiB depends on the number/size of retained media blocks, repeated turns, allocator behavior, and in-flight provider latency. The reported Windows session had many screenshots and long agent loops, which is the workload this fix bounds.

ReMe auto-memory is not the source of these image bytes in 0.4.1.5: it removes Base64 data before session JSONL persistence, and its history prompt uses text content only.

## Tests

- Added discovery coverage for both SiliconFlow regions and both V4 model IDs.
- Verified discovered models immediately receive `supports_image=False`, `supports_video=False`, `supports_multimodal=False`, and `probe_source=documentation`.
- `163 passed, 1 skipped` for SiliconFlow, capability catalog, and ProviderManager tests after rebasing onto current `main`.
- `749 passed, 1 skipped` across provider and formatter/message-normalization regression suites before the final rebase.
- Pre-commit passed: JSON validation, mypy, black, flake8, pylint, and repository checks.
