### PR TITLE
test(ci): allow slower Windows Hub cold starts

### DIFF
--- a/tests/e2e/test_hub_local_runtime.py
+++ b/tests/e2e/test_hub_local_runtime.py
@@ -15,6 +15,9 @@ import httpx
 import pytest
 
 
+_HUB_READY_TIMEOUT_SECONDS = 120.0
+
+
 def _allocate_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
         server.bind(("127.0.0.1", 0))
@@ -25,7 +28,7 @@ def _wait_for_hub(
     client: httpx.Client,
     process: subprocess.Popen[Any],
 ) -> None:
-    deadline = time.monotonic() + 60
+    deadline = time.monotonic() + _HUB_READY_TIMEOUT_SECONDS
     last_error = "Hub did not respond"
     while time.monotonic() < deadline:
         if process.poll() is not None:


### PR DESCRIPTION
## Description

Increase the Hub readiness budget in the packaged Local runtime E2E test from 60 to 120 seconds.

The failing Windows job completed all 7,962 unit tests, then timed out while waiting for the packaged Hub process to bind. The child process remained alive and its log stopped after CLI startup, so the final WinError 10061 was the last readiness probe rather than a port-binding failure. Historical successful Windows runs of the same E2E took about 110 and 132 seconds end to end, which shows that the previous 60-second Hub cold-start budget was too tight on hosted Windows runners.

This keeps the real Windows E2E enabled and preserves hard failures when the Hub process exits or does not become ready within the expanded budget. It does not xfail or suppress product errors.

**Related Issue:** Relates to #7268

**Security Considerations:** None. This changes only an E2E readiness deadline.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the packaged Hub Local runtime E2E on the Python 3.11 Windows matrix entry. The test must still start the Hub, register a user, start an isolated Local runtime, proxy its health endpoint, and stop the runtime successfully.

## Evidence

```text
QWENPAW_LOCAL_RUNTIME_E2E=1 pytest tests/e2e/test_hub_local_runtime.py -v
1 passed in 8.58s

pre-commit run --files tests/e2e/test_hub_local_runtime.py
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

Failing Windows job: https://github.com/agentscope-ai/QwenPaw/actions/runs/32817133090/job/97711270532

Historical successful Windows E2E: https://github.com/agentscope-ai/QwenPaw/actions/runs/32465714880/job/96721841254

## Additional Notes

This is intentionally separate from #7268 because the failure is pre-existing Windows CI timing behavior and is unrelated to the heartbeat source-timeout change.