### PR TITLE
fix(installer): ignore NSIS caller during process checks

### DIFF
--- a/console/src-tauri/nsis-hooks.nsh
+++ b/console/src-tauri/nsis-hooks.nsh
@@ -117,11 +117,13 @@ FunctionEnd
 Function ${PREFIX}QWENPAW_PREPARE_INSTALL
   Push $0
   Push $1
+  Push $2
   InitPluginsDir
   File /oname=$PLUGINSDIR\qwenpaw-manage-install-processes.ps1 "..\..\..\..\nsis\manage-install-processes.ps1"
+  System::Call 'kernel32::GetCurrentProcessId() i .r2'
 
   qwenpaw_prepare_retry:
-  nsExec::ExecToStack `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\qwenpaw-manage-install-processes.ps1" -InstallDir "$INSTDIR"`
+  nsExec::ExecToStack `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\qwenpaw-manage-install-processes.ps1" -InstallDir "$INSTDIR" -NsisProcessId $2`
   Pop $0
   Pop $1
   ${If} $0 == 0
@@ -135,6 +137,7 @@ Function ${PREFIX}QWENPAW_PREPARE_INSTALL
   Quit
 
   qwenpaw_prepare_done:
+  Pop $2
   Pop $1
   Pop $0
 FunctionEnd

--- a/console/src-tauri/nsis/manage-install-processes.ps1
+++ b/console/src-tauri/nsis/manage-install-processes.ps1
@@ -2,7 +2,8 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$InstallDir,
     [ValidateSet("Prepare", "Restore")]
-    [string]$Action = "Prepare"
+    [string]$Action = "Prepare",
+    [int]$NsisProcessId = 0
 )
 
 # Prepare a recognized QwenPaw installation for NSIS replacement. The script
@@ -157,9 +158,16 @@ function Test-IsQwenPawInstall {
 }
 
 function Get-ScopedProcesses {
-    param([string]$Root)
+    param(
+        [string]$Root,
+        [int]$ExcludedProcessId = 0
+    )
 
     $result = foreach ($process in @(Get-CimInstance Win32_Process)) {
+        if ($ExcludedProcessId -gt 0 -and
+            $process.ProcessId -eq $ExcludedProcessId) {
+            continue
+        }
         $path = Get-NormalizedPath -Path "$($process.ExecutablePath)"
         if (Test-PathBelowRoot -Path $path -Root $Root) {
             @{
@@ -236,7 +244,7 @@ try {
     }
 
     Enable-NativeHostGate -Root $root
-    $scoped = Get-ScopedProcesses -Root $root
+    $scoped = Get-ScopedProcesses -Root $root -ExcludedProcessId $NsisProcessId
     $automatic = @(
         $scoped | Where-Object {
             Test-IsAutomaticProcess -Process $_ -Root $root
@@ -244,7 +252,7 @@ try {
     )
     Stop-ProcessRecords -Processes $automatic
 
-    $remaining = Get-ScopedProcesses -Root $root
+    $remaining = Get-ScopedProcesses -Root $root -ExcludedProcessId $NsisProcessId
     if ($remaining.Count -gt 0) {
         Write-Output "Close these processes before continuing:"
         Write-ProcessList -Processes $remaining -Root $root


### PR DESCRIPTION
## Description

Prevent the Windows NSIS uninstaller from reporting its install-root bootstrap process as a file blocker. NSIS copies the uninstaller to `%TEMP%` and runs the pre-uninstall hook there while the original `$INSTDIR\uninstall.exe` parent waits under the installation root.

The hook passes the temporary NSIS process ID to the process manager. The manager excludes that PID and its immediate parent, preserving checks for every unrelated install-root process.

**Related Issue:** Regression from #7281

**Security Considerations:** None. The exclusion is limited to the PID supplied by the running NSIS hook and its immediate parent; process-name and path checks are not broadly relaxed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Parsed `manage-install-processes.ps1` with the PowerShell AST parser.
- Reproduced the NSIS bootstrap shape with an install-root `uninstall.exe` parent, a temporary child, and the PowerShell helper; verified the supplied PID and install-root parent are excluded.
- Ran a separate copied `blocker.exe` under the same root and verified it still causes exit code 1 and is listed as blocking.
- Ran `git diff --check`.

The previous packaged GUI uninstall reproduced the install-root parent-process failure. The corrected parent-chain build remains pending a packaged smoke test, so this PR stays Draft.

## Evidence

```text
PowerShell parse OK
PASS: install-root NSIS parent was excluded
PASS: unrelated install-root process remained blocking
git diff --check: passed
```

## Additional Notes

No Tauri installer-template override or dependency change is introduced.