### PR TITLE
refactor(task-tracker): use structured events

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -4,6 +4,7 @@
 """
 Base Channel: bound to AgentRequest/AgentResponse, unified by process.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -889,8 +890,8 @@ class BaseChannel(ABC):
     async def _stream_with_tracker(
         self,
         payload: Any,
-    ) -> AsyncGenerator[str, None]:
-        """Stream events via TaskTracker, yielding SSE strings.
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Stream event snapshots via TaskTracker.
 
         When ``streaming_enabled``, streaming hooks are invoked for
         reasoning / message events alongside the normal path.
@@ -939,19 +940,19 @@ class BaseChannel(ABC):
                         headline_stream_states,
                         msg_id=msg_id,
                     ):
-                        yield f"data: {pending_data}\n\n"
+                        yield pending_data
                 elif obj == "response" and status == RunStatus.Completed:
                     for pending_data in self._flush_headline_stream_states(
                         headline_stream_states,
                     ):
-                        yield f"data: {pending_data}\n\n"
+                        yield pending_data
 
-                data = self._serialize_event_for_sse(
+                data = self._event_to_stream_data(
                     event,
                     headline_stream_states,
                 )
 
-                yield f"data: {data}\n\n"
+                yield data
 
                 # --- streaming path ---
                 handled_by_streaming = False
@@ -996,7 +997,7 @@ class BaseChannel(ABC):
             for pending_data in self._flush_headline_stream_states(
                 headline_stream_states,
             ):
-                yield f"data: {pending_data}\n\n"
+                yield pending_data
 
             err_msg = self._get_response_error_message(last_response)
             if err_msg:
@@ -1012,12 +1013,12 @@ class BaseChannel(ABC):
                     to_handle,
                     send_meta,
                 )
-                for sse in await self._commit_turn_usage(
+                for usage_event in await self._commit_turn_usage(
                     request,
                     session_id,
-                    emit_sse=True,
+                    emit_event=True,
                 ):
-                    yield sse
+                    yield usage_event
 
             if self._on_reply_sent:
                 args = self.get_on_reply_sent_args(request, to_handle)
@@ -1082,13 +1083,13 @@ class BaseChannel(ABC):
     @staticmethod
     def _strip_event_headlines(
         event: Any,
-        fallback: str,
+        fallback: Dict[str, Any],
         headline_stream_states: dict[str, Any] | None = None,
-    ) -> str:
-        """Drop scroll headlines (``<!-- ⟦ … ⟧ -->``) from an SSE payload.
+    ) -> Dict[str, Any]:
+        """Drop scroll headlines from an independent event snapshot.
 
         Channels strip headlines via ``MessageRenderer``, but this raw-event
-        SSE path (console + web UI) bypasses it, so the comment leaks into the
+        stream path (console + web UI) bypasses it, so the comment leaks into
         rendered chat. We strip a dumped *copy* here — the live event, the
         persisted ``conversation_history`` row, and the durable index all keep
         the headline verbatim (those go through separate paths). A no-op on any
@@ -1144,20 +1145,25 @@ class BaseChannel(ABC):
             return node
 
         payload = walk(payload)
-        return json.dumps(payload, ensure_ascii=False, default=str)
+        return BaseChannel._sanitize_for_json(payload)
 
-    def _serialize_event_for_sse(
+    def _event_to_stream_data(
         self,
         event: Any,
         headline_stream_states: dict[str, Any] | None = None,
-    ) -> str:
+    ) -> Dict[str, Any]:
+        """Return an independent JSON-compatible snapshot of *event*."""
         try:
-            if hasattr(event, "model_dump_json"):
-                data = event.model_dump_json()
-            elif hasattr(event, "json"):
-                data = event.json()
+            if hasattr(event, "model_dump"):
+                data = event.model_dump(mode="json")
+            elif hasattr(event, "dict"):
+                data = event.dict()
+            elif isinstance(event, dict):
+                data = dict(event)
             else:
-                data = json.dumps({"text": str(event)}, ensure_ascii=True)
+                data = {"text": str(event)}
+
+            data = self._sanitize_for_json(data)
 
             # Headlines reach the UI only through this raw-event path; rewrite
             # to strip them, but only when a fence marker is actually present
@@ -1167,9 +1173,23 @@ class BaseChannel(ABC):
                 and getattr(event, "object", None) == "content"
                 and getattr(event, "delta", False)
             )
+
+            def contains_headline_marker(node: Any) -> bool:
+                if isinstance(node, str):
+                    return "⟦" in node or "〚" in node
+                if isinstance(node, dict):
+                    return any(
+                        contains_headline_marker(value)
+                        for value in node.values()
+                    )
+                if isinstance(node, list):
+                    return any(
+                        contains_headline_marker(value) for value in node
+                    )
+                return False
+
             should_strip = (
-                "⟦" in data
-                or "〚" in data
+                contains_headline_marker(data)
                 or bool(headline_stream_states)
                 or is_tracked_delta
             )
@@ -1180,11 +1200,11 @@ class BaseChannel(ABC):
                     headline_stream_states,
                 )
 
-            return self._sanitize_surrogate_text(data)
+            return data
 
         except Exception as err:
             logger.warning(
-                "Event JSON serialization failed; using safe fallback: %s",
+                "Event snapshot failed; using safe fallback: %s",
                 err,
             )
             try:
@@ -1196,31 +1216,30 @@ class BaseChannel(ABC):
                     payload = {"text": str(event)}
 
                 payload = self._sanitize_for_json(payload)
-                return json.dumps(payload, ensure_ascii=True, default=str)
+                if isinstance(payload, dict):
+                    return payload
+                return {"text": str(payload)}
             except Exception as fallback_err:
                 logger.error(
-                    "Fallback event serialization failed: %s",
+                    "Fallback event snapshot failed: %s",
                     fallback_err,
                 )
-                return json.dumps(
-                    {
-                        "text": self._sanitize_surrogate_text(str(event)),
-                    },
-                    ensure_ascii=True,
-                )
+                return {
+                    "text": self._sanitize_surrogate_text(str(event)),
+                }
 
     @staticmethod
     def _flush_headline_stream_states(
         headline_stream_states: dict[str, Any],
         *,
         msg_id: str | None = None,
-    ) -> list[str]:
+    ) -> list[Dict[str, Any]]:
         """Finalize buffered marker prefixes as ordinary content deltas."""
         from qwenpaw.agents.context.scroll.serialize import (
             flush_headline_delta,
         )
 
-        flushed: list[str] = []
+        flushed: list[Dict[str, Any]] = []
         for stream_key, state in list(headline_stream_states.items()):
             stream_msg_id, separator, raw_index = stream_key.rpartition(":")
             if not separator:
@@ -1236,16 +1255,13 @@ class BaseChannel(ABC):
             except ValueError:
                 index = 0
             flushed.append(
-                json.dumps(
-                    {
-                        "object": "content",
-                        "delta": True,
-                        "msg_id": stream_msg_id,
-                        "index": index,
-                        "text": text,
-                    },
-                    ensure_ascii=False,
-                ),
+                {
+                    "object": "content",
+                    "delta": True,
+                    "msg_id": stream_msg_id,
+                    "index": index,
+                    "text": text,
+                },
             )
         return flushed
 
@@ -1600,7 +1616,7 @@ class BaseChannel(ABC):
                 await self._commit_turn_usage(
                     request,
                     session_id,
-                    emit_sse=False,
+                    emit_event=False,
                 )
             if self._on_reply_sent:
                 args = self.get_on_reply_sent_args(request, to_handle)
@@ -1922,9 +1938,9 @@ class BaseChannel(ABC):
         request: "AgentRequest",
         session_id: str,
         *,
-        emit_sse: bool = True,
-    ) -> List[str]:
-        """Resolve, persist, and optionally emit a ``turn_usage`` SSE."""
+        emit_event: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Resolve, persist, and optionally emit a ``turn_usage`` event."""
         if not session_id:
             return []
         try:
@@ -1976,7 +1992,7 @@ class BaseChannel(ABC):
                         "turn usage persist skipped",
                         exc_info=True,
                     )
-            if not emit_sse:
+            if not emit_event:
                 return []
             payload: Dict[str, Any] = {
                 "type": "turn_usage",
@@ -1984,9 +2000,7 @@ class BaseChannel(ABC):
                 "usage": turn,
                 "context_usage": ctx,
             }
-            return [
-                f"data: {json.dumps(payload, ensure_ascii=False)}\n\n",
-            ]
+            return [payload]
         except Exception:
             logger.warning("turn usage commit skipped", exc_info=True)
             return []

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import copy
-import json as _json
 import logging
 import os
 import sys
@@ -45,7 +44,6 @@ from ..base import (
     TextContent,
 )
 from ..utils import file_url_to_local_path
-
 
 logger = logging.getLogger(__name__)
 
@@ -355,8 +353,11 @@ class ConsoleChannel(BaseChannel):
         )
         self._safe_print(f"📝 {turn_line}{ctx_line}")
 
-    async def stream_one(self, payload: Any) -> AsyncGenerator[str, None]:
-        """Process one payload and yield SSE-formatted events"""
+    async def stream_one(
+        self,
+        payload: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Process one payload and yield JSON-compatible event snapshots."""
         if isinstance(payload, dict) and "content_parts" in payload:
             session_id = self.resolve_session_id(
                 payload.get("sender_id") or "",
@@ -454,18 +455,18 @@ class ConsoleChannel(BaseChannel):
                         headline_stream_states,
                         msg_id=msg_id,
                     ):
-                        yield f"data: {pending_data}\n\n"
+                        yield pending_data
                 elif obj == "response" and status == RunStatus.Completed:
                     for pending_data in self._flush_headline_stream_states(
                         headline_stream_states,
                     ):
-                        yield f"data: {pending_data}\n\n"
+                        yield pending_data
 
-                data = self._serialize_event_for_sse(
+                data = self._event_to_stream_data(
                     event,
                     headline_stream_states,
                 )
-                yield f"data: {data}\n\n"
+                yield data
 
                 if obj == "message" and status == RunStatus.Completed:
                     parts = self._message_to_content_parts(event)
@@ -477,19 +478,19 @@ class ConsoleChannel(BaseChannel):
             for pending_data in self._flush_headline_stream_states(
                 headline_stream_states,
             ):
-                yield f"data: {pending_data}\n\n"
+                yield pending_data
 
             err_msg = self._get_response_error_message(last_response)
             if err_msg:
                 self._clear_session_turn_usage(session_id)
                 self._print_error(err_msg)
             else:
-                for sse in await self._commit_turn_usage(
+                for usage_event in await self._commit_turn_usage(
                     request,
                     session_id,
-                    emit_sse=True,
+                    emit_event=True,
                 ):
-                    yield sse
+                    yield usage_event
 
             logger.info(
                 "console stream done: event_count=%s has_response=%s",
@@ -512,14 +513,11 @@ class ConsoleChannel(BaseChannel):
             self._clear_session_turn_usage(session_id)
             logger.warning("rate limit hit: %s", e)
             alternatives = self._get_free_model_alternatives()
-            rl_event = _json.dumps(
-                {
-                    "type": "rate_limited",
-                    "error": str(e).strip(),
-                    "alternatives": alternatives,
-                },
-            )
-            yield f"data: {rl_event}\n\n"
+            yield {
+                "type": "rate_limited",
+                "error": str(e).strip(),
+                "alternatives": alternatives,
+            }
             self._print_error(str(e).strip())
         except Exception as e:
             self._clear_session_turn_usage(session_id)

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Console APIs: push messages, chat, and file upload for chat."""
+
 from __future__ import annotations
 
 import asyncio
@@ -34,7 +35,6 @@ from ..approvals.display import approval_display_fields
 from ..chats.title_generator import generate_and_update_title
 from ..utils import check_upload_size
 
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/console", tags=["console"])
@@ -64,6 +64,11 @@ class MarkInboxReadRequest(BaseModel):
 
 
 MAX_DEBUG_LOG_LINES = 1000
+
+
+def _encode_sse(data: Dict[str, Any]) -> str:
+    """Encode one internal stream event at the HTTP transport boundary."""
+    return f"data: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 def _resolve_effective_stream_task_timeout(
@@ -446,10 +451,10 @@ async def post_console_chat(
         try:
             try:
                 async for event_data in stream_it:
-                    yield event_data
+                    yield _encode_sse(event_data)
             except Exception as e:
                 logger.exception("Console chat stream error")
-                yield f"data: {json.dumps({'error': str(e)})}\n\n"
+                yield _encode_sse({"error": str(e)})
         finally:
             await stream_it.aclose()
 
@@ -710,17 +715,6 @@ async def get_inbox_trace(run_id: str):
 # ── Background chat task endpoints ──
 
 
-def _parse_sse_payload(line: str) -> Optional[Dict[str, Any]]:
-    """Parse a single SSE data line into a dict."""
-    stripped = line.strip()
-    if stripped.startswith("data: "):
-        try:
-            return json.loads(stripped[6:])
-        except (json.JSONDecodeError, ValueError):
-            return None
-    return None
-
-
 async def _finalize_background_fork(
     project_dir: str,
     branch: str,
@@ -875,12 +869,11 @@ async def post_console_chat_task(  # pylint: disable=too-many-statements
         last_response: Optional[Dict[str, Any]] = None
         finalize_started = False
         try:
-            async for sse_line in console_channel.stream_one(
+            async for event_data in console_channel.stream_one(
                 native_payload,
             ):
-                parsed = _parse_sse_payload(sse_line)
-                if parsed and parsed.get("type") != "turn_usage":
-                    last_response = parsed
+                if event_data.get("type") != "turn_usage":
+                    last_response = event_data
 
             # Fork subagents: commit dirty worktree so branch tips are
             # mergeable before exposing a completed task result.

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -5,10 +5,10 @@
 event buffer. Reconnects get buffer replay + new events. Cleanup when task
 completes.
 """
+
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import weakref
 from dataclasses import dataclass, field
@@ -18,7 +18,6 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
-    Coroutine,
     Optional,
 )
 
@@ -29,7 +28,7 @@ _SENTINEL = None
 # Emitted to reconnect subscribers right after the buffered events, so
 # the client can render the replayed part instantly (no token-by-token
 # re-animation) and switch to live streaming afterwards.
-REPLAY_END_SSE = f"data: {json.dumps({'type': 'replay_end'})}\n\n"
+REPLAY_END_EVENT = {"type": "replay_end"}
 
 
 @dataclass
@@ -38,10 +37,18 @@ class _RunState:
 
     task: asyncio.Future
     queues: list[asyncio.Queue] = field(default_factory=list)
-    buffer: list[str] = field(default_factory=list)
+    buffer: list[dict[str, Any]] = field(default_factory=list)
     start_time: Optional[datetime] = None
     finish_time: Optional[datetime] = None
     owner: object | None = None
+
+
+def _publish_event(run: _RunState, event: dict[str, Any]) -> None:
+    """Broadcast *event* and retain it only when reconnect needs it."""
+    if event.get("type") != "heartbeat":
+        run.buffer.append(event)
+    for queue in run.queues:
+        queue.put_nowait(event)
 
 
 class TaskTracker:
@@ -196,9 +203,9 @@ class TaskTracker:
             if state is None or state.task.done():
                 return None
             q: asyncio.Queue = asyncio.Queue()
-            for sse in state.buffer:
-                q.put_nowait(sse)
-            q.put_nowait(REPLAY_END_SSE)
+            for event in state.buffer:
+                q.put_nowait(event)
+            q.put_nowait(dict(REPLAY_END_EVENT))
             state.queues.append(q)
             return q
 
@@ -254,7 +261,7 @@ class TaskTracker:
         self,
         run_key: str,
         payload: Any,
-        stream_fn: Callable[..., Coroutine],
+        stream_fn: Callable[..., AsyncGenerator[dict[str, Any], None]],
         owner: object | None = None,
         on_finished: Callable[[str, datetime], Awaitable[Any]] | None = None,
     ) -> tuple[asyncio.Queue, bool]:
@@ -266,8 +273,8 @@ class TaskTracker:
             state = self._runs.get(run_key)
             if state is not None and not state.task.done():
                 q: asyncio.Queue = asyncio.Queue()
-                for sse in state.buffer:
-                    q.put_nowait(sse)
+                for event in state.buffer:
+                    q.put_nowait(event)
                 state.queues.append(q)
                 return q, False
 
@@ -293,28 +300,21 @@ class TaskTracker:
                             # pylint: disable=protected-access
                             tracker._global_last_run_at = start_time
 
-                    async for sse in stream_fn(payload):
+                    async for event in stream_fn(payload):
                         tracker = tracker_ref()
                         if tracker is None:
                             return
                         async with tracker.lock:
-                            run.buffer.append(sse)
-                            for q in run.queues:
-                                q.put_nowait(sse)
+                            _publish_event(run, event)
                 except asyncio.CancelledError:
                     logger.debug("run cancelled run_key=%s", run_key)
                 except Exception:
                     logger.exception("run error run_key=%s", run_key)
-                    err_sse = (
-                        "data: "
-                        f"{json.dumps({'error': 'internal server error'})}\n\n"
-                    )
+                    error_event = {"error": "internal server error"}
                     tracker = tracker_ref()
                     if tracker is not None:
                         async with tracker.lock:
-                            run.buffer.append(err_sse)
-                            for q in run.queues:
-                                q.put_nowait(err_sse)
+                            _publish_event(run, error_event)
                 finally:
                     finish_time = datetime.now(timezone.utc)
                     if on_finished is not None:
@@ -346,8 +346,8 @@ class TaskTracker:
         self,
         queue: asyncio.Queue,
         run_key: str,
-    ) -> AsyncGenerator[str, None]:
-        """Yield SSE strings from *queue* until the sentinel ``None``.
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Yield event snapshots from *queue* until the sentinel ``None``.
 
         Always detaches *queue* from *run_key* when this stream ends or is
         closed (including client disconnect), so reconnects do not leak queues.

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -8,6 +8,7 @@ client's stream reader completes normally and falls back to loading the
 persisted history. Returning ``None`` produced a JSON ``null`` body,
 which left the chat UI blank until a manual refresh.
 """
+
 # pylint: disable=protected-access,redefined-outer-name,unused-argument
 from __future__ import annotations
 
@@ -37,7 +38,7 @@ def console_workspace(workspace_mock):
 
     async def _stream_one(payload):
         stream_calls.append(payload)
-        yield "data: should-not-happen\n\n"
+        yield {"type": "should-not-happen"}
 
     console_channel.stream_one = _stream_one
     console_channel.stream_calls = stream_calls
@@ -130,7 +131,8 @@ async def test_reconnect_with_active_run_replays_buffer_and_marker(
     release = asyncio.Event()
 
     async def slow_stream(_payload):
-        yield "data: first\n\n"
+        yield {"type": "heartbeat"}
+        yield {"type": "first"}
         await release.wait()
 
     await tracker.attach_or_start("chat-1", None, slow_stream)
@@ -173,7 +175,8 @@ async def test_reconnect_with_active_run_replays_buffer_and_marker(
     finally:
         release.set()
 
-    assert received[0] == "data: first\n\n"
+    # Heartbeats are delivered live but excluded from reconnect replay.
+    assert json.loads(received[0][len("data: ") :]) == {"type": "first"}
     payload = json.loads(received[1][len("data: ") :])
     assert payload == {"type": "replay_end"}
     # No fresh run was started by the reconnect.

--- a/tests/unit/app/routers/test_console_chat_task.py
+++ b/tests/unit/app/routers/test_console_chat_task.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Regression tests for background console task completion."""
+
 # pylint: disable=protected-access,unused-argument
 from __future__ import annotations
 
@@ -106,8 +107,8 @@ class _ConsoleChannel:
     async def stream_one(
         self,
         payload: dict[str, Any],
-    ) -> AsyncGenerator[str, None]:
-        yield 'data: {"type":"message","output":[]}\n\n'
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        yield {"type": "message", "output": []}
 
 
 class _ChannelManager:

--- a/tests/unit/app/test_multi_agent_manager_startup.py
+++ b/tests/unit/app/test_multi_agent_manager_startup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for bounded multi-agent startup scheduling."""
+
 # pylint: disable=protected-access
 from __future__ import annotations
 
@@ -16,7 +17,7 @@ import qwenpaw.app.multi_agent_manager as multi_agent_manager_module
 import qwenpaw.constant as constants
 from qwenpaw.app.agent_startup import AgentStartupStatus
 from qwenpaw.app.multi_agent_manager import MultiAgentManager
-from qwenpaw.app.task_tracker import REPLAY_END_SSE, TaskTracker
+from qwenpaw.app.task_tracker import REPLAY_END_EVENT, TaskTracker
 from qwenpaw.app.workspace import Workspace
 from qwenpaw.agents.memory.adbpg_memory_manager import ADBPGMemoryManager
 from qwenpaw.agents.memory.dummy import NoopMemoryManager
@@ -201,10 +202,10 @@ async def test_reload_reuses_tracker_for_active_stream_reconnect(
     emitted = asyncio.Event()
 
     async def producer(_payload):
-        yield "data: replayed\n\n"
+        yield {"type": "replayed"}
         emitted.set()
         await release.wait()
-        yield "data: live\n\n"
+        yield {"type": "live"}
 
     original_queue, _ = await old_workspace.task_tracker.attach_or_start(
         "chat-1",
@@ -221,13 +222,13 @@ async def test_reload_reuses_tracker_for_active_stream_reconnect(
 
     reconnect_queue = await new_workspace.task_tracker.attach("chat-1")
     assert reconnect_queue is not None
-    assert await reconnect_queue.get() == "data: replayed\n\n"
-    assert await reconnect_queue.get() == REPLAY_END_SSE
+    assert await reconnect_queue.get() == {"type": "replayed"}
+    assert await reconnect_queue.get() == REPLAY_END_EVENT
 
     cleanup_tasks = list(manager._cleanup_tasks)
     assert cleanup_tasks
     release.set()
-    assert await reconnect_queue.get() == "data: live\n\n"
+    assert await reconnect_queue.get() == {"type": "live"}
     assert await reconnect_queue.get() is None
     async for _ in old_workspace.task_tracker.stream_from_queue(
         original_queue,

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -12,16 +12,14 @@ Covers:
 - wait_all_done() returns True when idle, False on timeout
 - global status counters update via run lifecycle
 """
+
 # pylint: disable=protected-access,redefined-outer-name,unused-argument
 from __future__ import annotations
 
 import asyncio
-import json
-
 import pytest
 
-from qwenpaw.app.task_tracker import TaskTracker
-
+from qwenpaw.app.task_tracker import REPLAY_END_EVENT, TaskTracker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,7 +34,7 @@ async def _drain(queue: asyncio.Queue, n: int) -> list:
     return items
 
 
-def _make_stream(events: list[str]):
+def _make_stream(events: list[dict]):
     async def stream(_payload):
         for ev in events:
             await asyncio.sleep(0)  # cooperate
@@ -81,7 +79,7 @@ async def test_has_active_tasks_excluding_uses_task_identity():
         )
         started.set()
         await release.wait()
-        yield "data: done\n\n"
+        yield {"type": "done"}
 
     queue, _ = await tracker.attach_or_start(
         "tracked-producer",
@@ -108,7 +106,7 @@ async def test_has_active_tasks_excluding_uses_task_identity():
 @pytest.mark.asyncio
 async def test_attach_or_start_streams_events_and_marks_completion():
     tracker = TaskTracker()
-    events = ["data: a\n\n", "data: b\n\n"]
+    events = [{"type": "a"}, {"type": "b"}]
 
     queue, is_new = await tracker.attach_or_start(
         "run-1",
@@ -160,10 +158,10 @@ async def test_attach_or_start_existing_run_returns_buffer_replay():
     release = asyncio.Event()
 
     async def slow_stream(_payload):
-        yield "data: first\n\n"
+        yield {"type": "first"}
         started.set()
         await release.wait()
-        yield "data: second\n\n"
+        yield {"type": "second"}
 
     queue_a, new_a = await tracker.attach_or_start(
         "run-2",
@@ -188,7 +186,7 @@ async def test_attach_or_start_existing_run_returns_buffer_replay():
 
     # queue_b should be pre-filled with the buffered first event.
     first_b = await asyncio.wait_for(queue_b.get(), timeout=1)
-    assert first_b == "data: first\n\n"
+    assert first_b == {"type": "first"}
 
     # Let the producer finish.
     release.set()
@@ -197,8 +195,44 @@ async def test_attach_or_start_existing_run_returns_buffer_replay():
     rest_a = await _drain(queue_a, 3)  # first, second, SENTINEL
     rest_b = await _drain(queue_b, 2)  # second, SENTINEL
 
-    assert rest_a == ["data: first\n\n", "data: second\n\n", None]
-    assert rest_b == ["data: second\n\n", None]
+    assert rest_a == [{"type": "first"}, {"type": "second"}, None]
+    assert rest_b == [{"type": "second"}, None]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_is_live_but_not_buffered_for_reconnect():
+    tracker = TaskTracker()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    heartbeat = {"type": "heartbeat"}
+    content = {"type": "content", "text": "heartbeat"}
+
+    async def slow_stream(_payload):
+        yield heartbeat
+        yield content
+        started.set()
+        await release.wait()
+
+    live_queue, _ = await tracker.attach_or_start(
+        "run-heartbeat",
+        payload=None,
+        stream_fn=slow_stream,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert await _drain(live_queue, 2) == [heartbeat, content]
+
+    reconnect_queue = await tracker.attach("run-heartbeat")
+    assert reconnect_queue is not None
+    assert await _drain(reconnect_queue, 2) == [
+        content,
+        REPLAY_END_EVENT,
+    ]
+
+    release.set()
+    assert await asyncio.wait_for(live_queue.get(), timeout=1) is None
+    assert await asyncio.wait_for(reconnect_queue.get(), timeout=1) is None
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +248,7 @@ async def test_request_stop_cancels_live_run():
     async def long_stream(_payload):
         started.set()
         await asyncio.sleep(60)
-        yield "never"
+        yield {"type": "never"}
 
     await tracker.attach_or_start(
         "run-cancel",
@@ -242,12 +276,12 @@ async def test_request_stop_returns_false_when_no_run():
 
 
 # ---------------------------------------------------------------------------
-# Error path: producer exception broadcasts an error SSE.
+# Error path: producer exception broadcasts an error event.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_producer_exception_emits_error_sse():
+async def test_producer_exception_emits_error_event():
     tracker = TaskTracker()
 
     async def boom(_payload):
@@ -266,9 +300,7 @@ async def test_producer_exception_emits_error_sse():
     err = await asyncio.wait_for(queue.get(), timeout=1)
     sentinel = await asyncio.wait_for(queue.get(), timeout=1)
 
-    assert err.startswith("data: ")
-    payload = json.loads(err[len("data: ") :].rstrip("\n"))
-    assert payload == {"error": "internal server error"}
+    assert err == {"error": "internal server error"}
     assert sentinel is None
 
 
@@ -286,7 +318,7 @@ async def test_detach_subscriber_is_idempotent():
     async def gated(_payload):
         started.set()
         await release.wait()
-        yield "data: done\n\n"
+        yield {"type": "done"}
 
     queue, _ = await tracker.attach_or_start(
         "run-detach",
@@ -314,7 +346,7 @@ async def test_detach_subscriber_is_idempotent():
 @pytest.mark.asyncio
 async def test_stream_from_queue_yields_until_sentinel_and_detaches():
     tracker = TaskTracker()
-    events = ["data: 1\n\n", "data: 2\n\n"]
+    events = [{"type": "1"}, {"type": "2"}]
 
     queue, _ = await tracker.attach_or_start(
         "run-stream",
@@ -350,7 +382,7 @@ async def test_wait_all_done_times_out_when_task_runs():
 
     async def producer(_payload):
         await release.wait()
-        yield "data: done\n\n"
+        yield {"type": "done"}
 
     queue, _ = await tracker.attach_or_start(
         "run-long",
@@ -375,7 +407,7 @@ async def test_snapshot_active_tasks_filters_by_owner():
 
     async def producer(_payload):
         await release.wait()
-        yield "data: done\n\n"
+        yield {"type": "done"}
 
     queue_a, _ = await tracker.attach_or_start(
         "run-owner-a",
@@ -409,11 +441,11 @@ async def test_wait_tasks_done_ignores_runs_started_after_snapshot():
 
     async def old_producer(_payload):
         await release_old.wait()
-        yield "data: old\n\n"
+        yield {"type": "old"}
 
     async def new_producer(_payload):
         await release_new.wait()
-        yield "data: new\n\n"
+        yield {"type": "new"}
 
     old_queue, _ = await tracker.attach_or_start(
         "run-old",
@@ -456,7 +488,7 @@ async def test_concurrent_attach_or_start_only_one_producer():
         nonlocal invocations
         invocations += 1
         await release.wait()
-        yield "data: done\n\n"
+        yield {"type": "done"}
 
     queues = await asyncio.gather(
         tracker.attach_or_start("run-concurrent", None, producer),
@@ -492,10 +524,10 @@ async def test_attach_appends_replay_end_marker_after_buffer():
     release = asyncio.Event()
 
     async def slow_stream(_payload):
-        yield "data: first\n\n"
+        yield {"type": "first"}
         started.set()
         await release.wait()
-        yield "data: second\n\n"
+        yield {"type": "second"}
 
     queue_a, _ = await tracker.attach_or_start(
         "run-replay",
@@ -510,15 +542,12 @@ async def test_attach_appends_replay_end_marker_after_buffer():
 
     first = await asyncio.wait_for(queue_b.get(), timeout=1)
     marker = await asyncio.wait_for(queue_b.get(), timeout=1)
-    assert first == "data: first\n\n"
-    assert marker.startswith("data: ")
-    assert json.loads(marker[len("data: ") :].strip()) == {
-        "type": "replay_end",
-    }
+    assert first == {"type": "first"}
+    assert marker == REPLAY_END_EVENT
 
     release.set()
     rest_b = await _drain(queue_b, 2)
-    assert rest_b == ["data: second\n\n", None]
+    assert rest_b == [{"type": "second"}, None]
     # The original (non-reconnect) subscriber never sees the marker.
     rest_a = await _drain(queue_a, 3)
-    assert rest_a == ["data: first\n\n", "data: second\n\n", None]
+    assert rest_a == [{"type": "first"}, {"type": "second"}, None]

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -14,6 +14,7 @@ Corresponding Tier Strategy:
 - This file: As B-tier supplement, covers complex internal logic
   (debounce, merge, permissions)
 """
+
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 # pylint: disable=reimported,broad-exception-raised,using-constant-test
 from __future__ import annotations
@@ -27,7 +28,6 @@ import pytest
 # Import BaseChannel directly for internal logic testing
 from qwenpaw.app.channels.base import BaseChannel, ProcessHandler
 from qwenpaw.app.channels.console.channel import ConsoleChannel
-
 
 # =============================================================================
 # Test Fixtures (Shared Infrastructure)
@@ -890,8 +890,11 @@ class TestStreamWithTracker:
     Core streaming logic through TaskTracker.
     """
 
-    async def test_stream_with_tracker_yields_sse_events(self, base_channel):
-        """_stream_with_tracker should yield SSE-formatted events."""
+    async def test_stream_with_tracker_yields_event_snapshots(
+        self,
+        base_channel,
+    ):
+        """_stream_with_tracker should yield structured event snapshots."""
         from qwenpaw.schemas import (
             RunStatus,
             Event,
@@ -951,7 +954,7 @@ class TestStreamWithTracker:
                         break  # Just check first event
 
                     assert len(events) == 1
-                    assert "data:" in events[0]
+                    assert events[0]["type"] == "message.in_progress"
 
     async def test_stream_with_tracker_handles_exception(self, base_channel):
         """_stream_with_tracker should handle exceptions gracefully."""
@@ -1052,9 +1055,8 @@ class TestStreamWithTracker:
                         break
 
         assert len(events) == 1
-        assert events[0].startswith("data: ")
-        assert "\\ud83c" not in events[0]
-        assert "? broken" in events[0]
+        assert "\ud83c" not in events[0]["text"]
+        assert "? broken" in events[0]["text"]
 
 
 # =============================================================================

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -12,6 +12,7 @@ Key patterns demonstrated:
 3. Lifecycle testing (start/stop)
 4. Simple mocking (no external dependencies)
 """
+
 # pylint: disable=redefined-outer-name,reimported,protected-access
 # pylint: disable=unused-argument
 from __future__ import annotations
@@ -108,12 +109,14 @@ class TestConsoleChannelUnit:
 
         data = ConsoleChannel._strip_event_headlines(
             _FakeDumpEvent(payload),
-            "{}",
+            {},
         )
 
-        assert "streamed headline" not in data
-        assert "completed headline" not in data
-        assert "visible" in data
+        assert "streamed headline" not in data["delta"]
+        assert (
+            "completed headline" not in data["output"][0]["content"][0]["text"]
+        )
+        assert "visible" in data["output"][0]["content"][0]["text"]
 
     def test_sse_headline_strip_tracks_split_delta_line(self):
         """Later headline chunks stay hidden without repeating the opener."""
@@ -135,15 +138,15 @@ class TestConsoleChannelUnit:
             }
             data = ConsoleChannel._strip_event_headlines(
                 _FakeDumpEvent(payload),
-                "{}",
+                {},
                 stream_states,
             )
             rendered.append(data)
 
-        assert "visible" in rendered[0]
-        assert all("model discovery" not in item for item in rendered)
-        assert all("status: fixed" not in item for item in rendered)
-        assert all("anchors: TC-1" not in item for item in rendered)
+        assert "visible" in rendered[0]["text"]
+        assert all("model discovery" not in item["text"] for item in rendered)
+        assert all("status: fixed" not in item["text"] for item in rendered)
+        assert all("anchors: TC-1" not in item["text"] for item in rendered)
         assert not stream_states
 
     def test_sse_serializer_hides_split_delta_line(self, channel):
@@ -167,16 +170,16 @@ class TestConsoleChannelUnit:
                 },
             )
             rendered.append(
-                channel._serialize_event_for_sse(
+                channel._event_to_stream_data(
                     event,
                     stream_states,
                 ),
             )
 
-        assert "visible" in rendered[0]
-        assert all("model discovery" not in item for item in rendered)
-        assert all("status: fixed" not in item for item in rendered)
-        assert all("anchors: TC-1" not in item for item in rendered)
+        assert "visible" in rendered[0]["text"]
+        assert all("model discovery" not in item["text"] for item in rendered)
+        assert all("status: fixed" not in item["text"] for item in rendered)
+        assert all("anchors: TC-1" not in item["text"] for item in rendered)
         assert not stream_states
 
     def test_sse_serializer_buffers_split_opening_marker(self, channel):
@@ -198,8 +201,8 @@ class TestConsoleChannelUnit:
                     "text": text,
                 },
             )
-            data = channel._serialize_event_for_sse(event, stream_states)
-            visible.append(json.loads(data)["text"])
+            data = channel._event_to_stream_data(event, stream_states)
+            visible.append(data["text"])
 
         assert "".join(visible) == "answer\n"
         assert not stream_states
@@ -221,11 +224,11 @@ class TestConsoleChannelUnit:
             },
         )
 
-        data = channel._serialize_event_for_sse(event, stream_states)
+        data = channel._event_to_stream_data(event, stream_states)
         flushed = channel._flush_headline_stream_states(stream_states)
 
-        assert json.loads(data)["text"] == "ordinary comparison ends in "
-        assert [json.loads(item)["text"] for item in flushed] == [suffix]
+        assert data["text"] == "ordinary comparison ends in "
+        assert [item["text"] for item in flushed] == [suffix]
         assert not stream_states
 
     def test_sse_serializer_discards_confirmed_headline_at_end(self, channel):
@@ -240,10 +243,10 @@ class TestConsoleChannelUnit:
             },
         )
 
-        data = channel._serialize_event_for_sse(event, stream_states)
+        data = channel._event_to_stream_data(event, stream_states)
         flushed = channel._flush_headline_stream_states(stream_states)
 
-        assert json.loads(data)["text"] == "answer\n"
+        assert data["text"] == "answer\n"
         assert flushed == []
         assert not stream_states
 
@@ -649,7 +652,7 @@ class TestConsoleStreaming:
             break
 
         assert len(events) == 1
-        assert "data:" in events[0]
+        assert events[0]["type"] == "message.completed"
 
     @pytest.mark.parametrize("suffix", ("<", "<!", "<!--"))
     async def test_stream_one_flushes_pending_prefix_before_completion(
@@ -709,10 +712,7 @@ class TestConsoleStreaming:
         }
 
         events = [event async for event in stream_channel.stream_one(payload)]
-        payloads = [
-            json.loads(event.removeprefix("data: ").strip())
-            for event in events
-        ]
+        payloads = events
 
         assert payloads[0]["text"] == "ordinary comparison ends in "
         assert payloads[1]["text"] == suffix
@@ -878,16 +878,18 @@ class TestConsoleStreaming:
             break
 
         assert len(events) == 1
-        assert events[0].startswith("data: ")
-        assert "\\ud83d" not in events[0]
-        assert "? broken" in events[0]
+        assert "\ud83d" not in events[0]["text"]
+        assert "? broken" in events[0]["text"]
 
     async def test_consume_one_drain_stream(self, stream_channel):
         """consume_one should drain stream_one."""
         from unittest.mock import patch, AsyncMock
 
         mock_stream = AsyncMock()
-        mock_stream.__aiter__.return_value = ["event1", "event2"]
+        mock_stream.__aiter__.return_value = [
+            {"type": "event1"},
+            {"type": "event2"},
+        ]
 
         with patch.object(
             stream_channel,

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -1515,11 +1515,11 @@ class TestDingTalkWorkspaceIntegration:
         dingtalk_channel.set_workspace(mock_workspace)
         return dingtalk_channel
 
-    async def test_stream_with_tracker_yields_sse_events(
+    async def test_stream_with_tracker_yields_event_snapshots(
         self,
         dingtalk_with_workspace,
     ):
-        """_stream_with_tracker should yield SSE formatted events."""
+        """_stream_with_tracker should yield structured event snapshots."""
         from qwenpaw.schemas import (
             RunStatus,
             Event,
@@ -1563,7 +1563,7 @@ class TestDingTalkWorkspaceIntegration:
             break  # Just check first event
 
         assert len(events) == 1
-        assert "data:" in events[0]
+        assert events[0]["type"] == "message.completed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- pass JSON-compatible event snapshots from BaseChannel and ConsoleChannel through TaskTracker
- broadcast heartbeat events live without retaining them in the reconnect buffer
- serialize JSON and frame SSE only at the console HTTP router boundary
- remove SSE parsing from console background tasks and keep replay/error/usage events structured

## Validation

- `269 passed, 2 skipped` in targeted TaskTracker, channel, console router, checkpoint, and reload tests
- all pre-commit hooks passed, including mypy, Black, flake8, and Pylint
- `git diff --check` passed