### PR TITLE
fix(installer): clarify application data cleanup

### DIFF
--- a/console/src-tauri/nsis-languages/English.nsh
+++ b/console/src-tauri/nsis-languages/English.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_ENGLISH} "WebView2 bootstrapper downlo
 LangString webview2Downloading ${LANG_ENGLISH} "Downloading WebView2 bootstrapper..."
 LangString webview2InstallError ${LANG_ENGLISH} "Error: Installing WebView2 failed with exit code $1"
 LangString webview2InstallSuccess ${LANG_ENGLISH} "WebView2 installed successfully"
-LangString deleteAppData ${LANG_ENGLISH} "Delete local app cache"
+LangString deleteAppData ${LANG_ENGLISH} "Clear app data (e.g. settings, drafts, cache; keeps agents/chats)"
 LangString qwenpawCliPathPageTitle ${LANG_ENGLISH} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_ENGLISH} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_ENGLISH} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Indonesian.nsh
+++ b/console/src-tauri/nsis-languages/Indonesian.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_INDONESIAN} "Bootstrapper WebView2 ber
 LangString webview2Downloading ${LANG_INDONESIAN} "Mengunduh bootstrapper WebView2..."
 LangString webview2InstallError ${LANG_INDONESIAN} "Kesalahan: Instalasi WebView2 gagal dengan kode keluar $1"
 LangString webview2InstallSuccess ${LANG_INDONESIAN} "WebView2 berhasil diinstal"
-LangString deleteAppData ${LANG_INDONESIAN} "Hapus cache aplikasi lokal"
+LangString deleteAppData ${LANG_INDONESIAN} "Hapus data (setelan, draf, cache, dll.; agen/chat disimpan)"
 LangString qwenpawCliPathPageTitle ${LANG_INDONESIAN} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_INDONESIAN} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_INDONESIAN} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Indonesian.nsh
+++ b/console/src-tauri/nsis-languages/Indonesian.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_INDONESIAN} "Bootstrapper WebView2 ber
 LangString webview2Downloading ${LANG_INDONESIAN} "Mengunduh bootstrapper WebView2..."
 LangString webview2InstallError ${LANG_INDONESIAN} "Kesalahan: Instalasi WebView2 gagal dengan kode keluar $1"
 LangString webview2InstallSuccess ${LANG_INDONESIAN} "WebView2 berhasil diinstal"
-LangString deleteAppData ${LANG_INDONESIAN} "Hapus data (setelan, draf, cache, dll.; agen/chat disimpan)"
+LangString deleteAppData ${LANG_INDONESIAN} "Hapus data aplikasi (setelan, draf, dll.; agen/chat disimpan)"
 LangString qwenpawCliPathPageTitle ${LANG_INDONESIAN} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_INDONESIAN} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_INDONESIAN} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Japanese.nsh
+++ b/console/src-tauri/nsis-languages/Japanese.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_JAPANESE} "WebView2 ブートストラ
 LangString webview2Downloading ${LANG_JAPANESE} "WebView2 ブートストラップ をダウンロード中です..."
 LangString webview2InstallError ${LANG_JAPANESE} "エラー: WebView2 のインストールは終了コード $1 で失敗しました。"
 LangString webview2InstallSuccess ${LANG_JAPANESE} "WebView2 が正常にインストールされました"
-LangString deleteAppData ${LANG_JAPANESE} "データ消去（設定、キャッシュなど；Agent/会話は保持）"
+LangString deleteAppData ${LANG_JAPANESE} "アプリデータ消去（設定、キャッシュ等；Agent/会話は保持）"
 LangString qwenpawCliPathPageTitle ${LANG_JAPANESE} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_JAPANESE} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_JAPANESE} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Japanese.nsh
+++ b/console/src-tauri/nsis-languages/Japanese.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_JAPANESE} "WebView2 ブートストラ
 LangString webview2Downloading ${LANG_JAPANESE} "WebView2 ブートストラップ をダウンロード中です..."
 LangString webview2InstallError ${LANG_JAPANESE} "エラー: WebView2 のインストールは終了コード $1 で失敗しました。"
 LangString webview2InstallSuccess ${LANG_JAPANESE} "WebView2 が正常にインストールされました"
-LangString deleteAppData ${LANG_JAPANESE} "ローカルアプリキャッシュを削除する"
+LangString deleteAppData ${LANG_JAPANESE} "データ消去（設定、キャッシュなど；Agent/会話は保持）"
 LangString qwenpawCliPathPageTitle ${LANG_JAPANESE} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_JAPANESE} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_JAPANESE} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/PortugueseBR.nsh
+++ b/console/src-tauri/nsis-languages/PortugueseBR.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_PORTUGUESEBR} "Bootstrapper do WebView
 LangString webview2Downloading ${LANG_PORTUGUESEBR} "Baixando o Bootstrapper do WebView2..."
 LangString webview2InstallError ${LANG_PORTUGUESEBR} "Erro: Instalação do Webview2 falhou com código $1"
 LangString webview2InstallSuccess ${LANG_PORTUGUESEBR} "WebView2 instalado com sucesso"
-LangString deleteAppData ${LANG_PORTUGUESEBR} "Remover cache local do aplicativo"
+LangString deleteAppData ${LANG_PORTUGUESEBR} "Limpar dados (ajustes, cache etc.; mantém agentes/chats)"
 LangString qwenpawCliPathPageTitle ${LANG_PORTUGUESEBR} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_PORTUGUESEBR} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_PORTUGUESEBR} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/PortugueseBR.nsh
+++ b/console/src-tauri/nsis-languages/PortugueseBR.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_PORTUGUESEBR} "Bootstrapper do WebView
 LangString webview2Downloading ${LANG_PORTUGUESEBR} "Baixando o Bootstrapper do WebView2..."
 LangString webview2InstallError ${LANG_PORTUGUESEBR} "Erro: Instalação do Webview2 falhou com código $1"
 LangString webview2InstallSuccess ${LANG_PORTUGUESEBR} "WebView2 instalado com sucesso"
-LangString deleteAppData ${LANG_PORTUGUESEBR} "Limpar dados (ajustes, cache etc.; mantém agentes/chats)"
+LangString deleteAppData ${LANG_PORTUGUESEBR} "Limpar dados do app (ajustes etc.; mantém agentes/chats)"
 LangString qwenpawCliPathPageTitle ${LANG_PORTUGUESEBR} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_PORTUGUESEBR} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_PORTUGUESEBR} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Russian.nsh
+++ b/console/src-tauri/nsis-languages/Russian.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_RUSSIAN} "WebView2 успешно за
 LangString webview2Downloading ${LANG_RUSSIAN} "Загрузка WebView2..."
 LangString webview2InstallError ${LANG_RUSSIAN} "Ошибка: Не удалось установить WebView2, код выхода: $1"
 LangString webview2InstallSuccess ${LANG_RUSSIAN} "WebView2 успешно установлен"
-LangString deleteAppData ${LANG_RUSSIAN} "Удалить данные (настр., кэш и др.; агенты/чаты сохранены)"
+LangString deleteAppData ${LANG_RUSSIAN} "Удалить данные приложения (настр. и др.; не агенты/чаты)"
 LangString qwenpawCliPathPageTitle ${LANG_RUSSIAN} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_RUSSIAN} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_RUSSIAN} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/Russian.nsh
+++ b/console/src-tauri/nsis-languages/Russian.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_RUSSIAN} "WebView2 успешно за
 LangString webview2Downloading ${LANG_RUSSIAN} "Загрузка WebView2..."
 LangString webview2InstallError ${LANG_RUSSIAN} "Ошибка: Не удалось установить WebView2, код выхода: $1"
 LangString webview2InstallSuccess ${LANG_RUSSIAN} "WebView2 успешно установлен"
-LangString deleteAppData ${LANG_RUSSIAN} "Удалить локальный кэш приложения"
+LangString deleteAppData ${LANG_RUSSIAN} "Удалить данные (настр., кэш и др.; агенты/чаты сохранены)"
 LangString qwenpawCliPathPageTitle ${LANG_RUSSIAN} "Command line"
 LangString qwenpawCliPathPageSubtitle ${LANG_RUSSIAN} "Choose whether qwenpaw is available in terminals."
 LangString qwenpawCliPathPageDescription ${LANG_RUSSIAN} "This adds the bundled qwenpaw command to your user PATH. You can change it later by reinstalling or uninstalling QwenPaw Desktop."

--- a/console/src-tauri/nsis-languages/SimpChinese.nsh
+++ b/console/src-tauri/nsis-languages/SimpChinese.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_SIMPCHINESE} "WebView2 引导程序下
 LangString webview2Downloading ${LANG_SIMPCHINESE} "正在下载 WebView2 引导程序..."
 LangString webview2InstallError ${LANG_SIMPCHINESE} "错误：安装 WebView2 时失败，错误代码：$1"
 LangString webview2InstallSuccess ${LANG_SIMPCHINESE} "成功安装 WebView2"
-LangString deleteAppData ${LANG_SIMPCHINESE} "清除数据（如设置、草稿、登录、缓存等；保留 Agent/会话）"
+LangString deleteAppData ${LANG_SIMPCHINESE} "清除应用数据（如设置、草稿、登录、缓存等；保留 Agent/会话）"
 LangString qwenpawCliPathPageTitle ${LANG_SIMPCHINESE} "命令行"
 LangString qwenpawCliPathPageSubtitle ${LANG_SIMPCHINESE} "选择是否让终端可以直接使用 qwenpaw。"
 LangString qwenpawCliPathPageDescription ${LANG_SIMPCHINESE} "这会把随包提供的 qwenpaw 命令加入你的用户 PATH。之后可通过重新安装或卸载 QwenPaw Desktop 变更。"

--- a/console/src-tauri/nsis-languages/SimpChinese.nsh
+++ b/console/src-tauri/nsis-languages/SimpChinese.nsh
@@ -24,7 +24,7 @@ LangString webview2DownloadSuccess ${LANG_SIMPCHINESE} "WebView2 引导程序下
 LangString webview2Downloading ${LANG_SIMPCHINESE} "正在下载 WebView2 引导程序..."
 LangString webview2InstallError ${LANG_SIMPCHINESE} "错误：安装 WebView2 时失败，错误代码：$1"
 LangString webview2InstallSuccess ${LANG_SIMPCHINESE} "成功安装 WebView2"
-LangString deleteAppData ${LANG_SIMPCHINESE} "删除本地应用缓存"
+LangString deleteAppData ${LANG_SIMPCHINESE} "清除数据（如设置、草稿、登录、缓存等；保留 Agent/会话）"
 LangString qwenpawCliPathPageTitle ${LANG_SIMPCHINESE} "命令行"
 LangString qwenpawCliPathPageSubtitle ${LANG_SIMPCHINESE} "选择是否让终端可以直接使用 qwenpaw。"
 LangString qwenpawCliPathPageDescription ${LANG_SIMPCHINESE} "这会把随包提供的 qwenpaw 命令加入你的用户 PATH。之后可通过重新安装或卸载 QwenPaw Desktop 变更。"


### PR DESCRIPTION
## Description

Clarifies the Windows NSIS uninstall cleanup option across all six custom installer languages. The copy now explicitly names the target as application data, gives representative examples, and states that agents and chats are kept, matching the existing cleanup behavior without changing it.

**Related Issue:** Fixes #7188

**Security Considerations:** None; wording-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `git diff --check`
- Verified exactly six `deleteAppData` declarations and zero matches for the replaced cache-only strings.
- Measured localized copy with the Windows message-box font; all six strings fit the conservative 375 px text budget.
- Fork packaging: non-reusable `QwenPaw Desktop Build` passed for Windows and macOS, including desktop verification and artifact upload.
- Not run locally: Python/frontend test suites and all-files pre-commit, because no executable code changed. Upstream Pre-commit, Vitest, Playwright UI Smoke, and formatting checks passed.

## Evidence

```text
git diff --check: PASS
Changed scope: 6 language files, 6 insertions, 6 deletions
Installer string coverage: 6/6 declarations
Old cache-only copy matches: 0
Measured widths: 350-375 px (Microsoft YaHei UI 9 pt; 375 px budget)
Packaged commit: 946fdc4f5dc1719c6c624a271ceb4e8f92ed7cf1
```

## Additional Notes

- Fork packaging run: https://github.com/jinglinpeng/CoPaw/actions/runs/33061356906
- Artifacts: `QwenPaw-Desktop-Tauri-Windows-2.2.0b2` and `QwenPaw-Desktop-Tauri-macOS-2.2.0b2`.
- Packaging used `QwenPaw Desktop Build` with `upload_to_oss=false`; release and OSS upload jobs were skipped.
