### PR TITLE
perf(runtime): stabilize prompt cache prefixes

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -189,14 +189,6 @@ def build_env_context(
     parts.append(
         "- Docs: https://qwenpaw.agentscope.io/",
     )
-    user_tz = load_config().user_timezone or "UTC"
-    try:
-        now = datetime.now(ZoneInfo(user_tz))
-    except (ZoneInfoNotFoundError, KeyError):
-        logger.warning("Invalid timezone %r, falling back to UTC", user_tz)
-        now = datetime.now(timezone.utc)
-        user_tz = "UTC"
-
     parts.append(
         f"- OS: {platform.system()} {platform.release()} "
         f"({platform.machine()})",
@@ -242,6 +234,14 @@ def build_env_context(
         parts.append(f"- User ID: {user_id}")
     if session_id is not None:
         parts.append(f"- Session ID: {session_id}")
+
+    user_tz = load_config().user_timezone or "UTC"
+    try:
+        now = datetime.now(ZoneInfo(user_tz))
+    except (ZoneInfoNotFoundError, KeyError):
+        logger.warning("Invalid timezone %r, falling back to UTC", user_tz)
+        now = datetime.now(timezone.utc)
+        user_tz = "UTC"
     parts.append(
         f"- Current date: {now.strftime('%Y-%m-%d')} "
         f"{user_tz} ({now.strftime('%A')})",

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -197,15 +197,6 @@ def build_env_context(
         now = datetime.now(timezone.utc)
         user_tz = "UTC"
 
-    if session_id is not None:
-        parts.append(f"- Session ID: {session_id}")
-    if user_id is not None:
-        parts.append(f"- User ID: {user_id}")
-    if user_name:
-        parts.append(f"- User Name: {user_name}")
-    if channel is not None:
-        parts.append(f"- Channel: {channel}")
-
     parts.append(
         f"- OS: {platform.system()} {platform.release()} "
         f"({platform.machine()})",
@@ -226,10 +217,6 @@ def build_env_context(
             )
     elif working_dir is not None:
         parts.append(f"- Working directory: {working_dir}")
-    parts.append(
-        f"- Current date: {now.strftime('%Y-%m-%d')} "
-        f"{user_tz} ({now.strftime('%A')})",
-    )
 
     if add_hint:
         parts.append(
@@ -245,6 +232,20 @@ def build_env_context(
             "you must generate a tool call or provide useful feedback if "
             "you are blocked.\n",
         )
+
+    # Keep request-specific values after the reusable environment prefix.
+    if channel is not None:
+        parts.append(f"- Channel: {channel}")
+    if user_name:
+        parts.append(f"- User Name: {user_name}")
+    if user_id is not None:
+        parts.append(f"- User ID: {user_id}")
+    if session_id is not None:
+        parts.append(f"- Session ID: {session_id}")
+    parts.append(
+        f"- Current date: {now.strftime('%Y-%m-%d')} "
+        f"{user_tz} ({now.strftime('%A')})",
+    )
 
     return (
         "====================\n" + "\n".join(parts) + "\n===================="

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -142,6 +142,7 @@ class AgentBuilder:
 
         # Final pass: cover workspace + extras + memory in one filter.
         tools = self.apply_subagent_tool_whitelist(tools, request_context)
+        tools.sort(key=self._tool_name)
 
         skills = await run_sync_io(
             self._load_runtime_skills,
@@ -153,7 +154,7 @@ class AgentBuilder:
 
     @staticmethod
     def _tool_name(tool: Any) -> str:
-        """Best-effort tool name for whitelist filtering."""
+        """Return the model-facing name used for sorting and filtering."""
         name = getattr(tool, "name", None)
         if isinstance(name, str) and name:
             return name


### PR DESCRIPTION
## Summary

- move request-specific environment metadata behind the reusable environment prefix
- sort the final filtered tool list by model-facing tool name
- keep environment content and tool schemas unchanged

## Validation

- `conda run -n QwenPaw pytest -q tests/unit/app/chats/test_utils.py tests/unit/runtime/test_project_dir_override.py tests/unit/runtime/test_agent_config_io.py` (53 passed)
- `conda run -n QwenPaw pre-commit run --files src/qwenpaw/app/chats/utils.py src/qwenpaw/runtime/builder.py`