### PR TITLE
fix(console): compact markdown list spacing

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -326,12 +326,16 @@
   [class*="bubble-start"] [class*="markdown"]:not(.x-markdown),
   [class*="bubble-assistant"] [class*="markdown"]:not(.x-markdown),
   [class*="bubble-start"] .x-markdown p,
-  [class*="bubble-start"] .x-markdown li,
-  [class*="bubble-assistant"] .x-markdown p,
-  [class*="bubble-assistant"] .x-markdown li {
+  [class*="bubble-assistant"] .x-markdown p {
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     word-break: normal;
+  }
+
+  /* Keep Markdown list structure compact while preserving paragraph breaks. */
+  [class*="bubble-start"] .x-markdown li,
+  [class*="bubble-assistant"] .x-markdown li {
+    white-space: normal;
   }
 
   [class*="bubble-start"] .x-markdown pre,

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -38,9 +38,24 @@ describe("Chat message markdown layout styles", () => {
     expect(rule).toContain(".x-markdown p");
     expect(rule).toContain(".x-markdown li");
     expect(rule).toMatch(/white-space:\s*pre-wrap/);
+    expect(rule).toMatch(/\.x-markdown li[\s\S]*white-space:\s*normal/);
     expect(rule).toMatch(/overflow-wrap:\s*anywhere/);
     expect(rule).toMatch(/overflow-x:\s*auto/);
     expect(rule).toMatch(/max-width:\s*100%/);
+  });
+
+  it("does not preserve structural whitespace between nested list items", () => {
+    const marker = '[class*="bubble-start"] .x-markdown li';
+    const markerIndex = stylesSource.indexOf(marker);
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("}", markerIndex) + 1,
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toContain(".x-markdown li");
+    expect(rule).toMatch(/white-space:\s*normal/);
+    expect(rule).not.toMatch(/white-space:\s*pre-wrap/);
   });
 });
 


### PR DESCRIPTION
Fixes #7282

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/eb8bf157-4a2b-428e-b869-b6cf2943fbd7" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
