### PR TITLE
fix(desktop): unify packaged Python runtime source

### DIFF
--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -5,7 +5,7 @@
 #   powershell ./scripts/pack-tauri/build_pyinstaller.ps1
 #
 # Prerequisites:
-#   - Python 3.10+ with virtual environment
+#   - Python 3.10+ on PATH (used only to bootstrap the bundled runtime)
 #   - PyInstaller 6.0+ (will be installed if not present)
 
 param()
@@ -18,6 +18,12 @@ $DIST = if ($env:DIST) { $env:DIST } else { "dist" }
 if (-not [System.IO.Path]::IsPathRooted($DIST)) {
     $DIST = Join-Path $REPO_ROOT $DIST
 }
+$BINARIES_DIR = Join-Path $REPO_ROOT "console\src-tauri\binaries"
+$PYTHON_RUNTIME_DIR = Join-Path $BINARIES_DIR "python-runtime"
+$RUNTIME_PYTHON_DIR = Join-Path $PYTHON_RUNTIME_DIR "python"
+$NATIVE_HOST_PYTHON = Join-Path $RUNTIME_PYTHON_DIR "python.exe"
+$BUILD_VENV = Join-Path $DIST "pyinstaller-venv"
+$PYTHON_BIN = Join-Path $BUILD_VENV "Scripts\python.exe"
 $VERSION_FILE = "src\qwenpaw\__version__.py"
 
 # Extract version
@@ -42,28 +48,74 @@ Write-Host ""
 # Check prerequisites
 Write-Host "== Checking prerequisites ==" -ForegroundColor Yellow
 
-$UV_BIN = (Get-Command uv -ErrorAction SilentlyContinue).Source
-$PYTHON_BIN = Join-Path $REPO_ROOT ".venv\Scripts\python.exe"
-if (-not (Test-Path $PYTHON_BIN)) {
-    if ($UV_BIN) {
-        Write-Host ".venv not found, creating virtual environment with uv" -ForegroundColor Yellow
-        & $UV_BIN venv "$REPO_ROOT\.venv"
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to create virtual environment with uv"
-        }
-    } else {
-        Write-Host ".venv not found, using system Python" -ForegroundColor Yellow
-        $PYTHON_BIN = (Get-Command python -ErrorAction SilentlyContinue).Source
-    }
-    if (-not $PYTHON_BIN -or -not (Test-Path $PYTHON_BIN)) {
-        Write-Host "ERROR: Python not found in .venv or PATH" -ForegroundColor Red
-        Write-Host "Please create virtual environment first: python -m venv .venv"
-        exit 1
-    }
+function Assert-LastExit {
+    param([string]$Message)
+    if ($LASTEXITCODE -ne 0) { throw $Message }
 }
 
-$pythonVersion = & $PYTHON_BIN --version
-Write-Host "Python: $pythonVersion" -ForegroundColor Green
+$UV_BIN = (Get-Command uv -ErrorAction SilentlyContinue).Source
+$BOOTSTRAP_PYTHON = (Get-Command python -ErrorAction SilentlyContinue).Source
+if (-not $BOOTSTRAP_PYTHON -or -not (Test-Path $BOOTSTRAP_PYTHON)) {
+    throw "Python not found on PATH; it is required to stage the bundled runtime"
+}
+
+New-Item -ItemType Directory -Force -Path $BINARIES_DIR | Out-Null
+
+# The staged python-build-standalone runtime is the canonical source for both
+# the helper interpreter and the PyInstaller build environment. The PATH
+# Python only selects the X.Y version to download and runs the staging script.
+Write-Host "== Staging canonical Python runtime ==" -ForegroundColor Yellow
+& $BOOTSTRAP_PYTHON `
+    (Join-Path $REPO_ROOT "scripts\pack-tauri\stage_python_runtime.py") `
+    --dest $PYTHON_RUNTIME_DIR
+Assert-LastExit "Failed to stage bundled Python runtime"
+if (-not (Test-Path $NATIVE_HOST_PYTHON -PathType Leaf)) {
+    throw "Bundled Python interpreter not found at $NATIVE_HOST_PYTHON"
+}
+
+Write-Host "== Creating PyInstaller build environment ==" -ForegroundColor Yellow
+& $NATIVE_HOST_PYTHON -m venv --clear $BUILD_VENV
+Assert-LastExit "Failed to create PyInstaller environment from bundled Python"
+
+$canonicalVersion = & $NATIVE_HOST_PYTHON -c "import sys; print(sys.version)"
+Assert-LastExit "Failed to inspect bundled Python version"
+$buildVersion = & $PYTHON_BIN -c "import sys; print(sys.version)"
+Assert-LastExit "Failed to inspect PyInstaller environment version"
+$canonicalOpenSSL = & $NATIVE_HOST_PYTHON -c "import ssl; print(ssl.OPENSSL_VERSION)"
+Assert-LastExit "Failed to inspect bundled Python OpenSSL"
+$buildOpenSSL = & $PYTHON_BIN -c "import ssl; print(ssl.OPENSSL_VERSION)"
+Assert-LastExit "Failed to inspect PyInstaller environment OpenSSL"
+$canonicalBasePrefix = & $NATIVE_HOST_PYTHON -c "import os, sys; print(os.path.realpath(sys.base_prefix))"
+Assert-LastExit "Failed to inspect bundled Python base prefix"
+$buildBasePrefix = & $PYTHON_BIN -c "import os, sys; print(os.path.realpath(sys.base_prefix))"
+Assert-LastExit "Failed to inspect PyInstaller environment base prefix"
+$expectedBasePrefix = (Resolve-Path -LiteralPath $RUNTIME_PYTHON_DIR).Path
+
+if ($canonicalVersion -ne $buildVersion) {
+    throw "Python version mismatch between bundled runtime and PyInstaller environment"
+}
+if ($canonicalOpenSSL -ne $buildOpenSSL) {
+    throw "OpenSSL mismatch between bundled runtime and PyInstaller environment"
+}
+if (
+    -not $canonicalBasePrefix.Equals(
+        $expectedBasePrefix,
+        [System.StringComparison]::OrdinalIgnoreCase
+    ) -or
+    -not $buildBasePrefix.Equals(
+        $expectedBasePrefix,
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+) {
+    throw "PyInstaller environment was not created from $RUNTIME_PYTHON_DIR"
+}
+
+Write-Host "Python: $canonicalVersion" -ForegroundColor Green
+Write-Host "OpenSSL: $canonicalOpenSSL" -ForegroundColor Green
+Write-Host "Canonical interpreter: $NATIVE_HOST_PYTHON" -ForegroundColor Green
+Write-Host "Build interpreter: $PYTHON_BIN" -ForegroundColor Green
+Write-Host "Build base prefix: $buildBasePrefix" -ForegroundColor Green
+Write-Host ""
 
 function Test-PythonImport {
     param([string]$Statement)
@@ -75,11 +127,6 @@ function Test-PythonImport {
     } finally {
         $ErrorActionPreference = $previousErrorActionPreference
     }
-}
-
-function Assert-LastExit {
-    param([string]$Message)
-    if ($LASTEXITCODE -ne 0) { throw $Message }
 }
 
 function Install-PythonPackages {
@@ -200,6 +247,53 @@ if (-not (Test-Path $MODEL_CATALOG)) {
 
 Write-Host "Backend bundle created: $BACKEND_DIR" -ForegroundColor Green
 
+# A venv can report the expected version while still resolving DLLs from an
+# unintended installation. Compare the frozen Windows runtime files directly
+# with the canonical python-build-standalone files before packaging them.
+Write-Host "== Verifying frozen Python runtime identity ==" -ForegroundColor Yellow
+function Assert-SameFileHash {
+    param(
+        [string]$Source,
+        [string]$Bundled
+    )
+    if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+        throw "Runtime file not found for identity check: $Source"
+    }
+    if (-not (Test-Path -LiteralPath $Bundled -PathType Leaf)) {
+        throw "PyInstaller file not found for identity check: $Bundled"
+    }
+    $sourceHash = (Get-FileHash -LiteralPath $Source -Algorithm SHA256).Hash
+    $bundledHash = (Get-FileHash -LiteralPath $Bundled -Algorithm SHA256).Hash
+    if ($sourceHash -ne $bundledHash) {
+        throw "Runtime identity check failed: $Source and $Bundled differ"
+    }
+    Write-Host "Verified identical: $(Split-Path -Leaf $Bundled)" -ForegroundColor Green
+}
+
+$BACKEND_INTERNAL_DIR = Join-Path $BACKEND_DIR "_internal"
+$PYTHON_DLL_NAME = & $NATIVE_HOST_PYTHON -c `
+    "import sys; print(f'python{sys.version_info.major}{sys.version_info.minor}.dll')"
+Assert-LastExit "Failed to determine bundled Python DLL name"
+Assert-SameFileHash `
+    -Source (Join-Path $RUNTIME_PYTHON_DIR $PYTHON_DLL_NAME) `
+    -Bundled (Join-Path $BACKEND_INTERNAL_DIR $PYTHON_DLL_NAME)
+Assert-SameFileHash `
+    -Source (Join-Path $RUNTIME_PYTHON_DIR "DLLs\_ssl.pyd") `
+    -Bundled (Join-Path $BACKEND_INTERNAL_DIR "_ssl.pyd")
+
+$runtimeOpenSslDlls = @(
+    Get-ChildItem -LiteralPath (Join-Path $RUNTIME_PYTHON_DIR "DLLs") -File |
+        Where-Object { $_.Name -match '^lib(ssl|crypto)-.*\.dll$' }
+)
+if ($runtimeOpenSslDlls.Count -lt 2) {
+    throw "Expected OpenSSL runtime DLLs under $RUNTIME_PYTHON_DIR\DLLs"
+}
+foreach ($runtimeDll in $runtimeOpenSslDlls) {
+    Assert-SameFileHash `
+        -Source $runtimeDll.FullName `
+        -Bundled (Join-Path $BACKEND_INTERNAL_DIR $runtimeDll.Name)
+}
+
 # Get size
 $bundleSize = (Get-ChildItem $BACKEND_DIR -Recurse -File | Measure-Object -Property Length -Sum).Sum / 1MB
 Write-Host "Bundle size: $([math]::Round($bundleSize, 2)) MB"
@@ -207,9 +301,6 @@ Write-Host ""
 
 # Copy to Tauri resources directory
 Write-Host "== Copying to Tauri binaries directory ==" -ForegroundColor Yellow
-$BINARIES_DIR = Join-Path $REPO_ROOT "console\src-tauri\binaries"
-New-Item -ItemType Directory -Force -Path $BINARIES_DIR | Out-Null
-
 $DEST = Join-Path $BINARIES_DIR "qwenpaw-backend"
 New-Item -ItemType Directory -Force -Path $DEST | Out-Null
 Get-ChildItem -LiteralPath $DEST -Force | Remove-Item -Recurse -Force
@@ -217,16 +308,9 @@ Copy-Item -Recurse -Force (Join-Path $BACKEND_DIR "*") $DEST
 Write-Host "Copied to: $DEST" -ForegroundColor Green
 Write-Host ""
 
-# Stage a standalone CPython (same X.Y/arch as this build's interpreter) so the
-# frozen backend can install third-party plugin dependencies at runtime.
-Write-Host "== Staging bundled Python runtime ==" -ForegroundColor Yellow
-& $PYTHON_BIN (Join-Path $REPO_ROOT "scripts\pack-tauri\stage_python_runtime.py") `
-    --dest (Join-Path $BINARIES_DIR "python-runtime")
-Assert-LastExit "Failed to stage bundled Python runtime"
-
 # The Chrome Native Messaging host runs under this standalone interpreter,
 # outside the PyInstaller backend, so its dependencies must be installed here.
-$NATIVE_HOST_PYTHON = Join-Path $BINARIES_DIR "python-runtime\python\python.exe"
+Write-Host "== Installing bundled Python helper dependencies ==" -ForegroundColor Yellow
 $NATIVE_HOST_REQUIREMENTS = Join-Path $REPO_ROOT "scripts\pack-tauri\native-host-requirements.txt"
 & $NATIVE_HOST_PYTHON -m pip install `
     --disable-pip-version-check `

--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -77,41 +77,21 @@ Write-Host "== Creating PyInstaller build environment ==" -ForegroundColor Yello
 & $NATIVE_HOST_PYTHON -m venv --clear $BUILD_VENV
 Assert-LastExit "Failed to create PyInstaller environment from bundled Python"
 
-$canonicalVersion = & $NATIVE_HOST_PYTHON -c "import sys; print(sys.version)"
-Assert-LastExit "Failed to inspect bundled Python version"
-$buildVersion = & $PYTHON_BIN -c "import sys; print(sys.version)"
-Assert-LastExit "Failed to inspect PyInstaller environment version"
-$canonicalOpenSSL = & $NATIVE_HOST_PYTHON -c "import ssl; print(ssl.OPENSSL_VERSION)"
-Assert-LastExit "Failed to inspect bundled Python OpenSSL"
-$buildOpenSSL = & $PYTHON_BIN -c "import ssl; print(ssl.OPENSSL_VERSION)"
-Assert-LastExit "Failed to inspect PyInstaller environment OpenSSL"
-$canonicalBasePrefix = & $NATIVE_HOST_PYTHON -c "import os, sys; print(os.path.realpath(sys.base_prefix))"
-Assert-LastExit "Failed to inspect bundled Python base prefix"
+$buildIdentity = & $PYTHON_BIN -c `
+    "import ssl, sys; print(f'{sys.version} | {ssl.OPENSSL_VERSION}')"
+Assert-LastExit "Failed to inspect PyInstaller environment"
 $buildBasePrefix = & $PYTHON_BIN -c "import os, sys; print(os.path.realpath(sys.base_prefix))"
 Assert-LastExit "Failed to inspect PyInstaller environment base prefix"
 $expectedBasePrefix = (Resolve-Path -LiteralPath $RUNTIME_PYTHON_DIR).Path
 
-if ($canonicalVersion -ne $buildVersion) {
-    throw "Python version mismatch between bundled runtime and PyInstaller environment"
-}
-if ($canonicalOpenSSL -ne $buildOpenSSL) {
-    throw "OpenSSL mismatch between bundled runtime and PyInstaller environment"
-}
-if (
-    -not $canonicalBasePrefix.Equals(
-        $expectedBasePrefix,
-        [System.StringComparison]::OrdinalIgnoreCase
-    ) -or
-    -not $buildBasePrefix.Equals(
-        $expectedBasePrefix,
-        [System.StringComparison]::OrdinalIgnoreCase
-    )
-) {
+if (-not $buildBasePrefix.Equals(
+    $expectedBasePrefix,
+    [System.StringComparison]::OrdinalIgnoreCase
+)) {
     throw "PyInstaller environment was not created from $RUNTIME_PYTHON_DIR"
 }
 
-Write-Host "Python: $canonicalVersion" -ForegroundColor Green
-Write-Host "OpenSSL: $canonicalOpenSSL" -ForegroundColor Green
+Write-Host "Runtime: $buildIdentity" -ForegroundColor Green
 Write-Host "Canonical interpreter: $NATIVE_HOST_PYTHON" -ForegroundColor Green
 Write-Host "Build interpreter: $PYTHON_BIN" -ForegroundColor Green
 Write-Host "Build base prefix: $buildBasePrefix" -ForegroundColor Green

--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -77,24 +77,8 @@ Write-Host "== Creating PyInstaller build environment ==" -ForegroundColor Yello
 & $NATIVE_HOST_PYTHON -m venv --clear $BUILD_VENV
 Assert-LastExit "Failed to create PyInstaller environment from bundled Python"
 
-$buildIdentity = & $PYTHON_BIN -c `
-    "import ssl, sys; print(f'{sys.version} | {ssl.OPENSSL_VERSION}')"
-Assert-LastExit "Failed to inspect PyInstaller environment"
-$buildBasePrefix = & $PYTHON_BIN -c "import os, sys; print(os.path.realpath(sys.base_prefix))"
-Assert-LastExit "Failed to inspect PyInstaller environment base prefix"
-$expectedBasePrefix = (Resolve-Path -LiteralPath $RUNTIME_PYTHON_DIR).Path
-
-if (-not $buildBasePrefix.Equals(
-    $expectedBasePrefix,
-    [System.StringComparison]::OrdinalIgnoreCase
-)) {
-    throw "PyInstaller environment was not created from $RUNTIME_PYTHON_DIR"
-}
-
-Write-Host "Runtime: $buildIdentity" -ForegroundColor Green
-Write-Host "Canonical interpreter: $NATIVE_HOST_PYTHON" -ForegroundColor Green
-Write-Host "Build interpreter: $PYTHON_BIN" -ForegroundColor Green
-Write-Host "Build base prefix: $buildBasePrefix" -ForegroundColor Green
+$pythonVersion = & $PYTHON_BIN --version
+Write-Host "Python: $pythonVersion" -ForegroundColor Green
 Write-Host ""
 
 function Test-PythonImport {
@@ -226,53 +210,6 @@ if (-not (Test-Path $MODEL_CATALOG)) {
 }
 
 Write-Host "Backend bundle created: $BACKEND_DIR" -ForegroundColor Green
-
-# A venv can report the expected version while still resolving DLLs from an
-# unintended installation. Compare the frozen Windows runtime files directly
-# with the canonical python-build-standalone files before packaging them.
-Write-Host "== Verifying frozen Python runtime identity ==" -ForegroundColor Yellow
-function Assert-SameFileHash {
-    param(
-        [string]$Source,
-        [string]$Bundled
-    )
-    if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
-        throw "Runtime file not found for identity check: $Source"
-    }
-    if (-not (Test-Path -LiteralPath $Bundled -PathType Leaf)) {
-        throw "PyInstaller file not found for identity check: $Bundled"
-    }
-    $sourceHash = (Get-FileHash -LiteralPath $Source -Algorithm SHA256).Hash
-    $bundledHash = (Get-FileHash -LiteralPath $Bundled -Algorithm SHA256).Hash
-    if ($sourceHash -ne $bundledHash) {
-        throw "Runtime identity check failed: $Source and $Bundled differ"
-    }
-    Write-Host "Verified identical: $(Split-Path -Leaf $Bundled)" -ForegroundColor Green
-}
-
-$BACKEND_INTERNAL_DIR = Join-Path $BACKEND_DIR "_internal"
-$PYTHON_DLL_NAME = & $NATIVE_HOST_PYTHON -c `
-    "import sys; print(f'python{sys.version_info.major}{sys.version_info.minor}.dll')"
-Assert-LastExit "Failed to determine bundled Python DLL name"
-Assert-SameFileHash `
-    -Source (Join-Path $RUNTIME_PYTHON_DIR $PYTHON_DLL_NAME) `
-    -Bundled (Join-Path $BACKEND_INTERNAL_DIR $PYTHON_DLL_NAME)
-Assert-SameFileHash `
-    -Source (Join-Path $RUNTIME_PYTHON_DIR "DLLs\_ssl.pyd") `
-    -Bundled (Join-Path $BACKEND_INTERNAL_DIR "_ssl.pyd")
-
-$runtimeOpenSslDlls = @(
-    Get-ChildItem -LiteralPath (Join-Path $RUNTIME_PYTHON_DIR "DLLs") -File |
-        Where-Object { $_.Name -match '^lib(ssl|crypto)-.*\.dll$' }
-)
-if ($runtimeOpenSslDlls.Count -lt 2) {
-    throw "Expected OpenSSL runtime DLLs under $RUNTIME_PYTHON_DIR\DLLs"
-}
-foreach ($runtimeDll in $runtimeOpenSslDlls) {
-    Assert-SameFileHash `
-        -Source $runtimeDll.FullName `
-        -Bundled (Join-Path $BACKEND_INTERNAL_DIR $runtimeDll.Name)
-}
 
 # Get size
 $bundleSize = (Get-ChildItem $BACKEND_DIR -Recurse -File | Measure-Object -Property Length -Sum).Sum / 1MB

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -58,22 +58,7 @@ fi
 echo "== Creating PyInstaller build environment =="
 "$NATIVE_HOST_PYTHON" -m venv --clear "$BUILD_VENV"
 
-BUILD_IDENTITY=$("$PYTHON_BIN" -c \
-    'import ssl, sys; print(f"{sys.version} | {ssl.OPENSSL_VERSION}")')
-BUILD_BASE_PREFIX=$("$PYTHON_BIN" -c 'import os, sys; print(os.path.realpath(sys.base_prefix))')
-EXPECTED_BASE_PREFIX=$("$NATIVE_HOST_PYTHON" -c \
-    'import os, sys; print(os.path.realpath(sys.argv[1]))' \
-    "$RUNTIME_PYTHON_DIR")
-
-if [ "$BUILD_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ]; then
-    echo "ERROR: PyInstaller environment was not created from ${RUNTIME_PYTHON_DIR}"
-    exit 1
-fi
-
-echo "Runtime: ${BUILD_IDENTITY}"
-echo "Canonical interpreter: ${NATIVE_HOST_PYTHON}"
-echo "Build interpreter: ${PYTHON_BIN}"
-echo "Build base prefix: ${BUILD_BASE_PREFIX}"
+echo "Python: $("$PYTHON_BIN" --version)"
 echo ""
 
 install_python_packages() {

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -6,7 +6,7 @@
 #   ./scripts/pack-tauri/build_pyinstaller.sh
 #
 # Prerequisites:
-#   - Python 3.10+ with virtual environment
+#   - Python 3.10+ on PATH (used only to bootstrap the bundled runtime)
 #   - PyInstaller 6.0+ (will be installed if not present)
 
 set -e
@@ -15,6 +15,12 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 DIST="${DIST:-dist}"
+BINARIES_DIR="${REPO_ROOT}/console/src-tauri/binaries"
+PYTHON_RUNTIME_DIR="${BINARIES_DIR}/python-runtime"
+RUNTIME_PYTHON_DIR="${PYTHON_RUNTIME_DIR}/python"
+NATIVE_HOST_PYTHON="${RUNTIME_PYTHON_DIR}/bin/python3"
+BUILD_VENV="${DIST}/pyinstaller-venv"
+PYTHON_BIN="${BUILD_VENV}/bin/python"
 VERSION=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)
 
 echo "========================================="
@@ -27,20 +33,61 @@ echo ""
 # Check prerequisites
 echo "== Checking prerequisites =="
 
-# Create venv if missing (prefer uv if available)
-PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
-if [ ! -f "$PYTHON_BIN" ]; then
-    if command -v uv &>/dev/null; then
-        echo "Creating virtual environment with uv..."
-        uv venv "${REPO_ROOT}/.venv"
-    else
-        echo "ERROR: Python not found in .venv"
-        echo "Please create virtual environment first: python -m venv .venv"
-        exit 1
-    fi
+if command -v python3 >/dev/null 2>&1; then
+    BOOTSTRAP_PYTHON=$(command -v python3)
+elif command -v python >/dev/null 2>&1; then
+    BOOTSTRAP_PYTHON=$(command -v python)
+else
+    echo "ERROR: Python not found on PATH; it is required to stage the bundled runtime"
+    exit 1
 fi
 
-echo "Python: $("$PYTHON_BIN" --version)"
+mkdir -p "${BINARIES_DIR}"
+
+# The staged python-build-standalone runtime is the canonical source for both
+# the helper interpreter and the PyInstaller build environment. The PATH
+# Python only selects the X.Y version to download and runs the staging script.
+echo "== Staging canonical Python runtime =="
+"$BOOTSTRAP_PYTHON" "${REPO_ROOT}/scripts/pack-tauri/stage_python_runtime.py" \
+    --dest "${PYTHON_RUNTIME_DIR}"
+if [ ! -f "$NATIVE_HOST_PYTHON" ]; then
+    echo "ERROR: Bundled Python interpreter not found at ${NATIVE_HOST_PYTHON}"
+    exit 1
+fi
+
+echo "== Creating PyInstaller build environment =="
+"$NATIVE_HOST_PYTHON" -m venv --clear "$BUILD_VENV"
+
+CANONICAL_VERSION=$("$NATIVE_HOST_PYTHON" -c 'import sys; print(sys.version)')
+BUILD_VERSION=$("$PYTHON_BIN" -c 'import sys; print(sys.version)')
+CANONICAL_OPENSSL=$("$NATIVE_HOST_PYTHON" -c 'import ssl; print(ssl.OPENSSL_VERSION)')
+BUILD_OPENSSL=$("$PYTHON_BIN" -c 'import ssl; print(ssl.OPENSSL_VERSION)')
+CANONICAL_BASE_PREFIX=$("$NATIVE_HOST_PYTHON" -c 'import os, sys; print(os.path.realpath(sys.base_prefix))')
+BUILD_BASE_PREFIX=$("$PYTHON_BIN" -c 'import os, sys; print(os.path.realpath(sys.base_prefix))')
+EXPECTED_BASE_PREFIX=$("$NATIVE_HOST_PYTHON" -c \
+    'import os, sys; print(os.path.realpath(sys.argv[1]))' \
+    "$RUNTIME_PYTHON_DIR")
+
+if [ "$CANONICAL_VERSION" != "$BUILD_VERSION" ]; then
+    echo "ERROR: Python version mismatch between bundled runtime and PyInstaller environment"
+    exit 1
+fi
+if [ "$CANONICAL_OPENSSL" != "$BUILD_OPENSSL" ]; then
+    echo "ERROR: OpenSSL mismatch between bundled runtime and PyInstaller environment"
+    exit 1
+fi
+if [ "$CANONICAL_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ] || \
+    [ "$BUILD_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ]; then
+    echo "ERROR: PyInstaller environment was not created from ${RUNTIME_PYTHON_DIR}"
+    exit 1
+fi
+
+echo "Python: ${CANONICAL_VERSION}"
+echo "OpenSSL: ${CANONICAL_OPENSSL}"
+echo "Canonical interpreter: ${NATIVE_HOST_PYTHON}"
+echo "Build interpreter: ${PYTHON_BIN}"
+echo "Build base prefix: ${BUILD_BASE_PREFIX}"
+echo ""
 
 install_python_packages() {
     if command -v uv &>/dev/null; then
@@ -139,9 +186,6 @@ echo ""
 
 # Copy to Tauri resources directory
 echo "== Copying to Tauri binaries directory =="
-BINARIES_DIR="${REPO_ROOT}/console/src-tauri/binaries"
-mkdir -p "${BINARIES_DIR}"
-
 DEST="${BINARIES_DIR}/qwenpaw-backend"
 rm -rf "${DEST}"
 mkdir -p "${DEST}"
@@ -151,15 +195,9 @@ chmod +x "${DEST}/qwenpaw"
 echo "Copied to: ${DEST}"
 echo ""
 
-# Stage a standalone CPython (same X.Y/arch as this build's interpreter) so the
-# frozen backend can install third-party plugin dependencies at runtime.
-echo "== Staging bundled Python runtime =="
-"$PYTHON_BIN" "${REPO_ROOT}/scripts/pack-tauri/stage_python_runtime.py" \
-    --dest "${BINARIES_DIR}/python-runtime"
-
 # The Chrome Native Messaging host runs under this standalone interpreter,
 # outside the PyInstaller backend, so its dependencies must be installed here.
-NATIVE_HOST_PYTHON="${BINARIES_DIR}/python-runtime/python/bin/python3"
+echo "== Installing bundled Python helper dependencies =="
 "$NATIVE_HOST_PYTHON" -m pip install \
     --disable-pip-version-check \
     --no-input \

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -58,32 +58,19 @@ fi
 echo "== Creating PyInstaller build environment =="
 "$NATIVE_HOST_PYTHON" -m venv --clear "$BUILD_VENV"
 
-CANONICAL_VERSION=$("$NATIVE_HOST_PYTHON" -c 'import sys; print(sys.version)')
-BUILD_VERSION=$("$PYTHON_BIN" -c 'import sys; print(sys.version)')
-CANONICAL_OPENSSL=$("$NATIVE_HOST_PYTHON" -c 'import ssl; print(ssl.OPENSSL_VERSION)')
-BUILD_OPENSSL=$("$PYTHON_BIN" -c 'import ssl; print(ssl.OPENSSL_VERSION)')
-CANONICAL_BASE_PREFIX=$("$NATIVE_HOST_PYTHON" -c 'import os, sys; print(os.path.realpath(sys.base_prefix))')
+BUILD_IDENTITY=$("$PYTHON_BIN" -c \
+    'import ssl, sys; print(f"{sys.version} | {ssl.OPENSSL_VERSION}")')
 BUILD_BASE_PREFIX=$("$PYTHON_BIN" -c 'import os, sys; print(os.path.realpath(sys.base_prefix))')
 EXPECTED_BASE_PREFIX=$("$NATIVE_HOST_PYTHON" -c \
     'import os, sys; print(os.path.realpath(sys.argv[1]))' \
     "$RUNTIME_PYTHON_DIR")
 
-if [ "$CANONICAL_VERSION" != "$BUILD_VERSION" ]; then
-    echo "ERROR: Python version mismatch between bundled runtime and PyInstaller environment"
-    exit 1
-fi
-if [ "$CANONICAL_OPENSSL" != "$BUILD_OPENSSL" ]; then
-    echo "ERROR: OpenSSL mismatch between bundled runtime and PyInstaller environment"
-    exit 1
-fi
-if [ "$CANONICAL_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ] || \
-    [ "$BUILD_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ]; then
+if [ "$BUILD_BASE_PREFIX" != "$EXPECTED_BASE_PREFIX" ]; then
     echo "ERROR: PyInstaller environment was not created from ${RUNTIME_PYTHON_DIR}"
     exit 1
 fi
 
-echo "Python: ${CANONICAL_VERSION}"
-echo "OpenSSL: ${CANONICAL_OPENSSL}"
+echo "Runtime: ${BUILD_IDENTITY}"
 echo "Canonical interpreter: ${NATIVE_HOST_PYTHON}"
 echo "Build interpreter: ${PYTHON_BIN}"
 echo "Build base prefix: ${BUILD_BASE_PREFIX}"

--- a/scripts/pack-tauri/stage_python_runtime.py
+++ b/scripts/pack-tauri/stage_python_runtime.py
@@ -9,8 +9,10 @@ at runtime we ship a standalone CPython (python-build-standalone) whose
 with it (see ``qwenpaw.plugins.loader``).
 
 This script downloads the matching ``install_only`` build and extracts it to
-``<dest>/python``. Run it with the SAME interpreter used for the PyInstaller
-build so the bundled runtime version matches automatically.
+``<dest>/python``. The desktop build scripts use their bootstrap interpreter
+only to select the requested ``X.Y``; they then create the PyInstaller build
+environment from this staged interpreter. This makes python-build-standalone
+the shared binary source for both the frozen backend and the helper runtime.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Description

Make the Tauri desktop backend and bundled helper derive from the same pinned python-build-standalone runtime.

- Stage the standalone runtime before creating the PyInstaller environment.
- Create a disposable build venv from that staged interpreter.
- Run PyInstaller from the disposable venv and keep the staged interpreter as the shipped helper runtime.

This keeps the desktop Python major/minor at 3.11 while aligning both packaged paths on the same Python/OpenSSL payload.

**Related Issue:** Relates to #7298

**Security Considerations:** No security boundary or credential handling changes. The change only controls the binary source used by desktop packaging.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```text
git diff --check
PowerShell parser: passed
bash -n scripts/pack-tauri/build_pyinstaller.sh
python -m py_compile scripts/pack-tauri/stage_python_runtime.py
python -m ruff check --ignore UP009 scripts/pack-tauri/stage_python_runtime.py
python -m pytest tests/unit/tauri/test_pyinstaller_spec.py -q
# 3 passed
```

Origin desktop packaging run (Windows + macOS, OSS upload disabled): https://github.com/jinglinpeng/CoPaw/actions/runs/33142784536 — passed. The later commits only remove diagnostic assertions and do not change runtime selection or packaged inputs.

## Evidence

- Independent inspection of the Windows candidate found the backend and helper on Python 3.11.15 / OpenSSL 3.5.7 with matching Python and TLS runtime payloads.
- Windows and macOS packaging and desktop verification passed in the run above.
- The reporter installed the Windows candidate on the same machine and affected network; both formerly reset HTTPS endpoints completed TLS 1.3 without `WinError 10054`: https://github.com/agentscope-ai/QwenPaw/issues/7298#issuecomment-5452852495

## Additional Notes

This PR does not change Python major/minor pins, dependencies, PyPI packaging, or application runtime behavior.
