### PR TITLE
docs(loop-engineering): fix PluginAPI casing to PluginApi

### DIFF
--- a/website/public/docs/loop-engineering.en.md
+++ b/website/public/docs/loop-engineering.en.md
@@ -295,10 +295,10 @@ class TimeoutGate(StopGate):
 
 ```python
 from qwenpaw.loop.gates import StopHandler
-from qwenpaw.plugins.api import PluginAPI
+from qwenpaw.plugins.api import PluginApi
 
 
-class MyLoopPlugin(PluginAPI):
+class MyLoopPlugin(PluginApi):
     def on_load(self):
         handler = StopHandler()
         handler.register(TimeoutGate(max_minutes=30))

--- a/website/public/docs/loop-engineering.zh.md
+++ b/website/public/docs/loop-engineering.zh.md
@@ -295,10 +295,10 @@ class TimeoutGate(StopGate):
 
 ```python
 from qwenpaw.loop.gates import StopHandler
-from qwenpaw.plugins.api import PluginAPI
+from qwenpaw.plugins.api import PluginApi
 
 
-class MyLoopPlugin(PluginAPI):
+class MyLoopPlugin(PluginApi):
     def on_load(self):
         handler = StopHandler()
         handler.register(TimeoutGate(max_minutes=30))


### PR DESCRIPTION
## Problem

The `loop-engineering` documentation (both EN and ZH) shows a code example that imports and subclasses `PluginAPI` (uppercase I):

```python
from qwenpaw.plugins.api import PluginAPI
class MyLoopPlugin(PluginAPI):
    ...
```

However, the actual class is named `PluginApi` (lowercase i) — it is defined at `src/qwenpaw/plugins/api.py:314` and exported via `__all__` in `src/qwenpaw/plugins/__init__.py`. Because Python identifiers are case-sensitive, any user who copies the snippet gets `ImportError: cannot import name 'PluginAPI' from 'qwenpaw.plugins.api'`. (The sibling `plugins.en.md` already uses the correct `PluginApi`, so this was an inconsistency isolated to the loop-engineering docs.)

## Solution

Correct the casing in the two affected lines of `loop-engineering.en.md` and `loop-engineering.zh.md` so the documented example matches the real public API. No code, runtime behavior, or public interface changes — purely a documentation fix.

## Changes

- `website/public/docs/loop-engineering.en.md`: `PluginAPI` → `PluginApi` (lines 298 import + 301 subclass)
- `website/public/docs/loop-engineering.zh.md`: same fix (lines 298 + 301)

Total: 2 files, 4 lines changed. Complies with the single-PR ≤100 lines / ≤3 files / no new dependency / no architectural change guideline.

## Testing / Verification

- `grep -rn "PluginAPI" website/public/docs/loop-engineering.*` → 0 matches (no stale uppercase remains)
- `grep -n "PluginApi" website/public/docs/loop-engineering.*` → import + subclass lines present
- Code reference verified: `class PluginApi` at `src/qwenpaw/plugins/api.py:314`; `from .api import PluginApi` in `src/qwenpaw/plugins/__init__.py`.
- This is a documentation-only change; no unit test is added because nothing executable changed, and the docs-site build/lint is unaffected.

## Notes for Reviewer

- This PR is a follow-up to my earlier documentation contributions on this repo (#7214 merged, #7255 open). Those touched `README*.md` only; this change touches `website/public/docs/loop-engineering.{en,zh}.md`, so there is **zero file overlap** with my previous PRs and **no conflict** risk.
- Conflict-risk check: no open PR currently modifies `loop-engineering.*`, and the target files are outside the recent hot doc areas (config/skills/cli). Risk score = 0.
