### PR TITLE
fix(console): reject conflicting chat payloads

### DIFF
--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -431,13 +431,31 @@ async def post_console_chat(
                     placeholder_name=name,
                 ),
             )
-        queue, _ = await tracker.attach_or_start(
+        queue, is_new_run = await tracker.attach_or_start(
             chat.id,
             native_payload,
             console_channel.stream_one,
             owner=workspace,
             on_finished=workspace.chat_manager.mark_chat_finished,
         )
+        if not is_new_run:
+            # attach_or_start returns a replay subscriber when this chat is
+            # already running. That is valid only for explicit reconnects;
+            # accepting a new payload here would acknowledge a message that
+            # will never be passed to stream_one.
+            await tracker.detach_subscriber(chat.id, queue)
+            logger.warning(
+                "Rejecting console chat payload for active run: chat_id=%s",
+                chat.id,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "CHAT_RUN_CONFLICT",
+                    "message": "A run is already active for this chat.",
+                    "chat_id": chat.id,
+                },
+            )
 
     async def event_generator() -> AsyncGenerator[str, None]:
         # Hold iterator so finally can aclose(); guarantees stream_from_queue's

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -16,7 +16,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from qwenpaw.app.routers.console import _extract_session_and_payload
@@ -178,3 +178,82 @@ async def test_reconnect_with_active_run_replays_buffer_and_marker(
     assert payload == {"type": "replay_end"}
     # No fresh run was started by the reconnect.
     assert console_workspace.console_channel.stream_calls == []
+
+
+@pytest.mark.asyncio
+async def test_new_payload_conflicts_instead_of_attaching_to_active_run(
+    app,
+    console_workspace,
+):
+    """A second send must not masquerade as a stream reconnect.
+
+    The payload passed to ``attach_or_start`` is ignored when the run already
+    exists. Returning that run's stream with HTTP 200 therefore acknowledges a
+    user message that will never execute.
+    """
+    from starlette.requests import Request
+    from qwenpaw.app.routers.console import post_console_chat
+
+    tracker = console_workspace.task_tracker
+    started = asyncio.Event()
+    release = asyncio.Event()
+    original_payload = object()
+
+    async def slow_stream(payload):
+        assert payload is original_payload
+        started.set()
+        await release.wait()
+        yield "data: original-finished\n\n"
+
+    original_queue, _ = await tracker.attach_or_start(
+        "chat-1",
+        original_payload,
+        slow_stream,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/api/console/chat",
+            "headers": [],
+            "app": app,
+        },
+    )
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await post_console_chat(
+                request_data={
+                    "session_id": "console:default",
+                    "user_id": "default",
+                    "channel": "console",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "second payload"},
+                            ],
+                        },
+                    ],
+                },
+                request=request,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == {
+            "code": "CHAT_RUN_CONFLICT",
+            "message": "A run is already active for this chat.",
+            "chat_id": "chat-1",
+        }
+        assert await tracker.get_status("chat-1") == "running"
+        async with tracker.lock:
+            # Rejecting the send must not retain the temporary replay queue.
+            assert tracker._runs["chat-1"].queues == [original_queue]
+        # The conflicting payload must not start another producer.
+        assert console_workspace.console_channel.stream_calls == []
+    finally:
+        release.set()
+        async for _ in tracker.stream_from_queue(original_queue, "chat-1"):
+            pass


### PR DESCRIPTION
## Description

A second non-reconnect `POST /api/console/chat` for a chat with an active run currently receives HTTP 200 and the existing SSE stream. However, `TaskTracker.attach_or_start()` does not execute the newly supplied payload in that path. The API therefore acknowledges a user message that is silently discarded.

This PR makes the admission contract fail closed:

- Explicit `reconnect=true` requests retain the existing replay/attach behavior.
- A normal payload uses the atomic `is_new_run` result from `TaskTracker`.
- If a run is already active, the temporary replay subscriber is detached and the endpoint returns HTTP 409 with `CHAT_RUN_CONFLICT` and the affected `chat_id`.
- A warning makes the rejected admission visible in server logs.

The regression test holds an original run open and proves that the conflicting payload receives 409, never invokes a second producer, does not cancel the original run, and does not leak a subscriber queue.

**Related Issue:** Relates to #6273

**Security Considerations:** No direct data exposure. This prevents silent input loss and false success acknowledgements at the agent execution boundary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed: existing `reconnect=true` contract is unchanged)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh --changed` and it passes (`No channel changes detected`)
- [ ] Contract test exists in `tests/contract/channels/test_<channel>_contract.py` (not applicable: no channel implementation changed)
- [ ] Contract test implements `create_instance()` (not applicable)
- [ ] All 19 contract verification points pass (not applicable)
- [x] Unit regression covers the Console router admission behavior

## Testing

1. Start a run for a Console chat and hold its producer open.
2. Submit a second ordinary payload for the same chat.
3. Verify HTTP 409 with `CHAT_RUN_CONFLICT`, while the first run remains active.
4. Verify the second payload does not reach `stream_one` and its temporary replay queue is detached.
5. Verify explicit reconnect tests continue to pass.

## Evidence

Fail-before on unmodified production code:

```text
$ uv run pytest tests/unit/app/routers/test_console_chat_reconnect.py -q
...F
FAILED ...::test_new_payload_conflicts_instead_of_attaching_to_active_run
E Failed: DID NOT RAISE HTTPException
1 failed, 3 passed in 5.16s
```

Pass-after, including TaskTracker coverage:

```text
$ uv run pytest tests/unit/app/test_task_tracker.py tests/unit/app/routers/test_console_chat_reconnect.py -q
.....................
21 passed in 1.46s
```

Full repository pre-commit gate:

```text
$ SKIP=prettier,actionlint pre-commit run --all-files
check python ast.........................................................Passed
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier................................................................Skipped
Lint GitHub Actions workflow files......................................Skipped
```

`prettier` and `actionlint` are unrelated to the two Python files in this PR; their local hook environments could not be installed because of the host npm policy and a GitHub binary download timeout. The Python checks ran across all repository files.

A full `pytest -q -x` smoke run reached `292 passed, 8 skipped` before stopping at the first browser integration test because the local Playwright Chromium executable is not installed. The failing test is `tests/integration/browser/test_browser_tool_e2e.py::test_browser_tool_drives_a_real_page` and is unrelated to this change.

## Additional Notes

This is intentionally scoped to the regular Console endpoint. It does not claim to solve the broader cross-entry-point execution registry described in #6273.