### PR TITLE
feat(tools): propagate console stop cancellation to agent tools

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -1109,6 +1109,10 @@ class QwenPawAgent(CodingModeMixin, Agent):
             default_timeout_secs=300.0,
             max_internal_timeout_secs=_owned_cap,
         )
+        mgr.hooks.register(
+            "spawn_subagent",
+            max_internal_timeout_secs=_owned_cap,
+        )
         mgr.hooks.register("check_agent_task", default_timeout_secs=30.0)
         mgr.hooks.register("grep_search", default_timeout_secs=30.0)
         mgr.hooks.register("glob_search", default_timeout_secs=15.0)

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_AGENT_API_BASE_URL = "http://127.0.0.1:8088"
 DEFAULT_AGENT_API_TIMEOUT = 30.0
+AGENT_CHAT_STOP_TIMEOUT = 3.0
 MAX_SPAWN_BATCH_SIZE = 10
 MAX_SPAWN_BATCH_CONCURRENCY = 3
 
@@ -359,6 +360,59 @@ async def collect_final_agent_chat_response_async(
     return response_data
 
 
+async def stop_agent_chat_async(
+    base_url: Optional[str],
+    session_id: str,
+    to_agent: str,
+    timeout: float = AGENT_CHAT_STOP_TIMEOUT,
+) -> bool:
+    """Stop an inter-agent chat running on the target agent.
+
+    The console chat stream continues after its HTTP subscriber disconnects.
+    Cancelling ``chat_with_agent`` must therefore call the target agent's
+    explicit Stop endpoint instead of only closing the collection stream.
+    """
+    normalized = _normalize_api_base_url(base_url)
+    async with httpx.AsyncClient(
+        base_url=normalized,
+        timeout=httpx.Timeout(timeout),
+        trust_env=trust_env_for_url(normalized),
+    ) as client:
+        response = await client.post(
+            "/console/chat/stop",
+            params={"chat_id": session_id},
+            headers=_request_headers(to_agent),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    return bool(payload.get("stopped")) if isinstance(payload, dict) else False
+
+
+async def _stop_cancelled_agent_chat(
+    session_id: str,
+    to_agent: str,
+    tool_name: str = "chat_with_agent",
+) -> None:
+    """Best-effort stop of a target chat after caller cancellation."""
+    try:
+        stopped = await asyncio.shield(
+            stop_agent_chat_async(None, session_id, to_agent),
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning(
+            "Failed to stop target agent chat after cancellation: %s",
+            exc,
+            exc_info=True,
+        )
+        return
+    if not stopped:
+        logger.warning(
+            "%s cancellation did not confirm target chat stop: %s",
+            tool_name,
+            session_id,
+        )
+
+
 def submit_agent_chat_task(
     base_url: Optional[str],
     request_payload: Dict[str, Any],
@@ -630,10 +684,11 @@ async def chat_with_agent(
             as_kill_deadline=True,
         )
     except asyncio.CancelledError:
-        return _tool_text_response(
-            "chat_with_agent was cancelled. "
-            "Do not retry unless the user explicitly asks.",
+        await _stop_cancelled_agent_chat(
+            final_session_id,
+            normalized_to_agent,
         )
+        raise
     if not response_data:
         return _tool_text_response("(No response received)")
 
@@ -994,6 +1049,18 @@ def _foreground_wait_seconds(parsed_timeout: Optional[int]) -> int:
     return parsed_timeout
 
 
+def _foreground_http_timeout(wait_seconds: int) -> float:
+    """Keep foreground HTTP alive while the Coordinator owns its deadline."""
+    from ...tool_calls import (
+        COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
+        get_call_context,
+    )
+
+    if get_call_context() is not None:
+        return float(COORDINATOR_OWNED_EXEC_TIMEOUT_SECS)
+    return float(wait_seconds)
+
+
 def _watchdog_timeout_from_submit_result(task_result: Any) -> int:
     """Prefer the ``/chat/task`` echo; never invent a third default.
 
@@ -1251,13 +1318,27 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             ),
         )
 
-    response_data = await asyncio.to_thread(
-        collect_final_agent_chat_response,
-        None,
-        request_payload,
-        current_agent_id,
-        _foreground_wait_seconds(parsed_timeout),
-    )
+    wait_seconds = _foreground_wait_seconds(parsed_timeout)
+    from ...tool_calls import cancellable_wait
+
+    try:
+        response_data = await cancellable_wait(
+            collect_final_agent_chat_response_async(
+                None,
+                request_payload,
+                current_agent_id,
+                _foreground_http_timeout(wait_seconds),
+            ),
+            fallback_secs=float(wait_seconds),
+            as_kill_deadline=True,
+        )
+    except asyncio.CancelledError:
+        await _stop_cancelled_agent_chat(
+            subagent_session_id,
+            current_agent_id,
+            tool_name="spawn_subagent",
+        )
+        raise
     if not response_data:
         return _tool_text_response(
             "(No response received from subagent)",
@@ -1486,6 +1567,7 @@ async def _spawn_forked_subagent(
         bind_fork_task,
         finalize_fork_worktree_or_fail,
         get_active_fork_scope,
+        mark_fork_failed,
         register_fork,
     )
     from ...config.context import get_current_workspace_dir
@@ -1587,13 +1669,42 @@ async def _spawn_forked_subagent(
             )
         return _tool_text_response(submission_text)
 
-    response_data = await asyncio.to_thread(
-        collect_final_agent_chat_response,
-        None,
-        request_payload,
-        current_agent_id,
-        _foreground_wait_seconds(timeout),
-    )
+    wait_seconds = _foreground_wait_seconds(timeout)
+    from ...tool_calls import cancellable_wait
+
+    try:
+        response_data = await cancellable_wait(
+            collect_final_agent_chat_response_async(
+                None,
+                request_payload,
+                current_agent_id,
+                _foreground_http_timeout(wait_seconds),
+            ),
+            fallback_secs=float(wait_seconds),
+            as_kill_deadline=True,
+        )
+    except asyncio.CancelledError:
+        await _stop_cancelled_agent_chat(
+            fork_session_id,
+            current_agent_id,
+            tool_name="spawn_subagent",
+        )
+        if worktree_path:
+            try:
+                await asyncio.to_thread(
+                    mark_fork_failed,
+                    worktree_path,
+                    worktree_branch,
+                    reason="Forked subagent cancelled",
+                    expected_scope=fork_scope_id or None,
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.warning(
+                    "Failed to mark cancelled fork as failed: %s",
+                    worktree_path,
+                    exc_info=True,
+                )
+        raise
 
     # Only commit on a successful worker response (avoid half-baked commits).
     finalize_ok = False
@@ -1606,8 +1717,6 @@ async def _spawn_forked_subagent(
             expected_scope=fork_scope_id or None,
         )
     elif worktree_path:
-        from ..fork_project import mark_fork_failed
-
         await asyncio.to_thread(
             mark_fork_failed,
             worktree_path,

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -655,40 +655,13 @@ async def chat_with_agent(
         root_session_id=final_root_session,
     )
 
-    # Register LLM/tool timeout as kill_deadline so keep_foreground clearing
-    # the shorter hook offload window does not force-cancel early (#6245).
-    from ...tool_calls import (
-        COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
-        cancellable_wait,
-        get_call_context,
+    response_data = await _collect_foreground_agent_chat(
+        request_payload,
+        normalized_to_agent,
+        final_session_id,
+        timeout,
+        tool_name="chat_with_agent",
     )
-
-    # Under ToolCallContext use a large but finite HTTP ceiling so extend
-    # works, while AsyncClient cancel still closes the stream (no zombie
-    # sync thread with timeout=None).
-    http_timeout = (
-        float(COORDINATOR_OWNED_EXEC_TIMEOUT_SECS)
-        if get_call_context() is not None
-        else float(timeout)
-    )
-
-    try:
-        response_data = await cancellable_wait(
-            collect_final_agent_chat_response_async(
-                None,
-                request_payload,
-                normalized_to_agent,
-                http_timeout,
-            ),
-            fallback_secs=float(timeout),
-            as_kill_deadline=True,
-        )
-    except asyncio.CancelledError:
-        await _stop_cancelled_agent_chat(
-            final_session_id,
-            normalized_to_agent,
-        )
-        raise
     if not response_data:
         return _tool_text_response("(No response received)")
 
@@ -1061,6 +1034,37 @@ def _foreground_http_timeout(wait_seconds: int) -> float:
     return float(wait_seconds)
 
 
+async def _collect_foreground_agent_chat(
+    request_payload: Dict[str, Any],
+    to_agent: str,
+    session_id: str,
+    wait_seconds: int,
+    *,
+    tool_name: str,
+) -> Dict[str, Any]:
+    """Collect a foreground agent chat with a shared cancel contract."""
+    from ...tool_calls import cancellable_wait
+
+    try:
+        return await cancellable_wait(
+            collect_final_agent_chat_response_async(
+                None,
+                request_payload,
+                to_agent,
+                _foreground_http_timeout(wait_seconds),
+            ),
+            fallback_secs=float(wait_seconds),
+            as_kill_deadline=True,
+        )
+    except asyncio.CancelledError:
+        await _stop_cancelled_agent_chat(
+            session_id,
+            to_agent,
+            tool_name=tool_name,
+        )
+        raise
+
+
 def _watchdog_timeout_from_submit_result(task_result: Any) -> int:
     """Prefer the ``/chat/task`` echo; never invent a third default.
 
@@ -1318,27 +1322,13 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             ),
         )
 
-    wait_seconds = _foreground_wait_seconds(parsed_timeout)
-    from ...tool_calls import cancellable_wait
-
-    try:
-        response_data = await cancellable_wait(
-            collect_final_agent_chat_response_async(
-                None,
-                request_payload,
-                current_agent_id,
-                _foreground_http_timeout(wait_seconds),
-            ),
-            fallback_secs=float(wait_seconds),
-            as_kill_deadline=True,
-        )
-    except asyncio.CancelledError:
-        await _stop_cancelled_agent_chat(
-            subagent_session_id,
-            current_agent_id,
-            tool_name="spawn_subagent",
-        )
-        raise
+    response_data = await _collect_foreground_agent_chat(
+        request_payload,
+        current_agent_id,
+        subagent_session_id,
+        _foreground_wait_seconds(parsed_timeout),
+        tool_name="spawn_subagent",
+    )
     if not response_data:
         return _tool_text_response(
             "(No response received from subagent)",
@@ -1670,25 +1660,16 @@ async def _spawn_forked_subagent(
         return _tool_text_response(submission_text)
 
     wait_seconds = _foreground_wait_seconds(timeout)
-    from ...tool_calls import cancellable_wait
 
     try:
-        response_data = await cancellable_wait(
-            collect_final_agent_chat_response_async(
-                None,
-                request_payload,
-                current_agent_id,
-                _foreground_http_timeout(wait_seconds),
-            ),
-            fallback_secs=float(wait_seconds),
-            as_kill_deadline=True,
-        )
-    except asyncio.CancelledError:
-        await _stop_cancelled_agent_chat(
-            fork_session_id,
+        response_data = await _collect_foreground_agent_chat(
+            request_payload,
             current_agent_id,
+            fork_session_id,
+            wait_seconds,
             tool_name="spawn_subagent",
         )
+    except asyncio.CancelledError:
         if worktree_path:
             try:
                 await asyncio.to_thread(

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -174,18 +174,22 @@ class ToolCoordinator:
                     await self._await_grace_or_force_cancel(entry)
                     terminal = "completed"
                     break
-        except asyncio.CancelledError:
-            await self._handle_parent_cancel(entry)
+
+            if terminal == "completed":
+                await self._await_background_task(entry)
+                yield await self._finalize_completed(entry)
+                return
+
+            yield await self._begin_offload(
+                entry,
+                background_result_processor,
+            )
+        except (asyncio.CancelledError, GeneratorExit):
+            if entry.status == ToolCallStatus.RUNNING:
+                await self._handle_parent_cancel(entry)
             raise
         finally:
             entry.stream.remove_subscriber(chunk_queue)
-
-        if terminal == "completed":
-            await self._await_background_task(entry)
-            yield await self._finalize_completed(entry)
-            return
-
-        yield await self._begin_offload(entry, background_result_processor)
 
     @staticmethod
     def _handle_deadline_reached(ctx: ToolCallContext) -> None:
@@ -194,6 +198,8 @@ class ToolCoordinator:
 
     async def _handle_parent_cancel(self, entry: ToolCallEntry) -> None:
         """Stop and reap a tool when its parent execution is cancelled."""
+        if entry.status != ToolCallStatus.RUNNING:
+            return
         ctx = entry.ctx
         if ctx.cancel_reason is None:
             ctx.cancel_reason = CancelReason.USER
@@ -204,6 +210,17 @@ class ToolCoordinator:
                 entry.background_task,
                 return_exceptions=True,
             )
+        entry.final_response = ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=self._cancel_message_for_llm(ctx),
+                ),
+            ],
+            id=ctx.tool_call_id,
+            state=ToolResultState.INTERRUPTED,
+        )
+        entry.end_state = "interrupted"
         await self._finalize_completed(entry)
 
     def _create_entry(

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -113,16 +113,10 @@ class ToolCoordinator:
             deadline_override,
         )
         ctx = entry.ctx
-
-        async with self._entries_lock:
-            self._entries[ctx.tool_call_id] = entry
-
-        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
-        entry.stream.add_subscriber(chunk_queue)
-
-        entry.background_task = asyncio.create_task(
-            self._run_tool_with_hooks(next_handler, tool_call, entry),
-            name=f"toolcall-{ctx.tool_call_id}",
+        chunk_queue = await self._start_entry(
+            entry,
+            next_handler,
+            tool_call,
         )
 
         terminal = "completed"
@@ -173,6 +167,9 @@ class ToolCoordinator:
                     await self._await_grace_or_force_cancel(entry)
                     terminal = "completed"
                     break
+        except asyncio.CancelledError:
+            await self._handle_parent_cancel(entry)
+            raise
         finally:
             entry.stream.remove_subscriber(chunk_queue)
 
@@ -187,6 +184,38 @@ class ToolCoordinator:
     def _handle_deadline_reached(ctx: ToolCallContext) -> None:
         if ctx.offload_reason is None:
             ctx.offload_reason = OffloadReason.TIMEOUT
+
+    async def _handle_parent_cancel(self, entry: ToolCallEntry) -> None:
+        """Stop and reap a tool when its parent execution is cancelled."""
+        ctx = entry.ctx
+        if ctx.cancel_reason is None:
+            ctx.cancel_reason = CancelReason.USER
+        ctx.cancel_event.set()
+        await self._await_grace_or_force_cancel(entry)
+        if entry.background_task is not None:
+            await asyncio.gather(
+                entry.background_task,
+                return_exceptions=True,
+            )
+        await self._finalize_completed(entry)
+
+    async def _start_entry(
+        self,
+        entry: ToolCallEntry,
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+        tool_call: Any,
+    ) -> asyncio.Queue[Any]:
+        """Register an entry, subscribe its caller, and start execution."""
+        async with self._entries_lock:
+            self._entries[entry.ctx.tool_call_id] = entry
+
+        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
+        entry.stream.add_subscriber(chunk_queue)
+        entry.background_task = asyncio.create_task(
+            self._run_tool_with_hooks(next_handler, tool_call, entry),
+            name=f"toolcall-{entry.ctx.tool_call_id}",
+        )
+        return chunk_queue
 
     def _create_entry(
         self,

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -94,6 +94,7 @@ class ToolCoordinator:
     # ================================================================
     # PRIMARY ENTRY
     # ================================================================
+    # pylint: disable-next=too-many-statements
     async def execute(  # pylint: disable=too-many-locals,too-many-branches
         self,
         tool_call: Any,
@@ -113,10 +114,16 @@ class ToolCoordinator:
             deadline_override,
         )
         ctx = entry.ctx
-        chunk_queue = await self._start_entry(
-            entry,
-            next_handler,
-            tool_call,
+
+        async with self._entries_lock:
+            self._entries[ctx.tool_call_id] = entry
+
+        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
+        entry.stream.add_subscriber(chunk_queue)
+
+        entry.background_task = asyncio.create_task(
+            self._run_tool_with_hooks(next_handler, tool_call, entry),
+            name=f"toolcall-{ctx.tool_call_id}",
         )
 
         terminal = "completed"
@@ -198,24 +205,6 @@ class ToolCoordinator:
                 return_exceptions=True,
             )
         await self._finalize_completed(entry)
-
-    async def _start_entry(
-        self,
-        entry: ToolCallEntry,
-        next_handler: Callable[..., AsyncGenerator[Any, None]],
-        tool_call: Any,
-    ) -> asyncio.Queue[Any]:
-        """Register an entry, subscribe its caller, and start execution."""
-        async with self._entries_lock:
-            self._entries[entry.ctx.tool_call_id] = entry
-
-        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
-        entry.stream.add_subscriber(chunk_queue)
-        entry.background_task = asyncio.create_task(
-            self._run_tool_with_hooks(next_handler, tool_call, entry),
-            name=f"toolcall-{entry.ctx.tool_call_id}",
-        )
-        return chunk_queue
 
     def _create_entry(
         self,

--- a/tests/unit/agents/test_tool_result_pruning_middleware.py
+++ b/tests/unit/agents/test_tool_result_pruning_middleware.py
@@ -40,6 +40,7 @@ from qwenpaw.constant import TRUNCATION_NOTICE_MARKER  # noqa: E402
 from qwenpaw.runtime.builder import AgentBuilder  # noqa: E402
 from qwenpaw.agents.react_agent import QwenPawAgent  # noqa: E402
 from qwenpaw.tool_calls import (  # noqa: E402
+    COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
     ToolCoordinator,
     ToolCoordinatorMiddleware,
 )
@@ -541,6 +542,24 @@ def test_builder_places_pruning_outside_tool_coordinator(tmp_path):
     assert (
         coordinator_middleware._background_result_processor
         == middlewares[pruning_index].prune_tool_response_async
+    )
+
+
+def test_spawn_subagent_hook_exposes_internal_timeout_cap():
+    coordinator = ToolCoordinator()
+    agent = types.SimpleNamespace(
+        _request_context={"agent_id": "agent-1"},
+        _agent_config=types.SimpleNamespace(tools=None),
+        name="agent-1",
+        _get_tool_coordinator=lambda: coordinator,
+    )
+
+    QwenPawAgent._register_tool_call_hooks(agent)
+
+    hook = coordinator.hooks.get("spawn_subagent")
+    assert hook.default_timeout_secs is None
+    assert hook.max_internal_timeout_secs == float(
+        COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
     )
 
 

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -221,6 +221,45 @@ def test_collect_final_agent_chat_response_keeps_last_sse_payload(monkeypatch):
     assert agent_management.extract_agent_text_content(result) == "second"
 
 
+async def test_stop_agent_chat_async_calls_target_stop_endpoint(monkeypatch):
+    calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, path, **kwargs):
+            calls.append((path, kwargs))
+            return _FakeResponse(json_data={"stopped": True})
+
+    monkeypatch.setattr(
+        agent_management.httpx,
+        "AsyncClient",
+        FakeAsyncClient,
+    )
+
+    stopped = await agent_management.stop_agent_chat_async(
+        "http://127.0.0.1:8088",
+        "session-1",
+        "bot_b",
+    )
+
+    assert stopped is True
+    assert calls[1] == (
+        "/console/chat/stop",
+        {
+            "params": {"chat_id": "session-1"},
+            "headers": {"X-Agent-Id": "bot_b"},
+        },
+    )
+
+
 async def test_agent_management_tools_can_be_registered_in_toolkit():
     toolkit = Toolkit(
         tools=[
@@ -325,6 +364,87 @@ async def test_chat_with_agent_uses_async_collect_for_final_mode(monkeypatch):
 
     assert calls
     assert "reply from peer" in response.content[0].text
+
+
+@pytest.mark.parametrize("stopped", [True, False])
+async def test_chat_with_agent_stops_target_when_cancelled(
+    monkeypatch,
+    stopped,
+):
+    stop_calls = []
+
+    async def fake_collect_async(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    async def fake_stop_async(*args, **kwargs):
+        stop_calls.append((args, kwargs))
+        return stopped
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response_async",
+        fake_collect_async,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "stop_agent_chat_async",
+        fake_stop_async,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "resolve_calling_agent_id",
+        lambda _from_agent=None: "bot_a",
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda _to_agent, _base_url=None: True,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent_management.chat_with_agent(
+            to_agent="bot_b",
+            text="Need help",
+            session_id="session-1",
+        )
+
+    assert stop_calls
+    assert stop_calls[0][0] == (None, "session-1", "bot_b")
+
+
+async def test_chat_with_agent_reports_target_stop_failure(monkeypatch):
+    async def fake_collect_async(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    async def fake_stop_async(*_args, **_kwargs):
+        raise httpx.ConnectError("target unavailable")
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response_async",
+        fake_collect_async,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "stop_agent_chat_async",
+        fake_stop_async,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "resolve_calling_agent_id",
+        lambda _from_agent=None: "bot_a",
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "agent_exists",
+        lambda _to_agent, _base_url=None: True,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent_management.chat_with_agent(
+            to_agent="bot_b",
+            text="Need help",
+        )
 
 
 async def test_chat_with_agent_arms_kill_deadline_from_timeout(monkeypatch):
@@ -453,7 +573,7 @@ async def test_chat_with_agent_returns_clear_error_when_agent_missing(
 async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
     captured = {}
 
-    def fake_collect(_base_url, request_payload, to_agent, _timeout):
+    async def fake_collect(_base_url, request_payload, to_agent, _timeout):
         captured["payload"] = request_payload
         captured["agent_id"] = to_agent
         return {
@@ -469,7 +589,7 @@ async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
 
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
@@ -504,7 +624,12 @@ async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
 async def test_spawn_subagent_inherits_approval_level(monkeypatch):
     captured = {}
 
-    def fake_collect(_base_url, request_payload, _to_agent, _timeout):
+    async def fake_collect(
+        _base_url,
+        request_payload,
+        _to_agent,
+        _timeout,
+    ):
         captured["payload"] = request_payload
         return {
             "output": [
@@ -519,7 +644,7 @@ async def test_spawn_subagent_inherits_approval_level(monkeypatch):
 
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
@@ -967,7 +1092,7 @@ async def test_spawn_subagent_empty_batch_uses_single_task(
 ):
     collected = []
 
-    def fake_collect(_base, payload, _agent_id, _timeout):
+    async def fake_collect(_base, payload, _agent_id, _timeout):
         collected.append(payload)
         return {
             "output": [
@@ -982,7 +1107,7 @@ async def test_spawn_subagent_empty_batch_uses_single_task(
 
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
@@ -1356,7 +1481,7 @@ async def test_spawn_subagent_top_level_string_bools(monkeypatch):
     collected: list[dict] = []
     forked: list[str] = []
 
-    def fake_collect(_base, payload, _agent_id, _timeout):
+    async def fake_collect(_base, payload, _agent_id, _timeout):
         collected.append(payload)
         return {
             "output": [
@@ -1375,7 +1500,7 @@ async def test_spawn_subagent_top_level_string_bools(monkeypatch):
 
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     monkeypatch.setattr(
@@ -1632,7 +1757,7 @@ async def test_spawn_foreground_omitted_timeout_waits_600(monkeypatch):
 
     captured: dict = {}
 
-    def fake_collect(_base, _payload, _agent_id, timeout):
+    async def fake_collect(_base, _payload, _agent_id, timeout):
         captured["timeout"] = timeout
         return {
             "output": [
@@ -1643,12 +1768,94 @@ async def test_spawn_foreground_omitted_timeout_waits_600(monkeypatch):
     _patch_spawn_runtime(monkeypatch)
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     response = await agent_management.spawn_subagent(task="do work")
     assert captured["timeout"] == DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
     assert "ERROR" not in response.content[0].text
+
+
+async def test_spawn_foreground_uses_coordinator_owned_http_timeout(
+    monkeypatch,
+):
+    from qwenpaw.tool_calls import (
+        COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
+        reset_call_context,
+        set_call_context,
+    )
+    from qwenpaw.tool_calls._context import ToolCallContext
+
+    captured = {}
+
+    async def fake_collect(_base, _payload, _agent_id, timeout):
+        captured["timeout"] = timeout
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response_async",
+        fake_collect,
+    )
+    loop = asyncio.get_running_loop()
+    ctx = ToolCallContext(
+        tool_call_id="tc-spawn",
+        tool_name="spawn_subagent",
+        session_id="s",
+        agent_id="a",
+        root_session_id="r",
+        started_at=loop.time(),
+        offload_deadline=None,
+        cancel_event=asyncio.Event(),
+    )
+    token = set_call_context(ctx)
+    try:
+        response = await agent_management.spawn_subagent(task="do work")
+    finally:
+        reset_call_context(token)
+
+    assert captured["timeout"] == float(
+        COORDINATOR_OWNED_EXEC_TIMEOUT_SECS,
+    )
+    assert "ERROR" not in response.content[0].text
+
+
+async def test_spawn_foreground_stops_subagent_when_cancelled(monkeypatch):
+    stop_calls = []
+
+    async def fake_collect(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    async def fake_stop(*args, **kwargs):
+        stop_calls.append((args, kwargs))
+        return True
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_management,
+        "_generate_subagent_session_id",
+        lambda: "sub-cancel",
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response_async",
+        fake_collect,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "stop_agent_chat_async",
+        fake_stop,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent_management.spawn_subagent(task="do work")
+
+    assert stop_calls == [((None, "sub-cancel", "bot-a"), {})]
 
 
 async def test_spawn_batch_omitted_timeout_passes_none(monkeypatch):
@@ -1693,7 +1900,7 @@ async def test_spawn_fork_foreground_omitted_timeout_waits_600(monkeypatch):
             "worktree_branch": "",
         }
 
-    def fake_collect(_base, _payload, _agent_id, timeout):
+    async def fake_collect(_base, _payload, _agent_id, timeout):
         captured["timeout"] = timeout
         return {
             "output": [
@@ -1705,7 +1912,7 @@ async def test_spawn_fork_foreground_omitted_timeout_waits_600(monkeypatch):
     monkeypatch.setattr(agent_management, "_call_fork_api", fake_fork_api)
     monkeypatch.setattr(
         agent_management,
-        "collect_final_agent_chat_response",
+        "collect_final_agent_chat_response_async",
         fake_collect,
     )
     response = await agent_management.spawn_subagent(
@@ -1714,6 +1921,77 @@ async def test_spawn_fork_foreground_omitted_timeout_waits_600(monkeypatch):
     )
     assert captured["timeout"] == DEFAULT_SPAWN_FOREGROUND_TIMEOUT_SECONDS
     assert "ERROR" not in response.content[0].text
+
+
+@pytest.mark.parametrize("mark_fails", [False, True])
+async def test_spawn_fork_foreground_stops_subagent_when_cancelled(
+    monkeypatch,
+    mark_fails,
+):
+    from qwenpaw.agents import fork_project
+
+    stop_calls = []
+    failed_calls = []
+
+    async def fake_fork_api(**_kwargs):
+        return {
+            "fork_session_id": "fork-cancel",
+            "worktree_path": "/tmp/fork-cancel",
+            "worktree_branch": "fork/cancel",
+        }
+
+    async def fake_collect(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    async def fake_stop(*args, **kwargs):
+        stop_calls.append((args, kwargs))
+        return True
+
+    def fake_mark_failed(*args, **kwargs):
+        failed_calls.append((args, kwargs))
+        if mark_fails:
+            raise RuntimeError("cannot mark fork failed")
+
+    _patch_spawn_runtime(monkeypatch)
+    monkeypatch.setattr(agent_management, "_call_fork_api", fake_fork_api)
+    monkeypatch.setattr(fork_project, "register_fork", lambda *a, **k: True)
+    monkeypatch.setattr(
+        fork_project,
+        "get_active_fork_scope",
+        lambda *_a, **_k: "scope-cancel",
+    )
+    monkeypatch.setattr(
+        fork_project,
+        "mark_fork_failed",
+        fake_mark_failed,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response_async",
+        fake_collect,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "stop_agent_chat_async",
+        fake_stop,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent_management.spawn_subagent(
+            task="do work",
+            fork=True,
+        )
+
+    assert stop_calls == [((None, "fork-cancel", "bot-a"), {})]
+    assert failed_calls == [
+        (
+            ("/tmp/fork-cancel", "fork/cancel"),
+            {
+                "reason": "Forked subagent cancelled",
+                "expected_scope": "scope-cancel",
+            },
+        ),
+    ]
 
 
 async def test_spawn_fork_background_uses_submit_echo_for_watchdog(

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -9,11 +9,11 @@ from typing import Any, AsyncGenerator
 
 import pytest
 from agentscope.message import TextBlock, ToolResultBlock, ToolResultState
-from agentscope.tool import ToolResponse
+from agentscope.tool import ToolChunk, ToolResponse
 
 from qwenpaw.tool_calls import ToolCoordinator, ToolCoordinatorMiddleware
 from qwenpaw.tool_calls._context import CancelReason, ToolCallContext
-from qwenpaw.tool_calls._entry import ToolCallEntry
+from qwenpaw.tool_calls._entry import ToolCallEntry, ToolCallStatus
 from qwenpaw.tool_calls._stream import ToolStream
 
 
@@ -119,6 +119,170 @@ async def test_parent_cancel_cooperatively_stops_background_tool():
     assert entry.status.value == "completed"
     assert entry.end_state == "interrupted"
     assert entry.final_response.state == ToolResultState.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_parent_cancel_after_stream_close_finalizes_interrupted():
+    coordinator = ToolCoordinator(cancel_grace_period_secs=0.2)
+    tool_call = _ToolCall(id="call-post-loop", name="post_loop_tool")
+    after_started = asyncio.Event()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        yield _text_response(tool_call.id, "done")
+
+    async def after_hook(
+        response: ToolResponse,
+        ctx: ToolCallContext,
+    ) -> ToolResponse:
+        after_started.set()
+        await ctx.cancel_event.wait()
+        return response
+
+    coordinator.hooks.register("post_loop_tool", after=after_hook)
+    execute_task = asyncio.create_task(
+        _collect(
+            coordinator.execute(
+                tool_call=tool_call,
+                next_handler=next_handler,
+                session_id="session-post-loop",
+                agent_id="agent-1",
+                root_session_id="root-1",
+            ),
+        ),
+    )
+
+    await asyncio.wait_for(after_started.wait(), timeout=1)
+    execute_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execute_task
+
+    entry = coordinator.get(tool_call.id)
+    assert entry is not None
+    assert entry.status == ToolCallStatus.COMPLETED
+    assert entry.end_state == "interrupted"
+    assert entry.final_response.state == ToolResultState.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_generator_close_cancels_running_tool():
+    coordinator = ToolCoordinator(cancel_grace_period_secs=0.2)
+    tool_call = _ToolCall(id="call-close-running", name="streaming_tool")
+    waiting = asyncio.Event()
+    cleanup_called = asyncio.Event()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        from qwenpaw.tool_calls import cancellable_wait
+
+        yield ToolChunk(
+            is_last=False,
+            state=ToolResultState.SUCCESS,
+            content=[TextBlock(type="text", text="partial")],
+        )
+        waiting.set()
+        try:
+            await cancellable_wait(asyncio.Event().wait())
+        except asyncio.CancelledError:
+            cleanup_called.set()
+            raise
+        yield _text_response(tool_call.id, "should not reach")
+
+    iterator = coordinator.execute(
+        tool_call=tool_call,
+        next_handler=next_handler,
+        session_id="session-close-running",
+        agent_id="agent-1",
+        root_session_id="root-1",
+    )
+    chunk = await asyncio.wait_for(iterator.__anext__(), timeout=1)
+    assert isinstance(chunk, ToolChunk)
+    await asyncio.wait_for(waiting.wait(), timeout=1)
+
+    await iterator.aclose()
+
+    entry = coordinator.get(tool_call.id)
+    assert entry is not None
+    assert cleanup_called.is_set()
+    assert entry.status == ToolCallStatus.COMPLETED
+    assert entry.final_response.state == ToolResultState.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_generator_close_preserves_offloaded_tool_ownership():
+    coordinator = ToolCoordinator(
+        default_timeout_secs=0.01,
+        offload_on_deadline=True,
+        cancel_grace_period_secs=0.2,
+    )
+    tool_call = _ToolCall(id="call-close-offloaded", name="slow_tool")
+    release = asyncio.Event()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        from qwenpaw.tool_calls import cancellable_wait
+
+        await cancellable_wait(
+            release.wait(),
+            fallback_secs=5.0,
+            as_kill_deadline=True,
+        )
+        yield _text_response(tool_call.id, "done")
+
+    iterator = coordinator.execute(
+        tool_call=tool_call,
+        next_handler=next_handler,
+        session_id="session-close-offloaded",
+        agent_id="agent-1",
+        root_session_id="root-1",
+    )
+    response = await asyncio.wait_for(iterator.__anext__(), timeout=1)
+    assert response.metadata.get("offloaded") is True
+
+    entry = coordinator.get(tool_call.id)
+    assert entry is not None
+    assert entry.status == ToolCallStatus.OFFLOADED
+    await iterator.aclose()
+    assert not entry.ctx.cancel_event.is_set()
+    assert entry.background_task is not None
+    assert not entry.background_task.done()
+
+    assert await coordinator.cancel(tool_call.id) is True
+    await asyncio.wait_for(
+        _wait_for_hint(coordinator, "session-close-offloaded"),
+        timeout=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generator_close_preserves_completed_result():
+    coordinator = ToolCoordinator()
+    tool_call = _ToolCall(id="call-close-completed", name="quick_tool")
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        yield _text_response(tool_call.id, "done")
+
+    iterator = coordinator.execute(
+        tool_call=tool_call,
+        next_handler=next_handler,
+        session_id="session-close-completed",
+        agent_id="agent-1",
+        root_session_id="root-1",
+    )
+    response = await asyncio.wait_for(iterator.__anext__(), timeout=1)
+    assert response.state == ToolResultState.SUCCESS
+
+    entry = coordinator.get(tool_call.id)
+    assert entry is not None
+    assert entry.status == ToolCallStatus.COMPLETED
+    await iterator.aclose()
+    assert not entry.ctx.cancel_event.is_set()
+    assert entry.final_response.state == ToolResultState.SUCCESS
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -258,34 +258,6 @@ async def test_generator_close_preserves_offloaded_tool_ownership():
 
 
 @pytest.mark.asyncio
-async def test_generator_close_preserves_completed_result():
-    coordinator = ToolCoordinator()
-    tool_call = _ToolCall(id="call-close-completed", name="quick_tool")
-
-    async def next_handler(
-        tool_call: _ToolCall,
-    ) -> AsyncGenerator[Any, None]:
-        yield _text_response(tool_call.id, "done")
-
-    iterator = coordinator.execute(
-        tool_call=tool_call,
-        next_handler=next_handler,
-        session_id="session-close-completed",
-        agent_id="agent-1",
-        root_session_id="root-1",
-    )
-    response = await asyncio.wait_for(iterator.__anext__(), timeout=1)
-    assert response.state == ToolResultState.SUCCESS
-
-    entry = coordinator.get(tool_call.id)
-    assert entry is not None
-    assert entry.status == ToolCallStatus.COMPLETED
-    await iterator.aclose()
-    assert not entry.ctx.cancel_event.is_set()
-    assert entry.final_response.state == ToolResultState.SUCCESS
-
-
-@pytest.mark.asyncio
 async def test_after_hook_transforms_final_response_and_blocks_caller():
     coordinator = ToolCoordinator()
     tool_call = _ToolCall(name="expanding_tool")

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator
 
 import pytest
-from agentscope.message import TextBlock, ToolResultBlock
+from agentscope.message import TextBlock, ToolResultBlock, ToolResultState
 from agentscope.tool import ToolResponse
 
 from qwenpaw.tool_calls import ToolCoordinator, ToolCoordinatorMiddleware
@@ -67,6 +67,58 @@ async def _wait_for_hint(
         if hints:
             return hints[0]
         await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_parent_cancel_cooperatively_stops_background_tool():
+    coordinator = ToolCoordinator(cancel_grace_period_secs=0.2)
+    tool_call = _ToolCall(id="call-parent-stop", name="chat_with_agent")
+    started = asyncio.Event()
+    cleanup_called = asyncio.Event()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        from qwenpaw.tool_calls import cancellable_wait
+
+        async def wait_for_peer() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        try:
+            await cancellable_wait(wait_for_peer())
+        except asyncio.CancelledError:
+            cleanup_called.set()
+            raise
+        yield _text_response(tool_call.id, "should not reach")
+
+    execute_task = asyncio.create_task(
+        _collect(
+            coordinator.execute(
+                tool_call=tool_call,
+                next_handler=next_handler,
+                session_id="session-parent-stop",
+                agent_id="agent-1",
+                root_session_id="root-1",
+            ),
+        ),
+    )
+
+    await asyncio.wait_for(started.wait(), timeout=1)
+    execute_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execute_task
+
+    entry = coordinator.get(tool_call.id)
+    assert entry is not None
+    assert cleanup_called.is_set()
+    assert entry.ctx.cancel_event.is_set()
+    assert entry.ctx.cancel_reason == CancelReason.USER
+    assert entry.background_task is not None
+    assert entry.background_task.done()
+    assert entry.status.value == "completed"
+    assert entry.end_state == "interrupted"
+    assert entry.final_response.state == ToolResultState.INTERRUPTED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- propagate parent chat cancellation into Coordinator-managed tool tasks
- stop target agent chats for cancelled foreground chat_with_agent and spawn_subagent calls
- preserve CancelledError so ToolCoordinator records ToolResultState.INTERRUPTED
- keep background submission behavior unchanged and mark cancelled fork worktrees failed

## Testing

- 706 passed, 1 skipped across tests/unit/agents/tools and tests/unit/tool_calls
- targeted spawn_subagent hook test passed
- Python compile checks passed
- Pylint R0915 check: 10.00/10
- git diff --check passed