### PR TITLE
docs(qwenpaw-data): align .env/Configure promises with datasource design

### DIFF
--- a/plugins/apps/qwenpaw-data/README.md
+++ b/plugins/apps/qwenpaw-data/README.md
@@ -198,8 +198,10 @@ volumes):
 
 QwenPaw-Data keeps all runtime settings in one place: open the app and go to
 **Configure**. From there you can set the language model, embedding model,
-Neo4j graph store, and optional SQL warehouse. Each section has a **Test
-connection** button so you can verify values before saving.
+and Neo4j graph store. Each section has a **Test connection** button so you
+can verify values before saving. SQL datasources (PostgreSQL / MySQL / ...)
+are registered through the embedded Context console's Data Sources page,
+not through `.env`.
 
 When you save, the app writes:
 

--- a/plugins/apps/qwenpaw-data/backend/config.py
+++ b/plugins/apps/qwenpaw-data/backend/config.py
@@ -4,7 +4,9 @@
 The plugin stores all user-editable configuration in ``config.json`` and
 translates it into the runtime files the managed context service expects:
 
-* ``.env`` for Neo4j and SQL datasource environment variables.
+* ``.env`` for Neo4j and model environment variables (SQL datasource
+  credentials are registered through the context service's datasource
+  API instead).
 * ``models.json`` for LLM and embedding model settings.
 
 These files live in the app working directory so the context service can


### PR DESCRIPTION
Follow-up to #7190 (merged before the docs-alignment commit landed). Docs-only; no functional changes.

## What Problem This Solves

QA case TC-DATA-04 (v2.2.0-beta.1): after saving Neo4j + LLM settings on the Configure page, the generated `.env` contains `NEO4J_URI/USER/PASSWORD/DATABASE` but no SQL datasource variables, while two docs still promise them:

- `plugins/apps/qwenpaw-data/backend/config.py` docstring: "``.env`` for Neo4j and SQL datasource environment variables"
- `plugins/apps/qwenpaw-data/README.md` Configure section: "you can set the language model, embedding model, Neo4j graph store, and optional SQL warehouse"

Neither promise is realizable by design: SQL datasource credentials are registered through the context service's datasource REST API (embedded Context console's Data Sources page) and stored in its SQLite `semantic_config.db`; the plugin persists only the active-id pointer. The README's own dependency table already states datasources are "not read from `.env`" — so the docs were internally inconsistent and pointed at a Configure section that does not exist. This PR aligns both promises with the shipped contract.

## Evidence

Real behavior on merged main (pre-fix), verified from source:

```
$ sed -n '7p' plugins/apps/qwenpaw-data/backend/config.py
* ``.env`` for Neo4j and SQL datasource environment variables.

$ grep -n 'NEO4J_\|OPENAI_\|LLM_MODEL\|EMBED_' plugins/apps/qwenpaw-data/backend/config.py  # _env_lines()
275:        ("NEO4J_URI", config.neo4j.uri),
276:        ("NEO4J_USER", config.neo4j.user),
277:        ("NEO4J_PASSWORD", config.neo4j.password),
278:        ("NEO4J_DATABASE", config.neo4j.database),
... OPENAI_API_KEY / OPENAI_BASE_URL / LLM_MODEL / EMBED_* — no SQL keys written
```

i.e. `_env_lines()` cannot produce the SQL variables the docstring/README promise, and Configure.tsx has no SQL warehouse section. QA checkpoints unrelated to docs (models.json payload, reuse_host snapshot refresh, config.json persistence) all passed — the implementation was already correct; only the promises needed alignment.

After this PR:

```
$ sed -n '7,9p' plugins/apps/qwenpaw-data/backend/config.py
* ``.env`` for Neo4j and model environment variables (SQL datasource
  credentials are registered through the context service's datasource
  API instead).
```

and the README Configure section now routes SQL datasources (PostgreSQL / MySQL / ...) to the embedded Context console's Data Sources page, matching the dependency table below it. `tests/unit/pawapp/test_qwenpaw_data_config.py` (17 cases) passes; pre-commit clean.
