### PR TITLE
fix(chat): improve mobile composer controls

### DIFF
--- a/console/src/components/LoopInput/LoopModeSelector.test.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.test.tsx
@@ -10,6 +10,14 @@ import {
 } from "../../stores/loopStore";
 import { LoopModeSelector } from "./LoopModeSelector";
 
+const { mockUseIsMobile } = vi.hoisted(() => ({
+  mockUseIsMobile: vi.fn(() => false),
+}));
+
+vi.mock("../../hooks/useIsMobile", () => ({
+  useIsMobile: mockUseIsMobile,
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -52,6 +60,7 @@ const ompUltraqa: LoopModeInfo = {
 
 describe("LoopModeSelector", () => {
   beforeEach(() => {
+    mockUseIsMobile.mockReturnValue(false);
     useLoopStore.setState({
       selectedModeId: "default",
       availableModes: [DEFAULT_LOOP_MODE, goal, custom, ompUltraqa],
@@ -100,6 +109,36 @@ describe("LoopModeSelector", () => {
     expect(useLoopStore.getState().selectedModeId).toBe("custom:quality");
   });
 
+  it("uses a bottom drawer for mode selection on mobile", async () => {
+    mockUseIsMobile.mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWithProviders(<LoopModeSelector compact />);
+
+    const trigger = screen.getByRole("button", { name: "loop.selectorAria" });
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", { name: "loop.selectorTitle" }),
+    ).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(document.querySelector(".ant-popover")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("loop.modes.goal.name"));
+
+    expect(useLoopStore.getState().selectedModeId).toBe("goal");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders only the mode icon in compact mode", () => {
+    renderWithProviders(<LoopModeSelector compact />);
+
+    const trigger = screen.getByRole("button", {
+      name: "loop.selectorAria",
+    });
+    expect(trigger.textContent).toBe("");
+    expect(trigger.querySelectorAll("svg")).toHaveLength(1);
+  });
+
   it("shows starting before the first response event", () => {
     useLoopStore.getState().setStartingMode(custom);
 
@@ -110,6 +149,21 @@ describe("LoopModeSelector", () => {
     expect(
       screen.queryByRole("button", { name: "loop.selectorAria" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps an active mode icon-only in compact mode", () => {
+    useLoopStore.getState().setSessionMode(custom, "running");
+
+    const { container } = renderWithProviders(<LoopModeSelector compact />);
+
+    const activeMode = container.querySelector('[data-state="running"]');
+    expect(activeMode).not.toBeNull();
+    expect(activeMode?.textContent).toBe("");
+    expect(activeMode?.querySelectorAll("svg")).toHaveLength(1);
+    expect(activeMode).toHaveAttribute(
+      "aria-label",
+      "Quality Review loop.running",
+    );
   });
 
   it("shows running after the first response event", () => {

--- a/console/src/components/LoopInput/LoopModeSelector.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.tsx
@@ -8,6 +8,7 @@ import {
   Settings2,
   Sparkles,
   Target,
+  X,
 } from "lucide-react";
 import { Popover, Tooltip } from "antd";
 import { useMemo, useState } from "react";
@@ -20,6 +21,8 @@ import {
   type LoopModeInfo,
   useLoopStore,
 } from "../../stores/loopStore";
+import { useIsMobile } from "../../hooks/useIsMobile";
+import { OsDrawer } from "../../os/OsOverlay";
 import { InlineMarkdown } from "../Markdown/InlineMarkdown";
 import {
   resolveLoopModeDescriptionMarkdown,
@@ -35,10 +38,19 @@ function ModeIcon({ mode, size = 14 }: { mode: LoopModeInfo; size?: number }) {
   return <CircleDot size={size} />;
 }
 
-export function LoopModeSelector() {
+interface LoopModeSelectorProps {
+  className?: string;
+  compact?: boolean;
+}
+
+export function LoopModeSelector({
+  className,
+  compact = false,
+}: LoopModeSelectorProps = {}) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language || "en";
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
   const availableModes = useLoopStore((state) => state.availableModes);
   const selectedModeId = useLoopStore((state) => state.selectedModeId);
@@ -61,6 +73,7 @@ export function LoopModeSelector() {
   );
 
   if (sessionState !== "idle" && activeMode) {
+    const modeName = resolveLoopModeName(activeMode, t, lang);
     const tooltip =
       activeMode.source === "custom"
         ? t("loop.activeCustomDescription")
@@ -68,7 +81,8 @@ export function LoopModeSelector() {
     return (
       <Tooltip title={tooltip}>
         <div
-          className={styles.activeMode}
+          className={[styles.activeMode, className].filter(Boolean).join(" ")}
+          aria-label={`${modeName} ${t(`loop.${sessionState}`)}`}
           aria-live="polite"
           data-state={sessionState}
         >
@@ -79,10 +93,14 @@ export function LoopModeSelector() {
           {sessionState === "awaiting_user" && (
             <MessageCircleQuestion size={14} />
           )}
-          <span>{resolveLoopModeName(activeMode, t, lang)}</span>
-          <span className={styles.activeState}>
-            {t(`loop.${sessionState}`)}
-          </span>
+          {!compact && (
+            <>
+              <span>{modeName}</span>
+              <span className={styles.activeState}>
+                {t(`loop.${sessionState}`)}
+              </span>
+            </>
+          )}
         </div>
       </Tooltip>
     );
@@ -130,39 +148,114 @@ export function LoopModeSelector() {
     );
   };
 
+  const settingsButton = (
+    <button
+      aria-label={t("loop.gotoSettings")}
+      className={styles.settingsButton}
+      onClick={() => {
+        setOpen(false);
+        navigate("/agent-config?tab=agentLoop");
+      }}
+      type="button"
+    >
+      <Settings2 size={16} />
+    </button>
+  );
+
   const content = (
-    <div className={styles.modeMenu} role="listbox">
+    <div className={styles.modeMenu}>
       <div className={styles.menuHeader}>
         <div>
           <div className={styles.menuTitle}>{t("loop.selectorTitle")}</div>
           <div className={styles.menuHint}>{t("loop.selectorHint")}</div>
         </div>
-        <Tooltip title={t("loop.gotoSettings")}>
-          <button
-            aria-label={t("loop.gotoSettings")}
-            className={styles.settingsButton}
-            onClick={() => {
-              setOpen(false);
-              navigate("/agent-config?tab=agentLoop");
-            }}
-            type="button"
-          >
-            <Settings2 size={16} />
-          </button>
-        </Tooltip>
-      </div>
-      {renderGroup(t("loop.builtInModes"), builtInModes)}
-      {renderGroup(t("loop.customModes"), extendedModes)}
-      {catalogError ? (
-        <div className={styles.menuError}>
-          <span>{t("loop.loadError")}</span>
-          <button onClick={() => void fetchAvailableLoopModes()} type="button">
-            {t("loop.retry")}
-          </button>
+        <div className={styles.menuActions}>
+          {isMobile ? (
+            settingsButton
+          ) : (
+            <Tooltip title={t("loop.gotoSettings")}>{settingsButton}</Tooltip>
+          )}
+          {isMobile && (
+            <button
+              aria-label={t("common.close")}
+              className={styles.settingsButton}
+              onClick={() => setOpen(false)}
+              type="button"
+            >
+              <X size={18} />
+            </button>
+          )}
         </div>
-      ) : null}
+      </div>
+      <div className={styles.modeList} role="listbox">
+        {renderGroup(t("loop.builtInModes"), builtInModes)}
+        {renderGroup(t("loop.customModes"), extendedModes)}
+        {catalogError ? (
+          <div className={styles.menuError}>
+            <span>{t("loop.loadError")}</span>
+            <button
+              onClick={() => void fetchAvailableLoopModes()}
+              type="button"
+            >
+              {t("loop.retry")}
+            </button>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
+
+  const triggerButton = (
+    <button
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      aria-label={t("loop.selectorAria")}
+      className={[styles.modeTrigger, className].filter(Boolean).join(" ")}
+      disabled={catalogLoading && availableModes.length === 0}
+      onClick={isMobile ? () => setOpen((current) => !current) : undefined}
+      type="button"
+    >
+      {catalogLoading ? (
+        <LoaderCircle className={styles.spin} size={14} />
+      ) : (
+        <ModeIcon mode={selectedMode} />
+      )}
+      {!compact && (
+        <>
+          <span>{resolveLoopModeName(selectedMode, t, lang)}</span>
+          <ChevronDown size={13} />
+        </>
+      )}
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {triggerButton}
+        <OsDrawer
+          aria-label={t("loop.selectorTitle")}
+          open={open}
+          placement="bottom"
+          height="auto"
+          closable={false}
+          destroyOnHidden
+          rootClassName={styles.modeDrawer}
+          onClose={() => setOpen(false)}
+          styles={{
+            body: { padding: 0, overflow: "hidden" },
+            content: {
+              borderRadius: "14px 14px 0 0",
+              overflow: "hidden",
+            },
+            wrapper: { maxHeight: "min(48dvh, 400px)" },
+          }}
+        >
+          {content}
+        </OsDrawer>
+      </>
+    );
+  }
 
   return (
     <Popover
@@ -174,22 +267,7 @@ export function LoopModeSelector() {
       placement="topLeft"
       trigger="click"
     >
-      <button
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label={t("loop.selectorAria")}
-        className={styles.modeTrigger}
-        disabled={catalogLoading && availableModes.length === 0}
-        type="button"
-      >
-        {catalogLoading ? (
-          <LoaderCircle className={styles.spin} size={14} />
-        ) : (
-          <ModeIcon mode={selectedMode} />
-        )}
-        <span>{resolveLoopModeName(selectedMode, t, lang)}</span>
-        <ChevronDown size={13} />
-      </button>
+      {triggerButton}
     </Popover>
   );
 }

--- a/console/src/components/LoopInput/index.module.less
+++ b/console/src/components/LoopInput/index.module.less
@@ -105,6 +105,13 @@
   padding: 5px 6px 10px;
 }
 
+.menuActions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+}
+
 .menuTitle {
   color: var(--ant-color-text);
   font-size: 13px;
@@ -133,6 +140,10 @@
 .settingsButton:hover {
   background: var(--ant-color-fill-tertiary);
   color: var(--ant-color-text);
+}
+
+.modeList {
+  min-height: 0;
 }
 
 .modeGroup + .modeGroup {
@@ -234,4 +245,38 @@
   color: var(--ant-color-primary);
   font: inherit;
   cursor: pointer;
+}
+
+.modeDrawer {
+  .modeMenu {
+    width: 100%;
+    height: auto;
+    max-height: min(48dvh, 400px);
+    padding: 10px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .menuHeader {
+    flex: 0 0 auto;
+    align-items: center;
+    padding: 2px 0 10px 6px;
+  }
+
+  .settingsButton {
+    width: 44px;
+    height: 44px;
+  }
+
+  .modeList {
+    flex: 0 1 auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .modeOption {
+    min-height: 56px;
+    padding: 8px 10px;
+  }
 }

--- a/console/src/features/project-directory/SessionProjectDirectory.module.less
+++ b/console/src/features/project-directory/SessionProjectDirectory.module.less
@@ -116,6 +116,15 @@
   overflow: hidden;
 }
 
+.desktopPopover {
+  z-index: 1100;
+
+  :global(.ant-popover-inner),
+  :global(.ant-popover-content) {
+    max-width: 100%;
+  }
+}
+
 .panelHeading {
   padding: 2px 2px 0;
   display: flex;
@@ -124,6 +133,7 @@
 
   > div {
     min-width: 0;
+    flex: 1;
     display: flex;
     flex-direction: column;
   }
@@ -133,6 +143,12 @@
     font-size: 14px;
     font-weight: 650;
   }
+}
+
+.panelClose {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
 }
 
 /* Bound-directory count, sitting at the end of the title row. */
@@ -603,48 +619,6 @@
       display: none;
     }
   }
-
-  .panel {
-    width: calc(100vw - 24px);
-    max-width: calc(100vw - 72px);
-    max-height: calc(100vh - 20px);
-    gap: 10px;
-  }
-
-  .splitBody {
-    height: auto;
-    min-height: 0;
-    grid-template-columns: minmax(0, 1fr);
-    overflow: auto;
-  }
-
-  /* Same specificity as the session override above, or that 110px floor
-     would win here and the stacked panes could not shrink. */
-  .panelWithList .splitBody {
-    min-height: 0;
-    flex: 1 1 auto;
-  }
-
-  .recentPane {
-    min-height: 145px;
-    max-height: 170px;
-    overflow: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--ant-color-border-secondary);
-  }
-
-  .browserPane {
-    min-height: 190px;
-    max-height: 220px;
-  }
-
-  .actions {
-    :global(.ant-btn-text) {
-      max-width: 65%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
 }
 
 /* ── Session scope: bound directory list ──────────────────────────────
@@ -814,4 +788,114 @@
   display: block;
   width: 0;
   height: 0;
+}
+
+.mobileDrawer {
+  .panel {
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: none;
+    padding: 10px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .panelHeading,
+  .pathInput,
+  .pathChip,
+  .actions {
+    flex: 0 0 auto;
+  }
+
+  .panelHeading {
+    min-height: 44px;
+  }
+
+  .panelClose {
+    margin: -4px -6px -4px 0;
+  }
+
+  .splitBody,
+  .panelWithList .splitBody {
+    height: auto;
+    min-height: 0;
+    flex: 1 1 auto;
+    grid-template-columns: minmax(0, 1fr);
+    overflow: hidden;
+  }
+
+  .recentPane {
+    min-height: 82px;
+    max-height: 104px;
+    padding: 8px;
+    border-right: 0;
+    border-bottom: 1px solid var(--ant-color-border-secondary);
+  }
+
+  .browserPane {
+    min-height: 0;
+    padding: 8px;
+  }
+
+  .browserHeading {
+    flex-wrap: wrap;
+  }
+
+  .browserHeading > div:first-child {
+    flex: 1 1 100%;
+  }
+
+  .browserActions {
+    width: 100%;
+    justify-content: space-between;
+
+    :global(.ant-btn) {
+      width: 44px;
+      height: 44px;
+    }
+  }
+
+  .createDirectoryForm {
+    grid-template-columns: minmax(0, 1fr) 44px 44px;
+    gap: 8px;
+
+    :global(.ant-btn) {
+      width: 44px;
+      height: 44px;
+    }
+  }
+
+  .recent,
+  .directories,
+  .boundList {
+    overscroll-behavior: contain;
+  }
+
+  .directories > button:not(:global(.ant-btn)) {
+    min-height: 44px;
+  }
+
+  .boundDirs {
+    flex: 0 0 auto;
+    max-height: 132px;
+  }
+
+  .boundList {
+    min-height: 44px;
+  }
+
+  .boundList li {
+    min-height: 44px;
+  }
+
+  .actions {
+    :global(.ant-btn) {
+      min-height: 44px;
+    }
+
+    :global(.ant-btn-text) {
+      max-width: 65%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }

--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -8,12 +8,14 @@ const {
   mockBrowseDirs,
   mockCreateDirectory,
   mockGetSessionDirectory,
+  mockUseIsMobile,
   mockListProjects,
   mockSetSessionDirectory,
 } = vi.hoisted(() => ({
   mockBrowseDirs: vi.fn(),
   mockCreateDirectory: vi.fn(),
   mockGetSessionDirectory: vi.fn(),
+  mockUseIsMobile: vi.fn(() => false),
   mockListProjects: vi.fn(),
   mockSetSessionDirectory: vi.fn(),
 }));
@@ -35,6 +37,10 @@ vi.mock("../../api/modules/chatProjectDirectory", () => ({
     getProjectDirs: vi.fn(),
     setProjectDirs: vi.fn(),
   },
+}));
+
+vi.mock("../../hooks/useIsMobile", () => ({
+  useIsMobile: mockUseIsMobile,
 }));
 
 // The single-path picker these tests drive (path field, clear button,
@@ -60,6 +66,7 @@ const projects = [
 describe("SessionProjectDirectory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseIsMobile.mockReturnValue(false);
     mockGetSessionDirectory.mockResolvedValue({
       path: "/projects/agentscope",
       name: "agentscope",
@@ -84,6 +91,59 @@ describe("SessionProjectDirectory", () => {
         name: "projectDirectory.agentTitle",
       }),
     );
+
+  it("renders a single icon trigger in compact mode", async () => {
+    renderWithProviders(
+      <SessionProjectDirectory
+        className="mobile-control"
+        compact
+        scope={scope}
+      />,
+    );
+
+    const trigger = await screen.findByRole("button", {
+      name: "projectDirectory.agentTitle",
+    });
+    expect(trigger).toHaveClass("mobile-control");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger.querySelectorAll("svg")).toHaveLength(1);
+    expect(trigger).not.toHaveTextContent("agentscope");
+  });
+
+  it("uses a bottom drawer on mobile without a path tooltip", async () => {
+    mockUseIsMobile.mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory compact scope={scope} />);
+
+    const trigger = await screen.findByRole("button", {
+      name: "projectDirectory.agentTitle",
+    });
+    await user.hover(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "projectDirectory.agentTitle",
+      }),
+    ).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(
+      document.querySelector(".ant-popover, .qwenpaw-popover"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "common.close",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+  });
 
   it("shows a removable path chip for a selected recent project", async () => {
     const user = userEvent.setup();

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -25,6 +25,8 @@ import {
   type ProjectDirPayloadEntry,
 } from "../../api/modules/chatProjectDirectory";
 import { projectDirectoryApi } from "../../api/modules/projectDirectory";
+import { useIsMobile } from "../../hooks/useIsMobile";
+import { OsDrawer } from "../../os/OsOverlay";
 import { useProjectDirectoryStore } from "../../stores/projectDirectoryStore";
 import type {
   BrowseDirsResponse,
@@ -74,6 +76,7 @@ function exactSamePath(a: string, b: string): boolean {
 interface SessionProjectDirectoryProps {
   scope: FilesWorkspaceScope;
   compact?: boolean;
+  className?: string;
   showFullPath?: boolean;
   beforeChange?: () => boolean | Promise<boolean>;
   onChanged?: () => void;
@@ -91,6 +94,7 @@ interface SessionProjectDirectoryProps {
 export default function SessionProjectDirectory({
   scope,
   compact = false,
+  className,
   showFullPath = false,
   beforeChange,
   onChanged,
@@ -99,6 +103,7 @@ export default function SessionProjectDirectory({
   hideTrigger = false,
 }: SessionProjectDirectoryProps) {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const selectedAgent = scope.agentId;
   const chatId = scope.kind === "session" ? scope.chatId : undefined;
   const sessionId = scope.kind === "session" ? scope.sessionId : "";
@@ -616,6 +621,15 @@ export default function SessionProjectDirectory({
         {!isAgentScope && (
           <span className={styles.headingCount}>{dirs.length}</span>
         )}
+        {isMobile && (
+          <Button
+            type="text"
+            className={styles.panelClose}
+            aria-label={t("common.close")}
+            icon={<X size={18} />}
+            onClick={() => handleOpenChange(false)}
+          />
+        )}
       </div>
 
       {/* Agent scope keeps the single-path field; session scope shows the
@@ -952,6 +966,100 @@ export default function SessionProjectDirectory({
     </div>
   );
 
+  const triggerButton = (
+    <button
+      type="button"
+      className={`${styles.trigger} ${
+        info && !info.exists ? styles.triggerError : ""
+      } ${compact ? styles.triggerCompact : ""} ${
+        showFullPath ? styles.triggerFullPath : ""
+      } ${className ?? ""}`}
+      aria-expanded={open}
+      aria-label={t(
+        isAgentScope
+          ? "projectDirectory.agentTitle"
+          : "projectDirectory.sessionTitle",
+      )}
+      onClick={isMobile ? () => handleOpenChange(!open) : undefined}
+    >
+      {!info ? (
+        <LoaderCircle className={styles.spin} size={14} />
+      ) : info.exists ? (
+        <FolderOpen size={14} />
+      ) : (
+        <CircleAlert size={14} />
+      )}
+      {!compact && (
+        <>
+          {showFullPath ? (
+            <span className={styles.triggerIdentity}>
+              <strong>{basename}</strong>
+              <small>{info?.project_dir}</small>
+            </span>
+          ) : (
+            <span>{basename}</span>
+          )}
+          {/* Extra roots are not listed here; the count signals that
+              more than the primary is bound. Driven by the applied list
+              so an abandoned edit never shows up as bound. */}
+          {!isAgentScope && appliedCount > 1 && (
+            <em title={t("projectDirectory.countTitle")}>·{appliedCount}</em>
+          )}
+          {!showFullPath && (
+            <em>
+              {t(
+                info?.source === "session"
+                  ? "projectDirectory.sessionSource"
+                  : "projectDirectory.agentSource",
+              )}
+            </em>
+          )}
+          <ChevronDown size={12} />
+        </>
+      )}
+    </button>
+  );
+  const trigger = isMobile ? (
+    triggerButton
+  ) : (
+    <Tooltip title={info?.project_dir}>{triggerButton}</Tooltip>
+  );
+
+  const mobileDrawer = (
+    <OsDrawer
+      aria-label={t(
+        isAgentScope
+          ? "projectDirectory.agentTitle"
+          : "projectDirectory.boundDirs",
+      )}
+      open={open}
+      placement="bottom"
+      height="min(72dvh, 620px)"
+      closable={false}
+      destroyOnHidden
+      rootClassName={styles.mobileDrawer}
+      onClose={() => handleOpenChange(false)}
+      styles={{
+        body: { padding: 0, overflow: "hidden" },
+        content: {
+          borderRadius: "14px 14px 0 0",
+          overflow: "hidden",
+        },
+      }}
+    >
+      {panel}
+    </OsDrawer>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {!hideTrigger && trigger}
+        {mobileDrawer}
+      </>
+    );
+  }
+
   // `hideTrigger` callers drive `open` themselves and already render their own
   // control, so the Popover only needs a zero-size element to anchor to — and
   // no trigger events, which would otherwise reopen it on a stray click.
@@ -963,6 +1071,7 @@ export default function SessionProjectDirectory({
         open={open}
         onOpenChange={handleOpenChange}
         placement={isAgentScope ? "rightTop" : "topRight"}
+        overlayClassName={styles.desktopPopover}
       >
         <span className={styles.hiddenAnchor} aria-hidden="true" />
       </Popover>
@@ -976,60 +1085,9 @@ export default function SessionProjectDirectory({
       open={open}
       onOpenChange={handleOpenChange}
       placement={isAgentScope ? "rightTop" : "topRight"}
+      overlayClassName={styles.desktopPopover}
     >
-      <Tooltip title={info?.project_dir}>
-        <button
-          type="button"
-          className={`${styles.trigger} ${
-            info && !info.exists ? styles.triggerError : ""
-          } ${compact ? styles.triggerCompact : ""} ${
-            showFullPath ? styles.triggerFullPath : ""
-          }`}
-          aria-label={t(
-            isAgentScope
-              ? "projectDirectory.agentTitle"
-              : "projectDirectory.sessionTitle",
-          )}
-        >
-          {!info ? (
-            <LoaderCircle className={styles.spin} size={14} />
-          ) : info.exists ? (
-            <FolderOpen size={14} />
-          ) : (
-            <CircleAlert size={14} />
-          )}
-          {!compact && (
-            <>
-              {showFullPath ? (
-                <span className={styles.triggerIdentity}>
-                  <strong>{basename}</strong>
-                  <small>{info?.project_dir}</small>
-                </span>
-              ) : (
-                <span>{basename}</span>
-              )}
-              {/* Extra roots are not listed here; the count signals that
-                  more than the primary is bound. Driven by the applied list
-                  so an abandoned edit never shows up as bound. */}
-              {!isAgentScope && appliedCount > 1 && (
-                <em title={t("projectDirectory.countTitle")}>
-                  ·{appliedCount}
-                </em>
-              )}
-              {!showFullPath && (
-                <em>
-                  {t(
-                    info?.source === "session"
-                      ? "projectDirectory.sessionSource"
-                      : "projectDirectory.agentSource",
-                  )}
-                </em>
-              )}
-              <ChevronDown size={12} />
-            </>
-          )}
-        </button>
-      </Tooltip>
+      {trigger}
     </Popover>
   );
 }

--- a/console/src/hooks/useIsMobile.test.ts
+++ b/console/src/hooks/useIsMobile.test.ts
@@ -1,8 +1,40 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useIsMobile } from "./useIsMobile";
 
-// Helper to set window dimensions and dispatch a resize event.
+const mediaQueryListeners = new Set<() => void>();
+const addMediaQueryListener = vi.fn((_event: string, listener: () => void) => {
+  mediaQueryListeners.add(listener);
+});
+const removeMediaQueryListener = vi.fn(
+  (_event: string, listener: () => void) => {
+    mediaQueryListeners.delete(listener);
+  },
+);
+
+const mobileMediaQuery = {
+  get matches() {
+    return window.innerWidth <= 768;
+  },
+  media: "(max-width: 768px)",
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: addMediaQueryListener,
+  removeEventListener: removeMediaQueryListener,
+  dispatchEvent: vi.fn(),
+} as unknown as MediaQueryList;
+
+// Helper to set the viewport used by the matchMedia test double.
 function setViewport(width: number) {
   Object.defineProperty(window, "innerWidth", {
     writable: true,
@@ -11,19 +43,29 @@ function setViewport(width: number) {
   });
 }
 
-function dispatchResize() {
-  window.dispatchEvent(new Event("resize"));
+function dispatchMediaChange() {
+  mediaQueryListeners.forEach((listener) => listener());
 }
 
 describe("useIsMobile", () => {
   const originalInnerWidth = window.innerWidth;
+  const originalMatchMedia = window.matchMedia;
+
+  beforeAll(() => {
+    window.matchMedia = vi.fn(() => mobileMediaQuery);
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mediaQueryListeners.clear();
   });
 
   afterEach(() => {
     setViewport(originalInnerWidth);
+  });
+
+  afterAll(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   // ---------------------------------------------------------------------------
@@ -59,7 +101,7 @@ describe("useIsMobile", () => {
 
     act(() => {
       setViewport(700);
-      dispatchResize();
+      dispatchMediaChange();
     });
 
     expect(result.current).toBe(true);
@@ -72,7 +114,7 @@ describe("useIsMobile", () => {
 
     act(() => {
       setViewport(800);
-      dispatchResize();
+      dispatchMediaChange();
     });
 
     expect(result.current).toBe(false);
@@ -85,7 +127,7 @@ describe("useIsMobile", () => {
 
     act(() => {
       setViewport(1200);
-      dispatchResize();
+      dispatchMediaChange();
     });
 
     expect(result.current).toBe(false);
@@ -98,7 +140,7 @@ describe("useIsMobile", () => {
 
     act(() => {
       setViewport(600);
-      dispatchResize();
+      dispatchMediaChange();
     });
 
     expect(result.current).toBe(true);
@@ -108,18 +150,35 @@ describe("useIsMobile", () => {
   // Cleanup
   // ---------------------------------------------------------------------------
 
-  it("removes the resize listener on unmount (no state update after unmount)", () => {
+  it("removes the media query listener on unmount", () => {
     setViewport(1024);
     const { result, unmount } = renderHook(() => useIsMobile());
     expect(result.current).toBe(false);
 
     unmount();
+    expect(mediaQueryListeners.size).toBe(0);
+    expect(removeMediaQueryListener).toHaveBeenCalledTimes(1);
 
     // Should not throw / update after unmount.
     expect(() => {
       setViewport(500);
-      dispatchResize();
+      dispatchMediaChange();
     }).not.toThrow();
     expect(result.current).toBe(false);
+  });
+
+  it("shares one media query listener across hook instances", () => {
+    const first = renderHook(() => useIsMobile());
+    const second = renderHook(() => useIsMobile());
+
+    expect(mediaQueryListeners.size).toBe(1);
+    expect(addMediaQueryListener).toHaveBeenCalledTimes(1);
+
+    first.unmount();
+    expect(mediaQueryListeners.size).toBe(1);
+
+    second.unmount();
+    expect(mediaQueryListeners.size).toBe(0);
+    expect(removeMediaQueryListener).toHaveBeenCalledTimes(1);
   });
 });

--- a/console/src/hooks/useIsMobile.ts
+++ b/console/src/hooks/useIsMobile.ts
@@ -1,7 +1,70 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useSyncExternalStore } from "react";
 import { OsWindowSizeContext } from "../os/osWindowSizeContext";
 
 const MOBILE_BREAKPOINT_PX = 768;
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`;
+
+const viewportSubscribers = new Set<() => void>();
+let mobileMediaQuery: MediaQueryList | null = null;
+let removeViewportListener: (() => void) | null = null;
+
+function getMobileMediaQuery(): MediaQueryList | null {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return null;
+  }
+  mobileMediaQuery ??= window.matchMedia(MOBILE_MEDIA_QUERY);
+  return mobileMediaQuery;
+}
+
+function notifyViewportSubscribers() {
+  viewportSubscribers.forEach((subscriber) => subscriber());
+}
+
+function subscribeToMobileViewport(subscriber: () => void) {
+  viewportSubscribers.add(subscriber);
+
+  if (viewportSubscribers.size === 1 && typeof window !== "undefined") {
+    const mediaQuery = getMobileMediaQuery();
+    if (mediaQuery?.addEventListener) {
+      mediaQuery.addEventListener("change", notifyViewportSubscribers);
+      removeViewportListener = () =>
+        mediaQuery.removeEventListener("change", notifyViewportSubscribers);
+    } else if (mediaQuery?.addListener) {
+      mediaQuery.addListener(notifyViewportSubscribers);
+      removeViewportListener = () =>
+        mediaQuery.removeListener(notifyViewportSubscribers);
+    } else {
+      window.addEventListener("resize", notifyViewportSubscribers);
+      removeViewportListener = () =>
+        window.removeEventListener("resize", notifyViewportSubscribers);
+    }
+  }
+
+  return () => {
+    viewportSubscribers.delete(subscriber);
+    if (viewportSubscribers.size === 0) {
+      removeViewportListener?.();
+      removeViewportListener = null;
+    }
+  };
+}
+
+function getViewportSnapshot() {
+  const mediaQuery = getMobileMediaQuery();
+  if (mediaQuery) {
+    return mediaQuery.matches;
+  }
+  return (
+    typeof window !== "undefined" && window.innerWidth <= MOBILE_BREAKPOINT_PX
+  );
+}
+
+function getServerSnapshot() {
+  return false;
+}
 
 /**
  * Returns true when the effective width is at or below the mobile breakpoint.
@@ -11,20 +74,11 @@ const MOBILE_BREAKPOINT_PX = 768;
  */
 export function useIsMobile() {
   const containerWidth = useContext(OsWindowSizeContext);
-  const [isViewportMobile, setIsViewportMobile] = useState(
-    typeof window !== "undefined" && window.innerWidth <= MOBILE_BREAKPOINT_PX,
+  const isViewportMobile = useSyncExternalStore(
+    subscribeToMobileViewport,
+    getViewportSnapshot,
+    getServerSnapshot,
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const sync = () =>
-      setIsViewportMobile(window.innerWidth <= MOBILE_BREAKPOINT_PX);
-    sync();
-    window.addEventListener("resize", sync);
-    return () => window.removeEventListener("resize", sync);
-  }, []);
 
   if (containerWidth != null) {
     return containerWidth <= MOBILE_BREAKPOINT_PX;

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -547,6 +547,53 @@ export default function Sidebar({
   // ── Render ────────────────────────────────────────────────────────────────
 
   const isChatActive = selectedKey === "core.chat";
+  const collapsedChatItem = collapsedNavItems.find(
+    (item) => item.key === "core.chat",
+  );
+  const collapsedScrollableItems = collapsedNavItems.filter(
+    (item) => item.key !== "core.chat",
+  );
+
+  const renderCollapsedNavItem = (item: FlatMenuEntry) => {
+    const isActive =
+      item.key === "core.chat" ? isChatActive : selectedKey === item.key;
+    return (
+      <Tooltip
+        key={item.key}
+        title={item.label}
+        placement="right"
+        overlayInnerStyle={{
+          background: "rgba(0,0,0,0.75)",
+          color: "#fff",
+        }}
+      >
+        <button
+          type="button"
+          aria-label={typeof item.label === "string" ? item.label : undefined}
+          className={`${styles.collapsedNavItem} ${
+            isActive ? styles.collapsedNavItemActive : ""
+          }${
+            item.key === "core.inbox" && effectiveShake
+              ? ` ${styles.inboxShake}`
+              : ""
+          }`}
+          onClick={() => {
+            if (item.href) {
+              window.open(item.href, "_blank", "noopener,noreferrer");
+            } else {
+              navigate(item.path);
+            }
+          }}
+          onMouseEnter={
+            item.key === "core.inbox" ? handleInboxHover : undefined
+          }
+        >
+          {item.icon}
+        </button>
+      </Tooltip>
+    );
+  };
+
   // `renderIcon` retained for tree-shaking awareness.
   void renderIcon;
 
@@ -572,45 +619,14 @@ export default function Sidebar({
     >
       {collapsed ? (
         <nav className={styles.collapsedNav}>
-          {collapsedNavItems.map((item) => {
-            const isActive =
-              item.key === "core.chat"
-                ? isChatActive
-                : selectedKey === item.key;
-            return (
-              <Tooltip
-                key={item.key}
-                title={item.label}
-                placement="right"
-                overlayInnerStyle={{
-                  background: "rgba(0,0,0,0.75)",
-                  color: "#fff",
-                }}
-              >
-                <button
-                  className={`${styles.collapsedNavItem} ${
-                    isActive ? styles.collapsedNavItemActive : ""
-                  }${
-                    item.key === "core.inbox" && effectiveShake
-                      ? ` ${styles.inboxShake}`
-                      : ""
-                  }`}
-                  onClick={() => {
-                    if (item.href) {
-                      window.open(item.href, "_blank", "noopener,noreferrer");
-                    } else {
-                      navigate(item.path);
-                    }
-                  }}
-                  onMouseEnter={
-                    item.key === "core.inbox" ? handleInboxHover : undefined
-                  }
-                >
-                  {item.icon}
-                </button>
-              </Tooltip>
-            );
-          })}
+          {collapsedChatItem && (
+            <div className={styles.collapsedNavPinned}>
+              {renderCollapsedNavItem(collapsedChatItem)}
+            </div>
+          )}
+          <div className={styles.collapsedNavScroll}>
+            {collapsedScrollableItems.map(renderCollapsedNavItem)}
+          </div>
         </nav>
       ) : isSimpleExpanded ? (
         <>

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -187,6 +187,14 @@
     flex-direction: column;
     padding: 0 8px;
 
+    :global(.qwenpaw-layout-sider-children) {
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
     .agentSelectorContainer {
       display: flex;
       justify-content: center;
@@ -881,11 +889,30 @@
 /* Collapsed nav (icon-only group list) */
 .collapsedNav {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
   padding: 4px 0;
+  overflow: hidden;
+}
+
+.collapsedNavPinned {
+  width: 100%;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+}
+
+.collapsedNavScroll {
+  width: 100%;
+  min-height: 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -943,6 +970,10 @@
   .collapsedNav {
     gap: 2px;
     padding: 2px 0;
+  }
+
+  .collapsedNavScroll {
+    gap: 2px;
   }
 
   .collapsedNavItem {

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -1,6 +1,16 @@
 // ─── MainLayout ───────────────────────────────────────────────────────────────
 .mainLayout {
   height: 100vh;
+  min-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  @media (max-width: 768px) {
+    .mainLayout {
+      height: 100dvh;
+      min-height: 100dvh;
+    }
+  }
 }
 
 // ─── Header ───────────────────────────────────────────────────────────────────
@@ -946,6 +956,14 @@
     margin: 0 -8px;
     padding: 8px 0;
     justify-content: center;
+  }
+}
+
+@supports (height: 100dvh) {
+  @media (max-width: 768px) {
+    .sider {
+      height: calc(100dvh - 56px) !important;
+    }
   }
 }
 

--- a/console/src/pages/Chat/components/ApprovalLevelToggle.tsx
+++ b/console/src/pages/Chat/components/ApprovalLevelToggle.tsx
@@ -5,16 +5,26 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Dropdown, Tag, Tooltip } from "antd";
+import { Dropdown, Tooltip } from "antd";
 import type { MenuProps } from "antd";
-import { Shield, Ban, AlertTriangle, CheckCircle } from "lucide-react";
-import { DownOutlined } from "@ant-design/icons";
+import {
+  AlertTriangle,
+  Ban,
+  Check,
+  CheckCircle,
+  ChevronDown,
+  Shield,
+  X,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   LEVELS,
   normalizeLevel,
   type ToolExecutionLevel,
 } from "../../../utils/approval";
+import { useIsMobile } from "../../../hooks/useIsMobile";
+import { OsDrawer } from "../../../os/OsOverlay";
+import drawerStyles from "./ApprovalToggle.module.less";
 
 const LEVEL_META: Record<
   ToolExecutionLevel,
@@ -38,6 +48,7 @@ interface ApprovalLevelToggleProps {
   /** null = no session override, backend uses running-config */
   onChange?: (sessionOverride: ToolExecutionLevel | null) => void;
   compact?: boolean;
+  className?: string;
 }
 
 const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
@@ -45,8 +56,11 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
   runningConfigApprovalLevel,
   onChange,
   compact = false,
+  className,
 }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
   const [sessionLevel, setSessionLevel] = useState<ToolExecutionLevel | null>(
     null,
   );
@@ -96,6 +110,7 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
   const handleSelect = useCallback(
     (level: ToolExecutionLevel) => {
       setSessionLevel(level);
+      setOpen(false);
       localStorage.setItem(storageKey(sessionId), level);
       onChangeRef.current?.(level);
     },
@@ -134,42 +149,131 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
     return items;
   }, [handleSelect, t]);
 
+  const trigger = (
+    <button
+      className={[drawerStyles.trigger, className].filter(Boolean).join(" ")}
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      aria-label={t("agentConfig.toolExecutionLevelTitle")}
+      onClick={isMobile ? () => setOpen((current) => !current) : undefined}
+      type="button"
+      style={{
+        cursor: "pointer",
+        userSelect: "none",
+        borderColor: meta.color,
+        color: meta.color,
+        transition: "all 0.2s",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        lineHeight: "22px",
+        width: compact ? 30 : undefined,
+        height: compact ? 30 : undefined,
+        padding: compact ? 0 : undefined,
+        marginInlineEnd: 0,
+        justifyContent: "center",
+      }}
+    >
+      {meta.icon}
+      {!compact && (
+        <>
+          {t(
+            `agentConfig.toolExecutionLevel.${effectiveLevel.toLowerCase()}`,
+            effectiveLevel,
+          )}
+          <ChevronDown size={12} />
+        </>
+      )}
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {trigger}
+        <OsDrawer
+          aria-label={t("agentConfig.toolExecutionLevelTitle")}
+          open={open}
+          placement="bottom"
+          height="auto"
+          closable={false}
+          destroyOnHidden
+          onClose={() => setOpen(false)}
+          styles={{
+            body: { padding: 0, overflow: "hidden" },
+            content: {
+              borderRadius: "14px 14px 0 0",
+              overflow: "hidden",
+            },
+            wrapper: { maxHeight: "min(52dvh, 430px)" },
+          }}
+        >
+          <div className={drawerStyles.sheet}>
+            <div className={drawerStyles.sheetHeader}>
+              <strong>{t("agentConfig.toolExecutionLevelTitle")}</strong>
+              <button
+                type="button"
+                aria-label={t("common.close")}
+                className={drawerStyles.closeButton}
+                onClick={() => setOpen(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className={drawerStyles.optionList} role="listbox">
+              {LEVELS.map((level) => {
+                const levelMeta = LEVEL_META[level];
+                const name = t(
+                  `agentConfig.toolExecutionLevel.${level.toLowerCase()}`,
+                  level,
+                );
+                const description = t(
+                  `agentConfig.toolExecutionLevel.${level.toLowerCase()}Desc`,
+                  "",
+                );
+                const selected = level === effectiveLevel;
+                return (
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    className={`${drawerStyles.option} ${
+                      selected ? drawerStyles.optionSelected : ""
+                    }`}
+                    data-level={level}
+                    key={level}
+                    onClick={() => handleSelect(level)}
+                  >
+                    <span
+                      className={drawerStyles.optionIcon}
+                      style={{ color: levelMeta.color }}
+                    >
+                      {levelMeta.icon}
+                    </span>
+                    <span className={drawerStyles.optionCopy}>
+                      <strong>{name}</strong>
+                      {description && <small>{description}</small>}
+                    </span>
+                    {selected && <Check size={16} />}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </OsDrawer>
+      </>
+    );
+  }
+
   return (
     <Tooltip title={t("agentConfig.toolExecutionLevelTitle")}>
       <Dropdown
         menu={{ items: menuItems, selectedKeys: [effectiveLevel] }}
         trigger={["click"]}
+        open={open}
+        onOpenChange={setOpen}
       >
-        <Tag
-          aria-label={t("agentConfig.toolExecutionLevelTitle")}
-          style={{
-            cursor: "pointer",
-            userSelect: "none",
-            borderColor: meta.color,
-            color: meta.color,
-            transition: "all 0.2s",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 4,
-            lineHeight: "22px",
-            width: compact ? 30 : undefined,
-            height: compact ? 30 : undefined,
-            padding: compact ? 0 : undefined,
-            marginInlineEnd: 0,
-            justifyContent: "center",
-          }}
-        >
-          {meta.icon}
-          {!compact && (
-            <>
-              {t(
-                `agentConfig.toolExecutionLevel.${effectiveLevel.toLowerCase()}`,
-                effectiveLevel,
-              )}
-              <DownOutlined style={{ fontSize: 10 }} />
-            </>
-          )}
-        </Tag>
+        {trigger}
       </Dropdown>
     </Tooltip>
   );

--- a/console/src/pages/Chat/components/ApprovalToggle.module.less
+++ b/console/src/pages/Chat/components/ApprovalToggle.module.less
@@ -1,0 +1,135 @@
+.sheet {
+  width: 100%;
+  height: auto;
+  max-height: min(52dvh, 430px);
+  padding: 10px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--ant-color-bg-elevated);
+}
+
+.sheetHeader {
+  min-height: 48px;
+  padding: 0 0 6px 8px;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  strong {
+    color: var(--ant-color-text);
+    font-size: 14px;
+    font-weight: 650;
+  }
+}
+
+.closeButton {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  display: inline-flex;
+  flex: 0 0 44px;
+  align-items: center;
+  justify-content: center;
+  color: var(--ant-color-text-secondary);
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover,
+  &:active {
+    color: var(--ant-color-text);
+    background: var(--ant-color-fill-tertiary);
+  }
+}
+
+.optionList {
+  min-height: 0;
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.option {
+  width: 100%;
+  min-width: 0;
+  min-height: 64px;
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 20px;
+  align-items: center;
+  gap: 10px;
+  color: var(--ant-color-text-tertiary);
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover,
+  &:active {
+    background: var(--ant-color-fill-quaternary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ant-color-primary-border);
+    outline-offset: -2px;
+  }
+}
+
+.optionSelected {
+  color: var(--ant-color-primary);
+  border-color: var(--ant-color-primary-border);
+  background: var(--ant-color-primary-bg);
+}
+
+.optionIcon {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ant-color-text-secondary);
+  border-radius: 9px;
+  background: var(--ant-color-fill-tertiary);
+}
+
+.optionCopy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+
+  strong,
+  small {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  strong {
+    color: var(--ant-color-text);
+    font-size: 13px;
+    font-weight: 650;
+    white-space: nowrap;
+  }
+
+  small {
+    color: var(--ant-color-text-tertiary);
+    font-size: 11px;
+    line-height: 1.35;
+  }
+}
+.trigger {
+  min-height: 28px;
+  padding: 0 7px;
+  border: 1px solid;
+  border-radius: 6px;
+  background: var(--ant-color-bg-container);
+  font: inherit;
+}

--- a/console/src/pages/Chat/components/ApprovalToggle.test.tsx
+++ b/console/src/pages/Chat/components/ApprovalToggle.test.tsx
@@ -1,0 +1,144 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test/common_setup";
+import ApprovalLevelToggle from "./ApprovalLevelToggle";
+import HarnessApprovalToggle from "./HarnessApprovalToggle";
+
+const { mockUseIsMobile } = vi.hoisted(() => ({
+  mockUseIsMobile: vi.fn(() => false),
+}));
+
+vi.mock("../../../hooks/useIsMobile", () => ({
+  useIsMobile: mockUseIsMobile,
+}));
+
+describe("compact approval controls", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUseIsMobile.mockReturnValue(false);
+  });
+
+  it("renders only the QwenPaw approval icon", () => {
+    const { container } = renderWithProviders(
+      <ApprovalLevelToggle
+        compact
+        onChange={vi.fn()}
+        runningConfigApprovalLevel="AUTO"
+        sessionId="compact-test"
+      />,
+    );
+
+    const trigger = container.querySelector<HTMLElement>("[aria-label]");
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toBe("");
+    expect(trigger?.querySelectorAll("svg")).toHaveLength(1);
+  });
+
+  it("renders only the harness approval icon", () => {
+    const { container } = renderWithProviders(
+      <HarnessApprovalToggle
+        backend="codex"
+        compact
+        onChange={vi.fn()}
+        presets={[
+          {
+            id: "auto",
+            name: "Automatic",
+            description: "Automatic approval",
+            settings: {},
+          },
+        ]}
+        sessionId="compact-test"
+      />,
+    );
+
+    const trigger = container.querySelector<HTMLElement>("[aria-label]");
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toBe("");
+    expect(trigger?.querySelectorAll("svg")).toHaveLength(1);
+  });
+
+  it("uses a bottom drawer for QwenPaw approval on mobile", async () => {
+    mockUseIsMobile.mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ApprovalLevelToggle
+        compact
+        onChange={vi.fn()}
+        runningConfigApprovalLevel="AUTO"
+        sessionId="mobile-test"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "agentConfig.toolExecutionLevelTitle",
+    });
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "agentConfig.toolExecutionLevelTitle",
+      }),
+    ).toBeInTheDocument();
+    expect(document.querySelector(".ant-dropdown")).not.toBeInTheDocument();
+
+    const offOption = document.querySelector<HTMLElement>('[data-level="OFF"]');
+    expect(offOption).not.toBeNull();
+    await user.click(offOption!);
+
+    expect(localStorage.getItem("approval_level-mobile-test")).toBe("OFF");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("uses a bottom drawer for harness approval on mobile", async () => {
+    mockUseIsMobile.mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWithProviders(
+      <HarnessApprovalToggle
+        backend="codex"
+        compact
+        onChange={vi.fn()}
+        presets={[
+          {
+            id: "auto",
+            name: "Automatic",
+            description: "Automatic approval",
+            settings: {},
+          },
+          {
+            id: "manual",
+            name: "Manual",
+            description: "Ask before running tools",
+            settings: { ask: true },
+          },
+        ]}
+        sessionId="mobile-test"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "agent.backend.approvalMode",
+    });
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "agent.backend.approvalMode",
+      }),
+    ).toBeInTheDocument();
+    expect(document.querySelector(".ant-dropdown")).not.toBeInTheDocument();
+
+    const manualOption = document.querySelector<HTMLElement>(
+      '[data-preset-id="manual"]',
+    );
+    expect(manualOption).not.toBeNull();
+    await user.click(manualOption!);
+
+    expect(localStorage.getItem("harness-approval-codex-mobile-test")).toBe(
+      "manual",
+    );
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/console/src/pages/Chat/components/ChatActionGroup/ChatActionGroup.module.less
+++ b/console/src/pages/Chat/components/ChatActionGroup/ChatActionGroup.module.less
@@ -1,3 +1,8 @@
+.actionGroup {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
 .workspaceButton {
   width: 32px !important;
   height: 32px !important;

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -70,7 +70,7 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
   }
 
   return (
-    <Flex gap={8} align="center">
+    <Flex className={styles.actionGroup} gap={8} align="center">
       {/* Essential actions always visible */}
       <Tooltip title={t("chat.newChatTooltip")} mouseEnterDelay={0.5}>
         <IconButton

--- a/console/src/pages/Chat/components/ChatHeaderTitle/ChatHeaderTitle.test.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/ChatHeaderTitle.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/common_setup";
 import ChatHeaderTitle from "./index";
+import styles from "./index.module.less";
 
 const { mockUseChatAnywhereSessionsState } = vi.hoisted(() => ({
   mockUseChatAnywhereSessionsState: vi.fn(),
@@ -50,5 +52,28 @@ describe("ChatHeaderTitle", () => {
     renderWithProviders(<ChatHeaderTitle />);
     expect(screen.getAllByText("Chat B")[0]).toBeInTheDocument();
     expect(screen.queryByText("Chat A")).not.toBeInTheDocument();
+  });
+
+  it("keeps a long session list inside the bounded dropdown", async () => {
+    const user = userEvent.setup();
+    mockUseChatAnywhereSessionsState.mockReturnValue({
+      sessions: Array.from({ length: 30 }, (_, index) => ({
+        id: `sess-${index}`,
+        name: `Chat ${index}`,
+      })),
+      currentSessionId: "sess-0",
+      setCurrentSessionId: vi.fn(),
+    });
+
+    renderWithProviders(<ChatHeaderTitle />);
+    const trigger = screen.getByRole("button", { name: "Chat 0" });
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(
+      (await screen.findByRole("menu")).closest(
+        ".qwenpaw-dropdown, .ant-dropdown",
+      ),
+    ).toHaveClass(styles.sessionDropdown);
   });
 });

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -116,14 +116,14 @@
     overflow-y: auto;
     overscroll-behavior: contain;
   }
-}
 
-.sessionDropdownCompact {
-  width: min(280px, calc(100vw - 96px));
+  @media (max-width: 768px) {
+    width: min(280px, calc(100vw - 96px));
 
-  :global(.qwenpaw-dropdown-menu),
-  :global(.ant-dropdown-menu) {
-    max-height: min(360px, calc(100dvh - 160px));
+    :global(.qwenpaw-dropdown-menu),
+    :global(.ant-dropdown-menu) {
+      max-height: min(360px, calc(100dvh - 160px));
+    }
   }
 }
 

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -69,14 +69,27 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-height: 44px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
   user-select: none;
+  min-width: 0;
   max-width: 260px;
 
   &:hover {
     .chatName {
       color: var(--colorPrimary, #ff7f16);
     }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ant-color-primary-border);
+    outline-offset: -2px;
+    border-radius: 6px;
   }
 
   @media (max-width: 768px) {
@@ -88,16 +101,44 @@
   }
 }
 
+/* Keep long session lists inside their own scroll region. Without an explicit
+ * width and height cap, the portalled popup expands the document itself. */
+.sessionDropdown {
+  width: min(320px, calc(100vw - 16px));
+  max-width: calc(100vw - 16px);
+
+  :global(.qwenpaw-dropdown-menu),
+  :global(.ant-dropdown-menu) {
+    box-sizing: border-box;
+    width: 100%;
+    max-height: min(420px, calc(100dvh - 120px));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
+.sessionDropdownCompact {
+  width: min(280px, calc(100vw - 96px));
+
+  :global(.qwenpaw-dropdown-menu),
+  :global(.ant-dropdown-menu) {
+    max-height: min(360px, calc(100dvh - 160px));
+  }
+}
+
 /* ---- Dropdown menu items ---- */
 .menuItem {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  min-width: 200px;
+  width: 100%;
+  min-width: 0;
 }
 
 .menuItemName {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -106,6 +147,5 @@
 
 .menuItemActive {
   color: var(--colorPrimary, #ff7f16);
-  font-size: 12px;
   flex-shrink: 0;
 }

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Dropdown } from "antd";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
+import { Check } from "lucide-react";
+import { useIsMobile } from "../../../../hooks/useIsMobile";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
 
@@ -10,6 +12,7 @@ const ChatHeaderTitle: React.FC = () => {
   const { sessions, currentSessionId, setCurrentSessionId } =
     useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
+  const isMobile = useIsMobile();
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
 
@@ -55,7 +58,7 @@ const ChatHeaderTitle: React.FC = () => {
           {session.name || "New Chat"}
         </span>
         {session.id === currentSessionId && (
-          <span className={styles.menuItemActive}>✓</span>
+          <Check className={styles.menuItemActive} size={16} aria-hidden />
         )}
       </div>
     ),
@@ -110,11 +113,19 @@ const ChatHeaderTitle: React.FC = () => {
       onOpenChange={setOpen}
       trigger={["click"]}
       placement="bottomLeft"
+      overlayClassName={`${styles.sessionDropdown} ${
+        isMobile ? styles.sessionDropdownCompact : ""
+      }`}
     >
-      <span className={styles.trigger}>
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
         {titleContent}
         {measureSpan}
-      </span>
+      </button>
     </Dropdown>
   );
 };

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from "react";
 import { Dropdown } from "antd";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
 import { Check } from "lucide-react";
-import { useIsMobile } from "../../../../hooks/useIsMobile";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
 
@@ -12,7 +11,6 @@ const ChatHeaderTitle: React.FC = () => {
   const { sessions, currentSessionId, setCurrentSessionId } =
     useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
-  const isMobile = useIsMobile();
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
 
@@ -113,9 +111,7 @@ const ChatHeaderTitle: React.FC = () => {
       onOpenChange={setOpen}
       trigger={["click"]}
       placement="bottomLeft"
-      overlayClassName={`${styles.sessionDropdown} ${
-        isMobile ? styles.sessionDropdownCompact : ""
-      }`}
+      overlayClassName={styles.sessionDropdown}
     >
       <button
         type="button"

--- a/console/src/pages/Chat/components/HarnessApprovalToggle.module.less
+++ b/console/src/pages/Chat/components/HarnessApprovalToggle.module.less
@@ -1,7 +1,14 @@
 .trigger {
+  min-height: 24px;
+  padding: 0 7px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  color: var(--ant-color-warning-text);
+  border: 1px solid var(--ant-color-warning-border);
+  border-radius: 6px;
+  background: var(--ant-color-warning-bg);
+  font: inherit;
   cursor: pointer;
   line-height: 22px;
 }

--- a/console/src/pages/Chat/components/HarnessApprovalToggle.tsx
+++ b/console/src/pages/Chat/components/HarnessApprovalToggle.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Dropdown, Tag, Tooltip } from "antd";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dropdown, Tooltip } from "antd";
 import type { MenuProps } from "antd";
-import { ChevronDown, ShieldCheck } from "lucide-react";
+import { Check, ChevronDown, ShieldCheck, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { HarnessApprovalPreset } from "@/api/modules/harness";
+import { useIsMobile } from "../../../hooks/useIsMobile";
+import { OsDrawer } from "../../../os/OsOverlay";
+import drawerStyles from "./ApprovalToggle.module.less";
 import styles from "./HarnessApprovalToggle.module.less";
 
 interface HarnessApprovalToggleProps {
@@ -12,6 +15,8 @@ interface HarnessApprovalToggleProps {
   sessionId: string;
   presets: HarnessApprovalPreset[];
   onChange: (settings: Record<string, unknown>) => void;
+  className?: string;
+  compact?: boolean;
 }
 
 function storageKey(backend: string, sessionId: string): string {
@@ -23,10 +28,14 @@ export default function HarnessApprovalToggle({
   sessionId,
   presets,
   onChange,
+  className,
+  compact = false,
 }: HarnessApprovalToggleProps) {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const defaultPreset = presets[0];
   const [selectedId, setSelectedId] = useState(defaultPreset?.id ?? "");
+  const [open, setOpen] = useState(false);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
@@ -39,6 +48,15 @@ export default function HarnessApprovalToggle({
 
   const selected =
     presets.find((item) => item.id === selectedId) ?? defaultPreset;
+  const selectPreset = useCallback(
+    (preset: HarnessApprovalPreset) => {
+      setSelectedId(preset.id);
+      setOpen(false);
+      localStorage.setItem(storageKey(backend, sessionId), preset.id);
+      onChangeRef.current(preset.settings);
+    },
+    [backend, sessionId],
+  );
   const items: MenuProps["items"] = useMemo(
     () =>
       presets.map((preset) => ({
@@ -59,30 +77,119 @@ export default function HarnessApprovalToggle({
             </div>
           </div>
         ),
-        onClick: () => {
-          setSelectedId(preset.id);
-          localStorage.setItem(storageKey(backend, sessionId), preset.id);
-          onChangeRef.current(preset.settings);
-        },
+        onClick: () => selectPreset(preset),
       })),
-    [backend, presets, sessionId, t],
+    [presets, selectPreset, t],
   );
 
   if (!selected) return null;
-  return (
-    <Tooltip title={t("agent.backend.approvalMode")}>
-      <Dropdown
-        menu={{ items, selectedKeys: [selected.id] }}
-        trigger={["click"]}
-      >
-        <Tag color="orange" className={styles.trigger}>
-          <ShieldCheck size={13} />
+  const trigger = (
+    <button
+      className={[styles.trigger, className].filter(Boolean).join(" ")}
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      aria-label={t("agent.backend.approvalMode")}
+      onClick={isMobile ? () => setOpen((current) => !current) : undefined}
+      type="button"
+    >
+      <ShieldCheck size={13} />
+      {!compact && (
+        <>
           {t(
             `agent.backend.approvalPresets.${selected.id}.name`,
             selected.name,
           )}
           <ChevronDown size={12} />
-        </Tag>
+        </>
+      )}
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {trigger}
+        <OsDrawer
+          aria-label={t("agent.backend.approvalMode")}
+          open={open}
+          placement="bottom"
+          height="auto"
+          closable={false}
+          destroyOnHidden
+          onClose={() => setOpen(false)}
+          styles={{
+            body: { padding: 0, overflow: "hidden" },
+            content: {
+              borderRadius: "14px 14px 0 0",
+              overflow: "hidden",
+            },
+            wrapper: { maxHeight: "min(52dvh, 430px)" },
+          }}
+        >
+          <div className={drawerStyles.sheet}>
+            <div className={drawerStyles.sheetHeader}>
+              <strong>{t("agent.backend.approvalMode")}</strong>
+              <button
+                type="button"
+                aria-label={t("common.close")}
+                className={drawerStyles.closeButton}
+                onClick={() => setOpen(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className={drawerStyles.optionList} role="listbox">
+              {presets.map((preset) => {
+                const presetSelected = preset.id === selected.id;
+                return (
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={presetSelected}
+                    className={`${drawerStyles.option} ${
+                      presetSelected ? drawerStyles.optionSelected : ""
+                    }`}
+                    data-preset-id={preset.id}
+                    key={preset.id}
+                    onClick={() => selectPreset(preset)}
+                  >
+                    <span className={drawerStyles.optionIcon}>
+                      <ShieldCheck size={15} />
+                    </span>
+                    <span className={drawerStyles.optionCopy}>
+                      <strong>
+                        {t(
+                          `agent.backend.approvalPresets.${preset.id}.name`,
+                          preset.name,
+                        )}
+                      </strong>
+                      <small>
+                        {t(
+                          `agent.backend.approvalPresets.${preset.id}.description`,
+                          preset.description,
+                        )}
+                      </small>
+                    </span>
+                    {presetSelected && <Check size={16} />}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </OsDrawer>
+      </>
+    );
+  }
+
+  return (
+    <Tooltip title={t("agent.backend.approvalMode")}>
+      <Dropdown
+        menu={{ items, selectedKeys: [selected.id] }}
+        trigger={["click"]}
+        open={open}
+        onOpenChange={setOpen}
+      >
+        {trigger}
       </Dropdown>
     </Tooltip>
   );

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -2,6 +2,7 @@
 .chatPageRoot {
   height: 100%;
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: row;
   position: relative;
@@ -84,6 +85,13 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+}
+
+.senderContextAffix {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  align-items: center;
 }
 
 @media (max-width: 1024px) {
@@ -187,6 +195,20 @@
   }
 }
 
+.headerSpacer {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+@media (max-width: 768px) {
+  .chatMessagesArea :global {
+    [class*="chat-anywhere-default-header-right"] {
+      gap: 4px;
+      padding-inline: 4px;
+    }
+  }
+}
+
 /* Right-side history panel */
 .historyPanel {
   width: 330px;
@@ -199,7 +221,7 @@
 @media (max-width: 900px) {
   .historyPanel {
     position: fixed;
-    top: 90px;
+    top: 56px;
     right: 0;
     bottom: 0;
     width: min(330px, 85vw);
@@ -212,6 +234,247 @@
     inset: 0;
     background: rgba(0, 0, 0, 0.45);
     z-index: 999;
+  }
+}
+
+/* The vendor chat layout keeps a 300px minimum width by default. Release
+ * that constraint on mobile so the page follows the available content width
+ * after the collapsed navigation rail is accounted for. */
+@media (max-width: 768px) {
+  .chatPageRoot,
+  .chatMainArea,
+  .chatMessagesArea {
+    min-width: 0;
+  }
+
+  .filesPreviewOpen .chatMainArea,
+  .filesWorkspaceOpen .chatMainArea {
+    min-width: 0;
+  }
+
+  .chatMessagesArea :global {
+    .qwenpaw-chat-anywhere,
+    .qwenpaw-chat-anywhere-layout,
+    .qwenpaw-chat-anywhere-layout-right,
+    .qwenpaw-chat-anywhere-chat,
+    .qwenpaw-chat-anywhere-message-list,
+    .qwenpaw-chat-anywhere-message-list-welcome,
+    .qwenpaw-chat-anywhere-welcome,
+    .qwenpaw-chat-anywhere-input,
+    .qwenpaw-chat-anywhere-input-wrapper,
+    .qwenpaw-chat-anywhere-sender-wrapper,
+    .qwenpaw-bubble-list {
+      width: 100%;
+      min-width: 0 !important;
+      max-width: 100% !important;
+    }
+
+    .qwenpaw-chat-anywhere-layout-right-header,
+    .qwenpaw-chat-anywhere-default-header-right,
+    .qwenpaw-chat-anywhere-default-header-right > * {
+      min-width: 0;
+    }
+
+    .qwenpaw-chat-anywhere-default-header-right {
+      overflow: hidden;
+    }
+
+    .qwenpaw-chat-anywhere-message-list .qwenpaw-bubble-list {
+      box-sizing: border-box;
+      padding-inline: 8px !important;
+    }
+
+    .qwenpaw-chat-anywhere-input {
+      box-sizing: border-box;
+      padding-inline: 8px !important;
+    }
+
+    .qwenpaw-chat-anywhere-sender-wrapper {
+      box-sizing: border-box;
+      padding: 0 8px calc(8px + env(safe-area-inset-bottom, 0px)) !important;
+    }
+
+    [class*="bubble-content-wrapper"],
+    [class*="bubble-content"] {
+      min-width: 0;
+      max-width: 100%;
+    }
+
+    [class$="-sender-content"],
+    [class$="-sender-prefix"],
+    [class$="-sender-input"] {
+      min-width: 0;
+    }
+
+    [class$="-sender-actions-list"] {
+      min-width: 0;
+      max-width: 100%;
+      flex-wrap: wrap;
+      column-gap: 4px;
+    }
+  }
+}
+
+/* Mobile composer: keep the input row dominant and the toolbar predictable. */
+@media (max-width: 600px) {
+  .chatMessagesArea :global {
+    [class$="-sender-content"] {
+      padding: 8px !important;
+    }
+
+    [class$="-sender-input"] {
+      min-height: 44px !important;
+      margin: 0;
+      padding-inline: 4px;
+      line-height: 22px;
+    }
+
+    [class$="-sender-content-bottom"] {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      column-gap: 8px;
+      margin-top: 8px;
+    }
+
+    [class$="-sender-prefix"] {
+      width: auto;
+      min-width: 0;
+      flex: 1 1 auto;
+      overflow-x: auto;
+      overflow-y: hidden;
+      overscroll-behavior-x: contain;
+      scrollbar-width: none;
+      touch-action: pan-x;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    [class$="-sender-prefix"] > [class*="flex"] {
+      width: 100%;
+      min-width: 0;
+      gap: 4px !important;
+      overflow: visible;
+    }
+
+    [class$="-sender-prefix"] button {
+      min-width: 44px;
+      min-height: 44px;
+      flex: 0 0 auto;
+    }
+
+    [class$="-sender-actions-list"] {
+      display: flex;
+      min-width: 0;
+      max-width: 100%;
+      flex-wrap: nowrap;
+      align-items: center;
+      column-gap: 4px;
+      margin-left: auto;
+    }
+
+    [class$="-sender-actions-list-presets"] {
+      flex: 0 0 auto;
+    }
+
+    [class$="-sender-actions-btn"] {
+      width: 44px !important;
+      min-width: 44px !important;
+      height: 44px !important;
+      border-radius: 12px !important;
+    }
+  }
+
+  .senderActionAffix {
+    min-width: 0;
+    max-width: 100%;
+    gap: 4px;
+  }
+
+  .senderActionAffix > button {
+    min-width: 0;
+    max-width: 116px;
+  }
+}
+
+@media (max-width: 480px) {
+  .chatMessagesArea :global {
+    [class$="-sender-content"] {
+      padding: 6px;
+    }
+
+    [class$="-sender-content-bottom"] {
+      column-gap: 4px;
+      row-gap: 4px;
+    }
+
+    [class$="-sender-actions-list-length"] {
+      display: none;
+    }
+  }
+
+  .senderContextAffix {
+    display: none;
+  }
+}
+
+/* Mobile composer controls share one quiet visual treatment. Their component
+ * compact variants remove labels and chevrons from the rendered structure. */
+.mobileComposerControl {
+  width: 44px !important;
+  max-width: 44px !important;
+  min-width: 44px !important;
+  height: 44px !important;
+  flex: 0 0 44px;
+  padding: 0 !important;
+  margin-inline-end: 0 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 0 !important;
+  border: 0 !important;
+  border-radius: 10px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  line-height: 1 !important;
+  touch-action: manipulation;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease !important;
+
+  > svg {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 18px;
+  }
+
+  &:hover,
+  &:active,
+  &[aria-expanded="true"] {
+    background: var(--ant-color-fill-tertiary) !important;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ant-color-primary-border);
+    outline-offset: 1px;
+  }
+
+  &[data-state] {
+    pointer-events: none;
+  }
+
+  &[data-state="starting"] {
+    color: var(--ant-color-primary) !important;
+  }
+
+  &[data-state="running"] {
+    color: var(--ant-color-success) !important;
+  }
+
+  &[data-state="awaiting_user"] {
+    color: var(--ant-color-warning) !important;
   }
 }
 

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -81,3 +81,84 @@ describe("Chat attachment preview styles", () => {
     expect(rule).toMatch(/padding-inline:\s*6px/);
   });
 });
+
+describe("Chat mobile layout styles", () => {
+  it("releases the vendor chat minimum width on narrow viewports", () => {
+    const mobileStart = stylesSource.indexOf(
+      "/* The vendor chat layout keeps a 300px minimum width",
+    );
+    const mobileRule = stylesSource.slice(mobileStart);
+
+    expect(mobileStart).toBeGreaterThanOrEqual(0);
+    expect(mobileRule).toContain("@media (max-width: 768px)");
+    expect(mobileRule).toContain(".qwenpaw-chat-anywhere-layout");
+    expect(mobileRule).toMatch(/min-width:\s*0\s*!important/);
+    expect(mobileRule).toContain("safe-area-inset-bottom");
+  });
+
+  it("keeps the history panel below the console header", () => {
+    const panelStart = stylesSource.indexOf(".historyPanel {");
+    const panelRule = stylesSource.slice(
+      panelStart,
+      stylesSource.indexOf(".suggestionLabel", panelStart),
+    );
+
+    expect(panelStart).toBeGreaterThanOrEqual(0);
+    expect(panelRule).toMatch(/top:\s*56px/);
+  });
+
+  it("keeps the mobile composer toolbar in two stable columns", () => {
+    const composerStart = stylesSource.indexOf(
+      "/* Mobile composer: keep the input row dominant",
+    );
+    const composerRule = stylesSource.slice(
+      composerStart,
+      stylesSource.indexOf("@media (max-width: 480px)", composerStart),
+    );
+
+    expect(composerStart).toBeGreaterThanOrEqual(0);
+    expect(composerRule).toContain(
+      "grid-template-columns: minmax(0, 1fr) auto",
+    );
+    expect(composerRule).toContain("min-height: 44px");
+    expect(composerRule).toContain("min-width: 44px !important");
+    expect(composerRule).toContain("flex-wrap: nowrap");
+    expect(composerRule).toContain("overflow-x: auto");
+    expect(composerRule).toContain("overflow: visible");
+  });
+
+  it("removes low-priority composer chrome on narrow phones", () => {
+    const narrowStart = stylesSource.indexOf("@media (max-width: 480px)");
+    const narrowRule = stylesSource.slice(
+      narrowStart,
+      stylesSource.indexOf(
+        "/* Mobile composer controls share one quiet visual treatment",
+        narrowStart,
+      ),
+    );
+
+    expect(narrowStart).toBeGreaterThanOrEqual(0);
+    expect(narrowRule).toContain(".senderContextAffix");
+    expect(narrowRule).toMatch(/display:\s*none/);
+  });
+
+  it("uses one quiet icon control treatment across the mobile toolbar", () => {
+    const toolbarStart = stylesSource.indexOf(
+      "/* Mobile composer controls share one quiet visual treatment",
+    );
+    const toolbarRule = stylesSource.slice(toolbarStart);
+
+    expect(toolbarStart).toBeGreaterThanOrEqual(0);
+    expect(toolbarRule).toContain(".mobileComposerControl");
+    expect(toolbarRule).toContain("width: 44px !important");
+    expect(toolbarRule).toContain("height: 44px !important");
+    expect(toolbarRule).toContain("width: 18px");
+    expect(toolbarRule).toContain("border: 0 !important");
+    expect(toolbarRule).toContain("background: transparent !important");
+    expect(toolbarRule).toContain("touch-action: manipulation");
+    expect(toolbarRule).toContain('&[aria-expanded="true"]');
+    expect(toolbarRule).toContain("&:focus-visible");
+    expect(toolbarRule).toContain('&[data-state="running"]');
+    expect(toolbarRule).toContain("var(--ant-color-success)");
+  });
+});

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -3127,7 +3127,7 @@ export default function ChatPage() {
               onLoadingChange={setChatLoading}
             />
             <ChatHeaderTitle />
-            <span style={{ flex: 1 }} />
+            <span className={styles.headerSpacer} />
             {usesQwenPawBackend ? (
               <ModelSelector />
             ) : backendCapabilities?.model_selection ? (
@@ -3195,7 +3195,12 @@ export default function ChatPage() {
                 onTranscription={handleWhisperTranscription}
               />
             ) : null}
-            {usesQwenPawBackend && <LoopModeSelector />}
+            {usesQwenPawBackend && (
+              <LoopModeSelector
+                className={isMobile ? styles.mobileComposerControl : undefined}
+                compact={isMobile}
+              />
+            )}
             {pluginSenderPrefix}
           </>
         ),
@@ -3206,22 +3211,34 @@ export default function ChatPage() {
             }`}
           >
             {(usesQwenPawBackend || backendCapabilities?.context_usage) && (
-              <ContextUsageIndicator
-                onCompact={handleCompactCommand}
-                onNew={handleNewCommand}
-              />
+              <span className={styles.senderContextAffix}>
+                <ContextUsageIndicator
+                  onCompact={handleCompactCommand}
+                  onNew={handleNewCommand}
+                />
+              </span>
             )}
             {usesQwenPawBackend && (
               <SessionProjectDirectory
                 scope={sessionScope}
-                compact={compactSender}
+                compact={isMobile || compactSender}
+                className={
+                  isMobile || compactSender
+                    ? styles.mobileComposerControl
+                    : undefined
+                }
               />
             )}
             {usesQwenPawBackend ? (
               <ApprovalLevelToggle
                 sessionId={queueSessionId}
                 runningConfigApprovalLevel={runningConfigApprovalLevel}
-                compact={compactSender}
+                compact={isMobile || compactSender}
+                className={
+                  isMobile || compactSender
+                    ? styles.mobileComposerControl
+                    : undefined
+                }
                 onChange={(sessionOverride) => {
                   sessionApprovalLevelRef.current = sessionOverride;
                 }}
@@ -3231,6 +3248,8 @@ export default function ChatPage() {
                 backend={selectedAgentBackend}
                 sessionId={queueSessionId}
                 presets={approvalPresets}
+                className={isMobile ? styles.mobileComposerControl : undefined}
+                compact={isMobile}
                 onChange={(settings) => {
                   backendControlsRef.current = settings;
                 }}
@@ -3545,6 +3564,7 @@ export default function ChatPage() {
     toggleHistoryPanel,
     handleCompactCommand,
     handleNewCommand,
+    isMobile,
     compactSender,
     sessionScope,
     filesWorkspaceOpen,

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -897,6 +897,7 @@ html.dark-mode
 
 #root {
   height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -908,6 +909,8 @@ html.dark-mode
 }
 
 .ant-layout-content {
+  min-width: 0;
+  min-height: 0;
   overflow: hidden;
   background: #f9f8f4;
 }
@@ -992,6 +995,8 @@ html.dark-mode .qwenpaw-sender-content {
 
 .page-container {
   height: 100%;
+  min-width: 0;
+  min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -1005,6 +1010,8 @@ html.dark-mode .qwenpaw-sender-content {
 
 .page-content {
   flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
   overflow: auto;
   background-color: #fff;
   border-radius: 8px;
@@ -1012,6 +1019,22 @@ html.dark-mode .qwenpaw-sender-content {
   box-sizing: border-box;
   border: 1px solid #eae9e7;
   /* #EAE9E7 */
+}
+
+@supports (height: 100dvh) {
+  @media (max-width: 768px) {
+    .ant-layout {
+      min-height: 100dvh;
+      max-height: 100dvh;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .page-container {
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 .table-container {


### PR DESCRIPTION
Improve the Chat page experience on mobile devices.

Rework composer controls into consistent 44px icon buttons.

Use bottom drawers for Loop mode, workspace directory, and approval settings.

Improve workspace/file selector layout and mobile safe-area spacing.

Prevent the session title dropdown from expanding the document and creating page-level scrollbars.

Limit long session lists to internal scrolling in portrait and landscape layouts.

Replace text symbols with Lucide React icons.

Improve responsive width constraints across the Chat layout.

<img width="446" height="962" alt="image" src="https://github.com/user-attachments/assets/108962f1-58fa-45ff-a167-bb353f1843ad" />
<img width="446" height="959" alt="image" src="https://github.com/user-attachments/assets/91240a43-022f-455c-bf7e-22a7c994e6f7" />
<img width="446" height="960" alt="image" src="https://github.com/user-attachments/assets/e4b690f3-e797-464b-8d4b-18a741c84118" />
<img width="442" height="959" alt="image" src="https://github.com/user-attachments/assets/794bff81-a04d-480a-8826-d3f4fb102772" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
