### PR TITLE
feat(console): show unread indicator when session task finishes

### DIFF
--- a/console/src/api/types/chat.ts
+++ b/console/src/api/types/chat.ts
@@ -19,6 +19,7 @@ export interface ChatSpec {
   name?: string; // Chat display name
   created_at: string | null; // Chat creation timestamp (ISO 8601)
   updated_at: string | null; // Chat last update timestamp (ISO 8601)
+  last_finished_at?: string | null; // Most recent task completion timestamp
   meta?: Record<string, unknown>; // Additional metadata
   status?: ChatStatus; // Conversation status: idle or running
   pinned?: boolean; // Whether the chat is pinned to the top

--- a/console/src/components/SessionItem/SessionItem.test.tsx
+++ b/console/src/components/SessionItem/SessionItem.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SessionItem from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("SessionItem status indicator", () => {
+  it.each([
+    {
+      name: "running takes priority",
+      props: { chatStatus: "running" as const, unseenResult: true },
+      label: "chat.statusInProgress",
+    },
+    {
+      name: "completed but unseen",
+      props: { chatStatus: "idle" as const, unseenResult: true },
+      label: "chat.statusUnseenResult",
+    },
+    {
+      name: "idle and seen",
+      props: { chatStatus: "idle" as const, unseenResult: false },
+      label: "chat.statusIdle",
+    },
+  ])("renders $name", ({ props, label }) => {
+    render(
+      <SessionItem
+        variant="drawer"
+        sessionId="chat-1"
+        name="Chat"
+        {...props}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: label })).toBeInTheDocument();
+  });
+});

--- a/console/src/components/SessionItem/index.tsx
+++ b/console/src/components/SessionItem/index.tsx
@@ -27,6 +27,7 @@ export interface SessionItemProps {
   channelLabel?: string;
   chatStatus?: ChatStatus;
   generating?: boolean;
+  unseenResult?: boolean;
   archived?: boolean;
   pinned?: boolean;
   source?: "chat" | "cron" | "subagent";
@@ -62,6 +63,7 @@ const SessionItem: React.FC<SessionItemProps> = ({
   channelLabel,
   chatStatus,
   generating,
+  unseenResult = false,
   archived,
   pinned = false,
   source,
@@ -95,8 +97,11 @@ const SessionItem: React.FC<SessionItemProps> = ({
     ? t("chat.groups.cronShort", "Cron")
     : t("chat.groups.subagentShort", "Subagent");
   const isIdle = !inProgress && !!chatStatus;
+  const hasUnseenResult = isIdle && unseenResult;
   const statusAriaLabel = inProgress
     ? t("chat.statusInProgress")
+    : hasUnseenResult
+    ? t("chat.statusUnseenResult", "New result")
     : t("chat.statusIdle");
 
   const handleClick = useCallback(() => {
@@ -203,7 +208,8 @@ const SessionItem: React.FC<SessionItemProps> = ({
       {!editing && variant === "sidebar" && (
         <span className={styles.statusSlot}>
           {inProgress && <span className={styles.runningDot} />}
-          {isIdle && <span className={styles.idleDot} />}
+          {hasUnseenResult && <span className={styles.unseenDot} />}
+          {isIdle && !hasUnseenResult && <span className={styles.idleDot} />}
         </span>
       )}
 
@@ -254,7 +260,11 @@ const SessionItem: React.FC<SessionItemProps> = ({
                 >
                   <span
                     className={`${styles.statusDot} ${
-                      inProgress ? styles.statusDotActive : styles.statusDotIdle
+                      inProgress
+                        ? styles.statusDotActive
+                        : hasUnseenResult
+                        ? styles.statusDotUnseen
+                        : styles.statusDotIdle
                     }`}
                     aria-hidden
                   />

--- a/console/src/components/SessionItem/sessionItem.module.less
+++ b/console/src/components/SessionItem/sessionItem.module.less
@@ -2,13 +2,13 @@
   0%,
   100% {
     opacity: 0.65;
-    box-shadow: 0 0 0 0 rgba(20, 184, 166, 0.55);
+    box-shadow: 0 0 0 0 rgba(0, 165, 251, 0.55);
     transform: scale(1);
   }
 
   50% {
     opacity: 1;
-    box-shadow: 0 0 10px 3px rgba(20, 184, 166, 0.35);
+    box-shadow: 0 0 10px 3px rgba(0, 165, 251, 0.35);
     transform: scale(1.12);
   }
 }
@@ -243,13 +243,13 @@
 }
 
 .statusDotActive {
-  background: rgba(20, 184, 166, 1);
+  background: #00a5fb;
   animation: chatStatusBreathe 1.6s ease-in-out infinite;
 }
 
 .statusDotUnseen {
-  background: rgba(20, 184, 166, 1);
-  box-shadow: 0 0 6px 1px rgba(20, 184, 166, 0.28);
+  background: #52c41a;
+  box-shadow: 0 0 6px 1px rgba(82, 196, 26, 0.28);
 }
 
 .runningDot {
@@ -257,7 +257,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #52c41a;
+  background: #00a5fb;
   animation: sidebarStatusBreathe 1.5s ease-in-out infinite;
   pointer-events: none;
 }
@@ -267,8 +267,8 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: rgba(20, 184, 166, 1);
-  box-shadow: 0 0 5px 1px rgba(20, 184, 166, 0.25);
+  background: #52c41a;
+  box-shadow: 0 0 5px 1px rgba(82, 196, 26, 0.25);
   pointer-events: none;
 }
 

--- a/console/src/components/SessionItem/sessionItem.module.less
+++ b/console/src/components/SessionItem/sessionItem.module.less
@@ -247,6 +247,11 @@
   animation: chatStatusBreathe 1.6s ease-in-out infinite;
 }
 
+.statusDotUnseen {
+  background: rgba(20, 184, 166, 1);
+  box-shadow: 0 0 6px 1px rgba(20, 184, 166, 0.28);
+}
+
 .runningDot {
   display: inline-block;
   width: 6px;
@@ -254,6 +259,16 @@
   border-radius: 50%;
   background: #52c41a;
   animation: sidebarStatusBreathe 1.5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.unseenDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(20, 184, 166, 1);
+  box-shadow: 0 0 5px 1px rgba(20, 184, 166, 0.25);
   pointer-events: none;
 }
 

--- a/console/src/hooks/useSessionAttention.ts
+++ b/console/src/hooks/useSessionAttention.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useMemo } from "react";
+import {
+  hasUnseenCompletion,
+  useSessionAttentionStore,
+  type AttentionSession,
+} from "../stores/sessionAttentionStore";
+
+function matchesCurrentSession(
+  session: AttentionSession,
+  currentSessionId: string,
+): boolean {
+  return session.id === currentSessionId || session.realId === currentSessionId;
+}
+
+export function useSessionAttention(
+  agentId: string,
+  sessions: AttentionSession[],
+  currentSessionId: string | undefined,
+): ReadonlySet<string> {
+  const seenFinishedAt = useSessionAttentionStore(
+    (state) => state.seenFinishedAt,
+  );
+  const initializeSessions = useSessionAttentionStore(
+    (state) => state.initializeSessions,
+  );
+  const markSeen = useSessionAttentionStore((state) => state.markSeen);
+
+  useEffect(() => {
+    initializeSessions(agentId, sessions);
+  }, [agentId, initializeSessions, sessions]);
+
+  const markCurrentSeen = useCallback(() => {
+    if (!currentSessionId || document.visibilityState !== "visible") return;
+    const current = sessions.find((session) =>
+      matchesCurrentSession(session, currentSessionId),
+    );
+    if (current) markSeen(agentId, current);
+  }, [agentId, currentSessionId, markSeen, sessions]);
+
+  useEffect(() => {
+    markCurrentSeen();
+    document.addEventListener("visibilitychange", markCurrentSeen);
+    return () =>
+      document.removeEventListener("visibilitychange", markCurrentSeen);
+  }, [markCurrentSeen]);
+
+  return useMemo(() => {
+    const unseen = new Set<string>();
+    for (const session of sessions) {
+      const isVisibleCurrentSession =
+        !!currentSessionId &&
+        document.visibilityState === "visible" &&
+        matchesCurrentSession(session, currentSessionId);
+      if (hasUnseenCompletion(seenFinishedAt, agentId, session)) {
+        if (!isVisibleCurrentSession) unseen.add(session.id);
+      }
+    }
+    return unseen;
+  }, [agentId, currentSessionId, seenFinishedAt, sessions]);
+}

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -45,6 +45,8 @@ import {
 import { chatApi } from "../api/modules/chat";
 import type { ChatGroup } from "../api/types/chat";
 import { useAppMessage } from "../hooks/useAppMessage";
+import { useSessionAttention } from "../hooks/useSessionAttention";
+import { useAgentStore } from "../stores/agentStore";
 import styles from "./sidebarSessionList.module.less";
 
 /** Fixed height of each session item row */
@@ -74,6 +76,7 @@ type FlatRow =
 /** Data passed to each virtual row */
 interface VirtualRowData {
   flatRows: FlatRow[];
+  unseenSessionIds: ReadonlySet<string>;
   currentSessionId: string | undefined;
   editingSessionId: string | null;
   editValue: string;
@@ -189,6 +192,7 @@ const VirtualRow = React.memo(function VirtualRow({
           channelLabel={channelLabel}
           chatStatus={session.status}
           generating={session.generating}
+          unseenResult={data.unseenSessionIds.has(session.id)}
           archived={session.archived}
           pinned={session.pinned}
           source={session.source}
@@ -230,6 +234,7 @@ export default function SidebarSessionList({
 }: SidebarSessionListProps = {}) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
+  const selectedAgent = useAgentStore((state) => state.selectedAgent);
   const location = useLocation();
   const currentSessionId = getSessionIdFromPath(location.pathname) ?? undefined;
 
@@ -304,6 +309,12 @@ export default function SidebarSessionList({
     currentSessionId,
     onSessionClick,
   });
+
+  const unseenSessionIds = useSessionAttention(
+    selectedAgent,
+    sortedSessions,
+    currentSessionId,
+  );
 
   const handleMove = useCallback(
     async (sessionId: string, groupId: string, expandTarget = true) => {
@@ -537,6 +548,7 @@ export default function SidebarSessionList({
   const virtualListData = useMemo(
     () => ({
       flatRows,
+      unseenSessionIds,
       currentSessionId,
       editingSessionId,
       editValue,
@@ -559,6 +571,7 @@ export default function SidebarSessionList({
     }),
     [
       flatRows,
+      unseenSessionIds,
       currentSessionId,
       editingSessionId,
       editValue,

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3193,6 +3193,7 @@
     "unpinDrawer": "Unpin",
     "statusIdle": "Idle",
     "statusInProgress": "In progress",
+    "statusUnseenResult": "New result",
     "disclaimer": "Works for you, grows with you",
     "greeting": "Hello, how can I help you today?",
     "description": "I am a helpful assistant that can help you with your questions.",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3050,6 +3050,7 @@
     "unpinDrawer": "取消固定",
     "statusIdle": "空闲",
     "statusInProgress": "进行中",
+    "statusUnseenResult": "有新结果",
     "disclaimer": "懂你所需，伴你左右",
     "greeting": "你好，我今天能帮你做什么？",
     "description": "我是一个智能助手，可以帮助你解答问题。",

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -50,6 +50,7 @@ import {
   type ChatDateGroup,
 } from "../../../../utils/chatGroups";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
+import { useSessionAttention } from "../../../../hooks/useSessionAttention";
 import styles from "./index.module.less";
 import type { ChatGroup, ChatStatus } from "../../../../api/types/chat";
 
@@ -78,6 +79,7 @@ type FlatRow =
 /** Data passed to each virtual row */
 interface VirtualRowData {
   flatRows: FlatRow[];
+  unseenSessionIds: ReadonlySet<string>;
   currentSessionId: string | undefined;
   switchingSessionId: string | null;
   editingSessionId: string | null;
@@ -197,6 +199,7 @@ const VirtualRow = React.memo(function VirtualRow({
           channelLabel={channelLabel}
           chatStatus={session.status}
           generating={session.generating}
+          unseenResult={data.unseenSessionIds.has(session.id)}
           archived={session.archived}
           pinned={session.pinned}
           source={session.source}
@@ -234,6 +237,7 @@ interface ExtendedChatSession extends IAgentScopeRuntimeWebUISession {
   channel?: string;
   createdAt?: string | null;
   updatedAt?: string | null;
+  lastFinishedAt?: string | null;
   meta?: Record<string, unknown>;
   status?: ChatStatus;
   generating?: boolean;
@@ -421,6 +425,12 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         return bTime < aTime ? -1 : bTime > aTime ? 1 : 0;
       });
   }, [resolvedSessions]);
+
+  const unseenSessionIds = useSessionAttention(
+    selectedAgent,
+    sortedSessions as ExtendedChatSession[],
+    currentSessionId,
+  );
 
   /** Re-fetch session list from the backend and sync to context state */
   const refreshSessions = useCallback(async () => {
@@ -930,6 +940,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   const virtualListData = useMemo(
     () => ({
       flatRows,
+      unseenSessionIds,
       currentSessionId,
       switchingSessionId,
       editingSessionId,
@@ -953,6 +964,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     }),
     [
       flatRows,
+      unseenSessionIds,
       currentSessionId,
       switchingSessionId,
       editingSessionId,

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -34,6 +34,7 @@ function sessionsEqual(
       a.id !== b.id ||
       a.name !== b.name ||
       a.updatedAt !== b.updatedAt ||
+      a.lastFinishedAt !== b.lastFinishedAt ||
       a.pinned !== b.pinned ||
       a.generating !== b.generating ||
       a.status !== b.status ||
@@ -55,6 +56,7 @@ export interface ExtendedChatSession extends IAgentScopeRuntimeWebUISession {
   channel?: string;
   createdAt?: string | null;
   updatedAt?: string | null;
+  lastFinishedAt?: string | null;
   meta?: Record<string, unknown>;
   status?: ChatStatus;
   generating?: boolean;

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -119,6 +119,8 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   createdAt?: string | null;
   /** ISO 8601 last-updated timestamp from backend. */
   updatedAt?: string | null;
+  /** ISO 8601 completion time of the most recent task. */
+  lastFinishedAt?: string | null;
   /** Whether the backend is still generating a response for this session. */
   generating?: boolean;
   /** Whether the chat is pinned to the top. */
@@ -388,6 +390,7 @@ const chatSpecToSession = (chat: ChatSpec): ExtendedSession =>
     status: chat.status ?? "idle",
     createdAt: chat.created_at ?? null,
     updatedAt: chat.updated_at ?? null,
+    lastFinishedAt: chat.last_finished_at ?? null,
     pinned: chat.pinned ?? false,
     source: chat.source ?? "chat",
     groupId: chat.group_id ?? null,
@@ -1278,6 +1281,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         a.name !== b.name ||
         a.status !== b.status ||
         a.updatedAt !== b.updatedAt ||
+        a.lastFinishedAt !== b.lastFinishedAt ||
         a.createdAt !== b.createdAt ||
         a.pinned !== b.pinned ||
         a.generating !== b.generating ||

--- a/console/src/stores/sessionAttentionStore.test.ts
+++ b/console/src/stores/sessionAttentionStore.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  hasUnseenCompletion,
+  sessionAttentionKey,
+  useSessionAttentionStore,
+} from "./sessionAttentionStore";
+
+const session = {
+  id: "local-id",
+  realId: "chat-1",
+  lastFinishedAt: "2026-08-25T08:00:00.000Z",
+};
+
+describe("sessionAttentionStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSessionAttentionStore.setState({ seenFinishedAt: {} });
+  });
+
+  it("uses the backend id so local id remapping keeps the read marker", () => {
+    expect(sessionAttentionKey("agent-a", session)).toBe("agent-a:chat-1");
+  });
+
+  it("baselines existing completions without marking old history unseen", () => {
+    useSessionAttentionStore
+      .getState()
+      .initializeSessions("agent-a", [session]);
+
+    expect(
+      hasUnseenCompletion(
+        useSessionAttentionStore.getState().seenFinishedAt,
+        "agent-a",
+        session,
+      ),
+    ).toBe(false);
+  });
+
+  it("marks a newer completion unseen until the session is viewed", () => {
+    const store = useSessionAttentionStore.getState();
+    store.initializeSessions("agent-a", [session]);
+    const rerun = {
+      ...session,
+      lastFinishedAt: "2026-08-25T09:00:00.000Z",
+    };
+
+    expect(
+      hasUnseenCompletion(
+        useSessionAttentionStore.getState().seenFinishedAt,
+        "agent-a",
+        rerun,
+      ),
+    ).toBe(true);
+
+    useSessionAttentionStore.getState().markSeen("agent-a", rerun);
+    expect(
+      hasUnseenCompletion(
+        useSessionAttentionStore.getState().seenFinishedAt,
+        "agent-a",
+        rerun,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps read markers separate for each agent", () => {
+    useSessionAttentionStore
+      .getState()
+      .initializeSessions("agent-a", [session]);
+
+    expect(
+      hasUnseenCompletion(
+        useSessionAttentionStore.getState().seenFinishedAt,
+        "agent-b",
+        session,
+      ),
+    ).toBe(false);
+  });
+});

--- a/console/src/stores/sessionAttentionStore.ts
+++ b/console/src/stores/sessionAttentionStore.ts
@@ -1,0 +1,85 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const STORAGE_KEY = "qwenpaw-session-attention";
+
+export interface AttentionSession {
+  id: string;
+  realId?: string;
+  lastFinishedAt?: string | null;
+}
+
+interface SessionAttentionState {
+  seenFinishedAt: Record<string, string | null>;
+  initializeSessions: (agentId: string, sessions: AttentionSession[]) => void;
+  markSeen: (agentId: string, session: AttentionSession) => void;
+}
+
+export function sessionAttentionKey(
+  agentId: string,
+  session: AttentionSession,
+): string {
+  return `${agentId}:${session.realId || session.id}`;
+}
+
+export function hasUnseenCompletion(
+  seenFinishedAt: Record<string, string | null>,
+  agentId: string,
+  session: AttentionSession,
+): boolean {
+  if (!session.lastFinishedAt) return false;
+  const key = sessionAttentionKey(agentId, session);
+  if (!Object.prototype.hasOwnProperty.call(seenFinishedAt, key)) return false;
+  const seenAt = seenFinishedAt[key];
+  if (!seenAt) return true;
+  const finishedMs = Date.parse(session.lastFinishedAt);
+  const seenMs = Date.parse(seenAt);
+  return (
+    Number.isFinite(finishedMs) &&
+    Number.isFinite(seenMs) &&
+    finishedMs > seenMs
+  );
+}
+
+export const useSessionAttentionStore = create<SessionAttentionState>()(
+  persist(
+    (set) => ({
+      seenFinishedAt: {},
+
+      initializeSessions: (agentId, sessions) =>
+        set((state) => {
+          let changed = false;
+          const next = { ...state.seenFinishedAt };
+          for (const session of sessions) {
+            const key = sessionAttentionKey(agentId, session);
+            if (!Object.prototype.hasOwnProperty.call(next, key)) {
+              // Existing completions are the baseline when this feature first
+              // sees a session, so an upgrade does not mark all history unread.
+              next[key] = session.lastFinishedAt ?? null;
+              changed = true;
+            }
+          }
+          return changed ? { seenFinishedAt: next } : state;
+        }),
+
+      markSeen: (agentId, session) => {
+        if (!session.lastFinishedAt) return;
+        const key = sessionAttentionKey(agentId, session);
+        set((state) => {
+          if (state.seenFinishedAt[key] === session.lastFinishedAt)
+            return state;
+          return {
+            seenFinishedAt: {
+              ...state.seenFinishedAt,
+              [key]: session.lastFinishedAt ?? null,
+            },
+          };
+        });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      partialize: (state) => ({ seenFinishedAt: state.seenFinishedAt }),
+    },
+  ),
+);

--- a/console/src/stores/sessionListStore.ts
+++ b/console/src/stores/sessionListStore.ts
@@ -21,6 +21,7 @@ export interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   channel?: string;
   createdAt?: string | null;
   updatedAt?: string | null;
+  lastFinishedAt?: string | null;
   meta?: Record<string, unknown>;
   status?: string;
   generating?: boolean;

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -569,6 +569,7 @@ class BaseChannel(ABC):
             payload,
             self._stream_with_tracker,
             owner=self._workspace,
+            on_finished=self._workspace.chat_manager.mark_chat_finished,
         )
 
         if is_new:

--- a/src/qwenpaw/app/chats/manager.py
+++ b/src/qwenpaw/app/chats/manager.py
@@ -401,6 +401,30 @@ class ChatManager:  # pylint: disable=too-many-public-methods
         """Refresh updated_at without rewriting other chat fields."""
         return await self.patch_chat(chat_id, ChatUpdate())
 
+    async def mark_chat_finished(
+        self,
+        chat_id: str,
+        finished_at: datetime,
+    ) -> Optional[ChatSpec]:
+        """Persist the newest task completion marker for one chat."""
+        async with self._lock:
+            existing = await self._repo.get_chat(chat_id)
+            if existing is None:
+                return None
+            if (
+                existing.last_finished_at is not None
+                and existing.last_finished_at >= finished_at
+            ):
+                return existing
+            updated = existing.model_copy(
+                update={
+                    "last_finished_at": finished_at,
+                    "updated_at": max(existing.updated_at, finished_at),
+                },
+            )
+            await self._repo.upsert_chat(updated)
+            return updated
+
     async def set_project_dir(
         self,
         chat_id: str,

--- a/src/qwenpaw/app/chats/models.py
+++ b/src/qwenpaw/app/chats/models.py
@@ -119,6 +119,10 @@ class ChatSpec(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="Chat last update timestamp",
     )
+    last_finished_at: Optional[datetime] = Field(
+        default=None,
+        description="When the most recent task for this chat finished",
+    )
     meta: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional metadata",

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -436,6 +436,7 @@ async def post_console_chat(
             native_payload,
             console_channel.stream_one,
             owner=workspace,
+            on_finished=workspace.chat_manager.mark_chat_finished,
         )
 
     async def event_generator() -> AsyncGenerator[str, None]:

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -13,7 +13,14 @@ import logging
 import weakref
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Callable, Coroutine, Optional
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Optional,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +256,7 @@ class TaskTracker:
         payload: Any,
         stream_fn: Callable[..., Coroutine],
         owner: object | None = None,
+        on_finished: Callable[[str, datetime], Awaitable[Any]] | None = None,
     ) -> tuple[asyncio.Queue, bool]:
         """Attach to an existing run or start a new one.
 
@@ -309,6 +317,14 @@ class TaskTracker:
                                 q.put_nowait(err_sse)
                 finally:
                     finish_time = datetime.now(timezone.utc)
+                    if on_finished is not None:
+                        try:
+                            await on_finished(run_key, finish_time)
+                        except Exception:  # pylint: disable=broad-except
+                            logger.exception(
+                                "run completion callback failed run_key=%s",
+                                run_key,
+                            )
                     tracker = tracker_ref()
                     if tracker is not None:
                         async with tracker.lock:

--- a/tests/unit/app/chats/test_manager.py
+++ b/tests/unit/app/chats/test_manager.py
@@ -403,6 +403,23 @@ async def test_touch_chat_refreshes_updated_at(manager: ChatManager):
     assert touched.updated_at >= before
 
 
+@pytest.mark.asyncio
+async def test_mark_chat_finished_persists_newest_completion(
+    manager: ChatManager,
+):
+    spec = await manager.create_chat(_make_spec())
+    first = spec.updated_at.replace(microsecond=100)
+    second = spec.updated_at.replace(microsecond=200)
+
+    marked = await manager.mark_chat_finished(spec.id, second)
+    stale = await manager.mark_chat_finished(spec.id, first)
+
+    assert marked is not None
+    assert marked.last_finished_at == second
+    assert stale is not None
+    assert stale.last_finished_at == second
+
+
 # ---------------------------------------------------------------------------
 # delete
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/chats/test_models.py
+++ b/tests/unit/app/chats/test_models.py
@@ -46,6 +46,7 @@ def test_chat_spec_default_values():
     assert spec.pinned is False
     assert spec.source == SessionSource.chat
     assert spec.status == "idle"
+    assert spec.last_finished_at is None
     assert spec.meta == {}
     assert spec.group_id is None
     assert spec.parent_session_id is None

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -132,6 +132,28 @@ async def test_attach_or_start_streams_events_and_marks_completion():
 
 
 @pytest.mark.asyncio
+async def test_attach_or_start_reports_completion_before_becoming_idle():
+    tracker = TaskTracker()
+    completions = []
+
+    async def on_finished(run_key, finished_at):
+        completions.append((run_key, finished_at))
+        assert await tracker.get_status(run_key) == "running"
+
+    queue, _ = await tracker.attach_or_start(
+        "run-with-callback",
+        payload=None,
+        stream_fn=_make_stream([]),
+        on_finished=on_finished,
+    )
+    assert await asyncio.wait_for(queue.get(), timeout=1) is None
+
+    assert len(completions) == 1
+    assert completions[0][0] == "run-with-callback"
+    assert await tracker.get_status("run-with-callback") == "idle"
+
+
+@pytest.mark.asyncio
 async def test_attach_or_start_existing_run_returns_buffer_replay():
     tracker = TaskTracker()
     started = asyncio.Event()


### PR DESCRIPTION
## Description

Adds a completion attention indicator for chat sessions.

When a task finishes:

- The indicator becomes gray if the user is viewing that session.
- The indicator becomes a solid teal dot if the user is viewing another session.
- Opening the completed session marks the result as viewed.
- Running tasks continue to use the animated indicator.

The backend now records each session's latest task completion time. The Console stores the latest viewed completion time per agent and session. Existing sessions are treated as viewed during initial migration to avoid marking old history as unread.

<img width="348" height="179" alt="image" src="https://github.com/user-attachments/assets/116d5d4e-7903-48e1-b8cc-0a59fef31d40" />


**Related Issue:** #7263 

**Security Considerations:** No security-sensitive behavior, authentication, or configuration changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

Not applicable: this change does not modify a channel implementation or channel contract.

## Testing

The following scenarios are covered:

1. A running session displays an animated indicator.
2. A completed session displays a solid indicator when its result has not been viewed.
3. Opening the session marks the latest result as viewed.
4. A session completing while currently visible remains in the viewed state.
5. Read markers are isolated by agent and backend session ID.
6. Existing sessions are initialized as viewed.
7. Task completion times are persisted by the backend.
8. Older completion timestamps cannot overwrite newer timestamps.

## Evidence
