### PR TITLE
fix(formatter): preserve local file URLs during media normalization

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1320,11 +1320,20 @@ def _reasoning_by_assistant_segment(
     return aligned
 
 
+def _local_path_to_file_url(path: str) -> str:
+    """Build an unescaped file URI from a decoded local path."""
+    if path.startswith("//"):
+        return f"file:{path}"
+    if len(path) >= 2 and path[0].isalpha() and path[1] == ":":
+        return f"file:///{path}"
+    return f"file://{path}"
+
+
 # pylint: disable=too-many-branches
 def _fixup_media_list(items: list) -> None:
     """Normalize media blocks in a list in-place.
 
-    - Strips ``file://`` prefixes from source URLs (dict blocks).
+    - Normalizes local source URLs while preserving typed ``file://`` URIs.
     - Replaces media blocks whose local file no longer exists with
       a text placeholder so the downstream formatter won't throw.
     - Converts ``file`` blocks to text placeholders — neither the
@@ -1374,9 +1383,8 @@ def _fixup_media_list(items: list) -> None:
                 )
         elif btype == "data":
             # 2.0 DataBlock — decode percent-encoded file:// URLs and
-            # check if local file still exists.  Pydantic's AnyUrl
-            # re-encodes non-ASCII chars; we must undo that before
-            # the DashScope formatter tries to open() the path.
+            # check if local file still exists. Keep the file scheme so
+            # formatters do not mistake the local path for a remote URL.
             source = getattr(block, "source", None)
             url_str = str(getattr(source, "url", "")) if source else ""
             if url_str.startswith("file://"):
@@ -1397,7 +1405,7 @@ def _fixup_media_list(items: list) -> None:
                         ),
                     )
                 elif source is not None:
-                    source.url = local_path
+                    source.url = _local_path_to_file_url(local_path)
         elif btype == "file":
             if isinstance(block, dict):
                 source = block.get("source") or {}

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1321,12 +1321,9 @@ def _reasoning_by_assistant_segment(
 
 
 def _local_path_to_file_url(path: str) -> str:
-    """Build an unescaped file URI from a decoded local path."""
-    if path.startswith("//"):
-        return f"file:{path}"
-    if len(path) >= 2 and path[0].isalpha() and path[1] == ":":
-        return f"file:///{path}"
-    return f"file://{path}"
+    """Build an unescaped file URL compatible with upstream formatters."""
+    normalized_path = path.replace("\\", "/")
+    return f"file://{normalized_path}"
 
 
 # pylint: disable=too-many-branches

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -975,7 +975,7 @@ def test_datablock_windows_file_uri_preserved(
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "file:///C:/Temp/x.png"
+    assert items[0].source.url == "file://C:/Temp/x.png"
 
 
 def test_datablock_unix_file_uri_preserved(
@@ -1020,7 +1020,7 @@ def test_datablock_unc_file_uri_preserved(
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "file://server/share/x.png"
+    assert items[0].source.url == "file:////server/share/x.png"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -961,40 +961,40 @@ def test_extra_content_original_preserved(monkeypatch) -> None:
 
 
 # -----------------------------------------------------------------
-# _fixup_media_list: Windows file URI → local path for DataBlock
+# _fixup_media_list: normalize local file URIs for DataBlock
 # -----------------------------------------------------------------
 
 
-def test_datablock_windows_file_uri_resolved_to_local_path(
+def test_datablock_windows_file_uri_preserved(
     monkeypatch,
 ) -> None:
-    """file:///C:/Temp/x.png must become C:/Temp/x.png in source.url."""
+    """Windows paths must remain local file URIs."""
     monkeypatch.setattr("os.path.exists", lambda p: True)
 
     block = _data_block("image/png", "file:///C:/Temp/x.png")
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "C:/Temp/x.png"
+    assert items[0].source.url == "file:///C:/Temp/x.png"
 
 
-def test_datablock_unix_file_uri_resolved_to_local_path(
+def test_datablock_unix_file_uri_preserved(
     monkeypatch,
 ) -> None:
-    """file:///tmp/demo.png must become /tmp/demo.png."""
+    """Unix paths must remain local file URIs."""
     monkeypatch.setattr("os.path.exists", lambda p: True)
 
     block = _data_block("image/png", "file:///tmp/demo.png")
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "/tmp/demo.png"
+    assert items[0].source.url == "file:///tmp/demo.png"
 
 
 def test_datablock_percent_encoded_uri_resolved(
     monkeypatch,
 ) -> None:
-    """file:///tmp/%E4%B8%AD%E6%96%87.png → /tmp/中文.png."""
+    """Percent-encoded paths must be decoded without losing the scheme."""
     monkeypatch.setattr("os.path.exists", lambda p: True)
 
     block = _data_block(
@@ -1004,13 +1004,13 @@ def test_datablock_percent_encoded_uri_resolved(
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "/tmp/中文.png"
+    assert items[0].source.url == "file:///tmp/中文.png"
 
 
-def test_datablock_unc_file_uri_resolved(
+def test_datablock_unc_file_uri_preserved(
     monkeypatch,
 ) -> None:
-    """file://server/share/x.png → //server/share/x.png (UNC)."""
+    """UNC paths must remain local file URIs."""
     monkeypatch.setattr("os.path.exists", lambda p: True)
 
     block = _data_block(
@@ -1020,7 +1020,63 @@ def test_datablock_unc_file_uri_resolved(
     items: list = [block]
     model_factory._fixup_media_list(items)
 
-    assert items[0].source.url == "//server/share/x.png"
+    assert items[0].source.url == "file://server/share/x.png"
+
+
+@pytest.mark.asyncio
+async def test_openai_local_pdf_uses_file_uri_without_http_download(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A local PDF must be read from disk instead of passed to requests."""
+    pdf_path = tmp_path / "hello.pdf"
+    pdf_bytes = b"%PDF-1.4\n%%EOF"
+    pdf_path.write_bytes(pdf_bytes)
+
+    def fail_http_download(*_args, **_kwargs):
+        raise AssertionError("Local PDF must not use requests.get")
+
+    monkeypatch.setattr(
+        "agentscope.formatter._openai_formatter.requests.get",
+        fail_http_download,
+    )
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class()
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[
+            DataBlock(
+                source=URLSource(
+                    url=f"file://{pdf_path}",
+                    media_type="application/pdf",
+                ),
+                name="hello.pdf",
+            ),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    encoded = base64.b64encode(pdf_bytes).decode("ascii")
+    assert formatted == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": "hello.pdf",
+                        "file_data": (
+                            f"data:application/pdf;base64,{encoded}"
+                        ),
+                    },
+                },
+            ],
+        },
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Preserve the `file://` scheme when normalizing local `DataBlock` sources, preventing formatters from treating local paths as remote URLs. Includes regression coverage for Unix, Windows, UNC, and percent-encoded paths.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
