### PR TITLE
fix(runtime): prevent heartbeat spin on source timeouts

### DIFF
--- a/src/qwenpaw/runtime/heartbeat.py
+++ b/src/qwenpaw/runtime/heartbeat.py
@@ -11,28 +11,30 @@ _HEARTBEAT_TICK = object()
 async def _iter_with_heartbeat(source_iter, interval: float):
     """Wrap an async-iter so it yields ``_HEARTBEAT_TICK`` on idle.
 
-    Uses ``asyncio.shield`` so that ``wait_for``'s cancellation on timeout
-    does NOT cancel the underlying ``__anext__()`` task — that task lives
-    across heartbeats and is awaited again on the next loop iteration.
-    Without shielding, a long approval wait would lose every heartbeat's
-    worth of pending state.
+    Keep one ``__anext__()`` task alive across heartbeat timeouts. Using
+    ``asyncio.wait`` distinguishes an idle wait from ``TimeoutError`` raised
+    by the source iterator, so source exceptions propagate unchanged.
     """
     pending = None
     try:
         while True:
             if pending is None:
                 pending = asyncio.ensure_future(source_iter.__anext__())
-            try:
-                value = await asyncio.wait_for(
-                    asyncio.shield(pending),
-                    timeout=interval,
-                )
-            except asyncio.TimeoutError:
+
+            done, _ = await asyncio.wait(
+                {pending},
+                timeout=interval,
+            )
+            if not done:
                 yield _HEARTBEAT_TICK
                 continue
+
+            try:
+                value = pending.result()
             except StopAsyncIteration:
                 pending = None
                 return
+
             pending = None
             yield value
     finally:

--- a/tests/unit/runtime/test_heartbeat.py
+++ b/tests/unit/runtime/test_heartbeat.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Tests for the runtime heartbeat iterator wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from qwenpaw.runtime.heartbeat import (
+    _iter_with_heartbeat,
+    _HEARTBEAT_TICK,
+)
+
+
+class _SourceIdleTimeoutError(TimeoutError):
+    """Represent a timeout raised by the wrapped source iterator."""
+
+
+class _FailingSource(AsyncIterator[object]):
+    """Raise a configured exception when the next item is requested."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def __aiter__(self) -> _FailingSource:
+        return self
+
+    async def __anext__(self) -> object:
+        raise self._error
+
+
+@pytest.mark.asyncio
+async def test_source_timeout_error_propagates() -> None:
+    stream = _iter_with_heartbeat(
+        _FailingSource(
+            _SourceIdleTimeoutError("source stream idle"),
+        ),
+        interval=1.0,
+    )
+
+    try:
+        with pytest.raises(
+            _SourceIdleTimeoutError,
+            match="source stream idle",
+        ):
+            await anext(stream)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pending_source_emits_heartbeat_then_value() -> None:
+    release = asyncio.Event()
+
+    async def source() -> AsyncIterator[str]:
+        await release.wait()
+        yield "value"
+
+    stream = _iter_with_heartbeat(source(), interval=0.01)
+
+    try:
+        assert await anext(stream) is _HEARTBEAT_TICK
+        release.set()
+        assert await anext(stream) == "value"
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_timeout_source_error_propagates() -> None:
+    stream = _iter_with_heartbeat(
+        _FailingSource(RuntimeError("source failed")),
+        interval=1.0,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="source failed"):
+            await anext(stream)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_closing_wrapper_cancels_pending_source() -> None:
+    source_cancelled = asyncio.Event()
+    wait_forever = asyncio.Event()
+
+    async def source() -> AsyncIterator[object]:
+        try:
+            await wait_forever.wait()
+            yield object()  # pragma: no cover
+        finally:
+            source_cancelled.set()
+
+    stream = _iter_with_heartbeat(source(), interval=0.01)
+
+    assert await anext(stream) is _HEARTBEAT_TICK
+    await stream.aclose()
+    await asyncio.sleep(0)
+
+    assert source_cancelled.is_set()


### PR DESCRIPTION
## Description

The runtime heartbeat wrapper previously used `asyncio.wait_for()` and
caught `asyncio.TimeoutError` to detect an idle source iterator. On Python
3.11+, `asyncio.TimeoutError` is an alias of the built-in `TimeoutError`, so
a `TimeoutError` raised by the source task was mistaken for the wrapper's own
heartbeat timeout.

When `StreamIdleTimeoutError` completed the pending source task, the wrapper
swallowed that exception, yielded a heartbeat, and awaited the same completed
task again. This formed a tight loop that could emit millions of heartbeat
events. `TaskTracker` retained those events for reconnect replay, causing high
CPU usage and unbounded backend memory growth while the UI remained stuck in
Thinking.

This PR replaces exception-based timeout detection with `asyncio.wait()`:

- an unfinished source task emits one heartbeat per interval;
- a completed source task returns its value through `Task.result()`;
- source exceptions, including `TimeoutError` subclasses, propagate unchanged;
- iterator completion and cancellation keep their existing behavior.

The fix is provider-agnostic and does not special-case
`StreamIdleTimeoutError`.

**Related Issue:** Relates to #7259 and #7150

**Security Considerations:** None. This changes only runtime task scheduling
and exception propagation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not required; behavior is covered by regression tests)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this PR does not change a channel or the Console.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
uv run pytest tests/unit/runtime/test_heartbeat.py -q
# 4 passed

uv run pytest \
  tests/unit/runtime/test_heartbeat.py \
  tests/unit/runtime/test_envelope_heartbeat.py \
  tests/unit/runtime/test_executor_finished_at.py \
  tests/unit/providers/test_retry_chat_model.py -q
# 87 passed

uv run pytest tests/unit/runtime -q
# 88 passed
```

## Evidence

The regression test failed against the old implementation because the source
timeout was converted into a heartbeat instead of propagating:

```text
FAILED tests/unit/runtime/test_heartbeat.py::test_source_timeout_error_propagates
Failed: DID NOT RAISE _SourceIdleTimeoutError
1 failed, 3 passed
```

After the fix:

```text
tests/unit/runtime/test_heartbeat.py: 4 passed
heartbeat/provider related tests: 87 passed
complete runtime unit tests: 88 passed
```

Changed-file pre-commit checks passed:

```text
check python ast: Passed
fix python encoding pragma: Passed
trim trailing whitespace: Passed
Add trailing commas: Passed
mypy: Passed
black: Passed
flake8: Passed
pylint: Passed
```

## Additional Notes

This is not Windows-specific. The faulty exception matching is caused by
Python 3.11+ asyncio semantics and can occur on every supported platform.
Windows was the platform of the captured customer dump.

The reconnect buffer policy is intentionally unchanged in this PR. Avoiding
heartbeat retention can be considered separately as defense in depth, but it
is not needed to fix the source-timeout spin.
