### PR TITLE
fix(installer): handle NSIS uninstall process blockers

### DIFF
--- a/console/src-tauri/nsis/manage-install-processes.ps1
+++ b/console/src-tauri/nsis/manage-install-processes.ps1
@@ -160,12 +160,11 @@ function Test-IsQwenPawInstall {
 function Get-ScopedProcesses {
     param(
         [string]$Root,
-        [int]$ExcludedProcessId = 0
+        [int[]]$ExcludedProcessIds = @()
     )
 
     $result = foreach ($process in @(Get-CimInstance Win32_Process)) {
-        if ($ExcludedProcessId -gt 0 -and
-            $process.ProcessId -eq $ExcludedProcessId) {
+        if ($ExcludedProcessIds -contains $process.ProcessId) {
             continue
         }
         $path = Get-NormalizedPath -Path "$($process.ExecutablePath)"
@@ -181,6 +180,18 @@ function Get-ScopedProcesses {
     return @($result)
 }
 
+function Get-NsisProcessIds {
+    param([int]$ProcessId)
+
+    if ($ProcessId -le 0) {
+        return @()
+    }
+    $process = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId"
+    return @($ProcessId, $process.ParentProcessId) |
+        Where-Object { $_ -gt 0 } |
+        Sort-Object -Unique
+}
+
 function Test-IsAutomaticProcess {
     param(
         [object]$Process,
@@ -188,7 +199,8 @@ function Test-IsAutomaticProcess {
     )
 
     $relative = $Process.ExecutablePath.Substring($Root.Length).TrimStart("\")
-    if ($relative -ieq "binaries\qwenpaw-backend\qwenpaw-backend.exe" -or
+    if ($relative -ieq "qwenpaw-desktop.exe" -or
+        $relative -ieq "binaries\qwenpaw-backend\qwenpaw-backend.exe" -or
         $relative -ieq "binaries\qwenpaw-backend\qwenpaw.exe") {
         return $true
     }
@@ -244,7 +256,8 @@ try {
     }
 
     Enable-NativeHostGate -Root $root
-    $scoped = Get-ScopedProcesses -Root $root -ExcludedProcessId $NsisProcessId
+    $nsisProcessIds = Get-NsisProcessIds -ProcessId $NsisProcessId
+    $scoped = Get-ScopedProcesses -Root $root -ExcludedProcessIds $nsisProcessIds
     $automatic = @(
         $scoped | Where-Object {
             Test-IsAutomaticProcess -Process $_ -Root $root
@@ -252,7 +265,7 @@ try {
     )
     Stop-ProcessRecords -Processes $automatic
 
-    $remaining = Get-ScopedProcesses -Root $root -ExcludedProcessId $NsisProcessId
+    $remaining = Get-ScopedProcesses -Root $root -ExcludedProcessIds $nsisProcessIds
     if ($remaining.Count -gt 0) {
         Write-Output "Close these processes before continuing:"
         Write-ProcessList -Processes $remaining -Root $root


### PR DESCRIPTION
## Description

Follow up on #7323, which excluded the temporary NSIS process but missed two processes present in the real uninstall flow: the install-root `uninstall.exe` bootstrap parent and a running `qwenpaw-desktop.exe`.

Resolve the hook-supplied NSIS PID to its immediate parent, and automatically stop the exact install-root desktop executable alongside the existing managed backend processes. Unrelated install-root processes remain blocking.

**Related Issue:** Regression from #7281; follow-up to #7323

**Security Considerations:** No process-name-wide termination is added. Automatic cleanup remains scoped to a recognized QwenPaw install root and exact relative executable paths.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

- PowerShell AST parsing passed.
- A temporary NSIS-shaped process hierarchy verified the install-root bootstrap parent is excluded.
- A running install-root `qwenpaw-desktop.exe` was stopped automatically.
- A separate install-root `blocker.exe` remained running, produced exit code 1, and was listed as blocking.
- `git diff --check` passed.

Known compatibility boundary: when a new installer invokes an older on-disk uninstaller, that older uninstaller still requires the user to exit QwenPaw and retry. Uninstallers generated with this change handle the managed processes automatically.

## Evidence

```text
PASS: install-root NSIS parent was excluded
PASS: running qwenpaw-desktop.exe was stopped automatically
PASS: unrelated install-root process remained blocking
PowerShell AST parse: PASS
git diff --check: passed
```