### PR TITLE
fix(scripts): local test runner skips suites and reports false success

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -8,7 +8,7 @@ Usage:
 
 Options:
     -u, --unit [DIR]      Run unit tests (optionally specify subdirectory)
-    -i, --integrated      Run integrated tests
+    -i, --integrated      Run integration tests (tests/integration)
     -a, --all             Run all tests (default)
     -c, --coverage        Generate coverage report
     -p, --parallel        Run tests in parallel
@@ -18,9 +18,19 @@ Examples:
     python scripts/run_tests.py                    # Run all tests
     python scripts/run_tests.py -u                 # Run all unit tests
     python scripts/run_tests.py -u providers       # Run unit tests in providers
-    python scripts/run_tests.py -i                 # Run integrated tests
+    python scripts/run_tests.py -i                 # Run integration tests
     python scripts/run_tests.py -a -c              # Run all tests with coverage
     python scripts/run_tests.py -p                 # Run tests in parallel
+
+Notes:
+    * The default ``-a`` run executes the complete ``tests/unit`` tree
+      (root-level files included), ``tests/contract`` and
+      ``tests/integration`` — the same tiers GitHub Actions runs.
+    * A missing test suite directory is reported as an error with a
+      nonzero exit status instead of being silently skipped.
+    * Output is safe on terminals with limited encodings (for example
+      CP936/GBK on Windows): unencodable status symbols are replaced
+      instead of raising ``UnicodeEncodeError``.
 """
 
 import argparse
@@ -30,7 +40,26 @@ from pathlib import Path
 from typing import Optional
 
 
-class Colors:
+def _make_output_safe(stream) -> None:
+    """Keep printing from crashing on limited terminal encodings.
+
+    Windows consoles frequently use CP936/GBK; the Unicode status
+    symbols below used to raise ``UnicodeEncodeError`` before the test
+    outcome was reported.  Replacing unencodable characters keeps the
+    runner usable there.
+    """
+    if hasattr(stream, "reconfigure"):
+        try:
+            stream.reconfigure(errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
+_make_output_safe(sys.stdout)
+_make_output_safe(sys.stderr)
+
+
+class Colors:  # pylint: disable=too-few-public-methods
     """ANSI color codes for terminal output."""
 
     RED = "\033[0;31m"
@@ -61,10 +90,10 @@ def print_warning(message: str) -> None:
 
 
 def check_pytest() -> bool:
-    """Check if pytest is installed."""
+    """Check that pytest is usable by the active interpreter."""
     try:
         subprocess.run(
-            ["pytest", "--version"],
+            [sys.executable, "-m", "pytest", "--version"],
             capture_output=True,
             check=True,
         )
@@ -73,85 +102,20 @@ def check_pytest() -> bool:
         return False
 
 
-def run_unit_tests(
-    project_root: Path,
-    subdir: Optional[str] = None,
-    coverage: bool = False,
-    parallel: bool = False,
-) -> int:
-    """Run unit tests."""
-    if subdir:
-        # Run specific subdirectory
-        test_path = project_root / "tests" / "unit" / subdir
-        if not test_path.is_dir():
-            print_error(f"Unit test directory not found: {test_path}")
-            return 1
-
-        print_info(f"Running unit tests in: {subdir}")
-        return_code = run_pytest(test_path, coverage, parallel)
-        if return_code == 0:
-            print_success(f"Unit tests in {subdir} completed")
-        return return_code
-    else:
-        # Run all unit test subdirectories
-        print_info("Running all unit tests...")
-        unit_dir = project_root / "tests" / "unit"
-
-        if not unit_dir.is_dir():
-            print_warning("Unit test directory not found: tests/unit")
-            return 0
-
-        subdirs = [d for d in unit_dir.iterdir() if d.is_dir()]
-        if not subdirs:
-            print_warning("No unit test subdirectories found")
-            return 0
-
-        overall_return_code = 0
-        for test_dir in subdirs:
-            dirname = test_dir.name
-            print_info(f"Running unit tests in: {dirname}")
-            return_code = run_pytest(test_dir, coverage, parallel)
-            if return_code == 0:
-                print_success(f"Unit tests in {dirname} completed")
-            else:
-                overall_return_code = return_code
-            print()
-
-        return overall_return_code
-
-
-def run_integrated_tests(
-    project_root: Path,
-    coverage: bool = False,
-    parallel: bool = False,
-) -> int:
-    """Run integrated tests."""
-    print_info("Running integrated tests...")
-    integrated_dir = project_root / "tests" / "integrated"
-
-    if not integrated_dir.is_dir():
-        print_warning("Integrated test directory not found: tests/integrated")
-        return 0
-
-    # Check if there are any Python test files
-    test_files = list(integrated_dir.glob("*.py"))
-    if not test_files:
-        print_warning("No integrated test files found in tests/integrated")
-        return 0
-
-    return_code = run_pytest(integrated_dir, coverage, parallel)
-    if return_code == 0:
-        print_success("Integrated tests completed")
-    return return_code
-
-
 def run_pytest(
+    project_root: Path,
     test_path: Path,
     coverage: bool = False,
     parallel: bool = False,
 ) -> int:
-    """Run pytest with specified options."""
-    cmd = ["pytest", "-v", str(test_path)]
+    """Run pytest for ``test_path`` from the repository root.
+
+    Running from the root lets pytest pick up the repository
+    configuration (markers, timeouts, ...), and invoking pytest through
+    ``sys.executable`` targets the active interpreter even when the
+    ``pytest`` entry point is not on PATH.
+    """
+    cmd = [sys.executable, "-m", "pytest", "-v", str(test_path)]
 
     if coverage:
         cmd.extend(
@@ -166,10 +130,93 @@ def run_pytest(
         cmd.extend(["-n", "auto"])
 
     try:
-        result = subprocess.run(cmd, cwd=test_path.parents[2], check=True)
+        result = subprocess.run(cmd, cwd=project_root, check=True)
         return result.returncode
     except subprocess.CalledProcessError as e:
         return e.returncode
+
+
+def run_unit_tests(
+    project_root: Path,
+    subdir: Optional[str] = None,
+    coverage: bool = False,
+    parallel: bool = False,
+) -> int:
+    """Run unit tests.
+
+    Without ``subdir`` the complete ``tests/unit`` tree is executed in
+    one pytest invocation, so files placed directly in ``tests/unit``
+    are included as well.
+    """
+    if subdir:
+        test_path = project_root / "tests" / "unit" / subdir
+        if not test_path.is_dir():
+            print_error(f"Unit test directory not found: {test_path}")
+            return 1
+
+        print_info(f"Running unit tests in: {subdir}")
+        return_code = run_pytest(project_root, test_path, coverage, parallel)
+        if return_code == 0:
+            print_success(f"Unit tests in {subdir} completed")
+        return return_code
+
+    unit_dir = project_root / "tests" / "unit"
+    if not unit_dir.is_dir():
+        print_error("Unit test directory not found: tests/unit")
+        return 1
+
+    print_info("Running all unit tests...")
+    return_code = run_pytest(project_root, unit_dir, coverage, parallel)
+    if return_code == 0:
+        print_success("Unit tests completed")
+    return return_code
+
+
+def run_contract_tests(
+    project_root: Path,
+    coverage: bool = False,
+    parallel: bool = False,
+) -> int:
+    """Run contract tests (tests/contract)."""
+    print_info("Running contract tests...")
+    contract_dir = project_root / "tests" / "contract"
+    if not contract_dir.is_dir():
+        print_error("Contract test directory not found: tests/contract")
+        return 1
+
+    return_code = run_pytest(project_root, contract_dir, coverage, parallel)
+    if return_code == 0:
+        print_success("Contract tests completed")
+    return return_code
+
+
+def run_integrated_tests(
+    project_root: Path,
+    coverage: bool = False,
+    parallel: bool = False,
+) -> int:
+    """Run integration tests (tests/integration).
+
+    A missing directory is an error: silently returning success here
+    used to mask the fact that no integration test ran at all.
+    """
+    print_info("Running integration tests...")
+    integration_dir = project_root / "tests" / "integration"
+    if not integration_dir.is_dir():
+        print_error(
+            "Integration test directory not found: tests/integration",
+        )
+        return 1
+
+    return_code = run_pytest(
+        project_root,
+        integration_dir,
+        coverage,
+        parallel,
+    )
+    if return_code == 0:
+        print_success("Integration tests completed")
+    return return_code
 
 
 def main() -> int:
@@ -191,7 +238,7 @@ def main() -> int:
         "-i",
         "--integrated",
         action="store_true",
-        help="Run integrated tests",
+        help="Run integration tests (tests/integration)",
     )
     parser.add_argument(
         "-a",
@@ -245,12 +292,18 @@ def main() -> int:
             parallel=args.parallel,
         )
         print()
+        contract_code = run_contract_tests(
+            project_root,
+            coverage=args.coverage,
+            parallel=args.parallel,
+        )
+        print()
         integrated_code = run_integrated_tests(
             project_root,
             coverage=args.coverage,
             parallel=args.parallel,
         )
-        return_code = unit_code or integrated_code
+        return_code = unit_code or contract_code or integrated_code
     elif args.unit is not None:
         return_code = run_unit_tests(
             project_root,
@@ -266,12 +319,18 @@ def main() -> int:
         )
 
     print()
-    if args.coverage:
-        print_success(
-            "Test run completed! Coverage report generated in htmlcov/index.html",
-        )
+    if return_code == 0:
+        if args.coverage:
+            print_success(
+                "Test run completed! Coverage report generated in "
+                "htmlcov/index.html",
+            )
+        else:
+            print_success("All test suites completed successfully!")
     else:
-        print_success("Test run completed!")
+        print_error(
+            f"Test run finished with failures (exit code {return_code})",
+        )
     print()
 
     return return_code

--- a/tests/unit/test_run_tests_script.py
+++ b/tests/unit/test_run_tests_script.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+# pylint: disable=superfluous-parens
+"""Regression tests for ``scripts/run_tests.py`` (issue #7229).
+
+The local test runner used to skip suites and report false success:
+``-u`` iterated only ``tests/unit`` subdirectories (dropping root-level
+test files), ``-a`` never ran ``tests/contract``, ``-i`` pointed at a
+nonexistent ``tests/integrated`` directory and treated it as success.
+These tests pin the corrected behaviour.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "run_tests.py"
+
+
+@pytest.fixture(scope="module")
+def runner_module():
+    """Load scripts/run_tests.py as a module (it is not importable)."""
+    spec = importlib.util.spec_from_file_location(
+        "qwenpaw_local_test_runner",
+        _SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def recorded_calls(runner_module, monkeypatch):
+    """Stub pytest out and record which directories the runner invokes."""
+    calls: list[str] = []
+
+    def fake_run_pytest(
+        project_root,
+        test_path,
+        coverage=False,
+        parallel=False,
+    ):
+        calls.append(str(test_path))
+        return 0
+
+    monkeypatch.setattr(runner_module, "check_pytest", lambda: True)
+    monkeypatch.setattr(runner_module, "run_pytest", fake_run_pytest)
+    return calls
+
+
+def test_all_mode_covers_unit_contract_and_integration(
+    runner_module,
+    recorded_calls,
+    monkeypatch,
+):
+    """``-a`` must execute all three suites, not just unit+integrated."""
+    monkeypatch.setattr(sys, "argv", ["run_tests.py", "-a"])
+    assert runner_module.main() == 0
+
+    paths = [Path(c) for c in recorded_calls]
+    assert (_REPO_ROOT / "tests" / "unit") in paths
+    assert (_REPO_ROOT / "tests" / "contract") in paths
+    assert (_REPO_ROOT / "tests" / "integration") in paths
+    assert len(paths) == 3
+
+
+def test_unit_mode_runs_complete_unit_tree(
+    runner_module,
+    recorded_calls,
+    monkeypatch,
+):
+    """``-u`` must run the whole tests/unit tree, root-level files too."""
+    monkeypatch.setattr(sys, "argv", ["run_tests.py", "-u"])
+    assert runner_module.main() == 0
+
+    paths = [Path(c) for c in recorded_calls]
+    # A single invocation covering the entire tree, not one call per
+    # subdirectory (the old behaviour that skipped root-level files).
+    assert paths == [_REPO_ROOT / "tests" / "unit"]
+
+
+def test_integrated_flag_targets_tests_integration(
+    runner_module,
+    recorded_calls,
+    monkeypatch,
+):
+    """``-i`` must point at tests/integration, not tests/integrated."""
+    monkeypatch.setattr(sys, "argv", ["run_tests.py", "-i"])
+    assert runner_module.main() == 0
+
+    paths = [Path(c) for c in recorded_calls]
+    assert paths == [_REPO_ROOT / "tests" / "integration"]
+    assert not any("integrated" in c for c in recorded_calls)
+
+
+def test_missing_suite_reports_error_not_success(
+    runner_module,
+    tmp_path,
+):
+    """A missing suite directory must fail loudly, never report success."""
+    assert runner_module.run_unit_tests(tmp_path) == 1
+    assert runner_module.run_contract_tests(tmp_path) == 1
+    assert runner_module.run_integrated_tests(tmp_path) == 1
+
+
+def test_missing_unit_subdir_reports_error(runner_module, tmp_path):
+    """``-u <dir>`` with an unknown subdirectory must fail."""
+    assert runner_module.run_unit_tests(tmp_path, subdir="nonexistent") == 1
+
+
+def test_status_symbols_survive_limited_encodings(runner_module):
+    """Printing status symbols must not crash on GBK/CP936 terminals."""
+    strict = io.TextIOWrapper(io.BytesIO(), encoding="gbk", errors="strict")
+    with pytest.raises(UnicodeEncodeError):
+        strict.write("✓ done\n")  # the old failure mode
+
+    buf = io.BytesIO()
+    safe = io.TextIOWrapper(buf, encoding="gbk", errors="strict")
+    runner_module._make_output_safe(safe)
+    safe.write("✓ done ✗ fail ⚠ note ℹ info\n")  # must not raise
+    safe.flush()
+    assert b"done" in buf.getvalue()


### PR DESCRIPTION
## Description

Fixes `scripts/run_tests.py`, the documented local pre-PR test entry
point. It does not execute the complete suite and can report success
while silently skipping tests.

**Four problems (all confirmed against the current main):**
1. **Unit mode skips root-level files**: it only iterates child
   directories of `tests/unit`, so the two test files placed directly
   in `tests/unit` (`test_integration_timeout_config.py`,
   `test_memory_reranker.py`) are never collected.
2. **Default/`--all` mode never runs contract tests**: the dispatch
   path contains only unit + integration; `tests/contract` is not
   invoked at all.
3. **Integration mode targets the wrong directory and reports false
   success** (worst one): it looks for the nonexistent
   `tests/integrated` (the real directory is `tests/integration`) and,
   on a missing directory, returns 0 and prints a success message —
   zero tests ran, yet the runner says everything passed.
4. **Windows GBK/CP936 terminals crash**: printing the ✓ ✗ ⚠ ℹ status
   symbols raises `UnicodeEncodeError` before the outcome is reported.

**Fix (script rewritten, all four addressed):**
1. Unit mode runs the complete `tests/unit` tree in one pytest
   invocation, so root-level files are included.
2. The run-all path adds the contract tier (unit → contract →
   integration), matching the tiers GitHub Actions runs.
3. Integration mode points at `tests/integration`; any missing suite
   directory now fails loudly with a nonzero exit status instead of
   being treated as success.
4. stdout/stderr are reconfigured with `errors="replace"` so printing
   stays safe on limited terminal encodings.

Also invoke pytest through `sys.executable -m pytest` from the
repository root so the active interpreter and repository pytest
configuration are used even when the `pytest` entry point is not on
PATH, and print a red failure message instead of the green success
message when the return code is nonzero. Command-line compatibility
(`-i/--integrated`, `-u DIR`, `-c`, `-p`) is preserved.

**Scope note:** this script is the documented local helper entry point;
the formal quality gates (Makefile, CONTRIBUTING.md, GitHub CI) invoke
pytest directly with the correct paths and are unaffected by it.

**Related Issue:** Fixes #7229

**Security considerations:** None.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Component(s) Affected

- [x] Tests
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — the runner docstring was
      updated; the CLI surface is unchanged
- [x] Ready for review

## Testing

- **New regression suite** `tests/unit/test_run_tests_script.py` (6
  tests): covers suite coverage of all three modes, the
  wrong-directory fix, fail-loud behaviour for missing suites/subdirs,
  and GBK-safe status output. Deliberately placed directly in
  `tests/unit` — exactly where the old runner used to skip files.
- Local: 6/6 regression tests pass, `-u _compat` end-to-end smoke
  passes, pre-commit (black/flake8/pylint/mypy) clean, pylint
  10.00/10.
- Fork full CI matrix (yutai78786/QwenPaw run 32697953779): the 6
  regression tests pass on **all four platforms including Windows**
  (the platform the encoding issue concerns). The only red job is
  `tests/e2e/test_hub_local_runtime.py` on Windows (connection
  refused), unrelated to this change — it was introduced by #7112 and
  fails the same way on the fork main baseline.

## Evidence

```text
# Before (reproducing the issue):
$ python scripts/run_tests.py -i
Running integrated tests...
Integrated test directory not found: tests/integrated
All tests completed successfully!
# exit 0 — nothing ran

# After:
$ python scripts/run_tests.py -i
Running integration tests...
# executes the real tests/integration suite

# Regression tests:
$ pytest tests/unit/test_run_tests_script.py -v
6 passed in 0.53s
```

Fork CI: https://github.com/yutai78786/QwenPaw/actions/runs/32697953779
(6 regression tests PASSED on ubuntu/macOS/Windows)

## Additional Notes

- The runner was introduced in March 2026 and never evolved with the
  unit/contract/integration test layout; it had no regression tests of
  its own. This PR adds them so the drift cannot silently recur.
- Combining coverage data across the separate pytest invocations of
  `--all --coverage` is a separate concern and intentionally out of
  scope (consistent with the issue report).
- GitHub CI is unaffected: it calls pytest directly with the correct
  directories. This change only affects the documented local helper.
