### PR TITLE
fix(governance): enforce File Guard paths in active policy evaluation

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -742,6 +742,12 @@ class GovernancePolicy:
                     source=_findings_source(findings),
                 )
 
+        sensitive_path_findings = [
+            finding
+            for finding in findings
+            if getattr(finding, "rule_id", "") == "SENSITIVE_FILE_BLOCK"
+        ]
+
         # ── Phase 1.5: Shell danger keyword detection ──
         # Regex-based check that catches command variants missed by
         # the fnmatch-based builtin deny rules.
@@ -773,6 +779,14 @@ class GovernancePolicy:
                         findings=findings or None,
                         source="STRICT mode",
                     )
+                if (
+                    action == GovernanceAction.ALLOW
+                    and sensitive_path_findings
+                ):
+                    return self._apply_execution_level_fallback(
+                        tc_spec,
+                        sensitive_path_findings,
+                    )
                 return GovernanceDecision(
                     action=action,
                     reason=rule.reason,
@@ -792,6 +806,14 @@ class GovernancePolicy:
                         reason="STRICT mode: all tool calls require approval",
                         findings=findings or None,
                         source="STRICT mode",
+                    )
+                if (
+                    action == GovernanceAction.ALLOW
+                    and sensitive_path_findings
+                ):
+                    return self._apply_execution_level_fallback(
+                        tc_spec,
+                        sensitive_path_findings,
                     )
                 return GovernanceDecision(
                     action=action,
@@ -859,7 +881,7 @@ class GovernancePolicy:
                 tool_name=tc_spec.tool_name,
                 target=tc_spec.target,
                 tool_type=tool_type,
-                sensitive_paths=self.sensitive_paths,
+                sensitive_paths=self._resolve_sensitive_paths(),
                 detection_rules=detection_rules,
                 shell_evasion_checks=shell_evasion_checks,
                 raw_params=tc_spec.raw_params,
@@ -870,6 +892,30 @@ class GovernancePolicy:
                 exc,
             )
             return []
+
+    def _resolve_sensitive_paths(self) -> list[str]:
+        """Return the effective sensitive paths for the active file guard."""
+        from ..security.tool_guard.guardians.file_guardian import (
+            ensure_file_guard_paths,
+        )
+
+        policy_paths = list(self.sensitive_paths)
+        try:
+            from ..config import load_config
+
+            file_guard = load_config().security.file_guard
+        except Exception as exc:
+            logger.warning(
+                "file_guard config load failed: %s; using policy paths",
+                exc,
+            )
+            return ensure_file_guard_paths(policy_paths)
+
+        if not file_guard.enabled:
+            return []
+
+        configured_paths = list(file_guard.sensitive_files or [])
+        return ensure_file_guard_paths(policy_paths + configured_paths)
 
     def _merge_config_rules(
         self,

--- a/tests/unit/governance/test_off_mode_sandbox.py
+++ b/tests/unit/governance/test_off_mode_sandbox.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from qwenpaw.governance import tool_adapter
 from qwenpaw.governance.resource_governor import ResourceGovernor
 from qwenpaw.governance.tool_registry import DEFAULT_REGISTRY
@@ -59,6 +61,23 @@ class TestRegistryFlag:
 
 
 class TestOffModeSandbox:
+    @pytest.mark.asyncio
+    async def test_off_allows_sensitive_call_without_policy_evaluation(self):
+        class _PolicyMustNotRun:
+            def assert_policy(self, _tc_spec):
+                raise AssertionError("OFF must not evaluate governance policy")
+
+        tool = _FakeTool("read_file")
+        tool._qp_governor = _PolicyMustNotRun()
+        tool._qp_request_context = {"approval_level": "off"}
+
+        decision = await tool_adapter._policy_tool_check_permissions(
+            tool,
+            {"file_path": "/home/user/.qwenpaw.secret/providers.json"},
+        )
+
+        assert decision.behavior.value == "allow"
+
     def test_repl_gets_sandbox_compiled(self):
         tool = _FakeTool("recall_history_python")
         gov = _FakeGovernor(sandbox_available=True)

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -1605,6 +1605,97 @@ class TestDeepScanConfigMerge:
         assert "YAML_FALLBACK_RULE" in rule_ids
 
 
+class TestFileGuardConfigBridge:
+    """File Guard settings participate in active governance decisions."""
+
+    @staticmethod
+    def _patch_config(monkeypatch, *, enabled: bool, paths: list[str]):
+        from types import SimpleNamespace
+
+        config = SimpleNamespace(
+            security=SimpleNamespace(
+                file_guard=SimpleNamespace(
+                    enabled=enabled,
+                    sensitive_files=paths,
+                ),
+                tool_guard=SimpleNamespace(
+                    custom_rules=[],
+                    disabled_rules=[],
+                    shell_evasion_checks={},
+                ),
+            ),
+        )
+        monkeypatch.setattr("qwenpaw.config.load_config", lambda: config)
+
+    def test_read_allow_rule_cannot_override_sensitive_path(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        secret_dir = tmp_path / "protected"
+        secret_dir.mkdir()
+        secret_file = secret_dir / "credentials.json"
+        self._patch_config(
+            monkeypatch,
+            enabled=True,
+            paths=[f"{secret_dir}/"],
+        )
+        policy = _create_default_policy(str(tmp_path), str(tmp_path))
+        policy.execution_level = "smart"
+
+        decision = policy.evaluate(_tc("Read", str(secret_file)))
+
+        assert decision.action is GovernanceAction.ASK
+        assert decision.source == "sensitive_paths"
+        assert [finding.rule_id for finding in decision.findings or []] == [
+            "SENSITIVE_FILE_BLOCK",
+        ]
+
+    def test_shell_uses_file_guard_paths_from_config(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        secret_dir = tmp_path / "protected"
+        secret_dir.mkdir()
+        self._patch_config(
+            monkeypatch,
+            enabled=True,
+            paths=[f"{secret_dir}/"],
+        )
+        policy = _create_default_policy(str(tmp_path), str(tmp_path))
+        policy.execution_level = "smart"
+
+        decision = policy.evaluate(_tc("Bash", f"ls -la {secret_dir}/"))
+
+        assert decision.action is GovernanceAction.ASK
+        assert decision.source == "sensitive_paths"
+
+    def test_disabled_file_guard_does_not_scan_sensitive_paths(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        secret_dir = tmp_path / "protected"
+        secret_dir.mkdir()
+        self._patch_config(
+            monkeypatch,
+            enabled=False,
+            paths=[f"{secret_dir}/"],
+        )
+        policy = _create_default_policy(str(tmp_path), str(tmp_path))
+        policy.sensitive_paths = [f"{secret_dir}/"]
+
+        findings = policy._deep_security_scan(
+            _tc("Read", str(secret_dir / "credentials.json")),
+            "file",
+        )
+
+        assert not any(
+            finding.rule_id == "SENSITIVE_FILE_BLOCK" for finding in findings
+        )
+
+
 # ===========================================================================
 # TestShellFindingDrivenApproval — shell commands with deep-scan findings
 # honor the execution-level severity threshold (Phase 3 fix).


### PR DESCRIPTION
## Description

Fixes #7362.

QwenPaw’s File Guard settings were only consumed by the legacy
`ToolGuardEngine`, while normal Agent tool calls use the newer
`GovernancePolicy` path. As a result, paths shown as protected in the
Security settings—including `.qwenpaw.secret`—could still be accessed by
`Read` or `Bash`.

This PR:

- Merges `security.file_guard.sensitive_files` into the active
  `GovernancePolicy` sensitive-path scan.
- Includes the default `.qwenpaw.secret` and `.copaw.secret` compatibility
  paths.
- Applies File Guard configuration changes on subsequent tool calls without
  requiring a restart.
- Prevents generic ALLOW rules such as `Read(**)` from overriding a
  `SENSITIVE_FILE_BLOCK` finding.
- Preserves the expected approval-level behavior:
  - `AUTO`, `SMART`, and `STRICT`: protected paths require approval.
  - `OFF`: governance remains fully bypassed and tool calls are allowed.
- Honors `security.file_guard.enabled=false` by disabling sensitive-path
  scanning.

## Root Cause

The Console stored File Guard configuration under
`config.json -> security.file_guard` and refreshed the legacy
`ToolGuardEngine`.

However, Agent tools were wrapped by `PolicyGuardedTool` and evaluated by
`GovernancePolicy`, which only read `policy.yaml.sensitive_paths`. The two
configuration paths were disconnected.

Additionally, a HIGH-severity sensitive-path finding could be carried into
Phase 2 and then overridden by a broad ALLOW rule such as `Read(**)`.

## Testing

Added regression coverage for:

- Reading a protected file through `Read`.
- Accessing a protected directory through `Bash`.
- Disabling File Guard.
- Confirming that `OFF` bypasses policy evaluation, including for protected
  paths.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
