### PR TITLE
fix(providers): sanitize DashScope tool schemas for strict models

### DIFF
--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -21,6 +21,7 @@ from pydantic import Field
 from .provider import ModelInfo
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .capping_formatter import _CappingDashScopeFormatter
+from .openai_chat_model_compat import _sanitize_tool_schemas
 from .openai_provider import (
     CODING_DASHSCOPE_BASE_URL,
     DASHSCOPE_BASE_URLS,
@@ -293,6 +294,11 @@ class _DashScopeChatModelCompat:
     base ``_call_api``, so the ``is not None`` guard in
     ``DashScopeChatModel._call_api`` skips emitting ``enable_thinking``
     and the DashScope API uses its own model-level default.
+
+    ``_format_tools`` applies the shared OpenAI-compat schema sanitizer
+    so strict models served through DashScope (e.g. kimi-k3) do not
+    reject nullable ``anyOf`` / empty JSON Schema branches generated
+    from ``Optional[...]`` tool annotations.
     """
 
     def __new__(cls, **kwargs: Any) -> Any:
@@ -309,6 +315,11 @@ class _DashScopeChatModelCompat:
             _qp_default_headers = default_headers
             _qp_thinking_explicit = thinking_explicitly_set
             _qp_extra_generate_kwargs = extra_generate_kwargs or {}
+
+            def _format_tools(self, tools, tool_choice):
+                if tools:
+                    tools = _sanitize_tool_schemas(tools)
+                return super()._format_tools(tools, tool_choice)
 
             async def _call_api(
                 self,

--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -21,7 +21,7 @@ from pydantic import Field
 from .provider import ModelInfo
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .capping_formatter import _CappingDashScopeFormatter
-from .openai_chat_model_compat import _sanitize_tool_schemas
+from .openai_chat_model_compat import _sanitize_nullable_tool_schemas
 from .openai_provider import (
     CODING_DASHSCOPE_BASE_URL,
     DASHSCOPE_BASE_URLS,
@@ -295,10 +295,10 @@ class _DashScopeChatModelCompat:
     ``DashScopeChatModel._call_api`` skips emitting ``enable_thinking``
     and the DashScope API uses its own model-level default.
 
-    ``_format_tools`` applies the shared OpenAI-compat schema sanitizer
+    ``_format_tools`` applies only nullable / empty-schema normalization
     so strict models served through DashScope (e.g. kimi-k3) do not
-    reject nullable ``anyOf`` / empty JSON Schema branches generated
-    from ``Optional[...]`` tool annotations.
+    reject ``Optional[...]`` unions.  It does not inline ``$ref`` /
+    ``$defs`` or run the rest of the OpenAI-compat schema pipeline.
     """
 
     def __new__(cls, **kwargs: Any) -> Any:
@@ -318,7 +318,7 @@ class _DashScopeChatModelCompat:
 
             def _format_tools(self, tools, tool_choice):
                 if tools:
-                    tools = _sanitize_tool_schemas(tools)
+                    tools = _sanitize_nullable_tool_schemas(tools)
                 return super()._format_tools(tools, tool_choice)
 
             async def _call_api(

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -589,6 +589,55 @@ def _expand_pattern_fields(schema: Any) -> Any:
     return result
 
 
+def _map_tool_parameters(
+    tools: list[dict[str, Any]],
+    transform: Callable[[dict[str, Any]], Any],
+) -> list[dict[str, Any]]:
+    """Apply *transform* to each tool's ``function.parameters`` object."""
+    sanitized = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            sanitized.append(tool)
+            continue
+        func = tool.get("function")
+        if not isinstance(func, dict):
+            sanitized.append(tool)
+            continue
+        params = func.get("parameters")
+        if not isinstance(params, dict):
+            sanitized.append(tool)
+            continue
+        sanitized.append(
+            {
+                **tool,
+                "function": {**func, "parameters": transform(params)},
+            },
+        )
+    return sanitized
+
+
+def _sanitize_nullable_tool_schemas(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize nullable / empty tool-parameter branches only.
+
+    Unlike :func:`_sanitize_tool_schemas`, this pass does not inline
+    ``$ref`` / ``$defs``, rewrite boolean schemas, or expand regex
+    shorthands.  Use it on providers that only reject ``Optional`` unions.
+    """
+    return _map_tool_parameters(tools, _sanitize_nullable_schemas)
+
+
+def _apply_openai_compat_schema_passes(params: dict[str, Any]) -> Any:
+    return _expand_pattern_fields(
+        _sanitize_nullable_schemas(
+            _sanitize_boolean_schemas(
+                _expand_schema_refs(params),
+            ),
+        ),
+    )
+
+
 def _sanitize_tool_schemas(
     tools: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -609,30 +658,7 @@ def _sanitize_tool_schemas(
        classes (``[0-9]``, ``[a-zA-Z0-9_]``, etc.).  llama.cpp's GBNF grammar
        parser does not support these escape sequences (#6201).
     """
-    sanitized = []
-    for tool in tools:
-        if not isinstance(tool, dict):
-            sanitized.append(tool)
-            continue
-        func = tool.get("function")
-        if not isinstance(func, dict):
-            sanitized.append(tool)
-            continue
-        params = func.get("parameters")
-        if not isinstance(params, dict):
-            sanitized.append(tool)
-            continue
-        sanitized_params = _expand_pattern_fields(
-            _sanitize_nullable_schemas(
-                _sanitize_boolean_schemas(
-                    _expand_schema_refs(params),
-                ),
-            ),
-        )
-        sanitized.append(
-            {**tool, "function": {**func, "parameters": sanitized_params}},
-        )
-    return sanitized
+    return _map_tool_parameters(tools, _apply_openai_compat_schema_passes)
 
 
 class OpenAIChatModelCompat(OpenAIChatModel):

--- a/tests/unit/providers/test_dashscope_tool_schema_compat.py
+++ b/tests/unit/providers/test_dashscope_tool_schema_compat.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""DashScope must sanitize tool schemas before they leave the client.
+
+Strict models served through DashScope (e.g. kimi-k3) reject nullable
+``anyOf`` / empty JSON Schema branches that AgentScope generates from
+``Optional[...]`` annotations.  OpenAI / Gemini already run
+``_sanitize_tool_schemas``; this file guards the DashScope native path
+that previously forwarded the raw toolkit schemas.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from agentscope.tool import Toolkit
+
+from qwenpaw.agents.tools.file_io import read_file
+from qwenpaw.agents.tools.file_search import grep_search
+from qwenpaw.agents.tools.shell import execute_shell_command
+from qwenpaw.governance import PolicyGuardedTool
+from qwenpaw.providers.dashscope_provider import DashScopeProvider
+
+
+def _type_null_paths(node: Any, path: tuple[str, ...] = ()) -> list[str]:
+    paths: list[str] = []
+    if isinstance(node, dict):
+        node_type = node.get("type")
+        if node_type == "null" or (
+            isinstance(node_type, list) and "null" in node_type
+        ):
+            paths.append(".".join(path + ("type",)))
+        for key, value in node.items():
+            paths.extend(_type_null_paths(value, path + (str(key),)))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            paths.extend(_type_null_paths(value, path + (str(index),)))
+    return paths
+
+
+def _schema_by_name(
+    schemas: list[dict[str, Any]],
+    name: str,
+) -> dict[str, Any]:
+    for schema in schemas:
+        function = schema.get("function", {})
+        if function.get("name") == name:
+            return function["parameters"]
+    raise AssertionError(f"missing tool schema: {name}")
+
+
+def _make_dashscope_model():
+    provider = DashScopeProvider(
+        id="dashscope",
+        name="DashScope",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        api_key="sk-test",
+    )
+    return provider.get_chat_model_instance("kimi-k3")
+
+
+def test_format_tools_strips_nullable_union_branches() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "execute_shell_command",
+                "description": "Run a command",
+                "parameters": {
+                    "type": "object",
+                    "required": ["command"],
+                    "properties": {
+                        "command": {"type": "string"},
+                        "cwd": {
+                            "anyOf": [
+                                {"type": "string", "format": "path"},
+                                {"type": "null"},
+                            ],
+                            "default": None,
+                        },
+                        "sandbox_config": {
+                            "anyOf": [
+                                {},
+                                {"type": "null"},
+                            ],
+                            "default": None,
+                        },
+                    },
+                },
+            },
+        },
+    ]
+
+    formatted, tool_choice = _make_dashscope_model()._format_tools(
+        tools,
+        None,
+    )
+
+    assert tool_choice is None
+    assert formatted is not None
+    assert not _type_null_paths(formatted)
+
+    properties = formatted[0]["function"]["parameters"]["properties"]
+    assert properties["cwd"] == {
+        "type": "string",
+        "format": "path",
+        "default": None,
+    }
+    assert properties["sandbox_config"] == {
+        "type": "object",
+        "default": None,
+    }
+    assert "anyOf" not in properties["cwd"]
+    assert "anyOf" not in properties["sandbox_config"]
+    # Source schemas stay intact so AgentScope's local validator still
+    # accepts omitted / null optional arguments.
+    source_function = tools[0]["function"]
+    assert isinstance(source_function, dict)
+    source_cwd = source_function["parameters"]["properties"]["cwd"]
+    assert isinstance(source_cwd, dict)
+    assert "anyOf" in source_cwd
+
+
+def test_format_tools_sanitizes_builtin_tool_schemas() -> None:
+    raw_schemas = asyncio.run(
+        Toolkit(
+            tools=[
+                PolicyGuardedTool(
+                    execute_shell_command,
+                    governor=None,
+                    request_context={},
+                ),
+                PolicyGuardedTool(
+                    read_file,
+                    governor=None,
+                    request_context={},
+                ),
+                PolicyGuardedTool(
+                    grep_search,
+                    governor=None,
+                    request_context={},
+                ),
+            ],
+        ).get_tool_schemas(),
+    )
+
+    formatted, _ = _make_dashscope_model()._format_tools(raw_schemas, None)
+
+    assert formatted is not None
+    assert not _type_null_paths(formatted)
+
+    cwd = _schema_by_name(formatted, "execute_shell_command")["properties"][
+        "cwd"
+    ]
+    assert cwd["type"] == "string"
+    assert "anyOf" not in cwd
+
+    sandbox = _schema_by_name(formatted, "execute_shell_command")[
+        "properties"
+    ]["sandbox_config"]
+    assert sandbox["type"] == "object"
+    assert "anyOf" not in sandbox
+
+    path = _schema_by_name(formatted, "grep_search")["properties"]["path"]
+    assert path["type"] == "string"
+    assert "anyOf" not in path
+
+
+def test_format_tools_passes_through_missing_tools() -> None:
+    formatted, tool_choice = _make_dashscope_model()._format_tools(
+        None,
+        None,
+    )
+    assert formatted is None
+    assert tool_choice is None

--- a/tests/unit/providers/test_dashscope_tool_schema_compat.py
+++ b/tests/unit/providers/test_dashscope_tool_schema_compat.py
@@ -4,13 +4,14 @@
 
 Strict models served through DashScope (e.g. kimi-k3) reject nullable
 ``anyOf`` / empty JSON Schema branches that AgentScope generates from
-``Optional[...]`` annotations.  OpenAI / Gemini already run
-``_sanitize_tool_schemas``; this file guards the DashScope native path
-that previously forwarded the raw toolkit schemas.
+``Optional[...]`` annotations.  The native DashScope path applies only
+that nullable pass; OpenAI uses the broader ``_sanitize_tool_schemas``
+pipeline, and Gemini has its own normalizer.
 """
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from agentscope.tool import Toolkit
@@ -173,3 +174,54 @@ def test_format_tools_passes_through_missing_tools() -> None:
     )
     assert formatted is None
     assert tool_choice is None
+
+
+def _shared_ref_parameters(depth: int) -> dict[str, Any]:
+    """Build a linearly sized schema whose shared refs form a binary tree.
+
+    Inlining every ``$ref`` would duplicate both children at each level
+    and grow exponentially with *depth*.  DashScope must keep the shared
+    references instead.
+    """
+    defs: dict[str, Any] = {"N0": {"type": "string"}}
+    for index in range(1, depth + 1):
+        previous = f"N{index - 1}"
+        defs[f"N{index}"] = {
+            "type": "object",
+            "properties": {
+                "left": {"$ref": f"#/$defs/{previous}"},
+                "right": {"$ref": f"#/$defs/{previous}"},
+            },
+        }
+    return {
+        "type": "object",
+        "properties": {"root": {"$ref": f"#/$defs/N{depth}"}},
+        "$defs": defs,
+    }
+
+
+def test_format_tools_keeps_shared_refs_bounded() -> None:
+    depth = 16
+    parameters = _shared_ref_parameters(depth)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo",
+                "description": "Shared-ref schema",
+                "parameters": parameters,
+            },
+        },
+    ]
+
+    formatted, _ = _make_dashscope_model()._format_tools(tools, None)
+
+    assert formatted is not None
+    formatted_params = formatted[0]["function"]["parameters"]
+    assert formatted_params["properties"]["root"] == {
+        "$ref": f"#/$defs/N{depth}",
+    }
+    assert set(formatted_params["$defs"]) == set(parameters["$defs"])
+    assert len(json.dumps(formatted_params, sort_keys=True)) <= 2 * len(
+        json.dumps(parameters, sort_keys=True),
+    )


### PR DESCRIPTION
## Description

DashScope's native chat path forwarded AgentScope-generated tool schemas unchanged. Optional tool parameters such as `cwd: Optional[Path]` and `sandbox_config: Optional[Any]` are emitted as nullable `anyOf` unions (including empty `{}` branches). Strict models served through DashScope (for example kimi-k3) reject that shape with a wrapped `400 invalid_parameter_error`, so agent turns that include the default tool list fail immediately. Qwen models on the same provider accept the same payload, which made the failure look model-specific rather than schema-related.

This PR applies the existing `_sanitize_tool_schemas` helper in `_DashScopeChatModelCompat._format_tools`, matching the OpenAI and Gemini request paths. Nullable unions are reduced to the non-null type, empty schemas become `{type: object}`, and optionality remains expressed by omitting the field from `required`. Source toolkit schemas are left intact so local validation is unchanged.

**Security Considerations:** Not applicable. This change only rewrites outbound tool JSON Schema for provider compatibility. It does not touch authentication, credentials, or request authorization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Configure the DashScope provider and select a strict model such as kimi-k3.
2. Start a new agent session (empty history is enough) and send any message that ships the default builtin tool list.
3. Confirm the request is no longer rejected with `400 invalid_parameter_error` / `Invalid request parameters`.
4. Switch the same session back to a Qwen model and confirm tool calling still works.
5. Unit coverage: `tests/unit/providers/test_dashscope_tool_schema_compat.py` asserts that DashScope `_format_tools` strips `{type: null}` / empty-schema unions from both a synthetic `cwd` / `sandbox_config` schema and real builtin tool schemas (`execute_shell_command`, `read_file`, `grep_search`).

## Additional Notes

Residual non-null unions such as `read_file`'s `start_line: int | str` (`anyOf: [integer, string]`) are intentionally left unchanged. The reproduced 400 was triggered by nullable / empty `anyOf` branches. If a strict model still rejects leftover non-null unions after this ships, that can be handled as a follow-up sanitizer pass rather than widening this fix.