### PR TITLE
feat(console): add chat scroll lock

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3196,6 +3196,8 @@
     "chatHistoryTooltip": "Chat history",
     "wideModeTooltip": "Wide mode",
     "normalModeTooltip": "Normal mode",
+    "lockScrollTooltip": "Lock auto-scroll",
+    "followScrollTooltip": "Follow latest message",
     "allChats": "All Chats",
     "createNewChat": "Create New Chat",
     "pinDrawer": "Pin",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -631,6 +631,8 @@
     "chatHistoryTooltip": "Riwayat chat",
     "wideModeTooltip": "Mode lebar",
     "normalModeTooltip": "Mode normal",
+    "lockScrollTooltip": "Kunci gulir otomatis",
+    "followScrollTooltip": "Ikuti pesan terbaru",
     "allChats": "Semua Chat",
     "createNewChat": "Buat Chat Baru",
     "pinDrawer": "Sematkan",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2610,6 +2610,8 @@
     "chatHistoryTooltip": "チャット履歴",
     "wideModeTooltip": "ワイドモード",
     "normalModeTooltip": "標準モード",
+    "lockScrollTooltip": "自動スクロールをロック",
+    "followScrollTooltip": "最新メッセージに追従",
     "allChats": "すべてのチャット",
     "createNewChat": "新しいチャットを作成",
     "pinDrawer": "固定",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2854,6 +2854,8 @@
     "chatHistoryTooltip": "Chat history",
     "wideModeTooltip": "Modo amplo",
     "normalModeTooltip": "Modo normal",
+    "lockScrollTooltip": "Bloquear rolagem automática",
+    "followScrollTooltip": "Seguir mensagem mais recente",
     "allChats": "Todos Chats",
     "createNewChat": "Criar Novo Chat",
     "pinDrawer": "Fixar",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2625,6 +2625,8 @@
     "chatHistoryTooltip": "История чатов",
     "wideModeTooltip": "Широкий режим",
     "normalModeTooltip": "Обычный режим",
+    "lockScrollTooltip": "Заблокировать автопрокрутку",
+    "followScrollTooltip": "Следовать за новым сообщением",
     "allChats": "Все чаты",
     "createNewChat": "Создать новый чат",
     "pinDrawer": "Закрепить",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -645,6 +645,8 @@
     "newChatTooltip": "Cuộc trò chuyện mới",
     "searchTooltip": "Tìm kiếm tất cả cuộc trò chuyện",
     "chatHistoryTooltip": "Lịch sử trò chuyện",
+    "lockScrollTooltip": "Khóa tự động cuộn",
+    "followScrollTooltip": "Theo dõi tin nhắn mới nhất",
     "allChats": "Tất cả cuộc trò chuyện",
     "createNewChat": "Tạo cuộc trò chuyện mới",
     "pinDrawer": "Ghim",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3053,6 +3053,8 @@
     "chatHistoryTooltip": "聊天历史",
     "wideModeTooltip": "宽屏模式",
     "normalModeTooltip": "正常模式",
+    "lockScrollTooltip": "锁定滚动",
+    "followScrollTooltip": "跟随最新消息",
     "allChats": "全部聊天",
     "createNewChat": "创建新聊天",
     "pinDrawer": "固定",

--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/common_setup";
 import ChatPage from "./index";
 import { chatExtensions } from "@/plugins/registry/chatExtensions";
@@ -192,7 +193,24 @@ vi.mock("./ModelSelector", () => ({
 }));
 
 vi.mock("./components/ChatActionGroup", () => ({
-  default: () => <div data-testid="action-group" />,
+  default: ({
+    onToggleAutoScroll,
+    scrollLocked,
+  }: {
+    onToggleAutoScroll?: () => void;
+    scrollLocked?: boolean;
+  }) => (
+    <div data-testid="action-group">
+      {onToggleAutoScroll ? (
+        <button
+          aria-pressed={scrollLocked}
+          data-testid="auto-scroll-toggle"
+          onClick={onToggleAutoScroll}
+          type="button"
+        />
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("./components/ChatHeaderTitle", () => ({
@@ -502,6 +520,7 @@ describe("ChatPage coverage", () => {
   beforeEach(() => {
     chatExtensions.__resetForTests();
     capturedOptions = null;
+    localStorage.removeItem("qwenpaw_chat_scroll_locked");
     mockListProviders.mockResolvedValue([
       {
         id: "openai",
@@ -556,6 +575,35 @@ describe("ChatPage coverage", () => {
     expect(screen.getByTestId("model-selector")).toBeInTheDocument();
     expect(screen.getByTestId("action-group")).toBeInTheDocument();
     expect(screen.getByTestId("header-title")).toBeInTheDocument();
+  });
+
+  it("lets users lock streaming auto-scroll from the chat header", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/test-session"],
+    });
+    await screen.findByTestId("chat-ui");
+
+    expect(capturedOptions.theme.bubbleList.autoScroll.enabled).toBe(true);
+
+    await user.click(screen.getByTestId("auto-scroll-toggle"));
+
+    await waitFor(() => {
+      expect(capturedOptions.theme.bubbleList.autoScroll.enabled).toBe(false);
+    });
+    expect(localStorage.getItem("qwenpaw_chat_scroll_locked")).toBe("true");
+  });
+
+  it("restores the persisted streaming auto-scroll lock preference", async () => {
+    localStorage.setItem("qwenpaw_chat_scroll_locked", "true");
+
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/test-session"],
+    });
+    await screen.findByTestId("chat-ui");
+
+    expect(capturedOptions.theme.bubbleList.autoScroll.enabled).toBe(false);
   });
 
   it("invokes customFetch via captured options", async () => {

--- a/console/src/pages/Chat/components/ChatActionGroup/ChatActionGroup.test.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/ChatActionGroup.test.tsx
@@ -77,4 +77,19 @@ describe("ChatActionGroup", () => {
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onToggleWorkspace).toHaveBeenCalledOnce();
   });
+
+  it("renders the scroll lock toggle and marks the locked state", () => {
+    const onToggleAutoScroll = vi.fn();
+    renderWithProviders(
+      <ChatActionGroup scrollLocked onToggleAutoScroll={onToggleAutoScroll} />,
+    );
+
+    const button = document.querySelector(
+      'button[aria-label="chat.followScrollTooltip"]',
+    ) as HTMLButtonElement | null;
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onToggleAutoScroll).toHaveBeenCalledOnce();
+  });
 });

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { Dropdown, Flex, Tooltip } from "antd";
-import { Files } from "lucide-react";
+import { ArrowDownToLine, Files, LockKeyhole } from "lucide-react";
 import type { MenuProps } from "antd";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
 import { useIsMobile } from "../../../../hooks/useIsMobile";
@@ -24,6 +24,8 @@ interface ChatActionGroupProps {
   workspaceOpen?: boolean;
   isWideMode?: boolean;
   onToggleWideMode?: () => void;
+  scrollLocked?: boolean;
+  onToggleAutoScroll?: () => void;
 }
 
 const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
@@ -33,6 +35,8 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
   workspaceOpen = false,
   isWideMode = false,
   onToggleWideMode,
+  scrollLocked = false,
+  onToggleAutoScroll,
 }) => {
   const { t } = useTranslation();
 
@@ -66,6 +70,20 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
         </div>
       ),
       onClick: () => onToggleWideMode(),
+    });
+  }
+  if (onToggleAutoScroll) {
+    moreItems.push({
+      key: "autoScroll",
+      icon: scrollLocked ? <LockKeyhole /> : <ArrowDownToLine />,
+      label: (
+        <div style={{ textAlign: "center" }}>
+          {scrollLocked
+            ? t("chat.followScrollTooltip")
+            : t("chat.lockScrollTooltip")}
+        </div>
+      ),
+      onClick: () => onToggleAutoScroll(),
     });
   }
 
@@ -139,6 +157,50 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
             bordered={false}
             icon={isWideMode ? <CompressOutlined /> : <ExpandAltOutlined />}
             onClick={onToggleWideMode}
+          />
+        </Tooltip>
+      )}
+      {!isCompact && onToggleAutoScroll && (
+        <Tooltip
+          title={
+            scrollLocked
+              ? t("chat.followScrollTooltip")
+              : t("chat.lockScrollTooltip")
+          }
+          mouseEnterDelay={0.5}
+        >
+          <IconButton
+            bordered={false}
+            aria-label={
+              scrollLocked
+                ? t("chat.followScrollTooltip")
+                : t("chat.lockScrollTooltip")
+            }
+            aria-pressed={scrollLocked}
+            icon={
+              scrollLocked ? (
+                <LockKeyhole
+                  size={16}
+                  strokeWidth={2}
+                  style={{ width: 16, height: 16 }}
+                />
+              ) : (
+                <ArrowDownToLine
+                  size={16}
+                  strokeWidth={2}
+                  style={{ width: 16, height: 16 }}
+                />
+              )
+            }
+            style={{
+              width: 32,
+              height: 32,
+              padding: 0,
+              ...(scrollLocked
+                ? { color: "var(--color-primary, #ff9d4d)" }
+                : {}),
+            }}
+            onClick={onToggleAutoScroll}
           />
         </Tooltip>
       )}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -130,7 +130,10 @@ import {
 import { useCodingTabsStore } from "../../stores/codingTabsStore";
 import { RichFileReferenceInputProvider } from "./RichFileReferenceInput";
 import type { ParsedFileReference } from "./fileReferenceFormatting";
-import { scrollReverseMessageList } from "./messageScroll";
+import {
+  installReverseMessageScrollLock,
+  scrollReverseMessageList,
+} from "./messageScroll";
 import { LONG_CHAT_USER_MESSAGE_ANCHORS } from "./longChatPerformance";
 
 interface ApprovalMessageData {
@@ -650,6 +653,7 @@ function renderSuggestionLabel(command: string, description?: string) {
 const DEFAULT_USER_ID = "default";
 const DEFAULT_CHANNEL = "console";
 const WIDE_MODE_STORAGE_KEY = "qwenpaw_chat_wide_mode";
+const SCROLL_LOCK_STORAGE_KEY = "qwenpaw_chat_scroll_locked";
 
 // Stable fallback so an absent queue entry doesn't produce a fresh array
 // reference on every render (which would invalidate the options memo).
@@ -1261,6 +1265,30 @@ export default function ChatPage() {
           localStorage.setItem(WIDE_MODE_STORAGE_KEY, "true");
         } else {
           localStorage.removeItem(WIDE_MODE_STORAGE_KEY);
+        }
+      } catch {
+        // storage unavailable
+      }
+      return next;
+    });
+  }, []);
+  const [scrollLocked, setScrollLocked] = useState(() => {
+    try {
+      return localStorage.getItem(SCROLL_LOCK_STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const scrollLockedRef = useRef(scrollLocked);
+  scrollLockedRef.current = scrollLocked;
+  const toggleAutoScroll = useCallback(() => {
+    setScrollLocked((prev) => {
+      const next = !prev;
+      try {
+        if (next) {
+          localStorage.setItem(SCROLL_LOCK_STORAGE_KEY, "true");
+        } else {
+          localStorage.removeItem(SCROLL_LOCK_STORAGE_KEY);
         }
       } catch {
         // storage unavailable
@@ -2792,6 +2820,12 @@ export default function ChatPage() {
     };
   }, []);
 
+  useEffect(() => {
+    const root = chatMessagesAreaRef.current;
+    if (!root) return;
+    return installReverseMessageScrollLock(root, () => scrollLockedRef.current);
+  }, []);
+
   const options = useMemo(() => {
     const i18nConfig = getDefaultConfig(t);
     const hostCommands: CommandSuggestion[] = [
@@ -3116,6 +3150,9 @@ export default function ChatPage() {
         ...(extColorPrimary ? { colorPrimary: extColorPrimary } : {}),
         bubbleList: {
           ...defaultConfig.theme.bubbleList,
+          autoScroll: {
+            enabled: !scrollLocked,
+          },
           userMessageAnchors: userMessageAnchorsConfig,
         },
         leftHeader: mergedLeftHeader,
@@ -3142,6 +3179,8 @@ export default function ChatPage() {
               historyOpen={effectiveIsFullMode ? historyPanelOpen : false}
               isWideMode={isWideMode}
               onToggleWideMode={toggleWideMode}
+              scrollLocked={scrollLocked}
+              onToggleAutoScroll={toggleAutoScroll}
             />
             {pluginRightHeader}
           </>
@@ -3529,6 +3568,8 @@ export default function ChatPage() {
     handleWhisperTranscription,
     isWideMode,
     toggleWideMode,
+    scrollLocked,
+    toggleAutoScroll,
     hasQueueItems,
     isQueueOnlyTab,
     showSenderBeforeUI,

--- a/console/src/pages/Chat/messageScroll.test.ts
+++ b/console/src/pages/Chat/messageScroll.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getNextReverseScrollTop,
+  installReverseMessageScrollLock,
   scrollReverseMessageList,
 } from "./messageScroll";
 
@@ -110,5 +111,35 @@ describe("scrollReverseMessageList", () => {
 
     expect(scrollReverseMessageList(root, outside, 100, 0)).toBe(false);
     expect(scroller.scrollTop).toBe(-420);
+  });
+});
+
+describe("installReverseMessageScrollLock", () => {
+  it("restores a locked reverse scroller after automatic bottom scrolling", async () => {
+    const { content, root, scroller } = createReverseScroller();
+    scroller.scrollTop = -240;
+    const cleanup = installReverseMessageScrollLock(root, () => true);
+
+    scroller.scrollTop = 0;
+    content.append(document.createElement("span"));
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(scroller.scrollTop).toBe(-240);
+    cleanup();
+  });
+
+  it("does not restore automatic scrolling when unlocked", async () => {
+    const { content, root, scroller } = createReverseScroller();
+    scroller.scrollTop = -240;
+    const cleanup = installReverseMessageScrollLock(root, () => false);
+
+    scroller.scrollTop = 0;
+    content.append(document.createElement("span"));
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(scroller.scrollTop).toBe(0);
+    cleanup();
   });
 });

--- a/console/src/pages/Chat/messageScroll.ts
+++ b/console/src/pages/Chat/messageScroll.ts
@@ -4,6 +4,8 @@ const REVERSE_MESSAGE_SCROLL_SELECTOR =
 
 const LINE_HEIGHT_PX = 16;
 const SCROLL_TOLERANCE_PX = 1;
+const LOCK_RESTORE_DELAY_MS = 0;
+const USER_SCROLL_WINDOW_MS = 250;
 
 function wheelDeltaInPixels(
   deltaY: number,
@@ -84,4 +86,105 @@ export function scrollReverseMessageList(
 
   scroller.scrollTop = nextScrollTop;
   return true;
+}
+
+export function installReverseMessageScrollLock(
+  root: HTMLElement,
+  isLocked: () => boolean,
+): () => void {
+  let scroller: HTMLElement | null = null;
+  let savedScrollTop = 0;
+  let userScrollUntil = 0;
+  let restoreFrame = 0;
+  let restoreTimer: ReturnType<typeof setTimeout> | null = null;
+  let restoring = false;
+
+  const findScroller = () =>
+    root.querySelector<HTMLElement>(REVERSE_MESSAGE_SCROLL_SELECTOR);
+
+  const syncScroller = () => {
+    const nextScroller = findScroller();
+    if (nextScroller === scroller) return;
+
+    if (scroller) {
+      scroller.removeEventListener("scroll", handleScroll, true);
+    }
+
+    scroller = nextScroller;
+    savedScrollTop = scroller?.scrollTop ?? 0;
+
+    if (scroller) {
+      scroller.addEventListener("scroll", handleScroll, true);
+    }
+  };
+
+  const restoreScrollTop = () => {
+    if (!isLocked()) return;
+    syncScroller();
+    if (!scroller || scroller.scrollTop === savedScrollTop) return;
+
+    restoring = true;
+    scroller.scrollTop = savedScrollTop;
+    queueMicrotask(() => {
+      restoring = false;
+    });
+  };
+
+  const scheduleRestore = () => {
+    if (restoreFrame) return;
+
+    restoreFrame = requestAnimationFrame(() => {
+      restoreFrame = 0;
+      restoreScrollTop();
+      requestAnimationFrame(restoreScrollTop);
+      restoreTimer = setTimeout(restoreScrollTop, LOCK_RESTORE_DELAY_MS);
+    });
+  };
+
+  function handleScroll() {
+    if (!isLocked() || restoring || !scroller) return;
+
+    if (performance.now() <= userScrollUntil) {
+      savedScrollTop = scroller.scrollTop;
+      return;
+    }
+
+    scheduleRestore();
+  }
+
+  const markUserScroll = () => {
+    if (!isLocked()) return;
+    syncScroller();
+    if (!scroller) return;
+
+    savedScrollTop = scroller.scrollTop;
+    userScrollUntil = performance.now() + USER_SCROLL_WINDOW_MS;
+  };
+
+  syncScroller();
+
+  const observer = new MutationObserver(() => {
+    if (!isLocked()) return;
+    syncScroller();
+    scheduleRestore();
+  });
+  observer.observe(root, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+
+  root.addEventListener("wheel", markUserScroll, true);
+  root.addEventListener("touchstart", markUserScroll, true);
+  root.addEventListener("keydown", markUserScroll, true);
+
+  return () => {
+    observer.disconnect();
+    root.removeEventListener("wheel", markUserScroll, true);
+    root.removeEventListener("touchstart", markUserScroll, true);
+    root.removeEventListener("keydown", markUserScroll, true);
+    scroller?.removeEventListener("scroll", handleScroll, true);
+    if (restoreFrame) cancelAnimationFrame(restoreFrame);
+    if (restoreTimer) clearTimeout(restoreTimer);
+  };
 }


### PR DESCRIPTION
## Summary
- Add a chat header control that lets users lock or resume streaming auto-scroll.
- Persist the scroll-lock preference in localStorage and pass the state into the bubble list auto-scroll option.
- Restore the current reverse-message scroll position when streaming DOM updates attempt to jump to the newest message.

## What Problem This Solves
During a streaming response, the desktop chat view currently keeps following the newest generated content. If a user scrolls upward to read earlier output while generation is still in progress, automatic scrolling can pull the viewport back down and interrupt reading. This PR adds an explicit scroll-lock control so users can keep their current reading position, then resume following the latest message when they want.

## Evidence
The change is covered by targeted console tests:
- Chat page options now disable `bubbleList.autoScroll` when the header toggle is enabled, and the preference is restored from localStorage.
- The reverse-message scroll helper restores the locked scrollTop after automatic DOM-driven scrolling, and leaves scrolling unchanged when unlocked.
- The action group renders an accessible pressed-state toggle for the locked state.

Validation run locally:
- `npm run test:run -- src/pages/Chat/messageScroll.test.ts src/pages/Chat/components/ChatActionGroup/ChatActionGroup.test.tsx src/pages/Chat/ChatPage.coverage.test.tsx --pool threads --maxWorkers 1`
- `npm run format:check -- src/pages/Chat/messageScroll.ts src/pages/Chat/messageScroll.test.ts src/pages/Chat/index.tsx src/pages/Chat/ChatPage.coverage.test.tsx src/pages/Chat/components/ChatActionGroup/index.tsx src/pages/Chat/components/ChatActionGroup/ChatActionGroup.test.tsx src/locales/en.json src/locales/id.json src/locales/ja.json src/locales/pt-BR.json src/locales/ru.json src/locales/vi.json src/locales/zh.json`

Closes #7339