### PR TITLE
fix(ci): derive Docker boundary version from package

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Get QwenPaw version
+        id: qwenpaw_version
+        uses: ./.github/actions/get-version
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -91,6 +95,7 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
           IS_PRERELEASE: ${{ steps.vars.outputs.is_prerelease }}
           QWENPAW_DISABLED_CHANNELS: "imessage"
+          QWENPAW_VERSION: ${{ steps.qwenpaw_version.outputs.version }}
         run: |
           TAGS="-t ${ACR_REGISTRY}/${IMAGE}:${VERSION} -t ${ACR_REGISTRY}/${IMAGE}:pre"
           TAGS="${TAGS} -t docker.io/${IMAGE}:${VERSION} -t docker.io/${IMAGE}:pre"
@@ -100,4 +105,6 @@ jobs:
           docker buildx build --platform linux/amd64,linux/arm64 \
             -f deploy/Dockerfile \
             --build-arg QWENPAW_DISABLED_CHANNELS="${QWENPAW_DISABLED_CHANNELS}" \
+            --build-arg \
+            QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="${QWENPAW_VERSION}" \
             ${TAGS} --push .

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -173,28 +173,9 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Verify managed runtime boundary version
-        shell: bash
-        run: |
-          python - <<'PY'
-          import re
-          from pathlib import Path
-
-          version_source = Path("src/qwenpaw/__version__.py").read_text()
-          dockerfile = Path("deploy/Dockerfile").read_text()
-          version = re.search(r'__version__ = "([^"]+)"', version_source)
-          boundary = re.search(
-              r'ARG QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="([^"]+)"',
-              dockerfile,
-          )
-          if version is None or boundary is None:
-              raise SystemExit("Unable to read runtime boundary versions")
-          if version.group(1) != boundary.group(1):
-              raise SystemExit(
-                  f"Runtime boundary version mismatch: "
-                  f"{boundary.group(1)} != {version.group(1)}",
-              )
-          PY
+      - name: Get QwenPaw version
+        id: version
+        uses: ./.github/actions/get-version
 
       - name: Log in to Aliyun ACR (when credentials available)
         if: env.ACR_USERNAME != ''
@@ -210,6 +191,7 @@ jobs:
         env:
           DOCKER_NODE_IMAGE: ${{ inputs.docker_node_image }}
           DOCKER_UV_IMAGE: ${{ inputs.docker_uv_image }}
+          QWENPAW_VERSION: ${{ steps.version.outputs.version }}
         run: |
           BUILD_ARGS=""
           if [ -n "$DOCKER_NODE_IMAGE" ]; then
@@ -221,8 +203,21 @@ jobs:
           docker build \
             -f deploy/Dockerfile \
             -t qwenpaw-verify:test \
+            --build-arg \
+            QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="$QWENPAW_VERSION" \
             $BUILD_ARGS \
             .
+
+      - name: Verify managed runtime boundary version
+        env:
+          QWENPAW_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          actual=$(docker image inspect qwenpaw-verify:test \
+            --format '{{ index .Config.Labels "io.qwenpaw.managed-runtime-boundary.version" }}')
+          if [ "$actual" != "$QWENPAW_VERSION" ]; then
+            echo "::error::Runtime boundary version mismatch: $actual != $QWENPAW_VERSION"
+            exit 1
+          fi
 
       - name: Start container
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,10 @@ jobs:
           ref: ${{ needs.resolve.outputs.sha }}
           submodules: recursive
 
+      - name: Get QwenPaw version
+        id: version
+        uses: ./.github/actions/get-version
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -285,6 +289,7 @@ jobs:
           DOCKER_NODE_IMAGE: ${{ inputs.dry_run && 'node:20-slim' || '' }}
           DOCKER_UV_IMAGE: ${{ inputs.dry_run && 'ghcr.io/astral-sh/uv:latest' || '' }}
           QWENPAW_DISABLED_CHANNELS: "imessage"
+          QWENPAW_VERSION: ${{ steps.version.outputs.version }}
         run: |
           BUILD_ARGS=()
           if [ -n "${DOCKER_NODE_IMAGE}" ]; then
@@ -296,6 +301,8 @@ jobs:
           docker buildx build --platform linux/amd64,linux/arm64 \
             -f deploy/Dockerfile \
             --build-arg QWENPAW_DISABLED_CHANNELS="${QWENPAW_DISABLED_CHANNELS}" \
+            --build-arg \
+            QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="${QWENPAW_VERSION}" \
             --output "type=oci,dest=${RUNNER_TEMP}/qwenpaw-image.tar" \
             "${BUILD_ARGS[@]}" .
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,7 +18,7 @@ FROM ${UV_IMAGE} AS uv-src
 # -----------------------------------------------------------------------------
 FROM ${NODE_IMAGE}
 
-ARG QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="2.1.1b1"
+ARG QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION
 LABEL io.qwenpaw.managed-runtime-boundary.version=\
 ${QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION}
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -19,10 +19,19 @@ shift || true
 
 # Channels to exclude from the image (default: imessage).
 DISABLED_CHANNELS="${QWENPAW_DISABLED_CHANNELS:-imessage}"
+QWENPAW_VERSION=$(sed -n \
+    's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+    src/qwenpaw/__version__.py)
+if [ -z "$QWENPAW_VERSION" ]; then
+    echo "[docker_build] Failed to read src/qwenpaw/__version__.py" >&2
+    exit 1
+fi
 
 echo "[docker_build] Building image: $TAG (Dockerfile: $DOCKERFILE)"
 docker build -f "$DOCKERFILE" \
     --build-arg QWENPAW_DISABLED_CHANNELS="$DISABLED_CHANNELS" \
+    --build-arg \
+    QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION="$QWENPAW_VERSION" \
     ${QWENPAW_ENABLED_CHANNELS:+--build-arg QWENPAW_ENABLED_CHANNELS="$QWENPAW_ENABLED_CHANNELS"} \
     -t "$TAG" "$@" .
 echo "[docker_build] Done."


### PR DESCRIPTION
## Summary

- remove the hard-coded managed runtime boundary version from deploy/Dockerfile
- derive the boundary version from src/qwenpaw/__version__.py for verification, release, legacy Docker release, and local builds
- verify the built image label matches the package version

## Root cause

The package was bumped to 2.1.1b2 while deploy/Dockerfile still defaulted the boundary label to 2.1.1b1. The release verification compared two manually maintained values and failed before the Docker build.

Failing run: https://github.com/agentscope-ai/QwenPaw/actions/runs/32711270064/job/97384034712

## Verification

- Codex-QwenPaw: pre-commit checks for all changed files
- Codex-QwenPaw: pytest -q tests/integration/test_version.py (3 passed)
- mocked local Docker build confirms QWENPAW_MANAGED_RUNTIME_BOUNDARY_VERSION=2.1.1b2 is passed automatically