### PR TITLE
fix(ci): bump bundled Python to 3.13 — desktop pipeline + Docker base image

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging
@@ -195,7 +195,7 @@ jobs:
         env:
           PIP_NO_CACHE_DIR: "1"
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: "3.11"
+          python-version: "3.13"
           activate-environment: "qwenpaw-build"
           condarc-file: .github/condarc
           conda-remove-defaults: false
@@ -137,7 +137,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: "3.11"
+          python-version: "3.13"
           activate-environment: "qwenpaw-build"
           condarc-file: .github/condarc
           conda-remove-defaults: false
@@ -179,7 +179,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging
@@ -335,7 +335,7 @@ jobs:
         env:
           PIP_NO_CACHE_DIR: "1"
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging
@@ -488,7 +488,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # Base images — override with --build-arg for environments without ACR access.
-ARG NODE_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+ARG NODE_IMAGE=node:24-trixie-slim
 ARG UV_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/uv:latest
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION

Fixes #7298

## Summary

Bumps the bundled Python in both distribution channels from 3.11 to 3.13 so the TLS stack moves from the OpenSSL 3.0.x era to OpenSSL 3.5.x:

- **Desktop (Tauri) pipeline**: `python-version` pins across the five desktop workflows — 9 × "3.11" → "3.13" plus the fork-verification workflow's 2 × "3.10" → "3.13".
- **Docker image**: `deploy/Dockerfile` default base image `agentscope-registry.../node:slim` (bookworm → Python 3.11.2 / OpenSSL 3.0.20) → `node:24-trixie-slim` (trixie → Python 3.13.5 / OpenSSL 3.5.6).

No application code changes. `scripts/pack-tauri/stage_python_runtime.py` is untouched: its pinned python-build-standalone release 20260623 already ships cpython-3.13.14 for both desktop targets (x86_64-pc-windows-msvc, aarch64-apple-darwin).

## What Problem This Solves

On some carrier networks, a DPI middlebox resets TLS handshakes from clients running the OpenSSL 3.0.x-era stack when the SNI belongs to a specific self-hosted domain family. Packet capture verified the RST is injected in-path (server side clean; controlled experiment matrix in #7298).

The affected clients are QwenPaw bundles, which freeze the TLS stack at build time — users on affected networks have **no workaround**:
- Desktop: frozen Python 3.11 runtime (OpenSSL 3.0.x).
- Docker image: the container Python is the Debian-distro `python3` inherited from the bookworm base (3.11.2 / OpenSSL 3.0.20); rebuilding on a trixie base works, but that is a per-deployment workaround, not a fix.

Python 3.13 bundles OpenSSL 3.5.x. **Python 3.12 is not a viable target**: Windows Python 3.12 still bundles OpenSSL 3.0.x — exactly the fingerprint being blocked.

### Runtime identity confirmed (2026-08-27, #7298 thread)

As requested in #7298, the failing client's execution identity was captured from the same run that produces the reset:

- `sys.executable` = `qwenpaw-backend.exe`, `frozen=True`, TLS modules (`_ssl.pyd`, `libssl-3.dll`, `libcrypto-3.dll`) loaded from `qwenpaw-backend\_internal` — embedded Python 3.11.9 / OpenSSL 3.0.13. The DPI-affected code therefore runs **in the frozen backend**.
- The bundled helper runtime (Python 3.11.15 / OpenSSL 3.5.7, pbs 20260623) was examined directly and is not on the failing path; no system Python is involved.
- **Scope consequence: none.** The single `python-version` pin already drives both bundled runtimes by design (the backend freeze + the helper staging both follow the CI interpreter), so no diff change is proposed — the bump below is the complete fix for the confirmed victim runtime.

## Changes

Line numbers as of `main @ 8368ff1b`.

- **Desktop pipeline** (`python-version` bumps):
  - `desktop-build.yml`: L50, L198 ("3.11" → "3.13")
  - `desktop-release.yml`: L77, L140, L182, L338, L491 ("3.11" → "3.13")
  - `desktop-publish.yml`: L77 ("3.11" → "3.13")
  - `desktop-promote.yml`: L51 ("3.11" → "3.13")
  - `fork-verify-desktop.yml`: L56, L125 ("3.10" → "3.13") — keeps the fork-verification staged runtime aligned with the real pipeline
- **Docker image**: `deploy/Dockerfile` L2 — default `NODE_IMAGE` → `node:24-trixie-slim`. The `NODE_IMAGE`/`UV_IMAGE` build-arg override mechanism already exists; no other Dockerfile change is needed (chromium/xfce/xvfb paths unchanged). The default now resolves from Docker Hub — if maintainers prefer an ACR trixie base instead, that is a one-line follow-up.

One pin drives **both** bundled desktop runtimes: `build_pyinstaller.ps1` freezes the CI Python venv into the backend, and `stage_python_runtime.py` stages the helper runtime matching the running interpreter's major.minor — so the frozen backend and the bundled helper runtime move together.

Not changed: 3.11 pins in non-desktop release workflows (CI tooling steps, not bundled runtimes).

## Evidence

- Upstream CI test matrices (`tests.yml` / `full-tests-nightly.yml` / `release-verify.yml` / `pr-preview-tests.yml`) already run Python 3.13 alongside 3.11 nightly — the codebase is continuously verified on 3.13.
- `pyproject.toml`: `requires-python = ">=3.11,<3.14"` — 3.13 is inside the supported range.
- All runtime dependencies have cp313 wheels (full dependency list reviewed category by category).
- The trixie Docker base was validated before this PR: the unmodified `deploy/Dockerfile` built with `--build-arg NODE_IMAGE=node:24-trixie-slim` from `main` source gives Python 3.13.5 / OpenSSL 3.5.6, `import qwenpaw` OK, chromium/xfce/xvfb/Node intact, and the DPI-affected endpoint from #7298 connects with TLSv1.3 on the affected network. **That image has been in production on our node since 2026-08-24** (2.1.1-beta.x series on the same trixie base); the in-app plugin's https probe to the DPI-affected endpoint — the same code path that fails on the desktop bundle — passes on it (2026-08-26), i.e. a live before/after of this exact change on the affected network.

## Suggested verification

- Docker: build `deploy/Dockerfile`; confirm `python3 -V` → 3.13.x and `python3 -c "import ssl; print(ssl.OPENSSL_VERSION)"` → OpenSSL 3.5.x; run the existing test suite.
- Desktop: run the desktop build for Windows + macOS; the produced installers' bundled runtimes should report Python 3.13.x / OpenSSL 3.5.x. On the affected network from #7298, the previously reset endpoint should connect (before/after capture available on request).
## 摘要

将两条分发渠道的捆绑 Python 从 3.11 升到 3.13，使 TLS 栈从 OpenSSL 3.0.x 代跨到 3.5.x 代：

- **桌面版（Tauri）管线**：5 个桌面 workflow 的 `python-version` 钉——9 处 "3.11" → "3.13"，外加 fork 验证流 2 处 "3.10" → "3.13"。
- **Docker 镜像**：`deploy/Dockerfile` 默认底座 `agentscope-registry.../node:slim`（bookworm → Python 3.11.2 / OpenSSL 3.0.20）→ `node:24-trixie-slim`（trixie → Python 3.13.5 / OpenSSL 3.5.6）。

无应用代码改动。`scripts/pack-tauri/stage_python_runtime.py` 未动：其钉住的 python-build-standalone release 20260623 已含两个桌面目标的 cpython-3.13.14 资产（x86_64-pc-windows-msvc、aarch64-apple-darwin）。

## 解决的问题

部分运营商网络上，DPI 中间盒会对「SNI 属于某自建域族 + OpenSSL 3.0.x 代客户端栈」的 TLS 握手注入 RST。抓包已验证 RST 为链路内注入（服务端干净；受控实验矩阵见 #7298）。

受影响的客户端正是 QwenPaw 的两种捆绑形态——TLS 栈在构建时冻结，受影响网络上的用户**没有绕过手段**：
- 桌面版：冻结的 Python 3.11 runtime（OpenSSL 3.0.x）。
- Docker 镜像：容器内 Python 是 bookworm 底座继承的发行版 `python3`（3.11.2 / OpenSSL 3.0.20）；在 trixie 底座上重建可以绕过，但那是逐部署的绕法，不是治本。

Python 3.13 捆绑 OpenSSL 3.5.x。**Python 3.12 不可行**：Windows 上的 Python 3.12 仍捆绑 OpenSSL 3.0.x——恰是被拦截的指纹。

### 执行身份已确认（2026-08-27，#7298 线程）

按 #7298 要求，从产生 RST 的同一次运行中捕获了失败客户端的执行身份：

- `sys.executable` = `qwenpaw-backend.exe`、`frozen=True`、TLS 模块（`_ssl.pyd`/`libssl-3.dll`/`libcrypto-3.dll`）从 `qwenpaw-backend\_internal` 加载——内嵌 Python 3.11.9 / OpenSSL 3.0.13。DPI 受害代码**跑在 frozen backend 内**。
- 捆绑 helper runtime（Python 3.11.15 / OpenSSL 3.5.7，pbs 20260623）已直接检查，不在失败路径上；不涉及系统 Python。
- **范围影响：无。** 单一 `python-version` 钉本就按设计同时驱动两个捆绑运行时（backend 冻结 + helper staging 都跟 CI 解释器），故不拟改 diff——下述升版即对已确认受害运行时的完整修复。

## 改动

行号以 `main @ 8368ff1b` 为准。

- **桌面管线**（`python-version` 升钉）：
  - `desktop-build.yml`：L50、L198（"3.11" → "3.13"）
  - `desktop-release.yml`：L77、L140、L182、L338、L491（"3.11" → "3.13"）
  - `desktop-publish.yml`：L77（"3.11" → "3.13"）
  - `desktop-promote.yml`：L51（"3.11" → "3.13"）
  - `fork-verify-desktop.yml`：L56、L125（"3.10" → "3.13"）——保持 fork 验证流 stage 的 runtime 与真管线一致
- **Docker 镜像**：`deploy/Dockerfile` L2——默认 `NODE_IMAGE` → `node:24-trixie-slim`。`NODE_IMAGE`/`UV_IMAGE` 的 build-arg 覆盖机制已存在，Dockerfile 无需其他改动（chromium/xfce/xvfb 路径不变）。默认值现在解析自 Docker Hub——若维护者更希望 ACR trixie 底座，那是一个后续一行的改动。

单一钉位驱动**两个**捆绑桌面 runtime：`build_pyinstaller.ps1` 把 CI Python venv 冻结进后端，`stage_python_runtime.py` stage 与运行解释器 major.minor 匹配的 helper runtime——冻结后端与捆绑 helper runtime 一并迁移。

未改动：非桌面 release workflow 的 3.11 钉（CI 工具步骤，非捆绑 runtime）。

## 验证证据

- Upstream CI 测试矩阵（`tests.yml` / `full-tests-nightly.yml` / `release-verify.yml` / `pr-preview-tests.yml`）已 nightly 双跑 Python 3.13 与 3.11——代码库在 3.13 上持续被验证。
- `pyproject.toml`：`requires-python = ">=3.11,<3.14"`——3.13 在支持范围内。
- 全部运行时依赖有 cp313 wheel（完整依赖清单已逐类核查）。
- trixie Docker 底座在本 PR 前已验证：用 `--build-arg NODE_IMAGE=node:24-trixie-slim` 从 `main` 源码构建未改动的 `deploy/Dockerfile`，得到 Python 3.13.5 / OpenSSL 3.5.6、`import qwenpaw` OK、chromium/xfce/xvfb/Node 完整，且 #7298 的 DPI 受影响端点在受影响网络上以 TLSv1.3 连通。**该镜像自 2026-08-24 起就在我们节点生产运行**（同一 trixie 底座的 2.1.1-beta.x 系列）；应用内插件对 DPI 受影响端点的 https 探测——桌面版 bundle 上失败的同一代码路径——在其上通过（2026-08-26），即本 PR 改动在受影响网络上的在产 before/after。

## 建议验证

- Docker：构建 `deploy/Dockerfile`；确认 `python3 -V` → 3.13.x、`python3 -c "import ssl; print(ssl.OPENSSL_VERSION)"` → OpenSSL 3.5.x；跑既有测试套件。
- 桌面：对 Windows + macOS 跑桌面构建；产出安装包内的捆绑 runtime 应报告 Python 3.13.x / OpenSSL 3.5.x。在 #7298 的受影响网络上，之前被 reset 的端点应可连通（前后抓包可按需提供）。
```