### PR TITLE
fix(console): preserve embedding verification across agent switches

### DIFF
--- a/console/src/pages/Agent/Config/components/useEmbeddingVerification.test.tsx
+++ b/console/src/pages/Agent/Config/components/useEmbeddingVerification.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { EmbeddingModelConfig } from "@/api/types/agent";
+import { useAgentStore } from "@/stores/agentStore";
+import { useEmbeddingVerificationStore } from "@/stores/embeddingVerificationStore";
+import { isEmbeddingEnabled } from "./embeddingUtils";
+import { useEmbeddingVerification } from "./useEmbeddingVerification";
+
+const enabledConfig: EmbeddingModelConfig = {
+  backend: "openai",
+  model_name: "text-embedding-v4",
+  api_key: "secret",
+  base_url: "",
+  dimensions: 1024,
+  enable_cache: true,
+  use_dimensions: true,
+  max_cache_size: 1000,
+  max_input_length: 8192,
+  max_batch_size: 10,
+};
+
+const disabledConfig: EmbeddingModelConfig = {
+  ...enabledConfig,
+  model_name: "",
+  api_key: "",
+};
+
+function renderVerificationHook(config: EmbeddingModelConfig) {
+  return renderHook(
+    ({ currentConfig }) =>
+      useEmbeddingVerification(
+        currentConfig,
+        isEmbeddingEnabled(currentConfig),
+      ),
+    { initialProps: { currentConfig: config } },
+  );
+}
+
+afterEach(() => {
+  useAgentStore.setState({ selectedAgent: "default" });
+  useEmbeddingVerificationStore.setState({ verificationByAgent: {} });
+});
+
+describe("useEmbeddingVerification", () => {
+  it("preserves the selected agent verification during a mixed config frame", () => {
+    const { result, rerender } = renderVerificationHook(enabledConfig);
+
+    act(() => result.current.markVerified(1024, 50));
+    expect(
+      useEmbeddingVerificationStore.getState().verificationByAgent.default,
+    ).toBeDefined();
+
+    act(() => useAgentStore.setState({ selectedAgent: "disabled-agent" }));
+    rerender({ currentConfig: disabledConfig });
+
+    // selectedAgent changes synchronously, while the form still contains the
+    // disabled agent's values until its asynchronous config load completes.
+    act(() => useAgentStore.setState({ selectedAgent: "default" }));
+
+    expect(
+      useEmbeddingVerificationStore.getState().verificationByAgent.default,
+    ).toBeDefined();
+
+    rerender({ currentConfig: enabledConfig });
+    expect(result.current.testedEmbeddingIsCurrent).toBe(true);
+  });
+
+  it("still clears verification when the same agent becomes disabled", () => {
+    const { result, rerender } = renderVerificationHook(enabledConfig);
+
+    act(() => result.current.markVerified(1024, 50));
+    rerender({ currentConfig: disabledConfig });
+
+    expect(
+      useEmbeddingVerificationStore.getState().verificationByAgent.default,
+    ).toBeUndefined();
+  });
+});

--- a/console/src/pages/Agent/Config/components/useEmbeddingVerification.ts
+++ b/console/src/pages/Agent/Config/components/useEmbeddingVerification.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { EmbeddingModelConfig } from "@/api/types/agent";
 import { useAgentStore } from "@/stores/agentStore";
@@ -21,6 +21,7 @@ export function useEmbeddingVerification(
   const clearStoredVerification = useEmbeddingVerificationStore(
     (state) => state.clearVerification,
   );
+  const previousAgentIdRef = useRef(agentId);
 
   const clearVerification = useCallback(
     () => clearStoredVerification(agentId),
@@ -39,8 +40,14 @@ export function useEmbeddingVerification(
   );
 
   useEffect(() => {
-    if (config !== undefined && !enabled) clearVerification();
-  }, [clearVerification, config, enabled]);
+    const agentChanged = previousAgentIdRef.current !== agentId;
+    previousAgentIdRef.current = agentId;
+
+    // The selected agent updates before the shared form is repopulated. On
+    // that transition frame, `config` still belongs to the previous agent and
+    // must not clear the newly selected agent's stored verification.
+    if (!agentChanged && config !== undefined && !enabled) clearVerification();
+  }, [agentId, clearVerification, config, enabled]);
 
   const testedEmbeddingIsCurrent =
     testedEmbedding?.fingerprint === getEmbeddingServiceFingerprint(config);

--- a/console/src/pages/Agent/Config/useAgentConfig.test.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.test.tsx
@@ -29,6 +29,7 @@ const hoisted = vi.hoisted(() => {
   // A stable translation function so useCallback dependencies don't change on
   // every render and trigger an infinite fetchConfig loop via useEffect.
   const stableT = (k: string) => k;
+  const agentState = { selectedAgent: "agent-1" };
   return {
     mockSetFieldsValue,
     mockValidateFields,
@@ -38,6 +39,7 @@ const hoisted = vi.hoisted(() => {
     apiMocks,
     modalConfirmMock,
     stableT,
+    agentState,
   };
 });
 
@@ -63,9 +65,13 @@ vi.mock("../../../api", () => ({
   default: hoisted.apiMocks,
 }));
 
-vi.mock("../../../stores/agentStore", () => ({
-  useAgentStore: () => ({ selectedAgent: "agent-1" }),
-}));
+vi.mock("../../../stores/agentStore", () => {
+  const useAgentStore = Object.assign(
+    () => ({ selectedAgent: hoisted.agentState.selectedAgent }),
+    { getState: () => hoisted.agentState },
+  );
+  return { useAgentStore };
+});
 
 vi.mock("../../../hooks/useAppMessage", () => ({
   useAppMessage: () => ({ message: hoisted.messageMock }),
@@ -84,6 +90,7 @@ const {
   apiMocks,
   messageMock,
   modalConfirmMock,
+  agentState,
 } = hoisted;
 
 type Config = AgentsRunningConfig;
@@ -144,6 +151,7 @@ describe("useAgentConfig", () => {
     messageMock.success.mockReset();
     messageMock.error.mockReset();
     modalConfirmMock.mockReset();
+    agentState.selectedAgent = "agent-1";
 
     apiMocks.getAgentRunningConfig.mockResolvedValue(makeConfig());
     apiMocks.getAgentLanguage.mockResolvedValue({ language: "en" });
@@ -207,6 +215,49 @@ describe("useAgentConfig", () => {
       expect(result.current.error).toBe("boom");
     });
     expect(result.current.loading).toBe(false);
+  });
+
+  it("ignores a stale config response after switching away and back", async () => {
+    let resolveDisabledAgent!: (config: Config) => void;
+    const disabledAgentConfig = new Promise<Config>((resolve) => {
+      resolveDisabledAgent = resolve;
+    });
+    const currentAgentConfig = makeConfig({ history_max_length: 300 });
+
+    const view = renderConfigHook();
+    await waitFor(() => expect(view.result.current.loading).toBe(false));
+    mockSetFieldsValue.mockClear();
+
+    apiMocks.getAgentRunningConfig
+      .mockImplementationOnce(() => disabledAgentConfig)
+      .mockResolvedValueOnce(currentAgentConfig);
+
+    agentState.selectedAgent = "agent-2";
+    view.rerender();
+    await waitFor(() =>
+      expect(apiMocks.getAgentRunningConfig).toHaveBeenCalledTimes(2),
+    );
+
+    agentState.selectedAgent = "agent-1";
+    view.rerender();
+    await waitFor(() =>
+      expect(apiMocks.getAgentRunningConfig).toHaveBeenCalledTimes(3),
+    );
+    await waitFor(() =>
+      expect(mockSetFieldsValue).toHaveBeenCalledWith(
+        expect.objectContaining({ history_max_length: 300 }),
+      ),
+    );
+
+    await act(async () => {
+      resolveDisabledAgent(makeConfig({ history_max_length: 200 }));
+      await disabledAgentConfig;
+    });
+
+    expect(mockSetFieldsValue).not.toHaveBeenCalledWith(
+      expect.objectContaining({ history_max_length: 200 }),
+    );
+    expect(view.result.current.loading).toBe(false);
   });
 
   it("falls back context_manager_backend to 'light' when not in MAPPINGS", async () => {

--- a/console/src/pages/Agent/Config/useAgentConfig.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.tsx
@@ -29,8 +29,15 @@ export function useAgentConfig(
   const [approvalLevel, setApprovalLevel] =
     useState<ToolExecutionLevel>("AUTO");
   const originalConfigRef = useRef<AgentsRunningConfig | null>(null);
+  const latestConfigRequestRef = useRef(0);
 
   const fetchConfig = useCallback(async () => {
+    const requestId = ++latestConfigRequestRef.current;
+    const requestedAgent = selectedAgent || "default";
+    const isCurrentRequest = () =>
+      requestId === latestConfigRequestRef.current &&
+      (useAgentStore.getState().selectedAgent || "default") === requestedAgent;
+
     setLoading(true);
     setError(null);
     try {
@@ -39,6 +46,8 @@ export function useAgentConfig(
         api.getAgentLanguage(),
         api.getUserTimezone(),
       ]);
+      if (!isCurrentRequest()) return;
+
       const loadedLevel = (
         config.approval_level || "AUTO"
       ).toUpperCase() as ToolExecutionLevel;
@@ -93,11 +102,13 @@ export function useAgentConfig(
       setLanguage(langResp.language);
       setTimezone(tzResp.timezone || "UTC");
     } catch (err) {
+      if (!isCurrentRequest()) return;
+
       const errMsg =
         err instanceof Error ? err.message : t("agentConfig.loadFailed");
       setError(errMsg);
     } finally {
-      setLoading(false);
+      if (isCurrentRequest()) setLoading(false);
     }
   }, [form, t, selectedAgent, onConfigLoaded]);
 


### PR DESCRIPTION
## Summary

- preserve per-agent embedding verification when the selected agent changes before the shared configuration form has finished refreshing
- bind every agent configuration load to both a request generation and the agent selected when the request started, ignoring stale success and failure completions
- continue clearing verification when the same agent is genuinely changed to a disabled embedding configuration
- add focused regression coverage for the mixed-frame agent-switch race, the same-agent disable path, and a late B response after an A → B → A switch

Together with the cancellation-safe failed reload candidate cleanup already merged into `main` in #7194, this resolves both tracked issues:

- https://project.aone.alibaba-inc.com/coco/projects/2155950/workitems?view=f6b7997843844f40a8dc0ef7&workitem=85858155
- https://project.aone.alibaba-inc.com/coco/projects/2155950/workitems?view=f6b7997843844f40a8dc0ef7&workitem=85950158

The first issue is covered by the reusable-service preservation logic and regression tests in the current `main`; this PR supplies the remaining Console fixes for the second issue.

## Testing

- `npx tsc -b --noEmit`
- Prettier checks for all changed TypeScript files
- targeted Vitest suites for agent config and embedding verification (47 tests passed)
- `git diff --check`

The existing `useAgentConfig.test.tsx` ESLint baseline still reports unrelated errors on unchanged legacy lines; this change adds no new ESLint findings.