### PR TITLE
docs(readme): add Access Policy as the fifth core security layer in EN

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,12 +386,13 @@ QwenPaw also provides the **QwenPaw-Flash** series — purpose-trained 2B / 4B /
 
 ## Security Features
 
-QwenPaw includes four core security layers:
+QwenPaw includes five core security layers:
 
 - **Sandbox** — Kernel-level execution isolation using Seatbelt (macOS), Bubblewrap / Landlock (Linux), and AppContainer (Windows). Shell commands run inside a restricted filesystem view.
 - **Tool Guard** — YAML rule engine with `ShellEvasionGuardian` inspects every tool call before execution, detecting command injection, path traversal, reverse shells, and obfuscated attacks. Configurable approval levels: STRICT / SMART / AUTO / OFF.
 - **File Guard** — Independent of Tool Guard; blocks agent access to sensitive files and directories (default-protects `~/.qwenpaw.secret/`, `~/.ssh`, etc.).
 - **Skill Scanner** — Pre-activation scanning with block / warn / off modes and whitelist support. Detects prompt injection, hardcoded secrets, data exfiltration, and more.
+- **Access Policy** — Declarative access policies that decide allow, deny, or ask for each capability call, with tool-level granularity and source-aware matching.
 
 See [Security](https://qwenpaw.agentscope.io/docs/security) for details.
 


### PR DESCRIPTION
## Description

The English `README.md` **Security Features** section still listed only *four* core security layers and omitted **Access Policy**, while the Chinese and Japanese READMEs (updated in #7214) already list five, and both the intro feature table and the Documentation table in `README.md` already reference Access Policy. This PR brings the English README in line with the rest of the repo:

- Change "four core security layers" → "five core security layers"
- Add the **Access Policy** bullet (declarative access policies that decide allow / deny / ask for each capability call, with tool-level granularity and source-aware matching)

**Related Issue:** Relates to #7214

**Security Considerations:** None — documentation only, no behavioral or code change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

> Note: this is a docs-only change to `README.md`. The repo's `pre-commit` `prettier` hook targets `.(tsx?)$` only (not markdown), and `trailing-whitespace` is the only hook that touches markdown — the added lines carry no trailing whitespace. No code or test impact.

## Testing

Verified locally:

- `git diff --stat` shows only `README.md | 3 ++-` (2 insertions, 1 deletion).
- `git show :README.md | prettier --check` (LF-normalized staged content) passes.
- `grep -c $'\r'` on the changed lines reports 0 trailing-whitespace issues.

## Evidence

```text
$ git diff --stat
 README.md | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

$ git show :README.md | npx prettier@3 --check --stdin-filepath README.md
(stdin)   # <- passes, no formatting issues
```

The English Security Features list now matches the ZH/JA count (five) and the already-present references in the intro feature table and Documentation table.

## Additional Notes

Pure documentation consistency fix completing the EN side of the Access Policy listing started in #7214. No functional change, no new dependencies, no architectural impact.
