### PR TITLE
feat(console): support game-dev file languages

### DIFF
--- a/console/src/components/RenderableCodeBlock/RenderableCodeBlock.test.tsx
+++ b/console/src/components/RenderableCodeBlock/RenderableCodeBlock.test.tsx
@@ -143,6 +143,28 @@ describe("RenderableCodeBlock", () => {
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
   });
 
+  it.each([
+    ["cs", "csharp"],
+    ["csharp", "csharp"],
+    ["shader", "hlsl"],
+    ["cginc", "hlsl"],
+    ["gdshader", "glsl"],
+    ["vert", "glsl"],
+    ["frag", "glsl"],
+    ["gd", "gdscript"],
+  ])("normalizes %s code fences to %s highlighting", (lang, expected) => {
+    const { container } = render(
+      <RenderableCodeBlock block lang={lang}>
+        {"void main() {}"}
+      </RenderableCodeBlock>,
+    );
+
+    expect(
+      container.querySelector(`[data-language='${expected}']`),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+  });
+
   it("keeps inline code HTML attributes and omits renderer-only props", () => {
     const handleClick = vi.fn();
 
@@ -177,7 +199,7 @@ describe("RenderableCodeBlock", () => {
     vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
 
     render(
-      <RenderableCodeBlock block lang="python">
+      <RenderableCodeBlock block lang="cs">
         {"answer = 42"}
       </RenderableCodeBlock>,
     );
@@ -186,7 +208,7 @@ describe("RenderableCodeBlock", () => {
 
     expect(createObjectURL).toHaveBeenCalledOnce();
     expect(anchorClick).toHaveBeenCalledOnce();
-    expect(document.querySelector("a[download='block.py']")).toBeNull();
+    expect(document.querySelector("a[download='block.cs']")).toBeNull();
     expect(revokeObjectURL).not.toHaveBeenCalled();
 
     vi.runOnlyPendingTimers();

--- a/console/src/components/RenderableCodeBlock/RenderableCodeBlock.tsx
+++ b/console/src/components/RenderableCodeBlock/RenderableCodeBlock.tsx
@@ -19,6 +19,16 @@ type RenderableCodeBlockProps = Partial<ComponentProps> & {
   children?: ReactNode;
 };
 
+const SOURCE_LANGUAGE_ALIASES: Record<string, string> = {
+  cginc: "hlsl",
+  cs: "csharp",
+  frag: "glsl",
+  gd: "gdscript",
+  gdshader: "glsl",
+  shader: "hlsl",
+  vert: "glsl",
+};
+
 const LANGUAGE_ALIASES: Record<string, RenderableLanguage> = {
   latex: "latex",
   math: "latex",
@@ -29,6 +39,9 @@ const LANGUAGE_ALIASES: Record<string, RenderableLanguage> = {
 const LANGUAGE_EXTENSIONS: Record<string, string> = {
   bash: "sh",
   csharp: "cs",
+  gdscript: "gd",
+  glsl: "glsl",
+  hlsl: "hlsl",
   javascript: "js",
   kotlin: "kt",
   markdown: "md",
@@ -38,6 +51,7 @@ const LANGUAGE_EXTENSIONS: Record<string, string> = {
   rust: "rs",
   shell: "sh",
   typescript: "ts",
+  wgsl: "wgsl",
   yaml: "yml",
   zsh: "sh",
 };
@@ -57,7 +71,8 @@ function extractText(children: ReactNode): string {
 function resolveLanguage(lang?: string, className?: string): string {
   const explicit = lang?.trim().split(/\s+/, 1)[0];
   const fromClassName = className?.match(/(?:^|\s)language-([^\s]+)/)?.[1];
-  return (explicit || fromClassName || "").toLowerCase();
+  const language = (explicit || fromClassName || "").toLowerCase();
+  return SOURCE_LANGUAGE_ALIASES[language] || language;
 }
 
 function downloadSource(source: string, language: string) {

--- a/console/src/pages/Coding/getLanguage.test.ts
+++ b/console/src/pages/Coding/getLanguage.test.ts
@@ -18,4 +18,23 @@ describe("getLanguage", () => {
     expect(getLanguage("app.tsx")).toBe("typescript");
     expect(getLanguage("unknown.xyz")).toBe("plaintext");
   });
+
+  it("maps C# and game shader extensions", () => {
+    expect(getLanguage("Assets/Scripts/PlayerController.cs")).toBe("csharp");
+    expect(getLanguage("Assets/Shaders/HologramShield.shader")).toBe("cpp");
+    expect(getLanguage("Assets/Shaders/Lighting.cginc")).toBe("cpp");
+    expect(getLanguage("Assets/Shaders/Dissolve.hlsl")).toBe("cpp");
+    expect(getLanguage("res://shaders/water.gdshader")).toBe("cpp");
+    expect(getLanguage("shaders/skybox.glsl")).toBe("cpp");
+    expect(getLanguage("shaders/fullscreen.vert")).toBe("cpp");
+    expect(getLanguage("shaders/fullscreen.frag")).toBe("cpp");
+    expect(getLanguage("shaders/compute.wgsl")).toBe("wgsl");
+  });
+
+  it("maps common game scripting and C/C++ header extensions", () => {
+    expect(getLanguage("scripts/player.gd")).toBe("python");
+    expect(getLanguage("engine/renderer.hpp")).toBe("cpp");
+    expect(getLanguage("engine/math.hxx")).toBe("cpp");
+    expect(getLanguage("engine/platform.hh")).toBe("cpp");
+  });
 });

--- a/console/src/pages/Coding/getLanguage.ts
+++ b/console/src/pages/Coding/getLanguage.ts
@@ -26,13 +26,30 @@ export function getLanguage(path: string): string {
     rs: "rust",
     go: "go",
     java: "java",
+    cs: "csharp",
     cpp: "cpp",
+    cc: "cpp",
+    cxx: "cpp",
     c: "c",
     h: "c",
+    hpp: "cpp",
+    hh: "cpp",
+    hxx: "cpp",
     kt: "kotlin",
     rb: "ruby",
     robot: "robotframework",
     resource: "robotframework",
+    // Monaco does not ship dedicated ShaderLab/HLSL/GLSL/GDScript tokenizers;
+    // these close built-in grammars still provide useful syntax highlighting.
+    shader: "cpp",
+    cginc: "cpp",
+    hlsl: "cpp",
+    gdshader: "cpp",
+    glsl: "cpp",
+    vert: "cpp",
+    frag: "cpp",
+    wgsl: "wgsl",
+    gd: "python",
   };
   return map[ext] ?? "plaintext";
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #7068.

The Console file/script viewer previously fell back to plain text for common game-development files such as C# scripts and shader sources. This makes Unity, Godot, and graphics workflow files harder to inspect during agent sessions.

## Changes

- Add Monaco language detection for C# and game-oriented file extensions.
- Use built-in Monaco fallbacks for shader and GDScript files where Monaco does not provide native tokenizers.
- Normalize Markdown code fence aliases such as `cs`, `shader`, `gdshader`, `vert`, `frag`, and `gd` for rendered code blocks.
- Preserve sensible download extensions for the newly supported code block languages.

## Evidence

- `npm run test:run -- src/pages/Coding/getLanguage.test.ts src/components/RenderableCodeBlock/RenderableCodeBlock.test.tsx --pool threads --maxWorkers 1`
- `npm run format:check`