### PR TITLE
Fix/stale chat project dirs

### DIFF
--- a/console/src/api/request.test.ts
+++ b/console/src/api/request.test.ts
@@ -111,7 +111,10 @@ describe("request", () => {
 
   it("calls clearAuthToken and redirects to /login on 401", async () => {
     mockFetch(401);
-    await expect(request("/models")).rejects.toThrow("Not authenticated");
+    const error = await request("/models").catch((err) => err);
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(401);
+    expect((error as ApiError).message).toBe("Not authenticated");
     expect(clearAuthToken).toHaveBeenCalledOnce();
     expect(window.location.href).toBe("/login?redirect=%2Fchat");
   });

--- a/console/src/api/request.test.ts
+++ b/console/src/api/request.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { request } from "./request";
+import { ApiError, isApiErrorWithStatus, request } from "./request";
 
 // mock config so URL is predictable and token is empty by default
 vi.mock("./config", () => ({
@@ -143,6 +143,30 @@ describe("request", () => {
     } as unknown as Response);
 
     await expect(request("/models")).rejects.toThrow("server exploded");
+  });
+
+  // Callers that treat one status as an expected outcome (a 404 on a
+  // chat-scoped endpoint means the chat is not theirs) branch on the status
+  // rather than matching the message text.
+  it("carries the response status on the thrown error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      headers: { get: () => "application/json" },
+      text: () => Promise.resolve('{"detail":"Chat not found"}'),
+    } as unknown as Response);
+
+    const error = await request("/chats/gone/project-dirs").catch((err) => err);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(404);
+    expect(isApiErrorWithStatus(error, 404)).toBe(true);
+    expect(isApiErrorWithStatus(error, 500)).toBe(false);
+    // The message keeps the shape message-based handling already relies on.
+    expect((error as ApiError).message).toBe(
+      'Chat not found - {"detail":"Chat not found"}',
+    );
   });
 
   it("injects Authorization header when token is present", async () => {

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -153,7 +153,7 @@ export async function request<T = unknown>(
           if (!isLoginPath(window.location.pathname)) {
             window.location.href = getLoginHref(window.location);
           }
-          throw new Error("Not authenticated");
+          throw new ApiError(response.status, "Not authenticated");
         }
 
         const text = await response.text().catch(() => "");

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -37,6 +37,33 @@ function getErrorMessageFromBody(
   return text;
 }
 
+/**
+ * A non-2xx response, carrying the status alongside the message.
+ *
+ * Callers that treat a specific status as an expected outcome — a 404 on a
+ * chat-scoped endpoint means "this chat is not ours (any more)", not a
+ * failure — can branch on `status` instead of matching on the message text.
+ * The message keeps the exact shape the plain `Error` used, so existing
+ * message-based handling and `parseErrorDetail()` are unaffected.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/** True for an `ApiError` with the given status. */
+export function isApiErrorWithStatus(
+  error: unknown,
+  status: number,
+): error is ApiError {
+  return error instanceof ApiError && error.status === status;
+}
+
 function buildHeaders(method?: string, extra?: HeadersInit): Headers {
   // Normalize extra to a Headers instance for consistent handling
   const headers = extra instanceof Headers ? extra : new Headers(extra);
@@ -138,7 +165,7 @@ export async function request<T = unknown>(
           ? `${errorMessage} - ${text}`
           : `Request failed: ${response.status} ${response.statusText}`;
 
-        throw new Error(finalMessage);
+        throw new ApiError(response.status, finalMessage);
       }
 
       if (response.status === 204) {

--- a/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../api/request";
 import FilesNavigator from "./FilesNavigator";
@@ -12,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   listDirectory: vi.fn(),
   listFiles: vi.fn(),
   setSystemPromptFiles: vi.fn(),
-  chatNotFound: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -83,7 +81,6 @@ function renderNavigator() {
       onShowMemoryGraph={vi.fn()}
       onShowFiles={vi.fn()}
       scope={{ kind: "agent", agentId: "default" }}
-      onChatNotFound={vi.fn()}
     />,
   );
 }
@@ -145,53 +142,37 @@ describe("FilesNavigator system prompt interactions", () => {
     ).toBeInTheDocument();
   });
 
-  it("reloads the agent default tree when the chat is missing", async () => {
-    mocks.getChatProjectDirectory.mockRejectedValue(
-      new ApiError(404, "Chat not found"),
+  it("uses the agent directory directly for a new conversation", async () => {
+    mocks.listDirectory.mockResolvedValue({
+      entries: [
+        {
+          name: "agent-default.txt",
+          path: "agent-default.txt",
+          kind: "file",
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    render(
+      <FilesNavigator
+        selectedPath=""
+        onSelect={vi.fn()}
+        activeMemoryGraphRoot={null}
+        onShowMemoryGraph={vi.fn()}
+        onShowFiles={vi.fn()}
+        scope={{
+          kind: "session",
+          agentId: "default",
+          sessionId: "new",
+        }}
+      />,
     );
-    mocks.listDirectory.mockImplementation((_path, _cursor, _limit, chatId) =>
-      chatId
-        ? Promise.reject(new ApiError(404, "Chat not found"))
-        : Promise.resolve({
-            entries: [
-              {
-                name: "fallback.txt",
-                path: "fallback.txt",
-                kind: "file",
-              },
-            ],
-            next_cursor: null,
-            has_more: false,
-          }),
-    );
 
-    function Harness() {
-      const [chatId, setChatId] = useState<string | undefined>("gone");
-      return (
-        <FilesNavigator
-          selectedPath=""
-          onSelect={vi.fn()}
-          activeMemoryGraphRoot={null}
-          onShowMemoryGraph={vi.fn()}
-          onShowFiles={vi.fn()}
-          scope={{
-            kind: "session",
-            agentId: "default",
-            sessionId: "s1",
-            chatId,
-          }}
-          onChatNotFound={(missingChatId) => {
-            mocks.chatNotFound(missingChatId);
-            setChatId(undefined);
-          }}
-        />
-      );
-    }
-
-    render(<Harness />);
-
-    expect(await screen.findByText("fallback.txt")).toBeInTheDocument();
-    expect(mocks.chatNotFound).toHaveBeenCalledWith("gone");
+    expect(await screen.findByText("agent-default.txt")).toBeInTheDocument();
+    expect(mocks.getChatProjectDirectory).not.toHaveBeenCalled();
+    expect(mocks.getChatProjectDirs).not.toHaveBeenCalled();
     expect(mocks.listDirectory).toHaveBeenCalledWith(
       "",
       undefined,

--- a/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
@@ -1,13 +1,18 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/request";
 import FilesNavigator from "./FilesNavigator";
 
 const mocks = vi.hoisted(() => ({
   getProjectDirectory: vi.fn(),
+  getChatProjectDirectory: vi.fn(),
+  getChatProjectDirs: vi.fn(),
   getSystemPromptFiles: vi.fn(),
   listDirectory: vi.fn(),
   listFiles: vi.fn(),
   setSystemPromptFiles: vi.fn(),
+  chatNotFound: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -41,6 +46,13 @@ vi.mock("../../api/modules/projectDirectory", () => ({
   projectDirectoryApi: { get: mocks.getProjectDirectory },
 }));
 
+vi.mock("../../api/modules/chatProjectDirectory", () => ({
+  chatProjectDirectoryApi: {
+    get: mocks.getChatProjectDirectory,
+    getProjectDirs: mocks.getChatProjectDirs,
+  },
+}));
+
 vi.mock("../../stores/codingTabsStore", () => ({
   useCodingTabsStore: {
     getState: () => ({
@@ -71,6 +83,7 @@ function renderNavigator() {
       onShowMemoryGraph={vi.fn()}
       onShowFiles={vi.fn()}
       scope={{ kind: "agent", agentId: "default" }}
+      onChatNotFound={vi.fn()}
     />,
   );
 }
@@ -85,6 +98,7 @@ describe("FilesNavigator system prompt interactions", () => {
     mocks.getProjectDirectory.mockResolvedValue({
       path: "/project",
       workspace_dir: "/workspace",
+      is_workspace_default: false,
     });
     mocks.listDirectory.mockResolvedValue({
       entries: [],
@@ -92,6 +106,8 @@ describe("FilesNavigator system prompt interactions", () => {
       has_more: false,
     });
     mocks.setSystemPromptFiles.mockImplementation(async (files) => files);
+    mocks.listFiles.mockResolvedValue([]);
+    mocks.getSystemPromptFiles.mockResolvedValue([]);
   });
 
   it("can add a custom prompt again after disabling it", async () => {
@@ -127,5 +143,70 @@ describe("FilesNavigator system prompt interactions", () => {
     expect(
       await screen.findByRole("switch", { name: "Toggle custom.md" }),
     ).toBeInTheDocument();
+  });
+
+  it("reloads the agent default tree when the chat is missing", async () => {
+    mocks.getChatProjectDirectory.mockRejectedValue(
+      new ApiError(404, "Chat not found"),
+    );
+    mocks.listDirectory.mockImplementation((_path, _cursor, _limit, chatId) =>
+      chatId
+        ? Promise.reject(new ApiError(404, "Chat not found"))
+        : Promise.resolve({
+            entries: [
+              {
+                name: "fallback.txt",
+                path: "fallback.txt",
+                kind: "file",
+              },
+            ],
+            next_cursor: null,
+            has_more: false,
+          }),
+    );
+
+    function Harness() {
+      const [chatId, setChatId] = useState<string | undefined>("gone");
+      return (
+        <FilesNavigator
+          selectedPath=""
+          onSelect={vi.fn()}
+          activeMemoryGraphRoot={null}
+          onShowMemoryGraph={vi.fn()}
+          onShowFiles={vi.fn()}
+          scope={{
+            kind: "session",
+            agentId: "default",
+            sessionId: "s1",
+            chatId,
+          }}
+          onChatNotFound={(missingChatId) => {
+            mocks.chatNotFound(missingChatId);
+            setChatId(undefined);
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("fallback.txt")).toBeInTheDocument();
+    expect(mocks.chatNotFound).toHaveBeenCalledWith("gone");
+    expect(mocks.listDirectory).toHaveBeenCalledWith(
+      "",
+      undefined,
+      200,
+      undefined,
+      "project",
+      undefined,
+    );
+  });
+
+  it("shows unexpected tree failures inside the navigator", async () => {
+    mocks.listDirectory.mockRejectedValue(new ApiError(500, "tree exploded"));
+
+    renderNavigator();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("tree exploded");
   });
 });

--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  CircleAlert,
   Folder,
   FolderOpen,
   GripVertical,
@@ -199,14 +200,7 @@ function DirectoryNode({
         setLoading(false);
       }
     },
-    [
-      chatId,
-      entry.path,
-      onChatNotFound,
-      onError,
-      projectDirOverride,
-      root,
-    ],
+    [chatId, entry.path, onChatNotFound, onError, projectDirOverride, root],
   );
 
   const toggle = () => {
@@ -770,11 +764,7 @@ export default function FilesNavigator({
 
   useEffect(() => {
     let active = true;
-    void Promise.all([
-      loadDirectoryIdentity(),
-      loadRoot(),
-      loadProfile(),
-    ])
+    void Promise.all([loadDirectoryIdentity(), loadRoot(), loadProfile()])
       .then(() => {
         if (active) setNavigatorError(null);
       })
@@ -804,12 +794,10 @@ export default function FilesNavigator({
       source === "profile"
         ? loadProfile()
         : source === "daily" || source === "digest"
-          ? loadMemory(source)
-          : null;
+        ? loadMemory(source)
+        : null;
     if (!task) return;
-    void task
-      .then(() => setNavigatorError(null))
-      .catch(reportNavigatorError);
+    void task.then(() => setNavigatorError(null)).catch(reportNavigatorError);
   }, [loadMemory, loadProfile, reportNavigatorError, source]);
 
   const refreshCurrent = async () => {
@@ -823,6 +811,29 @@ export default function FilesNavigator({
       }
       setNavigatorError(null);
     } catch (error) {
+      reportNavigatorError(error);
+    }
+  };
+
+  const loadMoreRoot = async () => {
+    try {
+      const page = await workspaceApi.listDirectory(
+        "",
+        cursor ?? undefined,
+        200,
+        chatId,
+        workspaceRoot,
+        projectDirOverride,
+      );
+      setEntries((current) => [...current, ...page.entries]);
+      setCursor(page.next_cursor);
+      setHasMore(page.has_more);
+      setNavigatorError(null);
+    } catch (error) {
+      if (chatId && isApiErrorWithStatus(error, 404)) {
+        handleChatNotFound(chatId);
+        return;
+      }
       reportNavigatorError(error);
     }
   };
@@ -850,7 +861,7 @@ export default function FilesNavigator({
         setConflictingNames(error.files);
         return;
       }
-      throw error;
+      reportNavigatorError(error);
     } finally {
       setUploading(false);
     }
@@ -936,7 +947,7 @@ export default function FilesNavigator({
                   beforeChange={confirmDirectoryChange}
                   onChanged={() => {
                     handleDirectoryChanged();
-                    void loadDirectoryIdentity();
+                    void loadDirectoryIdentity().catch(reportNavigatorError);
                   }}
                 />
               )}
@@ -1043,6 +1054,12 @@ export default function FilesNavigator({
           strategy={verticalListSortingStrategy}
         >
           <div className={styles.tree} role="tree" aria-busy={loading}>
+            {navigatorError && (
+              <div className={styles.loadError} role="alert">
+                <CircleAlert size={15} />
+                <span>{navigatorError}</span>
+              </div>
+            )}
             {source === "profile" && (
               <button
                 type="button"
@@ -1085,6 +1102,8 @@ export default function FilesNavigator({
                       selectedPath={selectedPath}
                       onSelect={onSelect}
                       root={workspaceRoot}
+                      onChatNotFound={handleChatNotFound}
+                      onError={reportNavigatorError}
                     />
                   );
                 }
@@ -1126,26 +1145,14 @@ export default function FilesNavigator({
                 );
               })
             )}
-            {!loading && displayEntries.length === 0 && (
+            {!loading && !navigatorError && displayEntries.length === 0 && (
               <div className={styles.empty}>{t("files.sourceEmpty")}</div>
             )}
             {source === "workspace" && hasMore && (
               <button
                 type="button"
                 className={styles.loadMore}
-                onClick={async () => {
-                  const page = await workspaceApi.listDirectory(
-                    "",
-                    cursor ?? undefined,
-                    200,
-                    chatId,
-                    workspaceRoot,
-                    projectDirOverride,
-                  );
-                  setEntries((current) => [...current, ...page.entries]);
-                  setCursor(page.next_cursor);
-                  setHasMore(page.has_more);
-                }}
+                onClick={() => void loadMoreRoot()}
               >
                 {t("files.loadMore")}
               </button>

--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -36,6 +36,7 @@ import {
   type ProjectDirEntry,
 } from "../../api/modules/chatProjectDirectory";
 import { projectDirectoryApi } from "../../api/modules/projectDirectory";
+import { isApiErrorWithStatus } from "../../api/request";
 import { useCodingTabsStore } from "../../stores/codingTabsStore";
 import SessionProjectDirectory from "../project-directory/SessionProjectDirectory";
 import { getPendingProjectDirectory } from "../project-directory/pendingProjectDirectory";
@@ -615,11 +616,19 @@ export default function FilesNavigator({
 
   const loadDirectoryIdentity = useCallback(async () => {
     const agentInfo = await projectDirectoryApi.get();
-    const effectiveProject = projectDirOverride
-      ? projectDirOverride
-      : chatId
-      ? (await chatProjectDirectoryApi.get(chatId)).project_dir
-      : agentInfo.path;
+    let effectiveProject = projectDirOverride || agentInfo.path;
+    if (!projectDirOverride && chatId) {
+      try {
+        effectiveProject = (await chatProjectDirectoryApi.get(chatId))
+          .project_dir;
+      } catch (err) {
+        // A chat id outlives its ownership (it stays put across an agent
+        // switch, and survives a deletion made elsewhere), and chat endpoints
+        // are scoped to the agent of the request. The agent default is the
+        // right answer for the agent now in view.
+        if (!isApiErrorWithStatus(err, 404)) throw err;
+      }
+    }
     setProjectDirectory(effectiveProject);
     setWorkspaceDirectory(agentInfo.workspace_dir ?? agentInfo.path);
     if (scopeKind !== "session") {
@@ -703,7 +712,14 @@ export default function FilesNavigator({
   }, []);
 
   useEffect(() => {
-    void Promise.all([loadDirectoryIdentity(), loadRoot(), loadProfile()]);
+    // Each loader owns its own degraded state, so a failure here has nothing
+    // left to handle — swallowing it keeps a stale chat id from turning into
+    // a page error.
+    void Promise.all([
+      loadDirectoryIdentity(),
+      loadRoot(),
+      loadProfile(),
+    ]).catch(() => {});
   }, [loadDirectoryIdentity, loadProfile, loadRoot]);
 
   // Keep the viewed root one the switcher actually offers. Covers both the

--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -37,7 +37,6 @@ import {
   type ProjectDirEntry,
 } from "../../api/modules/chatProjectDirectory";
 import { projectDirectoryApi } from "../../api/modules/projectDirectory";
-import { isApiErrorWithStatus } from "../../api/request";
 import { useCodingTabsStore } from "../../stores/codingTabsStore";
 import SessionProjectDirectory from "../project-directory/SessionProjectDirectory";
 import { getPendingProjectDirectory } from "../project-directory/pendingProjectDirectory";
@@ -74,7 +73,6 @@ interface DirectoryNodeProps {
   onSelect: (target: FileTarget) => void;
   depth: number;
   root: WorkspaceRoot;
-  onChatNotFound: (chatId: string) => void;
   onError: (error: unknown) => void;
 }
 
@@ -163,7 +161,6 @@ function DirectoryNode({
   onSelect,
   depth,
   root,
-  onChatNotFound,
   onError,
 }: DirectoryNodeProps) {
   const { t } = useTranslation();
@@ -191,16 +188,12 @@ function DirectoryNode({
         setCursor(page.next_cursor);
         setHasMore(page.has_more);
       } catch (error) {
-        if (chatId && isApiErrorWithStatus(error, 404)) {
-          onChatNotFound(chatId);
-          return;
-        }
         onError(error);
       } finally {
         setLoading(false);
       }
     },
-    [chatId, entry.path, onChatNotFound, onError, projectDirOverride, root],
+    [chatId, entry.path, onError, projectDirOverride, root],
   );
 
   const toggle = () => {
@@ -234,7 +227,6 @@ function DirectoryNode({
               selectedPath={selectedPath}
               onSelect={onSelect}
               root={root}
-              onChatNotFound={onChatNotFound}
               onError={onError}
             />
           ) : (
@@ -372,7 +364,6 @@ interface FilesNavigatorProps {
   onShowMemoryGraph: (root: MemoryGraphRoot) => void;
   onShowFiles: () => void;
   scope: FilesWorkspaceScope;
-  onChatNotFound: (chatId: string) => void;
 }
 
 export default function FilesNavigator({
@@ -382,7 +373,6 @@ export default function FilesNavigator({
   onShowMemoryGraph,
   onShowFiles,
   scope,
-  onChatNotFound,
 }: FilesNavigatorProps) {
   const { t } = useTranslation();
   const chatId = scope.kind === "session" ? scope.chatId : undefined;
@@ -434,17 +424,6 @@ export default function FilesNavigator({
   const reportNavigatorError = useCallback((error: unknown) => {
     setNavigatorError(error instanceof Error ? error.message : String(error));
   }, []);
-  const handleChatNotFound = useCallback(
-    (missingChatId: string) => {
-      if (!chatId || missingChatId !== chatId) return;
-      setEntries([]);
-      setCursor(null);
-      setHasMore(false);
-      setNavigatorError(null);
-      onChatNotFound(missingChatId);
-    },
-    [chatId, onChatNotFound],
-  );
 
   useEffect(() => {
     setPendingProjectDir(initialProjectDirOverride);
@@ -647,22 +626,11 @@ export default function FilesNavigator({
 
   const loadDirectoryIdentity = useCallback(async () => {
     const agentInfo = await projectDirectoryApi.get();
-    let effectiveProject = projectDirOverride || agentInfo.path;
-    let directoryChatId = chatId;
-    if (!projectDirOverride && chatId) {
-      try {
-        effectiveProject = (await chatProjectDirectoryApi.get(chatId))
-          .project_dir;
-      } catch (err) {
-        // A chat id outlives its ownership (it stays put across an agent
-        // switch, and survives a deletion made elsewhere), and chat endpoints
-        // are scoped to the agent of the request. The agent default is the
-        // right answer for the agent now in view.
-        if (!isApiErrorWithStatus(err, 404)) throw err;
-        directoryChatId = undefined;
-        handleChatNotFound(chatId);
-      }
-    }
+    const effectiveProject = projectDirOverride
+      ? projectDirOverride
+      : chatId
+      ? (await chatProjectDirectoryApi.get(chatId)).project_dir
+      : agentInfo.path;
     setProjectDirectory(effectiveProject);
     setWorkspaceDirectory(agentInfo.workspace_dir ?? agentInfo.path);
     if (scopeKind !== "session") {
@@ -671,25 +639,14 @@ export default function FilesNavigator({
       return;
     }
     try {
-      const snapshot = await loadSessionProjectDirs(
-        agentId,
-        sessionId,
-        directoryChatId,
-      );
+      const snapshot = await loadSessionProjectDirs(agentId, sessionId, chatId);
       setBoundDirs(snapshot.dirs);
     } catch {
       // Fall back to the single directory above rather than blanking the
       // switcher: the tree itself is still perfectly usable.
       setBoundDirs([]);
     }
-  }, [
-    agentId,
-    chatId,
-    handleChatNotFound,
-    projectDirOverride,
-    scopeKind,
-    sessionId,
-  ]);
+  }, [agentId, chatId, projectDirOverride, scopeKind, sessionId]);
 
   const loadRoot = useCallback(async () => {
     setLoading(true);
@@ -705,16 +662,10 @@ export default function FilesNavigator({
       setEntries(page.entries);
       setCursor(page.next_cursor);
       setHasMore(page.has_more);
-    } catch (error) {
-      if (chatId && isApiErrorWithStatus(error, 404)) {
-        handleChatNotFound(chatId);
-        return;
-      }
-      throw error;
     } finally {
       setLoading(false);
     }
-  }, [chatId, handleChatNotFound, projectDirOverride, workspaceRoot]);
+  }, [chatId, projectDirOverride, workspaceRoot]);
 
   const loadProfile = useCallback(async () => {
     setLoading(true);
@@ -830,10 +781,6 @@ export default function FilesNavigator({
       setHasMore(page.has_more);
       setNavigatorError(null);
     } catch (error) {
-      if (chatId && isApiErrorWithStatus(error, 404)) {
-        handleChatNotFound(chatId);
-        return;
-      }
       reportNavigatorError(error);
     }
   };
@@ -1102,7 +1049,6 @@ export default function FilesNavigator({
                       selectedPath={selectedPath}
                       onSelect={onSelect}
                       root={workspaceRoot}
-                      onChatNotFound={handleChatNotFound}
                       onError={reportNavigatorError}
                     />
                   );

--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -73,6 +73,8 @@ interface DirectoryNodeProps {
   onSelect: (target: FileTarget) => void;
   depth: number;
   root: WorkspaceRoot;
+  onChatNotFound: (chatId: string) => void;
+  onError: (error: unknown) => void;
 }
 
 interface ProfileFileRowProps {
@@ -160,6 +162,8 @@ function DirectoryNode({
   onSelect,
   depth,
   root,
+  onChatNotFound,
+  onError,
 }: DirectoryNodeProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -185,11 +189,24 @@ function DirectoryNode({
         );
         setCursor(page.next_cursor);
         setHasMore(page.has_more);
+      } catch (error) {
+        if (chatId && isApiErrorWithStatus(error, 404)) {
+          onChatNotFound(chatId);
+          return;
+        }
+        onError(error);
       } finally {
         setLoading(false);
       }
     },
-    [chatId, entry.path, projectDirOverride, root],
+    [
+      chatId,
+      entry.path,
+      onChatNotFound,
+      onError,
+      projectDirOverride,
+      root,
+    ],
   );
 
   const toggle = () => {
@@ -223,6 +240,8 @@ function DirectoryNode({
               selectedPath={selectedPath}
               onSelect={onSelect}
               root={root}
+              onChatNotFound={onChatNotFound}
+              onError={onError}
             />
           ) : (
             <button
@@ -359,6 +378,7 @@ interface FilesNavigatorProps {
   onShowMemoryGraph: (root: MemoryGraphRoot) => void;
   onShowFiles: () => void;
   scope: FilesWorkspaceScope;
+  onChatNotFound: (chatId: string) => void;
 }
 
 export default function FilesNavigator({
@@ -368,6 +388,7 @@ export default function FilesNavigator({
   onShowMemoryGraph,
   onShowFiles,
   scope,
+  onChatNotFound,
 }: FilesNavigatorProps) {
   const { t } = useTranslation();
   const chatId = scope.kind === "session" ? scope.chatId : undefined;
@@ -410,9 +431,25 @@ export default function FilesNavigator({
   const [boundDirs, setBoundDirs] = useState<ProjectDirEntry[]>([]);
   // Opens the binding panel from the switcher's "manage directories" item.
   const [managingDirs, setManagingDirs] = useState(false);
+  const [navigatorError, setNavigatorError] = useState<string | null>(null);
   const uploadRef = useRef<HTMLInputElement>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const reportNavigatorError = useCallback((error: unknown) => {
+    setNavigatorError(error instanceof Error ? error.message : String(error));
+  }, []);
+  const handleChatNotFound = useCallback(
+    (missingChatId: string) => {
+      if (!chatId || missingChatId !== chatId) return;
+      setEntries([]);
+      setCursor(null);
+      setHasMore(false);
+      setNavigatorError(null);
+      onChatNotFound(missingChatId);
+    },
+    [chatId, onChatNotFound],
   );
 
   useEffect(() => {
@@ -617,6 +654,7 @@ export default function FilesNavigator({
   const loadDirectoryIdentity = useCallback(async () => {
     const agentInfo = await projectDirectoryApi.get();
     let effectiveProject = projectDirOverride || agentInfo.path;
+    let directoryChatId = chatId;
     if (!projectDirOverride && chatId) {
       try {
         effectiveProject = (await chatProjectDirectoryApi.get(chatId))
@@ -627,6 +665,8 @@ export default function FilesNavigator({
         // are scoped to the agent of the request. The agent default is the
         // right answer for the agent now in view.
         if (!isApiErrorWithStatus(err, 404)) throw err;
+        directoryChatId = undefined;
+        handleChatNotFound(chatId);
       }
     }
     setProjectDirectory(effectiveProject);
@@ -637,14 +677,25 @@ export default function FilesNavigator({
       return;
     }
     try {
-      const snapshot = await loadSessionProjectDirs(agentId, sessionId, chatId);
+      const snapshot = await loadSessionProjectDirs(
+        agentId,
+        sessionId,
+        directoryChatId,
+      );
       setBoundDirs(snapshot.dirs);
     } catch {
       // Fall back to the single directory above rather than blanking the
       // switcher: the tree itself is still perfectly usable.
       setBoundDirs([]);
     }
-  }, [agentId, chatId, projectDirOverride, scopeKind, sessionId]);
+  }, [
+    agentId,
+    chatId,
+    handleChatNotFound,
+    projectDirOverride,
+    scopeKind,
+    sessionId,
+  ]);
 
   const loadRoot = useCallback(async () => {
     setLoading(true);
@@ -660,10 +711,16 @@ export default function FilesNavigator({
       setEntries(page.entries);
       setCursor(page.next_cursor);
       setHasMore(page.has_more);
+    } catch (error) {
+      if (chatId && isApiErrorWithStatus(error, 404)) {
+        handleChatNotFound(chatId);
+        return;
+      }
+      throw error;
     } finally {
       setLoading(false);
     }
-  }, [chatId, projectDirOverride, workspaceRoot]);
+  }, [chatId, handleChatNotFound, projectDirOverride, workspaceRoot]);
 
   const loadProfile = useCallback(async () => {
     setLoading(true);
@@ -712,15 +769,22 @@ export default function FilesNavigator({
   }, []);
 
   useEffect(() => {
-    // Each loader owns its own degraded state, so a failure here has nothing
-    // left to handle — swallowing it keeps a stale chat id from turning into
-    // a page error.
+    let active = true;
     void Promise.all([
       loadDirectoryIdentity(),
       loadRoot(),
       loadProfile(),
-    ]).catch(() => {});
-  }, [loadDirectoryIdentity, loadProfile, loadRoot]);
+    ])
+      .then(() => {
+        if (active) setNavigatorError(null);
+      })
+      .catch((error) => {
+        if (active) reportNavigatorError(error);
+      });
+    return () => {
+      active = false;
+    };
+  }, [loadDirectoryIdentity, loadProfile, loadRoot, reportNavigatorError]);
 
   // Keep the viewed root one the switcher actually offers. Covers both the
   // primary-is-the-workspace case (where "project" is never offered) and a
@@ -736,20 +800,31 @@ export default function FilesNavigator({
   }, [roots, workspaceRoot]);
 
   useEffect(() => {
-    if (source === "profile") void loadProfile();
-    if (source === "daily" || source === "digest") void loadMemory(source);
-  }, [loadMemory, loadProfile, source]);
+    const task =
+      source === "profile"
+        ? loadProfile()
+        : source === "daily" || source === "digest"
+          ? loadMemory(source)
+          : null;
+    if (!task) return;
+    void task
+      .then(() => setNavigatorError(null))
+      .catch(reportNavigatorError);
+  }, [loadMemory, loadProfile, reportNavigatorError, source]);
 
   const refreshCurrent = async () => {
-    if (source === "daily" || source === "digest") {
-      await loadMemory(source);
-      return;
+    try {
+      if (source === "daily" || source === "digest") {
+        await loadMemory(source);
+      } else if (source === "profile") {
+        await loadProfile();
+      } else {
+        await loadRoot();
+      }
+      setNavigatorError(null);
+    } catch (error) {
+      reportNavigatorError(error);
     }
-    if (source === "profile") {
-      await loadProfile();
-      return;
-    }
-    await loadRoot();
   };
 
   const runUpload = async (

--- a/console/src/features/files-workspace/FilesWorkspace.test.tsx
+++ b/console/src/features/files-workspace/FilesWorkspace.test.tsx
@@ -14,6 +14,12 @@ const lifecycle = vi.hoisted(() => ({
   navigatorProps: null as {
     onShowMemoryGraph: (root: "wiki" | "procedure" | "personal") => void;
     onShowFiles: () => void;
+    onChatNotFound: (chatId: string) => void;
+    scope: {
+      kind: "agent" | "session";
+      agentId: string;
+      chatId?: string;
+    };
   } | null,
   memoryGraphProps: null as {
     onOpenFile: (section: "daily" | "digest", path: string) => void;
@@ -64,6 +70,12 @@ vi.mock("./FilesNavigator", () => ({
   default: function MockFilesNavigator(props: {
     onShowMemoryGraph: (root: "wiki" | "procedure" | "personal") => void;
     onShowFiles: () => void;
+    onChatNotFound: (chatId: string) => void;
+    scope: {
+      kind: "agent" | "session";
+      agentId: string;
+      chatId?: string;
+    };
   }) {
     lifecycle.navigatorProps = props;
     useEffect(() => {
@@ -138,6 +150,29 @@ describe("FilesWorkspace directory changes", () => {
     expect(lifecycle.navigatorMounted).toHaveBeenCalledTimes(2);
     expect(lifecycle.editorUnmounted).toHaveBeenCalledTimes(1);
     expect(lifecycle.editorMounted).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a missing chat from the effective file scope", async () => {
+    render(
+      <FilesWorkspace
+        scope={{
+          kind: "session",
+          agentId: "agent-a",
+          sessionId: "session-a",
+          chatId: "chat-a",
+        }}
+      />,
+    );
+
+    expect(lifecycle.navigatorProps?.scope.chatId).toBe("chat-a");
+    act(() => lifecycle.navigatorProps?.onChatNotFound("chat-a"));
+
+    await waitFor(() => {
+      expect(lifecycle.navigatorProps?.scope.chatId).toBeUndefined();
+    });
+    expect(lifecycle.clearProjectTabs).toHaveBeenCalledWith(
+      "session:agent-a:session-a",
+    );
   });
 
   it("saves with the loaded ETag and stores the returned version", async () => {

--- a/console/src/features/files-workspace/FilesWorkspace.test.tsx
+++ b/console/src/features/files-workspace/FilesWorkspace.test.tsx
@@ -14,7 +14,6 @@ const lifecycle = vi.hoisted(() => ({
   navigatorProps: null as {
     onShowMemoryGraph: (root: "wiki" | "procedure" | "personal") => void;
     onShowFiles: () => void;
-    onChatNotFound: (chatId: string) => void;
     scope: {
       kind: "agent" | "session";
       agentId: string;
@@ -70,7 +69,6 @@ vi.mock("./FilesNavigator", () => ({
   default: function MockFilesNavigator(props: {
     onShowMemoryGraph: (root: "wiki" | "procedure" | "personal") => void;
     onShowFiles: () => void;
-    onChatNotFound: (chatId: string) => void;
     scope: {
       kind: "agent" | "session";
       agentId: string;
@@ -150,29 +148,6 @@ describe("FilesWorkspace directory changes", () => {
     expect(lifecycle.navigatorMounted).toHaveBeenCalledTimes(2);
     expect(lifecycle.editorUnmounted).toHaveBeenCalledTimes(1);
     expect(lifecycle.editorMounted).toHaveBeenCalledTimes(2);
-  });
-
-  it("drops a missing chat from the effective file scope", async () => {
-    render(
-      <FilesWorkspace
-        scope={{
-          kind: "session",
-          agentId: "agent-a",
-          sessionId: "session-a",
-          chatId: "chat-a",
-        }}
-      />,
-    );
-
-    expect(lifecycle.navigatorProps?.scope.chatId).toBe("chat-a");
-    act(() => lifecycle.navigatorProps?.onChatNotFound("chat-a"));
-
-    await waitFor(() => {
-      expect(lifecycle.navigatorProps?.scope.chatId).toBeUndefined();
-    });
-    expect(lifecycle.clearProjectTabs).toHaveBeenCalledWith(
-      "session:agent-a:session-a",
-    );
   });
 
   it("saves with the loaded ETag and stores the returned version", async () => {

--- a/console/src/features/files-workspace/FilesWorkspace.tsx
+++ b/console/src/features/files-workspace/FilesWorkspace.tsx
@@ -68,6 +68,9 @@ export default function FilesWorkspace({
     scopeKey: string;
     chatId: string;
   } | null>(null);
+  const activeChatScopeRef = useRef({ scopeKey, chatId });
+  activeChatScopeRef.current = { scopeKey, chatId };
+  const missingChatScopeRef = useRef(missingChatScope);
   const effectiveChatId =
     missingChatScope?.scopeKey === scopeKey &&
     missingChatScope.chatId === chatId
@@ -120,11 +123,20 @@ export default function FilesWorkspace({
 
   const handleChatNotFound = useCallback(
     (missingChatId: string) => {
-      if (!chatId || missingChatId !== chatId) return;
-      clearProjectTabs(scopeKey);
-      setMissingChatScope({ scopeKey, chatId: missingChatId });
+      const current = activeChatScopeRef.current;
+      if (!current.chatId || missingChatId !== current.chatId) return;
+      if (
+        missingChatScopeRef.current?.scopeKey === current.scopeKey &&
+        missingChatScopeRef.current.chatId === missingChatId
+      ) {
+        return;
+      }
+      const missing = { scopeKey: current.scopeKey, chatId: missingChatId };
+      missingChatScopeRef.current = missing;
+      clearProjectTabs(current.scopeKey);
+      setMissingChatScope(missing);
     },
-    [chatId, clearProjectTabs, scopeKey],
+    [clearProjectTabs],
   );
 
   useEffect(
@@ -214,13 +226,7 @@ export default function FilesWorkspace({
       }
       return target;
     },
-    [
-      agentId,
-      effectiveChatId,
-      projectDirOverride,
-      scopeKind,
-      sessionId,
-    ],
+    [agentId, effectiveChatId, projectDirOverride, scopeKind, sessionId],
   );
 
   const loadTarget = useCallback(

--- a/console/src/features/files-workspace/FilesWorkspace.tsx
+++ b/console/src/features/files-workspace/FilesWorkspace.tsx
@@ -64,18 +64,6 @@ export default function FilesWorkspace({
   const { codingMode } = useCodingMode();
   const scopeKey = filesWorkspaceScopeKey(scope);
   const chatId = scope.kind === "session" ? scope.chatId : undefined;
-  const [missingChatScope, setMissingChatScope] = useState<{
-    scopeKey: string;
-    chatId: string;
-  } | null>(null);
-  const activeChatScopeRef = useRef({ scopeKey, chatId });
-  activeChatScopeRef.current = { scopeKey, chatId };
-  const missingChatScopeRef = useRef(missingChatScope);
-  const effectiveChatId =
-    missingChatScope?.scopeKey === scopeKey &&
-    missingChatScope.chatId === chatId
-      ? undefined
-      : chatId;
   // Primitives rather than `scope`: the object is rebuilt by the parent on
   // every render, and callbacks keyed on it feed effects that would then
   // refetch and re-activate the initial tab on unrelated re-renders.
@@ -89,9 +77,7 @@ export default function FilesWorkspace({
         undefined
       : undefined;
   const effectiveScope: FilesWorkspaceScope =
-    scope.kind === "session"
-      ? { ...scope, chatId: effectiveChatId, projectDirOverride }
-      : scope;
+    scope.kind === "session" ? { ...scope, projectDirOverride } : scope;
   const tabs = useTabsForScope(scopeKey);
   const activeTabPath = useActiveTabPathForScope(scopeKey);
   const {
@@ -121,24 +107,6 @@ export default function FilesWorkspace({
     sequence: number;
   } | null>(null);
 
-  const handleChatNotFound = useCallback(
-    (missingChatId: string) => {
-      const current = activeChatScopeRef.current;
-      if (!current.chatId || missingChatId !== current.chatId) return;
-      if (
-        missingChatScopeRef.current?.scopeKey === current.scopeKey &&
-        missingChatScopeRef.current.chatId === missingChatId
-      ) {
-        return;
-      }
-      const missing = { scopeKey: current.scopeKey, chatId: missingChatId };
-      missingChatScopeRef.current = missing;
-      clearProjectTabs(current.scopeKey);
-      setMissingChatScope(missing);
-    },
-    [clearProjectTabs],
-  );
-
   useEffect(
     () =>
       listenForProjectDirectoryChanges((changedScopeKey) => {
@@ -163,13 +131,7 @@ export default function FilesWorkspace({
         // a file in an extra root stuck as a read-only historical artifact.
         const boundDirs =
           scopeKind === "session"
-            ? (
-                await loadSessionProjectDirs(
-                  agentId,
-                  sessionId,
-                  effectiveChatId,
-                )
-              ).dirs
+            ? (await loadSessionProjectDirs(agentId, sessionId, chatId)).dirs
             : [
                 {
                   path: agentInfo.path,
@@ -207,7 +169,7 @@ export default function FilesWorkspace({
           try {
             await workspaceApi.getFileMetadata(
               candidate.path,
-              effectiveChatId,
+              chatId,
               candidate.root,
               projectDirOverride,
             );
@@ -226,7 +188,7 @@ export default function FilesWorkspace({
       }
       return target;
     },
-    [agentId, effectiveChatId, projectDirOverride, scopeKind, sessionId],
+    [agentId, chatId, projectDirOverride, scopeKind, sessionId],
   );
 
   const loadTarget = useCallback(
@@ -262,7 +224,7 @@ export default function FilesWorkspace({
       if (target.source === "workspace") {
         const metadata = await workspaceApi.getFileMetadata(
           target.path,
-          effectiveChatId,
+          chatId,
           target.root,
           projectDirOverride,
         );
@@ -271,7 +233,7 @@ export default function FilesWorkspace({
         const loaded = isText
           ? await workspaceApi.loadFileText(
               target.path,
-              effectiveChatId,
+              chatId,
               target.root,
               projectDirOverride,
             )
@@ -304,7 +266,7 @@ export default function FilesWorkspace({
         etag: response.headers.get("ETag") ?? "",
       };
     },
-    [effectiveChatId, projectDirOverride],
+    [chatId, projectDirOverride],
   );
 
   const loadTabContent = useCallback(
@@ -390,10 +352,10 @@ export default function FilesWorkspace({
   }, [scopeKey]);
 
   useEffect(() => {
-    if (!effectiveChatId && projectDirOverride) {
+    if (!chatId && projectDirOverride) {
       setActivity("files");
     }
-  }, [effectiveChatId, projectDirOverride]);
+  }, [chatId, projectDirOverride]);
 
   useEffect(() => {
     tabs.forEach((tab) => {
@@ -448,7 +410,7 @@ export default function FilesWorkspace({
           >
             <Files size={18} />
           </button>
-          {effectiveChatId || !projectDirOverride ? (
+          {chatId || !projectDirOverride ? (
             <button
               type="button"
               className={activity === "git" ? styles.activityActive : ""}
@@ -462,11 +424,10 @@ export default function FilesWorkspace({
       )}
       {activity === "files" || !codingMode ? (
         <FilesNavigator
-          key={`${scopeKey}:${effectiveChatId ?? ""}:${
+          key={`${scopeKey}:${chatId ?? ""}:${
             projectDirOverride ?? ""
           }:${directoryRevision}`}
           scope={effectiveScope}
-          onChatNotFound={handleChatNotFound}
           selectedPath={
             tabs.find((tab) => tab.path === activeTabPath)?.displayPath ??
             activeTabPath
@@ -485,7 +446,7 @@ export default function FilesWorkspace({
             <GitBranch size={15} />
             <span>{t("files.sourceControl")}</span>
           </header>
-          <GitPanel chatId={effectiveChatId} />
+          <GitPanel chatId={chatId} />
         </aside>
       )}
       <main className={styles.documentSurface}>
@@ -520,7 +481,7 @@ export default function FilesWorkspace({
               setTabContent(scopeKey, path, content)
             }
             onLoadFile={loadTabContent}
-            chatId={effectiveChatId}
+            chatId={chatId}
             projectDirOverride={projectDirOverride}
             navigation={editorNavigation}
             onDownloadFile={async (path) => {
@@ -547,10 +508,8 @@ export default function FilesWorkspace({
                   {
                     headers: {
                       ...buildAuthHeaders(),
-                      ...(effectiveChatId
-                        ? { "X-Chat-Id": effectiveChatId }
-                        : {}),
-                      ...(!effectiveChatId && projectDirOverride
+                      ...(chatId ? { "X-Chat-Id": chatId } : {}),
+                      ...(!chatId && projectDirOverride
                         ? {
                             "X-Session-Project-Dir": projectDirOverride,
                           }
@@ -579,7 +538,7 @@ export default function FilesWorkspace({
                   tab?.displayPath ?? path,
                   content,
                   tab?.etag,
-                  effectiveChatId,
+                  chatId,
                   tab?.workspaceRoot,
                   projectDirOverride,
                 );

--- a/console/src/features/files-workspace/FilesWorkspace.tsx
+++ b/console/src/features/files-workspace/FilesWorkspace.tsx
@@ -64,6 +64,15 @@ export default function FilesWorkspace({
   const { codingMode } = useCodingMode();
   const scopeKey = filesWorkspaceScopeKey(scope);
   const chatId = scope.kind === "session" ? scope.chatId : undefined;
+  const [missingChatScope, setMissingChatScope] = useState<{
+    scopeKey: string;
+    chatId: string;
+  } | null>(null);
+  const effectiveChatId =
+    missingChatScope?.scopeKey === scopeKey &&
+    missingChatScope.chatId === chatId
+      ? undefined
+      : chatId;
   // Primitives rather than `scope`: the object is rebuilt by the parent on
   // every render, and callbacks keyed on it feed effects that would then
   // refetch and re-activate the initial tab on unrelated re-renders.
@@ -77,7 +86,9 @@ export default function FilesWorkspace({
         undefined
       : undefined;
   const effectiveScope: FilesWorkspaceScope =
-    scope.kind === "session" ? { ...scope, projectDirOverride } : scope;
+    scope.kind === "session"
+      ? { ...scope, chatId: effectiveChatId, projectDirOverride }
+      : scope;
   const tabs = useTabsForScope(scopeKey);
   const activeTabPath = useActiveTabPathForScope(scopeKey);
   const {
@@ -107,6 +118,15 @@ export default function FilesWorkspace({
     sequence: number;
   } | null>(null);
 
+  const handleChatNotFound = useCallback(
+    (missingChatId: string) => {
+      if (!chatId || missingChatId !== chatId) return;
+      clearProjectTabs(scopeKey);
+      setMissingChatScope({ scopeKey, chatId: missingChatId });
+    },
+    [chatId, clearProjectTabs, scopeKey],
+  );
+
   useEffect(
     () =>
       listenForProjectDirectoryChanges((changedScopeKey) => {
@@ -131,7 +151,13 @@ export default function FilesWorkspace({
         // a file in an extra root stuck as a read-only historical artifact.
         const boundDirs =
           scopeKind === "session"
-            ? (await loadSessionProjectDirs(agentId, sessionId, chatId)).dirs
+            ? (
+                await loadSessionProjectDirs(
+                  agentId,
+                  sessionId,
+                  effectiveChatId,
+                )
+              ).dirs
             : [
                 {
                   path: agentInfo.path,
@@ -169,7 +195,7 @@ export default function FilesWorkspace({
           try {
             await workspaceApi.getFileMetadata(
               candidate.path,
-              chatId,
+              effectiveChatId,
               candidate.root,
               projectDirOverride,
             );
@@ -188,7 +214,13 @@ export default function FilesWorkspace({
       }
       return target;
     },
-    [agentId, chatId, projectDirOverride, scopeKind, sessionId],
+    [
+      agentId,
+      effectiveChatId,
+      projectDirOverride,
+      scopeKind,
+      sessionId,
+    ],
   );
 
   const loadTarget = useCallback(
@@ -224,7 +256,7 @@ export default function FilesWorkspace({
       if (target.source === "workspace") {
         const metadata = await workspaceApi.getFileMetadata(
           target.path,
-          chatId,
+          effectiveChatId,
           target.root,
           projectDirOverride,
         );
@@ -233,7 +265,7 @@ export default function FilesWorkspace({
         const loaded = isText
           ? await workspaceApi.loadFileText(
               target.path,
-              chatId,
+              effectiveChatId,
               target.root,
               projectDirOverride,
             )
@@ -266,7 +298,7 @@ export default function FilesWorkspace({
         etag: response.headers.get("ETag") ?? "",
       };
     },
-    [chatId, projectDirOverride],
+    [effectiveChatId, projectDirOverride],
   );
 
   const loadTabContent = useCallback(
@@ -352,10 +384,10 @@ export default function FilesWorkspace({
   }, [scopeKey]);
 
   useEffect(() => {
-    if (!chatId && projectDirOverride) {
+    if (!effectiveChatId && projectDirOverride) {
       setActivity("files");
     }
-  }, [chatId, projectDirOverride]);
+  }, [effectiveChatId, projectDirOverride]);
 
   useEffect(() => {
     tabs.forEach((tab) => {
@@ -410,7 +442,7 @@ export default function FilesWorkspace({
           >
             <Files size={18} />
           </button>
-          {chatId || !projectDirOverride ? (
+          {effectiveChatId || !projectDirOverride ? (
             <button
               type="button"
               className={activity === "git" ? styles.activityActive : ""}
@@ -424,8 +456,11 @@ export default function FilesWorkspace({
       )}
       {activity === "files" || !codingMode ? (
         <FilesNavigator
-          key={`${scopeKey}:${projectDirOverride ?? ""}:${directoryRevision}`}
+          key={`${scopeKey}:${effectiveChatId ?? ""}:${
+            projectDirOverride ?? ""
+          }:${directoryRevision}`}
           scope={effectiveScope}
+          onChatNotFound={handleChatNotFound}
           selectedPath={
             tabs.find((tab) => tab.path === activeTabPath)?.displayPath ??
             activeTabPath
@@ -444,7 +479,7 @@ export default function FilesWorkspace({
             <GitBranch size={15} />
             <span>{t("files.sourceControl")}</span>
           </header>
-          <GitPanel chatId={chatId} />
+          <GitPanel chatId={effectiveChatId} />
         </aside>
       )}
       <main className={styles.documentSurface}>
@@ -479,7 +514,7 @@ export default function FilesWorkspace({
               setTabContent(scopeKey, path, content)
             }
             onLoadFile={loadTabContent}
-            chatId={chatId}
+            chatId={effectiveChatId}
             projectDirOverride={projectDirOverride}
             navigation={editorNavigation}
             onDownloadFile={async (path) => {
@@ -506,8 +541,10 @@ export default function FilesWorkspace({
                   {
                     headers: {
                       ...buildAuthHeaders(),
-                      ...(chatId ? { "X-Chat-Id": chatId } : {}),
-                      ...(!chatId && projectDirOverride
+                      ...(effectiveChatId
+                        ? { "X-Chat-Id": effectiveChatId }
+                        : {}),
+                      ...(!effectiveChatId && projectDirOverride
                         ? {
                             "X-Session-Project-Dir": projectDirOverride,
                           }
@@ -536,7 +573,7 @@ export default function FilesWorkspace({
                   tab?.displayPath ?? path,
                   content,
                   tab?.etag,
-                  chatId,
+                  effectiveChatId,
                   tab?.workspaceRoot,
                   projectDirOverride,
                 );

--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -2,6 +2,8 @@ import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/common_setup";
+import { chatProjectDirectoryApi } from "../../api/modules/chatProjectDirectory";
+import { ApiError } from "../../api/request";
 import SessionProjectDirectory from "./SessionProjectDirectory";
 
 const {
@@ -41,6 +43,13 @@ vi.mock("../../api/modules/chatProjectDirectory", () => ({
 // recent-project selection, Apply) lives on AGENT scope. Session scope
 // binds an ordered list of directories instead, so it has no path field.
 const scope = { kind: "agent" as const, agentId: "default" };
+
+const sessionScope = {
+  kind: "session" as const,
+  agentId: "default",
+  sessionId: "s1",
+  chatId: "ceb44050-d815-43f1-9212-c6b9a2054295",
+};
 
 const projects = [
   {
@@ -323,5 +332,38 @@ describe("SessionProjectDirectory", () => {
     await waitFor(() => {
       expect(mockSetSessionDirectory).toHaveBeenCalledWith("/projects/runtime");
     });
+  });
+
+  // A chat id outlives its chat: it stays in the URL across an agent switch,
+  // and it survives a deletion made in another tab. Both answer 404, and the
+  // panel refreshes on every scope change — so this must degrade to the agent
+  // default instead of leaving a rejection for the page to report.
+  it("shows the agent default when the session chat is gone", async () => {
+    vi.mocked(chatProjectDirectoryApi.getProjectDirs).mockRejectedValue(
+      new ApiError(404, "Chat not found"),
+    );
+
+    renderWithProviders(
+      <SessionProjectDirectory scope={sessionScope} showFullPath />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetSessionDirectory).toHaveBeenCalled();
+    });
+    expect(
+      await screen.findByText("/projects/agentscope", { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps an unexpected read failure inside the panel", async () => {
+    vi.mocked(chatProjectDirectoryApi.getProjectDirs).mockRejectedValue(
+      new ApiError(500, "directory service exploded"),
+    );
+
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} open />);
+
+    expect(
+      await screen.findByText("directory service exploded"),
+    ).toBeInTheDocument();
   });
 });

--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -334,25 +334,17 @@ describe("SessionProjectDirectory", () => {
     });
   });
 
-  // A chat id outlives its chat: it stays in the URL across an agent switch,
-  // and it survives a deletion made in another tab. Both answer 404, and the
-  // panel refreshes on every scope change — so this must degrade to the agent
-  // default instead of leaving a rejection for the page to report.
-  it("shows the agent default when the session chat is gone", async () => {
+  it("shows the read error instead of treating a missing chat as agent scope", async () => {
     vi.mocked(chatProjectDirectoryApi.getProjectDirs).mockRejectedValue(
       new ApiError(404, "Chat not found"),
     );
 
     renderWithProviders(
-      <SessionProjectDirectory scope={sessionScope} showFullPath />,
+      <SessionProjectDirectory scope={sessionScope} showFullPath open />,
     );
 
-    await waitFor(() => {
-      expect(mockGetSessionDirectory).toHaveBeenCalled();
-    });
-    expect(
-      await screen.findByText("/projects/agentscope", { exact: false }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Chat not found")).toBeInTheDocument();
+    expect(mockGetSessionDirectory).not.toHaveBeenCalled();
   });
 
   it("keeps an unexpected read failure inside the panel", async () => {

--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -366,4 +366,156 @@ describe("SessionProjectDirectory", () => {
       await screen.findByText("directory service exploded"),
     ).toBeInTheDocument();
   });
+
+  it("clears a read failure after the current scope refresh succeeds", async () => {
+    vi.mocked(chatProjectDirectoryApi.getProjectDirs)
+      .mockRejectedValueOnce(new ApiError(500, "directory service exploded"))
+      .mockResolvedValueOnce({
+        project_dirs: [
+          {
+            path: "/projects/recovered",
+            label: null,
+            exists: true,
+            nested_with: null,
+            is_workspace: false,
+          },
+        ],
+        source: "session",
+        agent_project_dir: "/projects/agentscope",
+      });
+
+    const view = renderWithProviders(
+      <SessionProjectDirectory scope={sessionScope} open />,
+    );
+    expect(
+      await screen.findByText("directory service exploded"),
+    ).toBeInTheDocument();
+
+    view.rerender(
+      <SessionProjectDirectory
+        scope={{ ...sessionScope, sessionId: "s2" }}
+        open
+      />,
+    );
+
+    expect(await screen.findByText("/projects/recovered")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("directory service exploded"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("ignores a failed refresh from the previous scope", async () => {
+    let rejectPrevious: (error: Error) => void = () => undefined;
+    vi.mocked(chatProjectDirectoryApi.getProjectDirs)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectPrevious = reject;
+          }),
+      )
+      .mockResolvedValueOnce({
+        project_dirs: [
+          {
+            path: "/projects/current",
+            label: null,
+            exists: true,
+            nested_with: null,
+            is_workspace: false,
+          },
+        ],
+        source: "session",
+        agent_project_dir: "/projects/agentscope",
+      });
+
+    const view = renderWithProviders(
+      <SessionProjectDirectory scope={sessionScope} open />,
+    );
+    await waitFor(() => {
+      expect(chatProjectDirectoryApi.getProjectDirs).toHaveBeenCalledTimes(1);
+    });
+
+    view.rerender(
+      <SessionProjectDirectory
+        scope={{ ...sessionScope, sessionId: "s2" }}
+        open
+      />,
+    );
+    expect(await screen.findByText("/projects/current")).toBeInTheDocument();
+
+    await act(async () => {
+      rejectPrevious(new ApiError(500, "stale failure"));
+      await Promise.resolve();
+    });
+    expect(screen.queryByText("stale failure")).not.toBeInTheDocument();
+  });
+
+  it("ignores a successful refresh from the previous scope", async () => {
+    let resolvePrevious: (value: {
+      project_dirs: Array<{
+        path: string;
+        label: null;
+        exists: boolean;
+        nested_with: null;
+        is_workspace: boolean;
+      }>;
+      source: "session";
+      agent_project_dir: string;
+    }) => void = () => undefined;
+    vi.mocked(chatProjectDirectoryApi.getProjectDirs)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePrevious = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        project_dirs: [
+          {
+            path: "/projects/current",
+            label: null,
+            exists: true,
+            nested_with: null,
+            is_workspace: false,
+          },
+        ],
+        source: "session",
+        agent_project_dir: "/projects/agentscope",
+      });
+
+    const view = renderWithProviders(
+      <SessionProjectDirectory scope={sessionScope} open />,
+    );
+    await waitFor(() => {
+      expect(chatProjectDirectoryApi.getProjectDirs).toHaveBeenCalledTimes(1);
+    });
+    view.rerender(
+      <SessionProjectDirectory
+        scope={{ ...sessionScope, sessionId: "s2" }}
+        open
+      />,
+    );
+    expect(await screen.findByText("/projects/current")).toBeInTheDocument();
+
+    await act(async () => {
+      resolvePrevious({
+        project_dirs: [
+          {
+            path: "/projects/previous",
+            label: null,
+            exists: true,
+            nested_with: null,
+            is_workspace: false,
+          },
+        ],
+        source: "session",
+        agent_project_dir: "/projects/agentscope",
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("/projects/current")).toBeInTheDocument();
+    expect(screen.queryByText("/projects/previous")).not.toBeInTheDocument();
+  });
 });

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -138,6 +138,7 @@ export default function SessionProjectDirectory({
   // Only the most recent request is allowed to update state, preventing stale
   // responses from overwriting newer results when requests complete out of order.
   const browseSeq = useRef(0);
+  const refreshSeq = useRef(0);
   // Session scope binds an ordered list of directories, index 0 = primary.
   // It replaces the single-path field, so the list is the whole selection.
   // Only used when !isAgentScope; agent scope stays single-valued via `draft`.
@@ -181,40 +182,53 @@ export default function SessionProjectDirectory({
     [],
   );
 
-  const refresh = useCallback(async () => {
-    if (isAgentScope) {
-      const next = await projectDirectoryApi.get();
-      const fallback: EffectiveProjectDirectory = {
-        project_dir: next.path,
-        source: next.is_workspace_default ? "workspace_fallback" : "agent",
-        agent_project_dir: next.is_workspace_default ? null : next.path,
-        exists: next.exists ?? true,
-      };
-      setInfo(fallback);
-      updateDraft(fallback.project_dir);
-      return;
-    }
-    // Shared with the Files navigator so the panel and the tree can never
-    // disagree about which directories the session is bound to.
-    const snapshot = await loadSessionProjectDirs(
-      selectedAgent,
-      sessionId,
-      chatId,
-    );
-    applyList(snapshot.dirs, {
-      source: snapshot.source,
-      agent_project_dir: snapshot.agentProjectDir,
-    });
-  }, [applyList, chatId, isAgentScope, selectedAgent, sessionId, updateDraft]);
+  const refresh = useCallback(
+    async (requestedSeq?: number) => {
+      const seq = requestedSeq ?? ++refreshSeq.current;
+      const isCurrent = () => seq === refreshSeq.current;
+      if (isAgentScope) {
+        const next = await projectDirectoryApi.get();
+        if (!isCurrent()) return;
+        const fallback: EffectiveProjectDirectory = {
+          project_dir: next.path,
+          source: next.is_workspace_default ? "workspace_fallback" : "agent",
+          agent_project_dir: next.is_workspace_default ? null : next.path,
+          exists: next.exists ?? true,
+        };
+        setInfo(fallback);
+        updateDraft(fallback.project_dir);
+        return;
+      }
+      // Shared with the Files navigator so the panel and the tree can never
+      // disagree about which directories the session is bound to.
+      const snapshot = await loadSessionProjectDirs(
+        selectedAgent,
+        sessionId,
+        chatId,
+      );
+      if (!isCurrent()) return;
+      applyList(snapshot.dirs, {
+        source: snapshot.source,
+        agent_project_dir: snapshot.agentProjectDir,
+      });
+    },
+    [applyList, chatId, isAgentScope, selectedAgent, sessionId, updateDraft],
+  );
 
   useEffect(() => {
-    // Keep a failed read inside the panel: it re-runs on every scope change,
-    // including the moment an agent switch pairs the new agent with the
-    // outgoing chat, and an unhandled rejection there surfaces as a page
-    // error even though the trigger just keeps its previous directory.
-    void refresh().catch((err) => {
-      setListError(err instanceof Error ? err.message : String(err));
-    });
+    const seq = ++refreshSeq.current;
+    void refresh(seq)
+      .then(() => {
+        if (seq === refreshSeq.current) setListError(null);
+      })
+      .catch((err) => {
+        if (seq === refreshSeq.current) {
+          setListError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      if (seq === refreshSeq.current) refreshSeq.current += 1;
+    };
   }, [refresh]);
 
   const browse = useCallback(

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -208,7 +208,13 @@ export default function SessionProjectDirectory({
   }, [applyList, chatId, isAgentScope, selectedAgent, sessionId, updateDraft]);
 
   useEffect(() => {
-    void refresh();
+    // Keep a failed read inside the panel: it re-runs on every scope change,
+    // including the moment an agent switch pairs the new agent with the
+    // outgoing chat, and an unhandled rejection there surfaces as a page
+    // error even though the trigger just keeps its previous directory.
+    void refresh().catch((err) => {
+      setListError(err instanceof Error ? err.message : String(err));
+    });
   }, [refresh]);
 
   const browse = useCallback(

--- a/console/src/features/project-directory/loadSessionProjectDirs.test.ts
+++ b/console/src/features/project-directory/loadSessionProjectDirs.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError } from "../../api/request";
 import { loadSessionProjectDirs } from "./loadSessionProjectDirs";
 
 const { mockGetProjectDirs, mockGetChatDir, mockGetAgentDir, mockGetPending } =
@@ -26,10 +25,6 @@ vi.mock("./pendingProjectDirectory", () => ({
 }));
 
 const CHAT_ID = "ceb44050-d815-43f1-9212-c6b9a2054295";
-
-function chatNotFound(): ApiError {
-  return new ApiError(404, 'Chat not found - {"detail":"Chat not found"}');
-}
 
 describe("loadSessionProjectDirs", () => {
   beforeEach(() => {
@@ -66,62 +61,22 @@ describe("loadSessionProjectDirs", () => {
     expect(mockGetAgentDir).not.toHaveBeenCalled();
   });
 
-  // A chat id outlives its ownership: it stays in the URL across an agent
-  // switch, and it survives a deletion made in another tab. Chat endpoints are
-  // scoped to the agent of the request, so the read answers 404 — the agent
-  // default is the right answer for the agent now in view, and the caller must
-  // not see a rejection it would report as a page error.
-  it("falls back to the agent default when the chat is not found", async () => {
-    mockGetProjectDirs.mockRejectedValue(chatNotFound());
-
-    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
-
-    expect(snapshot.dirs).toEqual([
-      {
-        path: "/agents/default/workspace",
-        label: null,
-        exists: true,
-        nested_with: null,
-        is_workspace: true,
-      },
-    ]);
-    expect(snapshot.source).toBe("workspace_fallback");
-    expect(snapshot.agentProjectDir).toBeNull();
-  });
-
-  it("falls back when the chat vanishes between the two reads", async () => {
-    mockGetProjectDirs.mockResolvedValue({
-      project_dirs: [],
-      source: "workspace_fallback",
-      agent_project_dir: null,
-    });
-    mockGetChatDir.mockRejectedValue(chatNotFound());
-
-    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
-
-    expect(snapshot.source).toBe("workspace_fallback");
-    expect(mockGetAgentDir).toHaveBeenCalledTimes(1);
-  });
-
-  it("prefers a pending pick over the agent default on fallback", async () => {
-    mockGetProjectDirs.mockRejectedValue(chatNotFound());
-    mockGetPending.mockReturnValue({
-      dirs: [{ path: "/projects/picked", label: "picked" }],
-    });
-
-    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
-
-    expect(snapshot.dirs.map((dir) => dir.path)).toEqual(["/projects/picked"]);
-    expect(snapshot.source).toBe("session");
-    expect(mockGetAgentDir).not.toHaveBeenCalled();
-  });
-
-  it("propagates failures that are not a missing chat", async () => {
-    mockGetProjectDirs.mockRejectedValue(new ApiError(500, "boom"));
+  it("propagates chat directory failures", async () => {
+    mockGetProjectDirs.mockRejectedValue(new Error("boom"));
 
     await expect(
       loadSessionProjectDirs("default", "s1", CHAT_ID),
     ).rejects.toThrow("boom");
     expect(mockGetAgentDir).not.toHaveBeenCalled();
+  });
+
+  it("skips chat queries for a new conversation and uses the agent default", async () => {
+    const snapshot = await loadSessionProjectDirs("other", "new");
+
+    expect(mockGetProjectDirs).not.toHaveBeenCalled();
+    expect(mockGetChatDir).not.toHaveBeenCalled();
+    expect(mockGetAgentDir).toHaveBeenCalledTimes(1);
+    expect(snapshot.dirs[0].path).toBe("/agents/default/workspace");
+    expect(snapshot.source).toBe("workspace_fallback");
   });
 });

--- a/console/src/features/project-directory/loadSessionProjectDirs.test.ts
+++ b/console/src/features/project-directory/loadSessionProjectDirs.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/request";
+import { loadSessionProjectDirs } from "./loadSessionProjectDirs";
+
+const { mockGetProjectDirs, mockGetChatDir, mockGetAgentDir, mockGetPending } =
+  vi.hoisted(() => ({
+    mockGetProjectDirs: vi.fn(),
+    mockGetChatDir: vi.fn(),
+    mockGetAgentDir: vi.fn(),
+    mockGetPending: vi.fn(),
+  }));
+
+vi.mock("../../api/modules/chatProjectDirectory", () => ({
+  chatProjectDirectoryApi: {
+    getProjectDirs: mockGetProjectDirs,
+    get: mockGetChatDir,
+  },
+}));
+
+vi.mock("../../api/modules/projectDirectory", () => ({
+  projectDirectoryApi: { get: mockGetAgentDir },
+}));
+
+vi.mock("./pendingProjectDirectory", () => ({
+  getPendingProjectDirs: mockGetPending,
+}));
+
+const CHAT_ID = "ceb44050-d815-43f1-9212-c6b9a2054295";
+
+function chatNotFound(): ApiError {
+  return new ApiError(404, 'Chat not found - {"detail":"Chat not found"}');
+}
+
+describe("loadSessionProjectDirs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPending.mockReturnValue(null);
+    mockGetAgentDir.mockResolvedValue({
+      path: "/agents/default/workspace",
+      exists: true,
+      is_workspace_default: true,
+    });
+  });
+
+  it("returns the directories bound to the chat", async () => {
+    mockGetProjectDirs.mockResolvedValue({
+      project_dirs: [
+        {
+          path: "/projects/agentscope",
+          label: null,
+          exists: true,
+          nested_with: null,
+          is_workspace: false,
+        },
+      ],
+      source: "session",
+      agent_project_dir: "/projects/runtime",
+    });
+
+    const snapshot = await loadSessionProjectDirs("default", "s1", CHAT_ID);
+
+    expect(snapshot.dirs.map((dir) => dir.path)).toEqual([
+      "/projects/agentscope",
+    ]);
+    expect(snapshot.source).toBe("session");
+    expect(mockGetAgentDir).not.toHaveBeenCalled();
+  });
+
+  // A chat id outlives its ownership: it stays in the URL across an agent
+  // switch, and it survives a deletion made in another tab. Chat endpoints are
+  // scoped to the agent of the request, so the read answers 404 — the agent
+  // default is the right answer for the agent now in view, and the caller must
+  // not see a rejection it would report as a page error.
+  it("falls back to the agent default when the chat is not found", async () => {
+    mockGetProjectDirs.mockRejectedValue(chatNotFound());
+
+    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
+
+    expect(snapshot.dirs).toEqual([
+      {
+        path: "/agents/default/workspace",
+        label: null,
+        exists: true,
+        nested_with: null,
+        is_workspace: true,
+      },
+    ]);
+    expect(snapshot.source).toBe("workspace_fallback");
+    expect(snapshot.agentProjectDir).toBeNull();
+  });
+
+  it("falls back when the chat vanishes between the two reads", async () => {
+    mockGetProjectDirs.mockResolvedValue({
+      project_dirs: [],
+      source: "workspace_fallback",
+      agent_project_dir: null,
+    });
+    mockGetChatDir.mockRejectedValue(chatNotFound());
+
+    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
+
+    expect(snapshot.source).toBe("workspace_fallback");
+    expect(mockGetAgentDir).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers a pending pick over the agent default on fallback", async () => {
+    mockGetProjectDirs.mockRejectedValue(chatNotFound());
+    mockGetPending.mockReturnValue({
+      dirs: [{ path: "/projects/picked", label: "picked" }],
+    });
+
+    const snapshot = await loadSessionProjectDirs("other", "s1", CHAT_ID);
+
+    expect(snapshot.dirs.map((dir) => dir.path)).toEqual(["/projects/picked"]);
+    expect(snapshot.source).toBe("session");
+    expect(mockGetAgentDir).not.toHaveBeenCalled();
+  });
+
+  it("propagates failures that are not a missing chat", async () => {
+    mockGetProjectDirs.mockRejectedValue(new ApiError(500, "boom"));
+
+    await expect(
+      loadSessionProjectDirs("default", "s1", CHAT_ID),
+    ).rejects.toThrow("boom");
+    expect(mockGetAgentDir).not.toHaveBeenCalled();
+  });
+});

--- a/console/src/features/project-directory/loadSessionProjectDirs.ts
+++ b/console/src/features/project-directory/loadSessionProjectDirs.ts
@@ -11,6 +11,7 @@ import {
   type ProjectDirEntry,
 } from "../../api/modules/chatProjectDirectory";
 import { projectDirectoryApi } from "../../api/modules/projectDirectory";
+import { isApiErrorWithStatus } from "../../api/request";
 import { getPendingProjectDirs } from "./pendingProjectDirectory";
 
 export interface SessionProjectDirsSnapshot {
@@ -32,20 +33,17 @@ function pendingEntry(path: string, label: string | null): ProjectDirEntry {
 }
 
 /**
- * Resolve the session's bound directories: the chat's persisted list, else the
- * pending pick a brand-new chat holds locally, else the agent default.
+ * The chat's own binding, or `null` when the backend does not have that chat.
  *
- * The returned list always has at least one entry. When nothing is configured
- * that entry is the agent workspace (with `source: "workspace_fallback"`), so
- * callers can render a directory rather than an empty panel — the rest of the
- * console resolves relative paths there too.
+ * A chat id outlives its ownership: it stays in the URL across an agent
+ * switch, and it survives a deletion made in another tab. Chat endpoints are
+ * scoped to the agent of the request, so both cases answer 404 — an expected
+ * state to fall back from, not a failure to propagate.
  */
-export async function loadSessionProjectDirs(
-  agentId: string,
-  sessionId: string,
-  chatId?: string,
-): Promise<SessionProjectDirsSnapshot> {
-  if (chatId) {
+async function loadChatProjectDirs(
+  chatId: string,
+): Promise<SessionProjectDirsSnapshot | null> {
+  try {
     const next = await chatProjectDirectoryApi.getProjectDirs(chatId);
     if (next.project_dirs.length > 0) {
       return {
@@ -73,6 +71,31 @@ export async function loadSessionProjectDirs(
       source: next.source,
       agentProjectDir: next.agent_project_dir,
     };
+  } catch (error) {
+    if (isApiErrorWithStatus(error, 404)) return null;
+    throw error;
+  }
+}
+
+/**
+ * Resolve the session's bound directories: the chat's persisted list, else the
+ * pending pick a brand-new chat holds locally, else the agent default.
+ *
+ * The returned list always has at least one entry. When nothing is configured
+ * that entry is the agent workspace (with `source: "workspace_fallback"`), so
+ * callers can render a directory rather than an empty panel — the rest of the
+ * console resolves relative paths there too.
+ */
+export async function loadSessionProjectDirs(
+  agentId: string,
+  sessionId: string,
+  chatId?: string,
+): Promise<SessionProjectDirsSnapshot> {
+  if (chatId) {
+    const bound = await loadChatProjectDirs(chatId);
+    if (bound) return bound;
+    // The chat is not this agent's (any more): continue as if there were no
+    // chat id at all, which lands on the agent default below.
   }
 
   // Brand-new chat: no server id yet, so the pick lives in sessionStorage.

--- a/console/src/features/project-directory/loadSessionProjectDirs.ts
+++ b/console/src/features/project-directory/loadSessionProjectDirs.ts
@@ -11,7 +11,6 @@ import {
   type ProjectDirEntry,
 } from "../../api/modules/chatProjectDirectory";
 import { projectDirectoryApi } from "../../api/modules/projectDirectory";
-import { isApiErrorWithStatus } from "../../api/request";
 import { getPendingProjectDirs } from "./pendingProjectDirectory";
 
 export interface SessionProjectDirsSnapshot {
@@ -33,17 +32,20 @@ function pendingEntry(path: string, label: string | null): ProjectDirEntry {
 }
 
 /**
- * The chat's own binding, or `null` when the backend does not have that chat.
+ * Resolve the session's bound directories: the chat's persisted list, else the
+ * pending pick a brand-new chat holds locally, else the agent default.
  *
- * A chat id outlives its ownership: it stays in the URL across an agent
- * switch, and it survives a deletion made in another tab. Chat endpoints are
- * scoped to the agent of the request, so both cases answer 404 — an expected
- * state to fall back from, not a failure to propagate.
+ * The returned list always has at least one entry. When nothing is configured
+ * that entry is the agent workspace (with `source: "workspace_fallback"`), so
+ * callers can render a directory rather than an empty panel — the rest of the
+ * console resolves relative paths there too.
  */
-async function loadChatProjectDirs(
-  chatId: string,
-): Promise<SessionProjectDirsSnapshot | null> {
-  try {
+export async function loadSessionProjectDirs(
+  agentId: string,
+  sessionId: string,
+  chatId?: string,
+): Promise<SessionProjectDirsSnapshot> {
+  if (chatId) {
     const next = await chatProjectDirectoryApi.getProjectDirs(chatId);
     if (next.project_dirs.length > 0) {
       return {
@@ -71,31 +73,6 @@ async function loadChatProjectDirs(
       source: next.source,
       agentProjectDir: next.agent_project_dir,
     };
-  } catch (error) {
-    if (isApiErrorWithStatus(error, 404)) return null;
-    throw error;
-  }
-}
-
-/**
- * Resolve the session's bound directories: the chat's persisted list, else the
- * pending pick a brand-new chat holds locally, else the agent default.
- *
- * The returned list always has at least one entry. When nothing is configured
- * that entry is the agent workspace (with `source: "workspace_fallback"`), so
- * callers can render a directory rather than an empty panel — the rest of the
- * console resolves relative paths there too.
- */
-export async function loadSessionProjectDirs(
-  agentId: string,
-  sessionId: string,
-  chatId?: string,
-): Promise<SessionProjectDirsSnapshot> {
-  if (chatId) {
-    const bound = await loadChatProjectDirs(chatId);
-    if (bound) return bound;
-    // The chat is not this agent's (any more): continue as if there were no
-    // chat id at all, which lands on the agent default below.
   }
 
   // Brand-new chat: no server id yet, so the pick lives in sessionStorage.

--- a/console/src/pages/Chat/components/ChatSessionInitializer/ChatSessionInitializer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/ChatSessionInitializer.test.tsx
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { renderWithProviders } from "@/test/common_setup";
 import { useSessionListStore } from "@/stores/sessionListStore";
+import { useAgentStore } from "@/stores/agentStore";
 import ChatSessionInitializer from "./index";
+import sessionApi from "../../sessionApi";
 
 const {
   mockCreateSession,
@@ -36,9 +38,12 @@ vi.mock("../../sessionApi", () => ({
     finishSessionSwitch: vi.fn(),
     getEffectiveSessionId: vi.fn((sessionId: string) => sessionId),
     isSessionSwitching: false,
+    lastActiveChatId: null,
     lastNavigatedChatId: null,
+    onSessionNotFound: null,
     preferredChatId: null,
     preloadSession: vi.fn(),
+    resetWindowIdentity: vi.fn(),
     trackNavigatedSession: vi.fn(),
   },
 }));
@@ -48,9 +53,11 @@ const NEW_SESSION_ID = "1787000000000-abcdefg";
 
 function NavigationHarness() {
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <>
+      <span data-testid="pathname">{location.pathname}</span>
       <button onClick={() => navigate("/chat")}>New chat</button>
       <button onClick={() => navigate(`/chat/${HISTORY_SESSION_ID}`)}>
         History session
@@ -65,6 +72,15 @@ describe("ChatSessionInitializer", () => {
     vi.clearAllMocks();
     mockSessionState.sessions = [{ id: HISTORY_SESSION_ID }];
     mockSessionState.currentSessionId = HISTORY_SESSION_ID;
+    useAgentStore.setState({
+      selectedAgent: "default",
+      lastChatIdByAgent: {},
+      pendingAgentChatSwitch: null,
+    });
+    sessionApi.lastActiveChatId = null;
+    sessionApi.lastNavigatedChatId = null;
+    sessionApi.onSessionNotFound = null;
+    sessionApi.preferredChatId = null;
     useSessionListStore.setState({
       sessions: [],
       lastUpdated: 0,
@@ -89,5 +105,79 @@ describe("ChatSessionInitializer", () => {
     await waitFor(() => {
       expect(mockSetCurrentSessionId).toHaveBeenCalledWith(HISTORY_SESSION_ID);
     });
+  });
+
+  it("validates a URL chat once when it is absent from the agent list", async () => {
+    mockSessionState.sessions = [];
+    vi.mocked(sessionApi.preloadSession).mockResolvedValue({
+      session: { id: "missing-chat" } as never,
+      realId: null,
+    });
+
+    renderWithProviders(<NavigationHarness />, {
+      initialEntries: ["/chat/missing-chat"],
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.preloadSession).toHaveBeenCalledTimes(1);
+    });
+    expect(sessionApi.preloadSession).toHaveBeenCalledWith(
+      "missing-chat",
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("clears stale chat state and returns to /chat after URL validation gets 404", async () => {
+    mockSessionState.sessions = [];
+    useAgentStore.setState({
+      lastChatIdByAgent: { default: "missing-chat" },
+      pendingAgentChatSwitch: {
+        agentId: "default",
+        chatId: "missing-chat",
+      },
+    });
+    vi.mocked(sessionApi.preloadSession).mockImplementation(async (chatId) => {
+      sessionApi.onSessionNotFound?.(chatId, "default");
+      return {
+        session: { id: chatId } as never,
+        realId: null,
+      };
+    });
+
+    renderWithProviders(<NavigationHarness />, {
+      initialEntries: ["/chat/missing-chat"],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pathname")).toHaveTextContent("/chat");
+    });
+    expect(mockSetCurrentSessionId).toHaveBeenCalledWith(undefined);
+    expect(useAgentStore.getState().getLastChatId("default")).toBeUndefined();
+    expect(useAgentStore.getState().pendingAgentChatSwitch).toBeNull();
+    expect(sessionApi.preferredChatId).toBeNull();
+    expect(sessionApi.lastActiveChatId).toBeNull();
+    expect(sessionApi.resetWindowIdentity).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a late not-found callback owned by a previous agent", async () => {
+    mockSessionState.sessions = [];
+    vi.mocked(sessionApi.preloadSession).mockResolvedValue({
+      session: { id: "current-chat" } as never,
+      realId: null,
+    });
+
+    renderWithProviders(<NavigationHarness />, {
+      initialEntries: ["/chat/current-chat"],
+    });
+
+    await waitFor(() =>
+      expect(sessionApi.onSessionNotFound).toBeTypeOf("function"),
+    );
+    sessionApi.onSessionNotFound?.("current-chat", "previous-agent");
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent(
+      "/chat/current-chat",
+    );
+    expect(mockSetCurrentSessionId).not.toHaveBeenCalledWith(undefined);
   });
 });

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -11,6 +11,7 @@ import {
   type ExtendedSession,
 } from "../../../../stores/sessionListStore";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
+import { useAgentStore } from "../../../../stores/agentStore";
 
 /**
  * URL chatId → context currentSessionId (one direction of bidirectional sync).
@@ -62,6 +63,11 @@ const ChatSessionInitializer: React.FC = () => {
   const createNewSessionRef = useRef(createNewSession);
   createNewSessionRef.current = createNewSession;
 
+  const chatIdRef = useRef(chatId);
+  chatIdRef.current = chatId;
+
+  const validatedUrlChatRef = useRef<string | null>(null);
+
   /** AbortController for embedded session switch — aborted when a new switch starts. */
   const switchControllerRef = useRef<AbortController | null>(null);
 
@@ -69,6 +75,64 @@ const ChatSessionInitializer: React.FC = () => {
    *  subsequent sessions array reference changes (from polling in pinned drawer)
    *  don't re-trigger setCurrentSessionId and cause infinite getSession loops. */
   const lastAppliedChatIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    sessionApi.onSessionNotFound = (sessionId, agentId) => {
+      const agentState = useAgentStore.getState();
+      if (
+        agentState.selectedAgent !== agentId ||
+        chatIdRef.current !== sessionId
+      ) {
+        return;
+      }
+
+      if (agentState.getLastChatId(agentId) === sessionId) {
+        agentState.removeLastChatId(agentId);
+      }
+      agentState.completeAgentChatSwitch(agentId);
+      sessionApi.preferredChatId = null;
+      sessionApi.lastActiveChatId = null;
+      sessionApi.lastNavigatedChatId = null;
+      sessionApi.finishSessionSwitch();
+      sessionApi.resetWindowIdentity();
+      lastAppliedChatIdRef.current = undefined;
+      validatedUrlChatRef.current = null;
+      setCurrentSessionId(undefined);
+      navigate("/chat", { replace: true });
+    };
+
+    return () => {
+      sessionApi.onSessionNotFound = null;
+    };
+  }, [navigate, setCurrentSessionId]);
+
+  // A URL chat that is absent from the active agent's list may be stale or
+  // belong to another agent. Validate it once; sessionApi owns status-aware
+  // 404 detection and the callback above owns URL/global-state cleanup.
+  useEffect(() => {
+    if (!chatId) {
+      validatedUrlChatRef.current = null;
+      return;
+    }
+
+    const matching = sessions.some((session) => {
+      const extended = session as ExtendedSession;
+      return (
+        session.id === chatId ||
+        extended.realId === chatId ||
+        extended.sessionId === chatId
+      );
+    });
+    if (matching || validatedUrlChatRef.current === chatId) return;
+
+    validatedUrlChatRef.current = chatId;
+    const controller = new AbortController();
+    void sessionApi.preloadSession(chatId, controller.signal).catch((error) => {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      console.error("Failed to validate chat from URL:", error);
+    });
+    return () => controller.abort();
+  }, [chatId, sessions]);
 
   useEffect(() => {
     if (!chatId || !sessions.length) return;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1177,12 +1177,25 @@ export default function ChatPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { isDark } = useTheme();
-  const { selectedAgent, agents } = useAgentStore();
-  const chatId = useMemo(
+  const {
+    selectedAgent,
+    agents,
+    pendingAgentChatSwitch,
+    completeAgentChatSwitch,
+  } = useAgentStore();
+  const routeChatId = useMemo(
     () => getSessionIdFromPath(location.pathname),
     [location.pathname],
   );
-  const queueSessionId = chatId ?? sessionApi.lastActiveChatId ?? "new";
+  const hasPendingAgentChatSwitch =
+    pendingAgentChatSwitch?.agentId === selectedAgent;
+  const chatId = hasPendingAgentChatSwitch
+    ? pendingAgentChatSwitch.chatId ?? undefined
+    : routeChatId;
+  const queueSessionId =
+    chatId ??
+    (hasPendingAgentChatSwitch ? null : sessionApi.lastActiveChatId) ??
+    "new";
   const backendChatId = resolveBackendChatId(chatId);
   const pendingProjectDir = backendChatId
     ? undefined
@@ -1866,6 +1879,7 @@ export default function ChatPage() {
   /** Tracks the stale auto-selected session ID that was skipped on init, so we can suppress its late-arriving onSessionSelected callback. */
   const staleAutoSelectedIdRef = useRef<string | null>(null);
   const chatIdRef = useRef(chatId);
+  const routeChatIdRef = useRef(routeChatId);
   const navigateRef = useRef(navigate);
   const chatRef = useRef<IAgentScopeRuntimeWebUIRef>(null);
   const pendingSenderClearRef = useRef<string | null>(null);
@@ -2242,6 +2256,7 @@ export default function ChatPage() {
     return () => document.removeEventListener("keydown", handleShortcut);
   }, [isChatActive, whisperEnabled]);
   chatIdRef.current = chatId;
+  routeChatIdRef.current = routeChatId;
   navigateRef.current = navigate;
 
   const scheduleHistoryClear = useCallback(() => {
@@ -2283,8 +2298,16 @@ export default function ChatPage() {
   const safeLastStored = isLocalTimestampId(getLastChatId(selectedAgent))
     ? null
     : getLastChatId(selectedAgent);
-  const effectiveChatId = chatId || safeLastActive || safeLastStored;
-  if (effectiveChatId && sessionApi.preferredChatId !== effectiveChatId) {
+  const effectiveChatId = hasPendingAgentChatSwitch
+    ? chatId
+    : chatId || safeLastActive || safeLastStored;
+  if (hasPendingAgentChatSwitch) {
+    sessionApi.preferredChatId = chatId ?? null;
+    sessionApi.lastActiveChatId = chatId ?? null;
+  } else if (
+    effectiveChatId &&
+    sessionApi.preferredChatId !== effectiveChatId
+  ) {
     sessionApi.preferredChatId = effectiveChatId;
   }
 
@@ -2494,37 +2517,49 @@ export default function ChatPage() {
       // Skip temporary local timestamp ids — they are not real backend
       // sessions and should not be restored later.
       const currentChatId =
-        chatIdRef.current || lastSessionIdRef.current || undefined;
+        routeChatIdRef.current || lastSessionIdRef.current || undefined;
       if (currentChatId && prevAgent && !isLocalTimestampId(currentChatId)) {
         setLastChatId(prevAgent, currentChatId);
-      }
-
-      // Restore last chat ID for the agent we're switching to.
-      // Ignore temporary local timestamp ids that may have been persisted
-      // before this guard was added.
-      const restored = getLastChatId(selectedAgent);
-      if (restored && !isLocalTimestampId(restored)) {
-        navigateRef.current(buildChatPath(restored), {
-          replace: true,
-        });
-        sessionApi.preferredChatId = restored;
-        sessionApi.lastActiveChatId = restored;
-      } else {
-        navigateRef.current("/chat", { replace: true });
-        sessionApi.lastActiveChatId = null;
       }
       // Mark the current session as stale so late-arriving onSessionSelected
       // callbacks from the OLD library instance are suppressed (Bug: after
       // agent switch, old library's in-flight getSession may complete and
       // trigger onSessionSelected for the wrong session).
       staleAutoSelectedIdRef.current =
-        lastSessionIdRef.current || chatIdRef.current || null;
+        lastSessionIdRef.current || routeChatIdRef.current || null;
       lastSessionIdRef.current = null;
 
       setRefreshKey((prev) => prev + 1);
     }
     prevSelectedAgentRef.current = selectedAgent;
-  }, [selectedAgent, setLastChatId, getLastChatId]);
+  }, [selectedAgent, setLastChatId]);
+
+  // setSelectedAgent captures this target in the same store update as the
+  // agent ID. Keep using it until the router has reached the matching URL, so
+  // no render can combine the new agent with the previous agent's chat ID.
+  useEffect(() => {
+    if (!hasPendingAgentChatSwitch || !pendingAgentChatSwitch) return;
+
+    const targetChatId = pendingAgentChatSwitch.chatId;
+    sessionApi.preferredChatId = targetChatId;
+    sessionApi.lastActiveChatId = targetChatId;
+
+    const targetPath = targetChatId
+      ? buildChatPath(targetChatId)
+      : CHAT_BASE_PATH;
+    if (location.pathname !== targetPath) {
+      navigateRef.current(targetPath, { replace: true });
+      return;
+    }
+
+    completeAgentChatSwitch(selectedAgent);
+  }, [
+    completeAgentChatSwitch,
+    hasPendingAgentChatSwitch,
+    location.pathname,
+    pendingAgentChatSwitch,
+    selectedAgent,
+  ]);
 
   const copyResponse = useCallback(
     async (response: CopyableResponse) => {

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -11,6 +11,7 @@ import api, {
 } from "../../../api";
 import { toDisplayUrl } from "../utils";
 import { useAgentStore } from "../../../stores/agentStore";
+import { isApiErrorWithStatus } from "../../../api/request";
 import {
   extractTurnUsageFromOutputMessages,
   extractLatestSnapshotFromCards,
@@ -131,6 +132,8 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   groupId?: string | null;
   parentSessionId?: string | null;
   rootSessionId?: string | null;
+  /** The requested backend chat does not exist for the active agent. */
+  notFound?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -687,6 +690,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       const extendedSession = session as ExtendedSession;
       const realId = extendedSession.realId || null;
 
+      if (extendedSession.notFound) {
+        return { session, realId };
+      }
+
       // Cache the result so subsequent getSession calls return immediately.
       const entry = { session, owner };
       this.sessionResultCache.set(sessionId, entry);
@@ -765,6 +772,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.sessionList = [];
     this._prevReturnedList = null;
     this.lastSelectedIds.clear();
+    this.preferredChatId = null;
+    this.lastActiveChatId = null;
+    this.lastNavigatedChatId = null;
+    this.resetWindowIdentity();
     // Release the switch lock: the switch it belonged to is owned by the
     // previous epoch and its completion handler may never run (e.g. the
     // initializer aborted on unmount). Leaving it set would make the new
@@ -826,6 +837,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.onSessionRemoved = null;
     this.onSessionSelected = null;
     this.onSessionCreated = null;
+    this.onSessionNotFound = null;
   }
 
   /**
@@ -930,6 +942,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    * Consumers can register here to update the URL with the new session id.
    */
   onSessionCreated: ((sessionId: string) => void) | null = null;
+
+  /** Called when a backend chat is missing for the active agent. */
+  onSessionNotFound: ((sessionId: string, agentId: string) => void) | null =
+    null;
 
   /**
    * When reconnecting to a running conversation, the backend history may not
@@ -1366,6 +1382,8 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       const extendedSession = session as ExtendedSession;
       const realId = extendedSession.realId || null;
 
+      if (extendedSession.notFound) return session;
+
       // Only trigger onSessionSelected if the result still belongs to the
       // active ownership epoch and neither the displayId nor the realId has
       // already been selected. The latter prevents the infinite loop where
@@ -1536,14 +1554,21 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         signal,
         owner,
       );
-    } catch (error: any) {
+    } catch (error: unknown) {
       // If the backend session doesn't exist (e.g. invalid UUID or expired session)
       // return an empty session to prevent repeated 404 API calls.
       // Keep message-based detection for compatibility with session adapters
       // that do not use the shared request layer's status-aware ApiError.
-      if (error.message?.includes("Chat not found")) {
+      if (
+        isApiErrorWithStatus(error, 404) ||
+        (error instanceof Error && error.message.includes("Chat not found"))
+      ) {
         const emptySession = this.createEmptySession(sessionId, owner);
         emptySession.id = sessionId;
+        (emptySession as ExtendedSession).notFound = true;
+        if (this.isActiveOwner(owner)) {
+          this.onSessionNotFound?.(sessionId, owner.agentId);
+        }
         return emptySession;
       }
       throw error;

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -1539,8 +1539,8 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     } catch (error: any) {
       // If the backend session doesn't exist (e.g. invalid UUID or expired session)
       // return an empty session to prevent repeated 404 API calls.
-      // Note: the request layer throws Error(message) without attaching .status,
-      // so only message-based detection is reliable here.
+      // Keep message-based detection for compatibility with session adapters
+      // that do not use the shared request layer's status-aware ApiError.
       if (error.message?.includes("Chat not found")) {
         const emptySession = this.createEmptySession(sessionId, owner);
         emptySession.id = sessionId;

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -18,6 +18,7 @@ import sessionApi from "../sessionApi";
 import { useAgentStore } from "../../../stores/agentStore";
 import { useTurnUsageStore } from "../turnUsageStore";
 import type { TurnUsageSnapshot } from "../turnUsage";
+import { ApiError } from "../../../api/request";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -69,6 +70,39 @@ afterEach(() => {
 });
 
 describe("agent session ownership epochs", () => {
+  it("reports an active 404 without selecting the missing session", async () => {
+    vi.spyOn(api, "getChat").mockRejectedValue(
+      new ApiError(404, "Chat not found"),
+    );
+    const onSessionNotFound = vi.fn();
+    const onSessionSelected = vi.fn();
+    sessionApi.onSessionNotFound = onSessionNotFound;
+    sessionApi.onSessionSelected = onSessionSelected;
+    sessionApi.setActiveAgent("agent-a");
+
+    const session = await sessionApi.getSession(A_CHAT);
+
+    expect(session.id).toBe(A_CHAT);
+    expect(session.messages).toEqual([]);
+    expect(onSessionNotFound).toHaveBeenCalledWith(A_CHAT, "agent-a");
+    expect(onSessionSelected).not.toHaveBeenCalled();
+  });
+
+  it("does not report a 404 that completes after its owner changed", async () => {
+    const pendingChat = deferred<ChatHistory>();
+    vi.spyOn(api, "getChat").mockReturnValue(pendingChat.promise);
+    const onSessionNotFound = vi.fn();
+    sessionApi.onSessionNotFound = onSessionNotFound;
+    sessionApi.setActiveAgent("agent-a");
+
+    const pending = sessionApi.getSession(A_CHAT);
+    sessionApi.setActiveAgent("agent-b");
+    pendingChat.reject(new ApiError(404, "Chat not found"));
+    await pending;
+
+    expect(onSessionNotFound).not.toHaveBeenCalled();
+  });
+
   it("requests only host-owned sessions and history in main Chat", async () => {
     const listSpy = vi
       .spyOn(api, "listChats")
@@ -306,10 +340,18 @@ describe("agent session ownership epochs", () => {
     sessionApi.setActiveAgent("agent-a");
     // Simulate an embedded switch whose finally never ran (unmount abort).
     sessionApi.isSessionSwitching = true;
+    sessionApi.preferredChatId = A_CHAT;
+    sessionApi.lastActiveChatId = A_CHAT;
+    sessionApi.lastNavigatedChatId = A_CHAT;
+    (window as { currentSessionId?: string }).currentSessionId = A_CHAT;
 
     sessionApi.setActiveAgent("agent-b");
 
     expect(sessionApi.isSessionSwitching).toBe(false);
+    expect(sessionApi.preferredChatId).toBeNull();
+    expect(sessionApi.lastActiveChatId).toBeNull();
+    expect(sessionApi.lastNavigatedChatId).toBeNull();
+    expect((window as { currentSessionId?: string }).currentSessionId).toBe("");
   });
 
   it("the previous agent's list entries cannot leak ids into the new agent's list", async () => {

--- a/console/src/stores/agentStore.test.ts
+++ b/console/src/stores/agentStore.test.ts
@@ -23,6 +23,7 @@ describe("agentStore", () => {
       selectedAgent: "default",
       agents: [],
       lastChatIdByAgent: {},
+      pendingAgentChatSwitch: null,
     });
   });
 
@@ -45,6 +46,55 @@ describe("agentStore", () => {
   it("setSelectedAgent updates selectedAgent", () => {
     useAgentStore.getState().setSelectedAgent("agent-123");
     expect(useAgentStore.getState().selectedAgent).toBe("agent-123");
+  });
+
+  it("captures the target chat atomically when switching agents", () => {
+    useAgentStore.getState().setLastChatId("agent-123", "chat-123");
+    const updates: Array<{
+      selectedAgent: string;
+      pendingAgentChatSwitch: {
+        agentId: string;
+        chatId: string | null;
+      } | null;
+    }> = [];
+    const unsubscribe = useAgentStore.subscribe((state) => {
+      updates.push({
+        selectedAgent: state.selectedAgent,
+        pendingAgentChatSwitch: state.pendingAgentChatSwitch,
+      });
+    });
+
+    useAgentStore.getState().setSelectedAgent("agent-123");
+    unsubscribe();
+
+    expect(updates).toEqual([
+      {
+        selectedAgent: "agent-123",
+        pendingAgentChatSwitch: {
+          agentId: "agent-123",
+          chatId: "chat-123",
+        },
+      },
+    ]);
+  });
+
+  it("captures a blank chat target when the next agent has no history", () => {
+    useAgentStore.getState().setSelectedAgent("agent-123");
+
+    expect(useAgentStore.getState().pendingAgentChatSwitch).toEqual({
+      agentId: "agent-123",
+      chatId: null,
+    });
+  });
+
+  it("only completes the pending switch for its owning agent", () => {
+    useAgentStore.getState().setSelectedAgent("agent-123");
+
+    useAgentStore.getState().completeAgentChatSwitch("agent-456");
+    expect(useAgentStore.getState().pendingAgentChatSwitch).not.toBeNull();
+
+    useAgentStore.getState().completeAgentChatSwitch("agent-123");
+    expect(useAgentStore.getState().pendingAgentChatSwitch).toBeNull();
   });
 
   // ---------------------------------------------------------------------------

--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -26,7 +26,13 @@ interface AgentStore {
   agents: AgentSummary[];
   /** Per-agent last active chat ID for restoring on agent switch */
   lastChatIdByAgent: Record<string, string>;
+  /** Chat target captured atomically with an agent switch. */
+  pendingAgentChatSwitch: {
+    agentId: string;
+    chatId: string | null;
+  } | null;
   setSelectedAgent: (agentId: string) => void;
+  completeAgentChatSwitch: (agentId: string) => void;
   setAgents: (agents: AgentSummary[]) => void;
   refreshAgents: () => Promise<void>;
   addAgent: (agent: AgentSummary) => void;
@@ -84,9 +90,20 @@ export const useAgentStore = create<AgentStore>()(
       selectedAgent: getInitialSelectedAgent(),
       agents: [],
       lastChatIdByAgent: {},
+      pendingAgentChatSwitch: null,
 
       setSelectedAgent: (agentId) => {
-        set({ selectedAgent: agentId });
+        set((state) => ({
+          selectedAgent: agentId,
+          ...(state.selectedAgent === agentId
+            ? {}
+            : {
+                pendingAgentChatSwitch: {
+                  agentId,
+                  chatId: state.lastChatIdByAgent[agentId] ?? null,
+                },
+              }),
+        }));
         menuRegistry.refresh();
         // Persist to localStorage so new tabs inherit this choice
         try {
@@ -95,6 +112,13 @@ export const useAgentStore = create<AgentStore>()(
           /* ignore */
         }
       },
+
+      completeAgentChatSwitch: (agentId) =>
+        set((state) =>
+          state.pendingAgentChatSwitch?.agentId === agentId
+            ? { pendingAgentChatSwitch: null }
+            : {},
+        ),
 
       setAgents: (agents) => set({ agents }),
 
@@ -123,11 +147,18 @@ export const useAgentStore = create<AgentStore>()(
         set((state) => {
           const remainingChatIds = { ...state.lastChatIdByAgent };
           delete remainingChatIds[agentId];
+          const selectedAgentRemoved = state.selectedAgent === agentId;
           return {
             agents: state.agents.filter((a) => a.id !== agentId),
             lastChatIdByAgent: remainingChatIds,
-            ...(state.selectedAgent === agentId
-              ? { selectedAgent: "default" }
+            ...(selectedAgentRemoved
+              ? {
+                  selectedAgent: "default",
+                  pendingAgentChatSwitch: {
+                    agentId: "default",
+                    chatId: remainingChatIds.default ?? null,
+                  },
+                }
               : {}),
           };
         });
@@ -169,6 +200,11 @@ export const useAgentStore = create<AgentStore>()(
     }),
     {
       name: STORAGE_KEY,
+      partialize: (state) => ({
+        selectedAgent: state.selectedAgent,
+        agents: state.agents,
+        lastChatIdByAgent: state.lastChatIdByAgent,
+      }),
       storage: {
         getItem: (name) => {
           try {


### PR DESCRIPTION
Added `ApiError.status` to API errors, allowing callers to reliably identify 404s while maintaining backward compatibility with original error messages.
When `/project-dirs` returns a 404 for a stale chat, the system automatically falls back to the pending directory or the current agent's default directory.
File navigator functions—including root directory access, subdirectories, pagination, and refreshing—now correctly handle stale chat 404 errors.
File editing, saving, downloading, and Git panel operations consistently utilize the valid fallback scope.
Old project tags are cleared when switching agents to prevent writing files from an old chat into the new agent's directory.
Implemented request sequence tracking to ensure that delayed success or failure responses from an old agent do not overwrite the current UI state.
Non-404 errors are displayed within the directory panel instead of resulting in unhandled Promise rejections.
Upload failures display an error message only; the system no longer automatically retries uploads to the fallback directory.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
