### PR TITLE
fix(token-usage): restore legacy model names from colon keys

### DIFF
--- a/src/qwenpaw/token_usage/manager.py
+++ b/src/qwenpaw/token_usage/manager.py
@@ -185,11 +185,13 @@ class TokenUsageManager:
                     rec_agent = entry.get("agent_id") or ""
                 rec_model = entry.get("model_name") or ""
                 if not rec_model:
-                    rec_model = (
-                        _key.rsplit("\x1f", 1)[-1]
-                        if "\x1f" in str(_key)
-                        else _key
-                    )
+                    key = str(_key)
+                    if "\x1f" in key:
+                        rec_model = key.rsplit("\x1f", 1)[-1]
+                    elif ":" in key:
+                        rec_model = key.split(":", 1)[1]
+                    else:
+                        rec_model = key
                 if model_name is not None and rec_model != model_name:
                     continue
                 if provider_id is not None and rec_provider != provider_id:

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -692,6 +692,77 @@ class TestTokenUsageManagerCore:
         assert named.model == "gpt-4"
         await manager.stop()
 
+    @pytest.mark.asyncio
+    async def test_query_legacy_key_fallback_without_model_name(self):
+        """Legacy colon keys should recover the model name from the key."""
+        manager = TokenUsageManager()
+        merged = {
+            "2026-04-24": {
+                "prov2:model-from-key": {
+                    "provider_id": "prov2",
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "call_count": 1,
+                },
+                "ollama:namespace:model:tag": {
+                    "provider_id": "ollama",
+                    "prompt_tokens": 7,
+                    "completion_tokens": 3,
+                    "call_count": 2,
+                },
+            },
+        }
+
+        # pylint: disable=protected-access
+        rows = await manager._query(
+            merged,
+            date(2026, 4, 24),
+            date(2026, 4, 24),
+            None,
+            None,
+        )
+
+        assert [row.model_dump() for row in rows] == [
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "call_count": 1,
+                "date": "2026-04-24",
+                "provider_id": "prov2",
+                "model": "model-from-key",
+                "agent_id": None,
+            },
+            {
+                "prompt_tokens": 7,
+                "completion_tokens": 3,
+                "call_count": 2,
+                "date": "2026-04-24",
+                "provider_id": "ollama",
+                "model": "namespace:model:tag",
+                "agent_id": None,
+            },
+        ]
+
+        # pylint: disable=protected-access
+        filtered = await manager._query(
+            merged,
+            date(2026, 4, 24),
+            date(2026, 4, 24),
+            "model-from-key",
+            None,
+        )
+        assert [row.model_dump() for row in filtered] == [
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "call_count": 1,
+                "date": "2026-04-24",
+                "provider_id": "prov2",
+                "model": "model-from-key",
+                "agent_id": None,
+            },
+        ]
+
 
 # =============================================================================
 # Test TokenRecordingModelWrapper


### PR DESCRIPTION
## Description

Fix backward-compatible token usage reads when legacy `provider:model` records lack `model_name`. The model is now correctly parsed from the key while preserving models containing colons. Adds regression coverage for legacy records and model filtering.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
