### PR TITLE
fix(context): bound oversized single-line tool results

### DIFF
--- a/src/qwenpaw/agents/tools/utils.py
+++ b/src/qwenpaw/agents/tools/utils.py
@@ -325,12 +325,15 @@ def _truncate_fresh(
     newline_count = result.count("\n")
 
     # Compute the first line number not yet fully included in this chunk.
-    # max(1, ...) prevents next_line from equaling start_line when a single line
-    # exceeds max_bytes (newline_count == 0), which would make the caller retry
-    # the same range indefinitely.
     next_line = start_line + max(1, newline_count)
 
-    if next_line <= total_lines:
+    if newline_count == 0:
+        # The preview contains no complete line, even when later lines exist
+        # in the source. Advancing to start_line + 1 would silently skip the
+        # unshown remainder of the current oversized line, while repeating
+        # start_line cannot make progress. Recover from the artifact instead.
+        read_from = None
+    elif next_line <= total_lines:
         # Truncation fell before the last line — continue reading from next_line.
         read_from = next_line
     elif start_line < total_lines:
@@ -338,11 +341,8 @@ def _truncate_fresh(
         # Re-read from the start of the last line so the caller gets it in full.
         read_from = total_lines
     else:
-        # The selected range is one oversized final line. Returning a markerless
-        # slice here makes ToolResultPruner reject the candidate and restore the
-        # complete result, defeating the admission cap. Keep the bounded preview
-        # and direct recovery to the saved artifact instead; line pagination
-        # cannot advance within a single line.
+        # Keep the bounded preview and direct recovery to the saved artifact;
+        # line pagination cannot advance safely from this range.
         read_from = None
 
     metadata = build_truncation_metadata(

--- a/src/qwenpaw/agents/tools/utils.py
+++ b/src/qwenpaw/agents/tools/utils.py
@@ -30,15 +30,25 @@ def _fit_truncation_notice(notice: str, info: dict[str, Any]) -> str:
     if len(notice.encode("utf-8")) <= MAX_TRUNCATION_NOTICE_BYTES:
         return notice
 
-    compact = (
-        TRUNCATION_NOTICE_MARKER
-        + "\nOutput truncated; recovery details are in "
-        "qwenpaw_truncation metadata."
-        f"\nTotal lines: {info['total_lines']}; "
-        f"excerpt starts at line {info['start_line']} and contains "
-        f"{info['excerpt_bytes']} bytes."
-        f"\nContinue with read_file at line {info['read_from']}."
-    )
+    if info.get("continuation_mode") == "artifact":
+        compact = (
+            TRUNCATION_NOTICE_MARKER
+            + "\nOversized single line truncated; recovery details are in "
+            "qwenpaw_truncation metadata."
+            f"\nThe {info['excerpt_bytes']}-byte preview starts at line "
+            f"{info['start_line']}. Inspect the saved artifact for the full "
+            "content."
+        )
+    else:
+        compact = (
+            TRUNCATION_NOTICE_MARKER
+            + "\nOutput truncated; recovery details are in "
+            "qwenpaw_truncation metadata."
+            f"\nTotal lines: {info['total_lines']}; "
+            f"excerpt starts at line {info['start_line']} and contains "
+            f"{info['excerpt_bytes']} bytes."
+            f"\nContinue with read_file at line {info['read_from']}."
+        )
     compact_bytes = compact.encode("utf-8")
     if len(compact_bytes) <= MAX_TRUNCATION_NOTICE_BYTES:
         return compact
@@ -57,7 +67,7 @@ def build_truncation_metadata(
     start_line: int,
     max_bytes: int,
     excerpt_bytes: int,
-    read_from: int,
+    read_from: int | None,
     block_index: int = 0,
 ) -> dict[str, Any]:
     """Build metadata and the matching user-facing truncation notice."""
@@ -71,13 +81,23 @@ def build_truncation_metadata(
         "excerpt_bytes": excerpt_bytes,
         "read_from": read_from,
     }
-    notice = (
-        TRUNCATION_NOTICE_MARKER + "\nThe output above was truncated."
-        f"\nThe full content is saved to the file and contains {total_lines} lines in total."
-        f"\nThis excerpt starts at line {start_line} and covers the next {excerpt_bytes} bytes."
-        "\nIf the current content is not enough, call `read_file` with "
-        f'file_path="{file_path or ""}" start_line={read_from} to read more.'
-    )
+    if read_from is None:
+        info["continuation_mode"] = "artifact"
+        notice = (
+            TRUNCATION_NOTICE_MARKER + "\nThe output above was truncated."
+            f"\nThe full content is saved to the file and contains {total_lines} lines in total."
+            f"\nThis excerpt starts at line {start_line} and covers the first {excerpt_bytes} bytes of an oversized line."
+            "\nThe remaining content is part of the same oversized line, so line-based continuation is unavailable."
+            f'\nInspect the saved artifact at file_path="{file_path or ""}" with a byte- or structure-aware tool.'
+        )
+    else:
+        notice = (
+            TRUNCATION_NOTICE_MARKER + "\nThe output above was truncated."
+            f"\nThe full content is saved to the file and contains {total_lines} lines in total."
+            f"\nThis excerpt starts at line {start_line} and covers the next {excerpt_bytes} bytes."
+            "\nIf the current content is not enough, call `read_file` with "
+            f'file_path="{file_path or ""}" start_line={read_from} to read more.'
+        )
     info["notice"] = _fit_truncation_notice(notice, info)
     return {TRUNCATION_METADATA_KEY: {str(block_index): info}}
 
@@ -282,8 +302,8 @@ def _truncate_fresh(
     Slices at the byte boundary and appends a truncation notice with a continuation
     hint so callers know which line to read next.
 
-    Returns the original text unchanged when it fits within max_bytes, or when the
-    last line itself exceeds max_bytes (unhandled edge case).
+    An oversized final line gets a bounded preview backed by the saved artifact;
+    line-based continuation is intentionally disabled for that preview.
     """
     text_bytes = text.encode(encoding)
 
@@ -292,9 +312,8 @@ def _truncate_fresh(
         return text, {}
 
     # Slice at the byte boundary.
-    # Assuming every single line is shorter than DEFAULT_MAX_BYTES, this cut always
-    # lands mid-line, guaranteeing at least one complete line before the boundary.
-    # Lines that exceed DEFAULT_MAX_BYTES are not handled and may be skipped entirely.
+    # This can land mid-line. Oversized final lines are kept as bounded,
+    # artifact-backed previews below instead of being restored in full.
     truncated = text_bytes[:max_bytes]
     # Decode back to str; errors="ignore" drops any split multi-byte character
     # at the cut boundary without raising an exception.
@@ -319,9 +338,12 @@ def _truncate_fresh(
         # Re-read from the start of the last line so the caller gets it in full.
         read_from = total_lines
     else:
-        # start_line == total_lines: the last line itself exceeds DEFAULT_MAX_BYTES.
-        # This case is outside our handled range — return without a truncation notice.
-        return result, {}
+        # The selected range is one oversized final line. Returning a markerless
+        # slice here makes ToolResultPruner reject the candidate and restore the
+        # complete result, defeating the admission cap. Keep the bounded preview
+        # and direct recovery to the saved artifact instead; line pagination
+        # cannot advance within a single line.
+        read_from = None
 
     metadata = build_truncation_metadata(
         file_path=file_path,
@@ -432,9 +454,11 @@ def _retruncate(
     newline_count = result.count("\n")
 
     # The next read should start at the line immediately after all complete lines.
-    # max(1, ...) guards against the theoretical zero-newline case
-    # (impossible when every line is shorter than DEFAULT_MAX_BYTES).
+    # max(1, ...) guards against a zero-newline preview.
     next_line = start_line + max(1, newline_count)
+    read_from = (
+        None if info.get("continuation_mode") == "artifact" else next_line
+    )
     updated = build_truncation_metadata(
         file_path=info.get("file_path"),
         file_size_bytes=info.get("file_size_bytes"),
@@ -442,7 +466,7 @@ def _retruncate(
         start_line=start_line,
         max_bytes=max_bytes,
         excerpt_bytes=len(result.encode(encoding)),
-        read_from=next_line,
+        read_from=read_from,
         block_index=block_index,
     )
     updated_info = updated[TRUNCATION_METADATA_KEY][str(block_index)]

--- a/tests/unit/agents/test_tool_result_pruning_middleware.py
+++ b/tests/unit/agents/test_tool_result_pruning_middleware.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import types
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, AsyncGenerator
 
 import pytest
@@ -142,6 +143,72 @@ async def test_tool_response_is_pruned_before_yield(tmp_path):
     saved = list(tmp_path.iterdir())
     assert len(saved) == 1
     assert saved[0].read_text(encoding="utf-8") == text
+
+
+@pytest.mark.asyncio
+async def test_single_line_tool_response_is_pruned_before_yield(tmp_path):
+    """Compact JSON must not bypass the fresh-result admission cap."""
+    middleware = ToolResultPruningMiddleware(
+        recent_max_bytes=512,
+        tool_results_dir=str(tmp_path),
+    )
+    text = '{"rows":["' + ("数据" * 1000) + '"]}'
+    response = ToolResponse(
+        id="call-single-line-json",
+        content=[TextBlock(type="text", text=text)],
+    )
+
+    async def next_handler() -> AsyncGenerator[Any, None]:
+        yield response
+
+    agent = type(
+        "AgentStub",
+        (),
+        {"state": type("StateStub", (), {"context": []})()},
+    )()
+
+    result = (
+        await _collect(
+            middleware.on_acting(agent, {}, next_handler),
+        )
+    )[0]
+
+    result_text = result.content[0].text
+    info = result.metadata[TRUNCATION_METADATA_KEY]["0"]
+    assert result_text != text
+    assert TRUNCATION_NOTICE_MARKER in result_text
+    assert len(result_text.encode("utf-8")) <= (
+        512 + MAX_TRUNCATION_NOTICE_BYTES
+    )
+    assert info["excerpt_bytes"] <= 512
+    assert info["file_size_bytes"] == len(text.encode("utf-8"))
+    assert info["continuation_mode"] == "artifact"
+    assert info["read_from"] is None
+    assert "line-based continuation is unavailable" in info["notice"]
+
+    saved = list(tmp_path.iterdir())
+    assert len(saved) == 1
+    assert saved[0].read_text(encoding="utf-8") == text
+
+
+def test_single_line_tool_result_retruncate_stays_artifact_backed(tmp_path):
+    """A smaller historical cap must preserve single-line recovery metadata."""
+    pruner = ToolResultPruner(tmp_path)
+    text = '{"rows":["' + ("x" * 5000) + '"]}'
+
+    first, metadata = pruner.prune_text(text, max_bytes=512)
+    second, updated = pruner.prune_text(
+        first,
+        max_bytes=128,
+        metadata=metadata,
+    )
+
+    info = updated[TRUNCATION_METADATA_KEY]["0"]
+    assert TRUNCATION_NOTICE_MARKER in second
+    assert len(second.split(TRUNCATION_NOTICE_MARKER, 1)[0].encode()) <= 128
+    assert info["continuation_mode"] == "artifact"
+    assert info["read_from"] is None
+    assert Path(info["file_path"]).read_text(encoding="utf-8") == text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agents/test_tool_result_pruning_middleware.py
+++ b/tests/unit/agents/test_tool_result_pruning_middleware.py
@@ -211,6 +211,31 @@ def test_single_line_tool_result_retruncate_stays_artifact_backed(tmp_path):
     assert Path(info["file_path"]).read_text(encoding="utf-8") == text
 
 
+def test_oversized_non_final_line_stays_artifact_backed(tmp_path):
+    """Line continuation must not skip an unseen oversized-line suffix."""
+    pruner = ToolResultPruner(tmp_path)
+    text = ("x" * 1000) + "\ntail"
+
+    first, metadata = pruner.prune_text(text, max_bytes=128)
+    first_info = metadata[TRUNCATION_METADATA_KEY]["0"]
+    assert first.split(TRUNCATION_NOTICE_MARKER, 1)[0] == "x" * 128
+    assert first_info["total_lines"] == 2
+    assert first_info["continuation_mode"] == "artifact"
+    assert first_info["read_from"] is None
+
+    second, updated = pruner.prune_text(
+        first,
+        max_bytes=64,
+        metadata=metadata,
+    )
+
+    info = updated[TRUNCATION_METADATA_KEY]["0"]
+    assert second.split(TRUNCATION_NOTICE_MARKER, 1)[0] == "x" * 64
+    assert info["continuation_mode"] == "artifact"
+    assert info["read_from"] is None
+    assert Path(info["file_path"]).read_text(encoding="utf-8") == text
+
+
 @pytest.mark.asyncio
 async def test_tool_response_write_failure_fails_open(
     tmp_path,


### PR DESCRIPTION
## Summary

- bound oversized single-line tool results before they enter the agent context
- preserve the complete result as a workspace artifact
- add artifact-only recovery metadata when line-based continuation cannot advance
- preserve artifact recovery information when truncated previews are compacted again
- add regression coverage for compact JSON and UTF-8 payloads

## Root cause

Fresh tool results are normally truncated before being yielded into the agent
context. However, `_truncate_fresh()` treated an oversized final line as an
unhandled edge case and returned a markerless slice.

`ToolResultPruner.prune_text()` requires a truncation marker before accepting a
candidate. Because the candidate had no marker, it discarded the bounded slice
and returned the complete original result.

This particularly affected compact JSON returned by MCP tools, where the entire
payload is commonly serialized onto one line. A large result could therefore
enter the active turn unchanged and leave Scroll unable to reduce the context.

## Changes

- return a bounded, UTF-8-safe preview for oversized single-line results
- attach standard truncation metadata and a recovery notice
- mark these results with `continuation_mode="artifact"`
- avoid suggesting line-based continuation for content contained in one
  oversized line
- retain artifact-only recovery semantics during subsequent re-truncation
- keep existing multiline line-pagination behavior unchanged

## Before / After

Using a representative compact JSON tool result:

| | Size |
|---|---:|
| Original input | 700,013 bytes |
| Before this fix | 700,013 bytes |
| After this fix | 50,456 bytes |
| Configured preview | 50,000 bytes |

The saved artifact remains byte-for-byte identical to the original payload.

## Testing

- added a middleware-level regression test for oversized single-line UTF-8 JSON
- added a regression test for re-truncating artifact-backed previews
- 24 relevant pruning tests passed
- 114 file I/O and Scroll tests passed
- manual 700 KB MCP-like payload reproduction passed
- all pre-commit hooks passed, including mypy, black, flake8, and pylint

Addresses #7288.

## Scope

This PR fixes the reproducible single-line text/JSON admission-cap bypass.
A response-wide aggregate cap for MCP responses containing many individually
bounded blocks can be handled separately as defense-in-depth.