### PR TITLE
feat(console): auto-fold assistant process messages

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3196,6 +3196,12 @@
     "chatHistoryTooltip": "Chat history",
     "wideModeTooltip": "Wide mode",
     "normalModeTooltip": "Normal mode",
+    "messageDisplay": {
+      "stepsRunning": "Running… · {{count}} steps",
+      "stepsCanceled": "Canceled · {{count}} steps",
+      "stepsFailed": "Failed · {{count}} steps",
+      "stepsCompleted": "Completed {{count}} steps"
+    },
     "allChats": "All Chats",
     "createNewChat": "Create New Chat",
     "pinDrawer": "Pin",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -631,6 +631,12 @@
     "chatHistoryTooltip": "Riwayat chat",
     "wideModeTooltip": "Mode lebar",
     "normalModeTooltip": "Mode normal",
+    "messageDisplay": {
+      "stepsRunning": "Berjalan… · {{count}} langkah",
+      "stepsCanceled": "Dibatalkan · {{count}} langkah",
+      "stepsFailed": "Gagal · {{count}} langkah",
+      "stepsCompleted": "Selesai {{count}} langkah"
+    },
     "allChats": "Semua Chat",
     "createNewChat": "Buat Chat Baru",
     "pinDrawer": "Sematkan",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2610,6 +2610,12 @@
     "chatHistoryTooltip": "チャット履歴",
     "wideModeTooltip": "ワイドモード",
     "normalModeTooltip": "標準モード",
+    "messageDisplay": {
+      "stepsRunning": "実行中… · {{count}} ステップ",
+      "stepsCanceled": "キャンセル済み · {{count}} ステップ",
+      "stepsFailed": "実行失敗 · {{count}} ステップ",
+      "stepsCompleted": "{{count}} ステップ完了"
+    },
     "allChats": "すべてのチャット",
     "createNewChat": "新しいチャットを作成",
     "pinDrawer": "固定",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2854,6 +2854,12 @@
     "chatHistoryTooltip": "Chat history",
     "wideModeTooltip": "Modo amplo",
     "normalModeTooltip": "Modo normal",
+    "messageDisplay": {
+      "stepsRunning": "Em execução… · {{count}} etapas",
+      "stepsCanceled": "Cancelado · {{count}} etapas",
+      "stepsFailed": "Falhou · {{count}} etapas",
+      "stepsCompleted": "{{count}} etapas concluídas"
+    },
     "allChats": "Todos Chats",
     "createNewChat": "Criar Novo Chat",
     "pinDrawer": "Fixar",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2625,6 +2625,12 @@
     "chatHistoryTooltip": "История чатов",
     "wideModeTooltip": "Широкий режим",
     "normalModeTooltip": "Обычный режим",
+    "messageDisplay": {
+      "stepsRunning": "Выполняется… · шагов: {{count}}",
+      "stepsCanceled": "Отменено · шагов: {{count}}",
+      "stepsFailed": "Ошибка · шагов: {{count}}",
+      "stepsCompleted": "Выполнено шагов: {{count}}"
+    },
     "allChats": "Все чаты",
     "createNewChat": "Создать новый чат",
     "pinDrawer": "Закрепить",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -645,6 +645,12 @@
     "newChatTooltip": "Cuộc trò chuyện mới",
     "searchTooltip": "Tìm kiếm tất cả cuộc trò chuyện",
     "chatHistoryTooltip": "Lịch sử trò chuyện",
+    "messageDisplay": {
+      "stepsRunning": "Đang chạy… · {{count}} bước",
+      "stepsCanceled": "Đã hủy · {{count}} bước",
+      "stepsFailed": "Thất bại · {{count}} bước",
+      "stepsCompleted": "Đã hoàn thành {{count}} bước"
+    },
     "allChats": "Tất cả cuộc trò chuyện",
     "createNewChat": "Tạo cuộc trò chuyện mới",
     "pinDrawer": "Ghim",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3053,6 +3053,12 @@
     "chatHistoryTooltip": "聊天历史",
     "wideModeTooltip": "宽屏模式",
     "normalModeTooltip": "正常模式",
+    "messageDisplay": {
+      "stepsRunning": "正在执行中… · {{count}} 个步骤",
+      "stepsCanceled": "已取消 · {{count}} 个步骤",
+      "stepsFailed": "执行失败 · {{count}} 个步骤",
+      "stepsCompleted": "已完成 {{count}} 个步骤"
+    },
     "allChats": "全部聊天",
     "createNewChat": "创建新聊天",
     "pinDrawer": "固定",

--- a/console/src/pages/Chat/HostBubbles.module.less
+++ b/console/src/pages/Chat/HostBubbles.module.less
@@ -22,8 +22,11 @@
       background-color: transparent;
     }
 
-    :global([class$="-accordion-group-icon-success"]) {
-      color: #52c41a;
+    /* Beat the dark chat blanket `span { color: ... !important }` rule. */
+    :global(
+        [class$="-accordion-group-icon-success"][class$="-accordion-group-icon-success"][class$="-accordion-group-icon-success"]
+      ) {
+      color: #52c41a !important;
     }
   }
 }

--- a/console/src/pages/Chat/HostBubbles.module.less
+++ b/console/src/pages/Chat/HostBubbles.module.less
@@ -1,0 +1,17 @@
+.collapsedSteps {
+  width: calc(100% + 8px);
+  margin-left: -8px;
+
+  /* Closed headers add a 1px border; keep both content baselines equal. */
+  :global([class$="-accordion-group-header-close"]) {
+    padding-left: 8px;
+  }
+
+  :global([class$="-accordion-group-header-open"]) {
+    padding-left: 9px;
+  }
+
+  :global([class$="-accordion-group-open"]) {
+    border: 0;
+  }
+}

--- a/console/src/pages/Chat/HostBubbles.module.less
+++ b/console/src/pages/Chat/HostBubbles.module.less
@@ -16,8 +16,14 @@
   }
 
   :global(.dark-mode) & {
+    :global([class$="-accordion-group-header-close"]),
+    :global([class$="-accordion-group-header-open"]),
     :global([class$="-accordion-group-open"]) {
       background-color: transparent;
+    }
+
+    :global([class$="-accordion-group-icon-success"]) {
+      color: #52c41a;
     }
   }
 }

--- a/console/src/pages/Chat/HostBubbles.module.less
+++ b/console/src/pages/Chat/HostBubbles.module.less
@@ -14,4 +14,10 @@
   :global([class$="-accordion-group-open"]) {
     border: 0;
   }
+
+  :global(.dark-mode) & {
+    :global([class$="-accordion-group-open"]) {
+      background-color: transparent;
+    }
+  }
 }

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -256,6 +256,13 @@ function DefaultHostResponseCard({
         const presentation = getCollapsedStepPresentation(groupStatus);
         const firstId = block.messages[0]?.id ?? index;
         const stepCount = countCollapsedSteps(block.messages);
+        if (stepCount === 0) {
+          return (
+            <React.Fragment key={`messages-${firstId}`}>
+              {block.messages.map(renderResponseMessage)}
+            </React.Fragment>
+          );
+        }
         return (
           <LazyAccordion
             className={styles.collapsedSteps}

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -32,8 +32,9 @@ import { useChatAnywhereOptions } from "@agentscope-ai/chat/lib/AgentScopeRuntim
 import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
 import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
 import Files from "@agentscope-ai/chat/lib/DefaultCards/Files";
-import { Bubble, Markdown } from "@agentscope-ai/chat";
+import { Accordion, Bubble, Markdown } from "@agentscope-ai/chat";
 import { Avatar, Flex } from "antd";
+import { useTranslation } from "react-i18next";
 import { renderableCodeComponents } from "../../components/RenderableCodeBlock";
 // Vendor `.d.ts` doesn't yet describe the request content slots.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,6 +51,17 @@ import type {
 } from "../../plugins/registry/types";
 import { DownloadableAudios } from "../../components/Chat/MediaDownload";
 import ResponseArtifactList from "../../features/files-workspace/ResponseArtifactList";
+import {
+  countCollapsedSteps,
+  findActiveStepBlockIndex,
+  findLastStepBlockIndex,
+  getCollapsedGroupStatus,
+  getCollapsedStepPresentation,
+  getCollapsedStepRenderKey,
+  getResponseMessageDisplayMode,
+  groupResponseMessages,
+} from "./messageDisplay";
+import styles from "./HostBubbles.module.less";
 
 function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
   return arr
@@ -161,6 +173,31 @@ const HostMessage = React.memo(function HostMessage({
   );
 });
 
+function renderResponseMessage(item: IAgentScopeRuntimeMessage) {
+  switch (item.type) {
+    case AgentScopeRuntimeMessageType.MESSAGE:
+      return <HostMessage key={item.id} data={item} />;
+    case AgentScopeRuntimeMessageType.PLUGIN_CALL:
+    case AgentScopeRuntimeMessageType.PLUGIN_CALL_OUTPUT:
+    case AgentScopeRuntimeMessageType.TOOL_CALL:
+    case AgentScopeRuntimeMessageType.TOOL_CALL_OUTPUT:
+    case AgentScopeRuntimeMessageType.MCP_CALL:
+    case AgentScopeRuntimeMessageType.MCP_CALL_OUTPUT:
+      return <ResponseTool key={item.id} data={item} />;
+    case AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST:
+      return <ResponseTool key={item.id} data={item} isApproval />;
+    case AgentScopeRuntimeMessageType.REASONING:
+      return <ResponseReasoning key={item.id} data={item} />;
+    case AgentScopeRuntimeMessageType.ERROR:
+      return <ResponseError key={item.id} data={item} />;
+    case AgentScopeRuntimeMessageType.HEARTBEAT:
+      return null;
+    default:
+      console.warn(`[WIP] Unknown message type: ${item.type}`);
+      return null;
+  }
+}
+
 function DefaultHostResponseCard({
   data,
   isLast,
@@ -172,12 +209,23 @@ function DefaultHostResponseCard({
   contentPrepend?: React.ReactNode;
   contentAppend?: React.ReactNode;
 }) {
+  const { t } = useTranslation();
   const avatar = useChatAnywhereOptions((options) => options.welcome?.avatar);
   const nick = useChatAnywhereOptions((options) => options.welcome?.nick);
   const messages = useMemo(
     () => AgentScopeRuntimeResponseBuilder.mergeToolMessages(data.output),
     [data.output],
   );
+  const messageDisplayMode = getResponseMessageDisplayMode(data.status);
+  const messageBlocks = useMemo(
+    () => groupResponseMessages(messages, messageDisplayMode),
+    [messageDisplayMode, messages],
+  );
+  const activeStepBlockIndex = findActiveStepBlockIndex(messageBlocks);
+  const statusStepBlockIndex =
+    messageDisplayMode === "text-only"
+      ? activeStepBlockIndex
+      : findLastStepBlockIndex(messageBlocks);
 
   if (
     !messages.length &&
@@ -195,29 +243,38 @@ function DefaultHostResponseCard({
         </Flex>
       ) : null}
       {contentPrepend}
-      {messages.map((item) => {
-        switch (item.type) {
-          case AgentScopeRuntimeMessageType.MESSAGE:
-            return <HostMessage key={item.id} data={item} />;
-          case AgentScopeRuntimeMessageType.PLUGIN_CALL:
-          case AgentScopeRuntimeMessageType.PLUGIN_CALL_OUTPUT:
-          case AgentScopeRuntimeMessageType.TOOL_CALL:
-          case AgentScopeRuntimeMessageType.TOOL_CALL_OUTPUT:
-          case AgentScopeRuntimeMessageType.MCP_CALL:
-          case AgentScopeRuntimeMessageType.MCP_CALL_OUTPUT:
-            return <ResponseTool key={item.id} data={item} />;
-          case AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST:
-            return <ResponseTool key={item.id} data={item} isApproval />;
-          case AgentScopeRuntimeMessageType.REASONING:
-            return <ResponseReasoning key={item.id} data={item} />;
-          case AgentScopeRuntimeMessageType.ERROR:
-            return <ResponseError key={item.id} data={item} />;
-          case AgentScopeRuntimeMessageType.HEARTBEAT:
-            return null;
-          default:
-            console.warn(`[WIP] Unknown message type: ${item.type}`);
-            return null;
+      {messageBlocks.map((block, index) => {
+        if (block.kind === "message") {
+          return renderResponseMessage(block.message);
         }
+
+        const groupStatus = getCollapsedGroupStatus(
+          data.status,
+          index === statusStepBlockIndex,
+        );
+        const presentation = getCollapsedStepPresentation(groupStatus);
+        const firstId = block.messages[0]?.id ?? index;
+        const stepCount = countCollapsedSteps(block.messages);
+        return (
+          <div
+            className={styles.collapsedSteps}
+            key={getCollapsedStepRenderKey(
+              firstId,
+              messageDisplayMode,
+              presentation.status,
+            )}
+          >
+            <Accordion
+              status={presentation.status}
+              title={t(presentation.titleKey, {
+                count: stepCount,
+              })}
+              defaultOpen={presentation.defaultOpen}
+            >
+              <>{block.messages.map(renderResponseMessage)}</>
+            </Accordion>
+          </div>
+        );
       })}
       {data.error ? <ResponseError data={data.error} /> : null}
       {contentAppend}

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -32,7 +32,7 @@ import { useChatAnywhereOptions } from "@agentscope-ai/chat/lib/AgentScopeRuntim
 import Images from "@agentscope-ai/chat/lib/DefaultCards/Images";
 import Videos from "@agentscope-ai/chat/lib/DefaultCards/Videos";
 import Files from "@agentscope-ai/chat/lib/DefaultCards/Files";
-import { Accordion, Bubble, Markdown } from "@agentscope-ai/chat";
+import { Bubble, Markdown } from "@agentscope-ai/chat";
 import { Avatar, Flex } from "antd";
 import { useTranslation } from "react-i18next";
 import { renderableCodeComponents } from "../../components/RenderableCodeBlock";
@@ -62,6 +62,7 @@ import {
   groupResponseMessages,
 } from "./messageDisplay";
 import styles from "./HostBubbles.module.less";
+import LazyAccordion from "./LazyAccordion";
 
 function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
   return arr
@@ -256,24 +257,22 @@ function DefaultHostResponseCard({
         const firstId = block.messages[0]?.id ?? index;
         const stepCount = countCollapsedSteps(block.messages);
         return (
-          <div
+          <LazyAccordion
             className={styles.collapsedSteps}
             key={getCollapsedStepRenderKey(
               firstId,
               messageDisplayMode,
               presentation.status,
             )}
-          >
-            <Accordion
-              status={presentation.status}
-              title={t(presentation.titleKey, {
-                count: stepCount,
-              })}
-              defaultOpen={presentation.defaultOpen}
-            >
+            status={presentation.status}
+            title={t(presentation.titleKey, {
+              count: stepCount,
+            })}
+            defaultOpen={presentation.defaultOpen}
+            renderChildren={() => (
               <>{block.messages.map(renderResponseMessage)}</>
-            </Accordion>
-          </div>
+            )}
+          />
         );
       })}
       {data.error ? <ResponseError data={data.error} /> : null}

--- a/console/src/pages/Chat/LazyAccordion.test.tsx
+++ b/console/src/pages/Chat/LazyAccordion.test.tsx
@@ -13,18 +13,20 @@ vi.mock("@agentscope-ai/chat", () => ({
     open: boolean;
     title: string;
   }) => (
-    <div
-      className={`sdk-accordion-group sdk-accordion-group-${
-        open ? "open" : "close"
-      }`}
-    >
-      <button
-        className={`sdk-accordion-group-header-${open ? "open" : "close"}`}
-        type="button"
+    <div data-testid="vendor-shell">
+      <div
+        className={`sdk-accordion-group sdk-accordion-group-${
+          open ? "open" : "close"
+        }`}
       >
-        {title}
-      </button>
-      <div>{children}</div>
+        <button
+          className={`sdk-accordion-group-header-${open ? "open" : "close"}`}
+          type="button"
+        >
+          {title}
+        </button>
+        <div>{children}</div>
+      </div>
     </div>
   ),
 }));
@@ -42,6 +44,19 @@ describe("LazyAccordion", () => {
 
     expect(renderChildren).toHaveBeenCalledTimes(1);
     expect(screen.getByText("expensive process content")).toBeInTheDocument();
+  });
+
+  it("does not depend on the vendor group being a direct wrapper child", () => {
+    render(
+      <LazyAccordion
+        title="Wrapped group"
+        renderChildren={() => <div>wrapped content</div>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Wrapped group" }));
+
+    expect(screen.getByText("wrapped content")).toBeInTheDocument();
   });
 
   it("unmounts process children when the group closes again", () => {

--- a/console/src/pages/Chat/LazyAccordion.test.tsx
+++ b/console/src/pages/Chat/LazyAccordion.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LazyAccordion from "./LazyAccordion";
+
+vi.mock("@agentscope-ai/chat", () => ({
+  Accordion: ({
+    children,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) => (
+    <div
+      className={`sdk-accordion-group sdk-accordion-group-${
+        open ? "open" : "close"
+      }`}
+    >
+      <button
+        className={`sdk-accordion-group-header-${open ? "open" : "close"}`}
+        type="button"
+      >
+        {title}
+      </button>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
+describe("LazyAccordion", () => {
+  it("does not render process children until the closed group is opened", () => {
+    const renderChildren = vi.fn(() => <div>expensive process content</div>);
+
+    render(<LazyAccordion title="4 steps" renderChildren={renderChildren} />);
+
+    expect(renderChildren).not.toHaveBeenCalled();
+    expect(screen.queryByText("expensive process content")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "4 steps" }));
+
+    expect(renderChildren).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("expensive process content")).toBeInTheDocument();
+  });
+
+  it("unmounts process children when the group closes again", () => {
+    const renderChildren = vi.fn(() => <div>process content</div>);
+
+    render(
+      <LazyAccordion
+        defaultOpen
+        title="Running"
+        renderChildren={renderChildren}
+      />,
+    );
+    expect(screen.getByText("process content")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Running" }));
+
+    expect(screen.queryByText("process content")).toBeNull();
+  });
+
+  it("ignores clicks on an accordion nested inside process content", () => {
+    render(
+      <LazyAccordion
+        defaultOpen
+        title="Outer steps"
+        renderChildren={() => (
+          <div className="sdk-accordion-group">
+            <button className="sdk-accordion-group-header-close" type="button">
+              Nested tool
+            </button>
+          </div>
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Nested tool" }));
+
+    expect(screen.getByRole("button", { name: "Nested tool" })).toBeVisible();
+  });
+});

--- a/console/src/pages/Chat/LazyAccordion.tsx
+++ b/console/src/pages/Chat/LazyAccordion.tsx
@@ -32,8 +32,10 @@ export default function LazyAccordion({
     if (!(event.target instanceof Element)) return;
     const header = event.target.closest(HEADER_SELECTOR);
 
-    // Ignore headers belonging to nested tool/reasoning accordions.
-    if (header?.parentElement?.parentElement !== event.currentTarget) return;
+    // The vendor contract exposes open/close header classes, but its wrapper
+    // depth is not stable. Only the first (outer) header controls this group;
+    // later headers belong to nested tool/reasoning accordions.
+    if (header !== event.currentTarget.querySelector(HEADER_SELECTOR)) return;
     setOpen((current) => !current);
   }, []);
 

--- a/console/src/pages/Chat/LazyAccordion.tsx
+++ b/console/src/pages/Chat/LazyAccordion.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useState } from "react";
+import { Accordion } from "@agentscope-ai/chat";
+
+type AccordionProps = React.ComponentProps<typeof Accordion>;
+
+interface LazyAccordionProps
+  extends Omit<AccordionProps, "children" | "defaultOpen" | "open"> {
+  className?: string;
+  defaultOpen?: boolean;
+  renderChildren: () => React.ReactElement;
+}
+
+const HEADER_SELECTOR =
+  '[class*="-accordion-group-header-open"], [class*="-accordion-group-header-close"]';
+
+/**
+ * Adds destroy-on-close semantics to the vendor Accordion.
+ *
+ * The vendor component always mounts its children and hides them with
+ * `height: 0`. Keeping this adapter controlled lets closed process groups
+ * avoid rendering reasoning, Markdown, and tool-card subtrees altogether.
+ */
+export default function LazyAccordion({
+  className,
+  defaultOpen = false,
+  renderChildren,
+  ...accordionProps
+}: LazyAccordionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof Element)) return;
+    const header = event.target.closest(HEADER_SELECTOR);
+
+    // Ignore headers belonging to nested tool/reasoning accordions.
+    if (header?.parentElement?.parentElement !== event.currentTarget) return;
+    setOpen((current) => !current);
+  }, []);
+
+  return (
+    <div className={className} onClick={handleClick}>
+      <Accordion {...accordionProps} open={open}>
+        <>{open ? renderChildren() : null}</>
+      </Accordion>
+    </div>
+  );
+}

--- a/console/src/pages/Chat/messageDisplay.test.ts
+++ b/console/src/pages/Chat/messageDisplay.test.ts
@@ -12,8 +12,6 @@ import {
   getCollapsedStepRenderKey,
   getResponseMessageDisplayMode,
   groupResponseMessages,
-  partitionResponseMessages,
-  selectVisibleResponseMessages,
 } from "./messageDisplay";
 
 function message(
@@ -42,8 +40,8 @@ describe("message display mode", () => {
     ];
 
     expect(
-      selectVisibleResponseMessages(messages, "text-only").map(
-        (item) => item.id,
+      groupResponseMessages(messages, "text-only").flatMap((block) =>
+        block.kind === "message" ? [block.message.id] : [],
       ),
     ).toEqual(["first", "approval", "error", "last"]);
   });
@@ -58,8 +56,8 @@ describe("message display mode", () => {
     ];
 
     expect(
-      selectVisibleResponseMessages(messages, "result-only").map(
-        (item) => item.id,
+      groupResponseMessages(messages, "result-only").flatMap((block) =>
+        block.kind === "message" ? [block.message.id] : [],
       ),
     ).toEqual(["approval", "last", "error"]);
   });
@@ -104,8 +102,8 @@ describe("message display mode", () => {
     ];
 
     expect(
-      selectVisibleResponseMessages(messages, "result-only").map(
-        (item) => item.id,
+      groupResponseMessages(messages, "result-only").flatMap((block) =>
+        block.kind === "message" ? [block.message.id] : [],
       ),
     ).toEqual(["error"]);
   });
@@ -118,19 +116,34 @@ describe("message display mode", () => {
       message("last", AgentScopeRuntimeMessageType.MESSAGE),
     ];
 
-    const textOnly = partitionResponseMessages(messages, "text-only");
-    expect(textOnly.collapsedMessages.map((item) => item.id)).toEqual([
-      "reasoning",
-      "tool",
-    ]);
+    const collapsedIds = (mode: "text-only" | "result-only") =>
+      groupResponseMessages(messages, mode).flatMap((block) =>
+        block.kind === "steps" ? block.messages.map((item) => item.id) : [],
+      );
 
-    const resultOnly = partitionResponseMessages(messages, "result-only");
-    expect(resultOnly.collapsedMessages.map((item) => item.id)).toEqual([
-      "first",
-      "reasoning",
-      "tool",
-    ]);
-    expect(countCollapsedSteps(resultOnly.collapsedMessages)).toBe(2);
+    expect(collapsedIds("text-only")).toEqual(["reasoning", "tool"]);
+    expect(collapsedIds("result-only")).toEqual(["first", "reasoning", "tool"]);
+    expect(
+      countCollapsedSteps(
+        groupResponseMessages(messages, "result-only").flatMap((block) =>
+          block.kind === "steps" ? block.messages : [],
+        ),
+      ),
+    ).toBe(2);
+  });
+
+  it("identifies an earlier pure-text run as having no process steps", () => {
+    const blocks = groupResponseMessages(
+      [
+        message("first", AgentScopeRuntimeMessageType.MESSAGE),
+        message("last", AgentScopeRuntimeMessageType.MESSAGE),
+      ],
+      "result-only",
+    );
+
+    expect(blocks[0].kind).toBe("steps");
+    if (blocks[0].kind !== "steps") throw new Error("Expected a steps block");
+    expect(countCollapsedSteps(blocks[0].messages)).toBe(0);
   });
 
   it("groups consecutive steps around each visible text message", () => {

--- a/console/src/pages/Chat/messageDisplay.test.ts
+++ b/console/src/pages/Chat/messageDisplay.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentScopeRuntimeMessageType,
+  AgentScopeRuntimeRunStatus,
+} from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types";
+import {
+  countCollapsedSteps,
+  findActiveStepBlockIndex,
+  findLastStepBlockIndex,
+  getCollapsedGroupStatus,
+  getCollapsedStepPresentation,
+  getCollapsedStepRenderKey,
+  getResponseMessageDisplayMode,
+  groupResponseMessages,
+  partitionResponseMessages,
+  selectVisibleResponseMessages,
+} from "./messageDisplay";
+
+function message(
+  id: string,
+  type: AgentScopeRuntimeMessageType,
+  status: AgentScopeRuntimeRunStatus = AgentScopeRuntimeRunStatus.Completed,
+) {
+  return {
+    id,
+    type,
+    content: [],
+    role: "assistant",
+    status,
+  } as never;
+}
+
+describe("message display mode", () => {
+  it("keeps text, approvals, and errors in text-only mode", () => {
+    const messages = [
+      message("reasoning", AgentScopeRuntimeMessageType.REASONING),
+      message("first", AgentScopeRuntimeMessageType.MESSAGE),
+      message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("approval", AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST),
+      message("error", AgentScopeRuntimeMessageType.ERROR),
+      message("last", AgentScopeRuntimeMessageType.MESSAGE),
+    ];
+
+    expect(
+      selectVisibleResponseMessages(messages, "text-only").map(
+        (item) => item.id,
+      ),
+    ).toEqual(["first", "approval", "error", "last"]);
+  });
+
+  it("keeps only the latest text plus approvals and errors in result mode", () => {
+    const messages = [
+      message("first", AgentScopeRuntimeMessageType.MESSAGE),
+      message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("approval", AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST),
+      message("last", AgentScopeRuntimeMessageType.MESSAGE),
+      message("error", AgentScopeRuntimeMessageType.ERROR),
+    ];
+
+    expect(
+      selectVisibleResponseMessages(messages, "result-only").map(
+        (item) => item.id,
+      ),
+    ).toEqual(["approval", "last", "error"]);
+  });
+
+  it("derives the display mode only from the response SSE status", () => {
+    expect(
+      getResponseMessageDisplayMode(AgentScopeRuntimeRunStatus.Created),
+    ).toBe("text-only");
+    expect(
+      getResponseMessageDisplayMode(AgentScopeRuntimeRunStatus.InProgress),
+    ).toBe("text-only");
+    expect(
+      getResponseMessageDisplayMode(AgentScopeRuntimeRunStatus.Completed),
+    ).toBe("result-only");
+    expect(
+      getResponseMessageDisplayMode(AgentScopeRuntimeRunStatus.Canceled),
+    ).toBe("result-only");
+    expect(
+      getResponseMessageDisplayMode(AgentScopeRuntimeRunStatus.Failed),
+    ).toBe("result-only");
+  });
+
+  it("remounts collapsed steps when streaming enters the result phase", () => {
+    const streamingKey = getCollapsedStepRenderKey(
+      "reasoning",
+      "text-only",
+      "finished",
+    );
+    const resultKey = getCollapsedStepRenderKey(
+      "reasoning",
+      "result-only",
+      "finished",
+    );
+
+    expect(resultKey).not.toBe(streamingKey);
+  });
+
+  it("returns critical messages when a result has no text", () => {
+    const messages = [
+      message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("error", AgentScopeRuntimeMessageType.ERROR),
+    ];
+
+    expect(
+      selectVisibleResponseMessages(messages, "result-only").map(
+        (item) => item.id,
+      ),
+    ).toEqual(["error"]);
+  });
+
+  it("keeps filtered process messages available for manual expansion", () => {
+    const messages = [
+      message("first", AgentScopeRuntimeMessageType.MESSAGE),
+      message("reasoning", AgentScopeRuntimeMessageType.REASONING),
+      message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("last", AgentScopeRuntimeMessageType.MESSAGE),
+    ];
+
+    const textOnly = partitionResponseMessages(messages, "text-only");
+    expect(textOnly.collapsedMessages.map((item) => item.id)).toEqual([
+      "reasoning",
+      "tool",
+    ]);
+
+    const resultOnly = partitionResponseMessages(messages, "result-only");
+    expect(resultOnly.collapsedMessages.map((item) => item.id)).toEqual([
+      "first",
+      "reasoning",
+      "tool",
+    ]);
+    expect(countCollapsedSteps(resultOnly.collapsedMessages)).toBe(2);
+  });
+
+  it("groups consecutive steps around each visible text message", () => {
+    const messages = [
+      message("reasoning-1", AgentScopeRuntimeMessageType.REASONING),
+      message("tool-1", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("text-1", AgentScopeRuntimeMessageType.MESSAGE),
+      message("reasoning-2", AgentScopeRuntimeMessageType.REASONING),
+      message("tool-2", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("tool-3", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("text-2", AgentScopeRuntimeMessageType.MESSAGE),
+    ];
+
+    const blocks = groupResponseMessages(messages, "text-only");
+    expect(
+      blocks.map((block) =>
+        block.kind === "message"
+          ? `message:${block.message.id}`
+          : `steps:${block.messages.map((item) => item.id).join(",")}`,
+      ),
+    ).toEqual([
+      "steps:reasoning-1,tool-1",
+      "message:text-1",
+      "steps:reasoning-2,tool-2,tool-3",
+      "message:text-2",
+    ]);
+  });
+
+  it("uses approvals and errors as visible group boundaries", () => {
+    const messages = [
+      message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+      message("approval", AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST),
+      message("reasoning", AgentScopeRuntimeMessageType.REASONING),
+      message("error", AgentScopeRuntimeMessageType.ERROR),
+    ];
+
+    expect(
+      groupResponseMessages(messages, "text-only").map((block) =>
+        block.kind === "message"
+          ? `message:${block.message.id}`
+          : `steps:${block.messages.length}`,
+      ),
+    ).toEqual(["steps:1", "message:approval", "steps:1", "message:error"]);
+  });
+
+  it("uses only the response SSE status for the active step group", () => {
+    expect(
+      getCollapsedGroupStatus(AgentScopeRuntimeRunStatus.InProgress, false),
+    ).toBe(AgentScopeRuntimeRunStatus.Completed);
+    expect(
+      getCollapsedGroupStatus(AgentScopeRuntimeRunStatus.InProgress, true),
+    ).toBe(AgentScopeRuntimeRunStatus.InProgress);
+    expect(
+      getCollapsedGroupStatus(AgentScopeRuntimeRunStatus.Canceled, true),
+    ).toBe(AgentScopeRuntimeRunStatus.Canceled);
+    expect(
+      getCollapsedGroupStatus(AgentScopeRuntimeRunStatus.Failed, true),
+    ).toBe(AgentScopeRuntimeRunStatus.Failed);
+  });
+
+  it("keeps the latest step group active until following text arrives", () => {
+    const runningBlocks = groupResponseMessages(
+      [
+        message("text-1", AgentScopeRuntimeMessageType.MESSAGE),
+        message("tool-1", AgentScopeRuntimeMessageType.TOOL_CALL),
+        message("tool-2", AgentScopeRuntimeMessageType.TOOL_CALL_OUTPUT),
+      ],
+      "text-only",
+    );
+    expect(findActiveStepBlockIndex(runningBlocks)).toBe(1);
+
+    const completedBlocks = groupResponseMessages(
+      [
+        message("text-1", AgentScopeRuntimeMessageType.MESSAGE),
+        message("tool", AgentScopeRuntimeMessageType.TOOL_CALL),
+        message("text-2", AgentScopeRuntimeMessageType.MESSAGE),
+      ],
+      "text-only",
+    );
+    expect(findActiveStepBlockIndex(completedBlocks)).toBe(-1);
+    expect(findLastStepBlockIndex(completedBlocks)).toBe(1);
+  });
+
+  it.each([
+    [
+      AgentScopeRuntimeRunStatus.InProgress,
+      "generating",
+      "chat.messageDisplay.stepsRunning",
+      true,
+    ],
+    [
+      AgentScopeRuntimeRunStatus.Canceled,
+      "interrupted",
+      "chat.messageDisplay.stepsCanceled",
+      false,
+    ],
+    [
+      AgentScopeRuntimeRunStatus.Failed,
+      "error",
+      "chat.messageDisplay.stepsFailed",
+      false,
+    ],
+    [
+      AgentScopeRuntimeRunStatus.Completed,
+      "finished",
+      "chat.messageDisplay.stepsCompleted",
+      false,
+    ],
+  ])(
+    "maps %s responses to the collapsed step state",
+    (runStatus, status, key, defaultOpen) => {
+      expect(getCollapsedStepPresentation(runStatus)).toEqual({
+        status,
+        titleKey: key,
+        defaultOpen,
+      });
+    },
+  );
+});

--- a/console/src/pages/Chat/messageDisplay.ts
+++ b/console/src/pages/Chat/messageDisplay.ts
@@ -25,11 +25,6 @@ function isAlwaysVisible(message: IAgentScopeRuntimeMessage): boolean {
   );
 }
 
-export interface PartitionedResponseMessages {
-  visibleMessages: IAgentScopeRuntimeMessage[];
-  collapsedMessages: IAgentScopeRuntimeMessage[];
-}
-
 export type ResponseMessageBlock =
   | { kind: "message"; message: IAgentScopeRuntimeMessage }
   | { kind: "steps"; messages: IAgentScopeRuntimeMessage[] };
@@ -163,30 +158,4 @@ export function groupResponseMessages(
   });
   flushCollapsedRun();
   return blocks;
-}
-
-/** Partition response messages without mutating the runtime response. */
-export function partitionResponseMessages(
-  messages: IAgentScopeRuntimeMessage[],
-  mode: ResponseMessageDisplayMode,
-): PartitionedResponseMessages {
-  const visibleMessages: IAgentScopeRuntimeMessage[] = [];
-  const collapsedMessages: IAgentScopeRuntimeMessage[] = [];
-  groupResponseMessages(messages, mode).forEach((block) => {
-    if (block.kind === "message") {
-      visibleMessages.push(block.message);
-    } else {
-      collapsedMessages.push(...block.messages);
-    }
-  });
-
-  return { visibleMessages, collapsedMessages };
-}
-
-/** Select response messages without mutating the runtime response. */
-export function selectVisibleResponseMessages(
-  messages: IAgentScopeRuntimeMessage[],
-  mode: ResponseMessageDisplayMode,
-): IAgentScopeRuntimeMessage[] {
-  return partitionResponseMessages(messages, mode).visibleMessages;
 }

--- a/console/src/pages/Chat/messageDisplay.ts
+++ b/console/src/pages/Chat/messageDisplay.ts
@@ -1,0 +1,192 @@
+import {
+  AgentScopeRuntimeMessageType,
+  AgentScopeRuntimeRunStatus,
+  type IAgentScopeRuntimeMessage,
+} from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types";
+
+export type ResponseMessageDisplayMode = "text-only" | "result-only";
+
+export function getResponseMessageDisplayMode(
+  responseStatus: AgentScopeRuntimeRunStatus,
+): ResponseMessageDisplayMode {
+  if (
+    responseStatus === AgentScopeRuntimeRunStatus.Created ||
+    responseStatus === AgentScopeRuntimeRunStatus.InProgress
+  ) {
+    return "text-only";
+  }
+  return "result-only";
+}
+
+function isAlwaysVisible(message: IAgentScopeRuntimeMessage): boolean {
+  return (
+    message.type === AgentScopeRuntimeMessageType.MCP_APPROVAL_REQUEST ||
+    message.type === AgentScopeRuntimeMessageType.ERROR
+  );
+}
+
+export interface PartitionedResponseMessages {
+  visibleMessages: IAgentScopeRuntimeMessage[];
+  collapsedMessages: IAgentScopeRuntimeMessage[];
+}
+
+export type ResponseMessageBlock =
+  | { kind: "message"; message: IAgentScopeRuntimeMessage }
+  | { kind: "steps"; messages: IAgentScopeRuntimeMessage[] };
+
+export interface CollapsedStepPresentation {
+  status: "finished" | "interrupted" | "generating" | "error";
+  titleKey: string;
+  defaultOpen: boolean;
+}
+
+export function getCollapsedStepRenderKey(
+  firstId: string | number,
+  mode: ResponseMessageDisplayMode,
+  status: CollapsedStepPresentation["status"],
+): string {
+  return `steps-${firstId}-${mode}-${status}`;
+}
+
+export function getCollapsedStepPresentation(
+  status: AgentScopeRuntimeRunStatus,
+): CollapsedStepPresentation {
+  if (
+    status === AgentScopeRuntimeRunStatus.Created ||
+    status === AgentScopeRuntimeRunStatus.InProgress
+  ) {
+    return {
+      status: "generating",
+      titleKey: "chat.messageDisplay.stepsRunning",
+      defaultOpen: true,
+    };
+  }
+  if (status === AgentScopeRuntimeRunStatus.Failed) {
+    return {
+      status: "error",
+      titleKey: "chat.messageDisplay.stepsFailed",
+      defaultOpen: false,
+    };
+  }
+  if (
+    status === AgentScopeRuntimeRunStatus.Canceled ||
+    status === AgentScopeRuntimeRunStatus.Rejected
+  ) {
+    return {
+      status: "interrupted",
+      titleKey: "chat.messageDisplay.stepsCanceled",
+      defaultOpen: false,
+    };
+  }
+  return {
+    status: "finished",
+    titleKey: "chat.messageDisplay.stepsCompleted",
+    defaultOpen: false,
+  };
+}
+
+export function getCollapsedGroupStatus(
+  responseStatus: AgentScopeRuntimeRunStatus,
+  isActiveGroup: boolean,
+): AgentScopeRuntimeRunStatus {
+  if (!isActiveGroup) return AgentScopeRuntimeRunStatus.Completed;
+  if (responseStatus === AgentScopeRuntimeRunStatus.Created) {
+    return AgentScopeRuntimeRunStatus.InProgress;
+  }
+  return responseStatus;
+}
+
+/** Find the latest step group that has no following assistant text. */
+export function findActiveStepBlockIndex(
+  blocks: ResponseMessageBlock[],
+): number {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (block.kind === "steps") return index;
+    if (block.message.type === AgentScopeRuntimeMessageType.MESSAGE) return -1;
+  }
+  return -1;
+}
+
+export function findLastStepBlockIndex(blocks: ResponseMessageBlock[]): number {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    if (blocks[index].kind === "steps") return index;
+  }
+  return -1;
+}
+
+export function countCollapsedSteps(
+  messages: IAgentScopeRuntimeMessage[],
+): number {
+  return messages.filter(
+    (message) => message.type !== AgentScopeRuntimeMessageType.MESSAGE,
+  ).length;
+}
+
+/** Group collapsed runs in their original position between visible messages. */
+export function groupResponseMessages(
+  messages: IAgentScopeRuntimeMessage[],
+  mode: ResponseMessageDisplayMode,
+): ResponseMessageBlock[] {
+  let lastMessageIndex = -1;
+  if (mode === "result-only") {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index].type === AgentScopeRuntimeMessageType.MESSAGE) {
+        lastMessageIndex = index;
+        break;
+      }
+    }
+  }
+
+  const blocks: ResponseMessageBlock[] = [];
+  let collapsedRun: IAgentScopeRuntimeMessage[] = [];
+  const flushCollapsedRun = () => {
+    if (!collapsedRun.length) return;
+    blocks.push({ kind: "steps", messages: collapsedRun });
+    collapsedRun = [];
+  };
+
+  messages.forEach((message, index) => {
+    if (message.type === AgentScopeRuntimeMessageType.HEARTBEAT) return;
+    const visible =
+      isAlwaysVisible(message) ||
+      (mode === "text-only" &&
+        message.type === AgentScopeRuntimeMessageType.MESSAGE) ||
+      (mode === "result-only" && index === lastMessageIndex);
+
+    if (visible) {
+      flushCollapsedRun();
+      blocks.push({ kind: "message", message });
+    } else {
+      collapsedRun.push(message);
+    }
+  });
+  flushCollapsedRun();
+  return blocks;
+}
+
+/** Partition response messages without mutating the runtime response. */
+export function partitionResponseMessages(
+  messages: IAgentScopeRuntimeMessage[],
+  mode: ResponseMessageDisplayMode,
+): PartitionedResponseMessages {
+  const visibleMessages: IAgentScopeRuntimeMessage[] = [];
+  const collapsedMessages: IAgentScopeRuntimeMessage[] = [];
+  groupResponseMessages(messages, mode).forEach((block) => {
+    if (block.kind === "message") {
+      visibleMessages.push(block.message);
+    } else {
+      collapsedMessages.push(...block.messages);
+    }
+  });
+
+  return { visibleMessages, collapsedMessages };
+}
+
+/** Select response messages without mutating the runtime response. */
+export function selectVisibleResponseMessages(
+  messages: IAgentScopeRuntimeMessage[],
+  mode: ResponseMessageDisplayMode,
+): IAgentScopeRuntimeMessage[] {
+  return partitionResponseMessages(messages, mode).visibleMessages;
+}


### PR DESCRIPTION
## Description

Automatically groups and folds assistant reasoning and tool-call steps while keeping user-facing text visible during streaming.

- Groups process messages by adjacent text boundaries.
- Shows running, completed, interrupted, and error states with step counts.
- Keeps the active SSE step group expanded and folds completed groups.
- Switches to the final-result view when streaming completes.
- Uses a controlled LazyAccordion that unmounts closed reasoning, Markdown, and tool-card subtrees.
- Preserves manual per-group expansion without adding borders around expanded content.

Performance traces with 100, 500, and 1000 synthetic conversation groups show approximately 27% fewer initial DOM nodes, 30% fewer post-SSE DOM nodes, and 31% to 62% lower accumulated SSE long-task time versus the pre-change version without folding.

**Related Issue:** None

**Security Considerations:** None. Console rendering behavior only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `npm test -- --run src/pages/Chat/LazyAccordion.test.tsx src/pages/Chat/messageDisplay.test.ts`
- `npx eslint src/pages/Chat/LazyAccordion.tsx src/pages/Chat/LazyAccordion.test.tsx src/pages/Chat/HostBubbles.tsx src/pages/Chat/messageDisplay.ts src/pages/Chat/messageDisplay.test.ts`
- `npx tsc -b --noEmit`

## Evidence

```text
Test Files  2 passed (2)
Tests       17 passed (17)
```

ESLint and TypeScript checks completed successfully with no output.

Performance report: https://alidocs.dingtalk.com/i/nodes/dpYLaezmVNRMGX56CKY959vxVrMqPxX6

## Additional Notes

The 1000-group trace was repeated three times and compared by median because browser wall-clock timing showed noticeable scheduling variance. DOM counts and main-thread long-task improvements remained consistent.