### PR TITLE
feat(console): chain provider config straight into model management (#4036)

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -280,6 +280,10 @@ interface ProviderConfigModalProps {
   open: boolean;
   onClose: () => void;
   onSaved: () => void;
+  /** Called after a successful save so the parent can chain straight into the
+   *  provider's model-management modal — the "configure then add a model"
+   *  flow used to require closing this modal and reopening another one. (#4036) */
+  onOpenModels?: () => void;
 }
 
 export function ProviderConfigModal({
@@ -288,6 +292,7 @@ export function ProviderConfigModal({
   open,
   onClose,
   onSaved,
+  onOpenModels,
 }: ProviderConfigModalProps) {
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
@@ -540,6 +545,12 @@ export function ProviderConfigModal({
           name: (provider.is_custom && values.name?.trim()) || provider.name,
         }),
       );
+      // Chain straight into the model-management modal so "configure the
+      // provider" and "add a model" don't require closing this modal and
+      // reopening another one (#4036).
+      if (onOpenModels) {
+        onOpenModels();
+      }
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) return;
       const errMsg =

--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -567,6 +567,10 @@ function ModelsPage() {
                 open={!!configModalProvider}
                 onClose={() => setConfigModalProvider(null)}
                 onSaved={refreshProvidersSilently}
+                // After a successful save, jump straight into the model
+                // management modal for the same provider instead of making the
+                // user close this modal and reopen the Models one (#4036).
+                onOpenModels={() => handleOpenModels(configModalProvider)}
               />
             )}
             {modelsModalProvider && (


### PR DESCRIPTION
## What Problem This Solves

Adding a model in the console required five steps across two separate modals:

1. Go to Settings → Models
2. Find the provider card, click "Settings" to fill in the API key → Save
3. Go back to the provider card list, click "Models"
4. Click "Add Model" and fill in Model ID and Model Name
5. Go back to the Chat page to select the model

The round trip between the provider **config** modal and the **model management** modal is the friction: after configuring the provider, the user has to close the config modal, find the same provider card again, and reopen a different modal just to add a model. This collapses that round trip by chaining straight into the model-management modal after a successful config save.

## Changes

- **`ProviderConfigModal.tsx`** — new optional `onOpenModels` callback, invoked after a successful save (right after `onClose`), so the parent can open the model-management modal without the user closing and reopening.
- **`Models/index.tsx`** — wires `onOpenModels={() => handleOpenModels(configModalProvider)}` into the shared `ProviderConfigModal` instance.

The callback is optional and only wired at the single `ProviderConfigModal` usage site, so no other caller is affected.

## Evidence

- `tsc -b --noEmit` passes.
- `vitest run src/pages/Settings/Models` — 20 tests pass (3 files: `useProviders.test.ts`, `utils.test.ts`, `providerIcon.test.ts`), no regressions.
- Behavior: after a successful provider config save, `onOpenModels()` fires and the model-management modal for the same provider opens immediately, replacing the previous "close config modal → reopen Models modal" flow.
