### PR TITLE
feat(console): add copy actions to file previews

### DIFF
--- a/console/src/features/files-workspace/FilesDrawer.test.tsx
+++ b/console/src/features/files-workspace/FilesDrawer.test.tsx
@@ -4,6 +4,25 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import FilesDrawer from "./FilesDrawer";
 
+const clipboardMocks = vi.hoisted(() => ({
+  copyText: vi.fn().mockResolvedValue(undefined),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("../../utils/clipboard", () => ({
+  copyText: clipboardMocks.copyText,
+}));
+
+vi.mock("../../hooks/useAppMessage", () => ({
+  useAppMessage: () => ({
+    message: {
+      error: clipboardMocks.error,
+      success: clipboardMocks.success,
+    },
+  }),
+}));
+
 vi.mock("../../api/modules/workspace", () => ({
   workspaceApi: {
     getFileMetadata: vi.fn().mockResolvedValue({
@@ -25,6 +44,50 @@ vi.mock("./FilesWorkspace", () => ({
 }));
 
 describe("FilesDrawer", () => {
+  it("copies the complete text file content", async () => {
+    clipboardMocks.copyText.mockClear();
+    clipboardMocks.success.mockClear();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <FilesDrawer
+        state={{
+          kind: "preview",
+          target: {
+            source: "workspace",
+            path: "hello.txt",
+            root: "project",
+          },
+          trigger: null,
+        }}
+        dispatch={vi.fn()}
+        scope={{
+          kind: "session",
+          agentId: "default",
+          sessionId: "session-1",
+        }}
+      />,
+    );
+
+    const copyButton = await screen.findByRole("button", {
+      name: /copy|复制/i,
+    });
+    const downloadButton = screen.getByRole("button", {
+      name: /download|下载/i,
+    });
+
+    expect(
+      copyButton.compareDocumentPosition(downloadButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    await user.click(copyButton);
+
+    await waitFor(() => {
+      expect(clipboardMocks.copyText).toHaveBeenCalledWith("hello");
+      expect(clipboardMocks.success).toHaveBeenCalled();
+    });
+  });
+
   it("does not repeat the Workspace label in the expanded header", async () => {
     renderWithProviders(
       <FilesDrawer

--- a/console/src/features/files-workspace/FilesDrawer.tsx
+++ b/console/src/features/files-workspace/FilesDrawer.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeft,
+  Copy,
   Download,
   Expand,
   FileText,
@@ -21,6 +22,8 @@ import { buildAuthHeaders } from "../../api/authHeaders";
 import FilePreview, { isPreviewable } from "../../pages/Coding/FilePreview";
 import { setTextareaValue } from "../../pages/Chat/utils";
 import { downloadFileFromUrl } from "../../utils/downloadFileFromUrl";
+import { copyText } from "../../utils/clipboard";
+import { useAppMessage } from "../../hooks/useAppMessage";
 import type { FileMetadata, FilesDrawerEvent, FilesDrawerState } from "./types";
 import type { FilesWorkspaceScope } from "./filesWorkspaceScope";
 import styles from "./FilesWorkspace.module.less";
@@ -63,6 +66,7 @@ export default function FilesDrawer({
   scope,
 }: FilesDrawerProps) {
   const { t } = useTranslation();
+  const { message } = useAppMessage();
   const drawerRef = useRef<HTMLElement>(null);
   const [metadata, setMetadata] = useState<FileMetadata | null>(null);
   const [content, setContent] = useState("");
@@ -246,6 +250,17 @@ export default function FilesDrawer({
 
   const drawerStyle = width > 0 ? { width: `${width}px` } : undefined;
   const filename = target?.path.split("/").pop() ?? t("files.title");
+  const canCopy =
+    metadata?.preview_kind === "text" || metadata?.preview_kind === "csv";
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await copyText(content);
+      message.success(t("common.copied"));
+    } catch {
+      message.error(t("common.copyFailed"));
+    }
+  }, [content, message, t]);
 
   return (
     <motion.aside
@@ -339,6 +354,16 @@ export default function FilesDrawer({
           >
             <ArrowLeft size={15} />
             {t("files.backToPreview")}
+          </button>
+        )}
+        {target && canCopy && (
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label={t("common.copy")}
+            onClick={() => void handleCopy()}
+          >
+            <Copy size={16} />
           </button>
         )}
         {target && (target.source === "workspace" || target.artifactUrl) && (

--- a/console/src/pages/Coding/TabbedEditor.test.tsx
+++ b/console/src/pages/Coding/TabbedEditor.test.tsx
@@ -12,6 +12,12 @@ import { useCodingTabsStore } from "../../stores/codingTabsStore";
 
 const SCOPE_KEY = "agent:default";
 
+const clipboardMocks = vi.hoisted(() => ({
+  copyText: vi.fn().mockResolvedValue(undefined),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
 vi.mock("../../monacoSetup", () => ({}));
 
 vi.mock("@monaco-editor/react", () => ({
@@ -39,10 +45,25 @@ vi.mock("../../contexts/ThemeContext", () => ({
   useTheme: () => ({ isDark: false }),
 }));
 
+vi.mock("../../utils/clipboard", () => ({
+  copyText: clipboardMocks.copyText,
+}));
+
+vi.mock("../../hooks/useAppMessage", () => ({
+  useAppMessage: () => ({
+    message: {
+      error: clipboardMocks.error,
+      success: clipboardMocks.success,
+    },
+  }),
+}));
+
 function Harness({
   onSaveFile,
+  onDownloadFile,
 }: {
   onSaveFile: (path: string, content: string) => Promise<void>;
+  onDownloadFile?: (path: string) => Promise<void>;
 }) {
   const tabs = useCodingTabsStore(
     (state) => state.tabsByAgent[SCOPE_KEY] ?? [],
@@ -71,6 +92,7 @@ function Harness({
       onTabContentChange={(path, content) =>
         store.setTabContent(SCOPE_KEY, path, content)
       }
+      onDownloadFile={onDownloadFile}
       onSaveFile={onSaveFile}
     />
   );
@@ -114,6 +136,51 @@ describe("TabbedEditor diff resolution", () => {
       expect(onSaveFile).toHaveBeenLastCalledWith("hello.txt", "original");
     });
     expect(onSaveFile).not.toHaveBeenCalledWith("hello.txt", "");
+  });
+});
+
+describe("TabbedEditor clipboard action", () => {
+  beforeEach(() => {
+    clipboardMocks.copyText.mockClear();
+    clipboardMocks.success.mockClear();
+    useCodingTabsStore.setState({
+      tabsByAgent: {
+        [SCOPE_KEY]: [
+          {
+            path: "hello.txt",
+            content: "unsaved content",
+            dirty: true,
+            previewKind: "text",
+          },
+        ],
+      },
+      activeTabByAgent: { [SCOPE_KEY]: "hello.txt" },
+      diffsByAgent: { [SCOPE_KEY]: {} },
+    });
+  });
+
+  it("copies the current in-memory file content", async () => {
+    render(
+      <Harness
+        onSaveFile={vi.fn(async () => undefined)}
+        onDownloadFile={vi.fn(async () => undefined)}
+      />,
+    );
+    const copyButton = screen.getByRole("button", { name: /copy|复制/i });
+    const downloadButton = screen.getByRole("button", {
+      name: /download|下载/i,
+    });
+
+    expect(
+      copyButton.compareDocumentPosition(downloadButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(clipboardMocks.copyText).toHaveBeenCalledWith("unsaved content");
+      expect(clipboardMocks.success).toHaveBeenCalled();
+    });
   });
 });
 

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -24,6 +24,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Code2,
+  Copy,
   Download,
   Eye,
   FileCode,
@@ -41,6 +42,8 @@ import FilePreview, { isPreviewable } from "./FilePreview";
 import { workspaceApi } from "../../api/modules/workspace";
 import { useWorkspaceWatch } from "../../hooks/useWorkspaceWatch";
 import { useTheme } from "../../contexts/ThemeContext";
+import { useAppMessage } from "../../hooks/useAppMessage";
+import { copyText } from "../../utils/clipboard";
 import { setTextareaValue } from "../Chat/utils";
 import { clearLastEditorCopy, setLastEditorCopy } from "./lastEditorCopy";
 import {
@@ -193,6 +196,7 @@ export default function TabbedEditor({
   navigation,
 }: TabbedEditorProps) {
   const { t } = useTranslation();
+  const { message } = useAppMessage();
   const { isDark } = useTheme();
   const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
   const tabElementsRef = useRef(new Map<string, HTMLDivElement>());
@@ -358,6 +362,17 @@ export default function TabbedEditor({
     activeDiffRaw && activeDiffRaw.modified !== null
       ? { original: activeDiffRaw.original, modified: activeDiffRaw.modified }
       : undefined;
+  const activeRenderedContent =
+    activeDiff?.modified ?? activeTab?.content ?? "";
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await copyText(activeRenderedContent);
+      message.success(t("common.copied"));
+    } catch {
+      message.error(t("common.copyFailed"));
+    }
+  }, [activeRenderedContent, message, t]);
 
   // Hydrate the `modified` side of any persisted diff by re-reading the
   // current disk content. Drop diffs whose file no longer exists.
@@ -999,8 +1014,9 @@ export default function TabbedEditor({
     Boolean(activeTab) &&
     !activeTab?.readOnly &&
     !["image", "pdf", "binary"].includes(activeTab?.previewKind ?? "text");
-  const activeRenderedContent =
-    activeDiff?.modified ?? activeTab?.content ?? "";
+  const activeCanCopy =
+    Boolean(activeTab) &&
+    !["image", "pdf", "binary"].includes(activeTab?.previewKind ?? "text");
 
   return (
     <div className={styles.wrap} onKeyDown={handleKeyDown}>
@@ -1281,11 +1297,24 @@ export default function TabbedEditor({
                 </button>
               )}
             </div>
+            {activeCanCopy && (
+              <Tooltip title={t("common.copy")}>
+                <button
+                  type="button"
+                  className={styles.iconBtn}
+                  aria-label={t("common.copy")}
+                  onClick={() => void handleCopy()}
+                >
+                  <Copy size={13} />
+                </button>
+              </Tooltip>
+            )}
             {onDownloadFile && activeTabPath && (
               <Tooltip title={t("files.download")}>
                 <button
                   type="button"
                   className={styles.iconBtn}
+                  aria-label={t("files.download")}
                   onClick={() => void onDownloadFile(activeTabPath)}
                 >
                   <Download size={13} />


### PR DESCRIPTION
## Summary

- add a copy-to-clipboard action to text and CSV previews in FilesDrawer
- add the same action to FileWorkspace preview and edit modes, including unsaved content
- keep file actions ordered as Copy, Download, and Save
- hide copy actions for image, PDF, and binary files

## Tests

- npm run test:run -- src/features/files-workspace/FilesDrawer.test.tsx src/pages/Coding/TabbedEditor.test.tsx
- npm exec tsc -- -b --noEmit
- npm exec prettier -- --check on changed files
- git diff --check