### PR TITLE
fix(exception): fix misleading hardcoded model timeout duration

### DIFF
--- a/src/qwenpaw/exceptions.py
+++ b/src/qwenpaw/exceptions.py
@@ -101,9 +101,12 @@ class ModelTimeoutException(AgentRuntimeErrorException):
     ) -> None:
         self.model = model
         self.timeout = timeout
+        message = f"Model '{model}' timed out"
+        if timeout is not None:
+            message = f"{message} after {timeout:g}s"
         super().__init__(
             error_code="MODEL_TIMEOUT",
-            message=f"Model '{model}' timed out after {timeout}s",
+            message=message,
             details=details,
             **kwargs,
         )
@@ -789,10 +792,16 @@ def convert_model_exception(  # pylint: disable=too-many-return-statements
             "deadline exceeded",
         ]
     ):
+        timeout_seconds = getattr(exc, "timeout_seconds", None)
+        if isinstance(timeout_seconds, bool) or not isinstance(
+            timeout_seconds,
+            (int, float),
+        ):
+            timeout_seconds = None
         return _append_error_detail(
             ModelTimeoutException(
                 model,
-                timeout=60,
+                timeout=timeout_seconds,
                 details=details,
             ),
             exc,

--- a/src/qwenpaw/exceptions.py
+++ b/src/qwenpaw/exceptions.py
@@ -95,18 +95,13 @@ class ModelTimeoutException(AgentRuntimeErrorException):
     def __init__(
         self,
         model: str,
-        timeout: float | int | None = None,
         details: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         self.model = model
-        self.timeout = timeout
-        message = f"Model '{model}' timed out"
-        if timeout is not None:
-            message = f"{message} after {timeout:g}s"
         super().__init__(
             error_code="MODEL_TIMEOUT",
-            message=message,
+            message=f"Model '{model}' timed out",
             details=details,
             **kwargs,
         )
@@ -792,16 +787,9 @@ def convert_model_exception(  # pylint: disable=too-many-return-statements
             "deadline exceeded",
         ]
     ):
-        timeout_seconds = getattr(exc, "timeout_seconds", None)
-        if isinstance(timeout_seconds, bool) or not isinstance(
-            timeout_seconds,
-            (int, float),
-        ):
-            timeout_seconds = None
         return _append_error_detail(
             ModelTimeoutException(
                 model,
-                timeout=timeout_seconds,
                 details=details,
             ),
             exc,


### PR DESCRIPTION
## Description

Use the actual stream timeout duration in model timeout errors instead of the hardcoded `60s`. When the duration is unavailable, omit it rather than displaying an inaccurate value.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
