### PR TITLE
fix: keep rich input caret visible

### DIFF
--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../Coding/lastEditorCopy";
 import { useState } from "react";
 import "../../i18n";
+import { scrollRectIntoViewWithin } from "./RichFileReferenceInput";
 
 function ControlledRichInput() {
   const [value, setValue] = useState("");
@@ -24,6 +25,43 @@ function ControlledRichInput() {
 
 describe("RichFileReferenceInput", () => {
   afterEach(() => clearLastEditorCopy());
+
+  it("scrolls the rich composer viewport to keep the caret line visible", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollTop", {
+      value: 0,
+      writable: true,
+    });
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+      top: 100,
+      bottom: 220,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: 120,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+
+    scrollRectIntoViewWithin(
+      container,
+      {
+        top: 236,
+        bottom: 256,
+        left: 0,
+        right: 20,
+        width: 20,
+        height: 20,
+        x: 0,
+        y: 236,
+        toJSON: () => ({}),
+      },
+      8,
+    );
+
+    expect(container.scrollTop).toBe(44);
+  });
 
   it("shows only atomic chips while preserving the raw submitted value", async () => {
     const raw = "/work/app.ts:7-9\n```typescript\nconst ready = true;\n```";

--- a/console/src/pages/Chat/RichFileReferenceInput.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.tsx
@@ -40,6 +40,8 @@ import {
   type ComponentProps,
   type FocusEvent,
   type KeyboardEvent,
+  type MutableRefObject,
+  type RefObject,
   type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -394,17 +396,56 @@ function selectionPointOffset(targetKey: string, targetOffset: number): number {
   return resolved ?? rawOffset;
 }
 
+export function scrollRectIntoViewWithin(
+  container: HTMLElement,
+  rect: DOMRect,
+  padding: number = 8,
+) {
+  const containerRect = container.getBoundingClientRect();
+  const visibleTop = containerRect.top + padding;
+  const visibleBottom = containerRect.bottom - padding;
+
+  if (rect.top < visibleTop) {
+    container.scrollTop -= visibleTop - rect.top;
+  } else if (rect.bottom > visibleBottom) {
+    container.scrollTop += rect.bottom - visibleBottom;
+  }
+}
+
+function scrollCurrentSelectionIntoView(container: HTMLElement) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+
+  const range = selection.getRangeAt(0);
+  if (
+    !container.contains(range.startContainer) ||
+    !container.contains(range.endContainer)
+  ) {
+    return;
+  }
+
+  if (!("getBoundingClientRect" in range) || !("getClientRects" in range)) {
+    return;
+  }
+
+  const rangeRect = range.getBoundingClientRect();
+  const rect = rangeRect.height > 0 ? rangeRect : range.getClientRects()[0];
+  if (rect) scrollRectIntoViewWithin(container, rect);
+}
+
 function RichEditorBridge({
   value,
   editable,
+  rootRef,
   hiddenTextarea,
   editorRef,
   onRawChange,
 }: {
   value: string;
   editable: boolean;
-  hiddenTextarea: React.RefObject<HTMLTextAreaElement | null>;
-  editorRef: React.MutableRefObject<LexicalEditor | null>;
+  rootRef: RefObject<HTMLDivElement | null>;
+  hiddenTextarea: RefObject<HTMLTextAreaElement | null>;
+  editorRef: MutableRefObject<LexicalEditor | null>;
   onRawChange: (value: string, start: number, end: number) => void;
 }) {
   const [editor] = useLexicalComposerContext();
@@ -460,6 +501,10 @@ function RichEditorBridge({
             hiddenTextarea.current.selectionStart = start;
             hiddenTextarea.current.selectionEnd = end;
           }
+        });
+        window.requestAnimationFrame(() => {
+          const container = rootRef.current;
+          if (container) scrollCurrentSelectionIntoView(container);
         });
       }}
     />
@@ -632,6 +677,7 @@ const RichFileReferenceInput = forwardRef<unknown, TextAreaProps>(
   ) {
     const { token } = theme.useToken();
     const rawValue = String(value ?? "");
+    const rootRef = useRef<HTMLDivElement>(null);
     const hiddenTextarea = useRef<HTMLTextAreaElement>(null);
     const editorRef = useRef<LexicalEditor | null>(null);
 
@@ -658,6 +704,7 @@ const RichFileReferenceInput = forwardRef<unknown, TextAreaProps>(
 
     return (
       <div
+        ref={rootRef}
         className={`${styles.richInputRoot} ${className ?? ""}`}
         style={style}
         data-disabled={disabled || undefined}
@@ -702,6 +749,7 @@ const RichFileReferenceInput = forwardRef<unknown, TextAreaProps>(
           <RichEditorBridge
             value={rawValue}
             editable={!disabled && !readOnly}
+            rootRef={rootRef}
             hiddenTextarea={hiddenTextarea}
             editorRef={editorRef}
             onRawChange={handleRawChange}


### PR DESCRIPTION
## What Problem This Solves

When the rich chat composer grows beyond its capped height, the visible editor scroll container can stop following the active insertion point. Users typing near the bottom of a long multi-line prompt can have the current input line hidden below the composer viewport, then flicker back into view while typing.

The root cause is that Lexical selection changes only synchronized offsets into the hidden textarea used for form compatibility. The visible scroll container was never adjusted to keep the DOM selection/caret rectangle inside the composer viewport.

## Summary

- Scroll the rich composer viewport after Lexical selection changes so the current caret line remains visible.
- Keep the fix scoped to the existing composer scroll container; no layout or height behavior is changed.
- Add a focused regression test for scrolling a caret rectangle into the composer viewport.

## Evidence

- The issue is visible from the current component structure: `.richInputRoot` is capped with `max-height: 128px` and `overflow: auto`, while `RichEditorBridge` previously updated the hidden textarea selection but did not scroll `.richInputRoot` after Lexical selection changes.
- The new unit test verifies the exact viewport math: a caret rectangle below a 120px composer viewport with 8px padding scrolls the container by 44px.
- Local validation:
  - `npm run test:run -- RichFileReferenceInput.test.tsx` passed: 5 tests passed.
  - `npx tsc -b --noEmit` passed.

Fixes #7306

🤖 Generated with Claude Code