### PR TITLE
fix(dingtalk): detect stale stream connections and bound SDK requests

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -36,6 +36,8 @@ import ssl
 import aiohttp
 import certifi
 import dingtalk_stream
+import dingtalk_stream.stream as dingtalk_stream_module
+import requests
 from dingtalk_stream import ChatbotMessage
 from alibabacloud_tea_openapi import models as open_api_models
 from alibabacloud_dingtalk.oauth2_1_0 import (
@@ -104,6 +106,26 @@ _RobotDeliverModel = (
 )
 
 logger = logging.getLogger(__name__)
+
+_STREAM_CONNECT_TIMEOUT_SECONDS = 10
+_STREAM_READ_TIMEOUT_SECONDS = 30
+_STREAM_WATCHDOG_INTERVAL_SECONDS = 30
+_STREAM_WATCHDOG_STALE_SECONDS = 90
+
+
+class _DingTalkRequestsWithTimeout:
+    """Add bounded timeouts to synchronous DingTalk Stream requests."""
+
+    @staticmethod
+    def post(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault(
+            "timeout",
+            (
+                _STREAM_CONNECT_TIMEOUT_SECONDS,
+                _STREAM_READ_TIMEOUT_SECONDS,
+            ),
+        )
+        return requests.post(*args, **kwargs)
 
 
 class DingTalkChannel(BaseChannel):
@@ -220,6 +242,7 @@ class DingTalkChannel(BaseChannel):
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._stream_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._stream_watchdog_at = 0.0
         self._http: Optional[aiohttp.ClientSession] = None
 
         # DingTalk OpenAPI SDK clients
@@ -2601,23 +2624,23 @@ class DingTalkChannel(BaseChannel):
             sleep/wake cycles are also covered (SDK reconnects internally
             via its while-True loop without exiting main_task).
             """
-            check_interval = 30
-            jump_threshold = 90  # 3x interval → definite sleep/wake
             last_wall = time.time()
+            self._stream_watchdog_at = last_wall
             while not self._stop_event.is_set():
-                await asyncio.sleep(check_interval)
+                await asyncio.sleep(_STREAM_WATCHDOG_INTERVAL_SECONDS)
                 if self._stop_event.is_set():
                     break
                 now = time.time()
                 elapsed = now - last_wall
                 last_wall = now
-                if elapsed > jump_threshold:
+                self._stream_watchdog_at = now
+                if elapsed > _STREAM_WATCHDOG_STALE_SECONDS:
                     logger.warning(
                         "dingtalk: liveness watchdog detected "
                         "wake-from-sleep (elapsed=%.0fs, "
                         "expected~%ds); forcing reconnect...",
                         elapsed,
-                        check_interval,
+                        _STREAM_WATCHDOG_INTERVAL_SECONDS,
                     )
                     ws = client.websocket
                     if ws is not None:
@@ -2665,8 +2688,18 @@ class DingTalkChannel(BaseChannel):
             except asyncio.TimeoutError:
                 pass
 
+    @staticmethod
+    def _is_websocket_open(websocket: Any) -> bool:
+        """Return whether an SDK websocket reports an open state."""
+        if websocket is None:
+            return False
+        state = getattr(websocket, "state", None)
+        if state is not None:
+            return getattr(state, "name", None) == "OPEN"
+        return not bool(getattr(websocket, "closed", True))
+
     async def health_check(self) -> Dict[str, Any]:
-        """Check DingTalk stream client and HTTP session status."""
+        """Check DingTalk stream connection and event-loop liveness."""
         if not self.enabled:
             return {
                 "channel": self.channel,
@@ -2676,6 +2709,21 @@ class DingTalkChannel(BaseChannel):
         issues = []
         if self._client is None:
             issues.append("Stream client not initialized")
+        else:
+            websocket = getattr(self._client, "websocket", None)
+            if not self._is_websocket_open(websocket):
+                issues.append("WebSocket connection is not open")
+        stream_thread_alive = (
+            self._stream_thread is not None and self._stream_thread.is_alive()
+        )
+        if not stream_thread_alive:
+            issues.append("Stream thread is not running")
+        watchdog_age = time.time() - self._stream_watchdog_at
+        if stream_thread_alive and (
+            self._stream_watchdog_at <= 0
+            or watchdog_age > _STREAM_WATCHDOG_STALE_SECONDS
+        ):
+            issues.append("Stream event loop is unresponsive")
         if self._http is None or self._http.closed:
             issues.append("HTTP session not available")
         if issues:
@@ -2690,6 +2738,10 @@ class DingTalkChannel(BaseChannel):
             "detail": "DingTalk stream client and HTTP session are active.",
         }
 
+    def _apply_stream_request_timeout(self) -> None:
+        """Apply bounded timeouts to the SDK's synchronous HTTP calls."""
+        dingtalk_stream_module.requests = _DingTalkRequestsWithTimeout
+
     def _apply_custom_endpoint(self) -> None:
         """Monkey-patch dingtalk_stream SDK modules to use a custom endpoint.
 
@@ -2702,15 +2754,14 @@ class DingTalkChannel(BaseChannel):
             return
 
         import dingtalk_stream.utils as _ds_utils
-        import dingtalk_stream.stream as _ds_stream
         import dingtalk_stream.chatbot as _ds_chatbot
         import dingtalk_stream.card_replier as _ds_card_replier
 
         _ds_utils.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
-        _ds_stream.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
+        dingtalk_stream_module.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
         _ds_chatbot.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
         _ds_card_replier.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
-        _ds_stream.DingTalkStreamClient.OPEN_CONNECTION_API = (
+        dingtalk_stream_module.DingTalkStreamClient.OPEN_CONNECTION_API = (
             f"{self.endpoint}/v1.0/gateway/connections/open"
         )
         logger.info(
@@ -2734,6 +2785,7 @@ class DingTalkChannel(BaseChannel):
 
         self._loop = asyncio.get_running_loop()
 
+        self._apply_stream_request_timeout()
         self._apply_custom_endpoint()
 
         credential = dingtalk_stream.Credential(
@@ -2756,6 +2808,7 @@ class DingTalkChannel(BaseChannel):
         )
 
         self._stop_event.clear()
+        self._stream_watchdog_at = time.time()
         self._stream_thread = threading.Thread(
             target=self._run_stream_forever,
             daemon=True,
@@ -2784,6 +2837,7 @@ class DingTalkChannel(BaseChannel):
         self._stop_event.set()
         if self._stream_thread:
             self._stream_thread.join(timeout=3)
+        self._stream_watchdog_at = 0.0
         for task in self._debounce_timers.values():
             if task and not task.done():
                 task.cancel()

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -36,6 +36,7 @@ import ssl
 import aiohttp
 import certifi
 import dingtalk_stream
+import dingtalk_stream.chatbot as dingtalk_chatbot_module
 import dingtalk_stream.stream as dingtalk_stream_module
 import requests
 from dingtalk_stream import ChatbotMessage
@@ -109,12 +110,16 @@ logger = logging.getLogger(__name__)
 
 _STREAM_CONNECT_TIMEOUT_SECONDS = 10
 _STREAM_READ_TIMEOUT_SECONDS = 30
+_STREAM_HEALTH_PING_TIMEOUT_SECONDS = 3
 _STREAM_WATCHDOG_INTERVAL_SECONDS = 30
 _STREAM_WATCHDOG_STALE_SECONDS = 90
 
 
 class _DingTalkRequestsWithTimeout:
-    """Add bounded timeouts to synchronous DingTalk Stream requests."""
+    """Add bounded timeouts to synchronous DingTalk POST requests."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(requests, name)
 
     @staticmethod
     def post(*args: Any, **kwargs: Any) -> Any:
@@ -126,6 +131,9 @@ class _DingTalkRequestsWithTimeout:
             ),
         )
         return requests.post(*args, **kwargs)
+
+
+_DINGTALK_REQUESTS_WITH_TIMEOUT = _DingTalkRequestsWithTimeout()
 
 
 class DingTalkChannel(BaseChannel):
@@ -240,9 +248,9 @@ class DingTalkChannel(BaseChannel):
 
         self._client: Optional[dingtalk_stream.DingTalkStreamClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._stream_event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._stream_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
-        self._stream_watchdog_at = 0.0
         self._http: Optional[aiohttp.ClientSession] = None
 
         # DingTalk OpenAPI SDK clients
@@ -2581,6 +2589,7 @@ class DingTalkChannel(BaseChannel):
         except Exception:
             logger.exception("dingtalk stream thread failed")
         finally:
+            self._stream_event_loop = None
             self._stop_event.set()
             logger.info("dingtalk stream thread stopped")
 
@@ -2599,6 +2608,8 @@ class DingTalkChannel(BaseChannel):
         client = self._client
         if not client:
             return
+        stream_loop = asyncio.get_running_loop()
+        self._stream_event_loop = stream_loop
         main_task = asyncio.create_task(client.start())
 
         async def stop_watcher() -> None:
@@ -2625,7 +2636,6 @@ class DingTalkChannel(BaseChannel):
             via its while-True loop without exiting main_task).
             """
             last_wall = time.time()
-            self._stream_watchdog_at = last_wall
             while not self._stop_event.is_set():
                 await asyncio.sleep(_STREAM_WATCHDOG_INTERVAL_SECONDS)
                 if self._stop_event.is_set():
@@ -2633,7 +2643,6 @@ class DingTalkChannel(BaseChannel):
                 now = time.time()
                 elapsed = now - last_wall
                 last_wall = now
-                self._stream_watchdog_at = now
                 if elapsed > _STREAM_WATCHDOG_STALE_SECONDS:
                     logger.warning(
                         "dingtalk: liveness watchdog detected "
@@ -2687,6 +2696,8 @@ class DingTalkChannel(BaseChannel):
                 )
             except asyncio.TimeoutError:
                 pass
+        if self._stream_event_loop is stream_loop:
+            self._stream_event_loop = None
 
     @staticmethod
     def _is_websocket_open(websocket: Any) -> bool:
@@ -2698,8 +2709,14 @@ class DingTalkChannel(BaseChannel):
             return getattr(state, "name", None) == "OPEN"
         return not bool(getattr(websocket, "closed", True))
 
+    @staticmethod
+    async def _ping_websocket(websocket: Any) -> None:
+        """Send a WebSocket Ping and wait for its matching Pong."""
+        pong_waiter = await websocket.ping()
+        await pong_waiter
+
     async def health_check(self) -> Dict[str, Any]:
-        """Check DingTalk stream connection and event-loop liveness."""
+        """Actively verify the DingTalk Stream WebSocket connection."""
         if not self.enabled:
             return {
                 "channel": self.channel,
@@ -2707,6 +2724,7 @@ class DingTalkChannel(BaseChannel):
                 "detail": "DingTalk channel is disabled.",
             }
         issues = []
+        websocket = None
         if self._client is None:
             issues.append("Stream client not initialized")
         else:
@@ -2718,14 +2736,42 @@ class DingTalkChannel(BaseChannel):
         )
         if not stream_thread_alive:
             issues.append("Stream thread is not running")
-        watchdog_age = time.time() - self._stream_watchdog_at
+        stream_loop = self._stream_event_loop
         if stream_thread_alive and (
-            self._stream_watchdog_at <= 0
-            or watchdog_age > _STREAM_WATCHDOG_STALE_SECONDS
+            stream_loop is None or not stream_loop.is_running()
         ):
-            issues.append("Stream event loop is unresponsive")
+            issues.append("Stream event loop is not running")
         if self._http is None or self._http.closed:
             issues.append("HTTP session not available")
+        if not issues and websocket is not None and stream_loop is not None:
+            ping_coro = self._ping_websocket(websocket)
+            try:
+                ping_future = asyncio.run_coroutine_threadsafe(
+                    ping_coro,
+                    stream_loop,
+                )
+            except RuntimeError:
+                ping_coro.close()
+                issues.append("Stream event loop is not available")
+            else:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.wrap_future(ping_future),
+                        timeout=_STREAM_HEALTH_PING_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    ping_future.cancel()
+                    issues.append("WebSocket Ping timed out")
+                except asyncio.CancelledError:
+                    ping_future.cancel()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
+                    issues.append("WebSocket Ping was cancelled")
+                except Exception as exc:
+                    issues.append(
+                        f"WebSocket Ping failed: {type(exc).__name__}",
+                    )
         if issues:
             return {
                 "channel": self.channel,
@@ -2735,12 +2781,13 @@ class DingTalkChannel(BaseChannel):
         return {
             "channel": self.channel,
             "status": "healthy",
-            "detail": "DingTalk stream client and HTTP session are active.",
+            "detail": "DingTalk Stream WebSocket responded to Ping.",
         }
 
     def _apply_stream_request_timeout(self) -> None:
         """Apply bounded timeouts to the SDK's synchronous HTTP calls."""
-        dingtalk_stream_module.requests = _DingTalkRequestsWithTimeout
+        dingtalk_stream_module.requests = _DINGTALK_REQUESTS_WITH_TIMEOUT
+        dingtalk_chatbot_module.requests = _DINGTALK_REQUESTS_WITH_TIMEOUT
 
     def _apply_custom_endpoint(self) -> None:
         """Monkey-patch dingtalk_stream SDK modules to use a custom endpoint.
@@ -2754,12 +2801,11 @@ class DingTalkChannel(BaseChannel):
             return
 
         import dingtalk_stream.utils as _ds_utils
-        import dingtalk_stream.chatbot as _ds_chatbot
         import dingtalk_stream.card_replier as _ds_card_replier
 
         _ds_utils.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
         dingtalk_stream_module.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
-        _ds_chatbot.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
+        dingtalk_chatbot_module.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
         _ds_card_replier.DINGTALK_OPENAPI_ENDPOINT = self.endpoint
         dingtalk_stream_module.DingTalkStreamClient.OPEN_CONNECTION_API = (
             f"{self.endpoint}/v1.0/gateway/connections/open"
@@ -2808,7 +2854,6 @@ class DingTalkChannel(BaseChannel):
         )
 
         self._stop_event.clear()
-        self._stream_watchdog_at = time.time()
         self._stream_thread = threading.Thread(
             target=self._run_stream_forever,
             daemon=True,
@@ -2837,7 +2882,6 @@ class DingTalkChannel(BaseChannel):
         self._stop_event.set()
         if self._stream_thread:
             self._stream_thread.join(timeout=3)
-        self._stream_watchdog_at = 0.0
         for task in self._debounce_timers.values():
             if task and not task.done():
                 task.cancel()

--- a/tests/integration/test_dingtalk_mock_im.py
+++ b/tests/integration/test_dingtalk_mock_im.py
@@ -274,7 +274,8 @@ def test_dingtalk_health_reports_channel(
     assert resp is not None, "health request timed out"
     assert resp.status_code == 200, app_server.logs_tail()
     body = resp.json()
-    assert body.get("channel") == "dingtalk" or "status" in body, body
+    assert body.get("channel") == "dingtalk", body
+    assert body.get("status") == "healthy", body
 
 
 @pytest.mark.integration

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -2806,6 +2806,33 @@ class TestDingTalkFileDownload:
 # =============================================================================
 
 
+class TestDingTalkStreamRequestTimeout:
+    """Tests for bounded synchronous requests in the stream SDK."""
+
+    def test_stream_requests_add_default_timeout(self, monkeypatch):
+        """SDK HTTP calls should use bounded connect and read timeouts."""
+        from qwenpaw.app.channels.dingtalk.channel import (
+            _DingTalkRequestsWithTimeout,
+        )
+
+        mock_post = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "qwenpaw.app.channels.dingtalk.channel.requests.post",
+            mock_post,
+        )
+
+        _DingTalkRequestsWithTimeout.post(
+            "https://api.dingtalk.com/connection",
+            data=b"{}",
+        )
+
+        mock_post.assert_called_once_with(
+            "https://api.dingtalk.com/connection",
+            data=b"{}",
+            timeout=(10, 30),
+        )
+
+
 @pytest.mark.asyncio
 class TestDingTalkStreamMode:
     """Tests for Stream/WebSocket mode."""
@@ -2862,6 +2889,75 @@ class TestDingTalkStreamMode:
         dingtalk_channel.robot_code = "robot_123"
 
         assert dingtalk_channel._ai_card_enabled() is False
+
+
+@pytest.mark.asyncio
+class TestDingTalkHealthCheck:
+    """Tests for DingTalk connection health reporting."""
+
+    @staticmethod
+    def _set_runtime_state(
+        channel,
+        *,
+        thread_alive: bool = True,
+        websocket_state: str = "OPEN",
+        watchdog_age: float = 0.0,
+    ) -> None:
+        websocket = MagicMock()
+        websocket.state.name = websocket_state
+        client = MagicMock()
+        client.websocket = websocket
+        channel._client = client
+        channel._stream_thread = MagicMock()
+        channel._stream_thread.is_alive.return_value = thread_alive
+        channel._stream_watchdog_at = time.time() - watchdog_age
+        channel._http = MagicMock()
+        channel._http.closed = False
+
+    async def test_reports_healthy_for_live_stream(
+        self,
+        dingtalk_channel,
+    ):
+        """A connected and responsive stream should be healthy."""
+        self._set_runtime_state(dingtalk_channel)
+
+        result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "healthy"
+
+    @pytest.mark.parametrize(
+        (
+            "thread_alive",
+            "websocket_state",
+            "watchdog_age",
+            "expected_detail",
+        ),
+        [
+            (False, "OPEN", 0.0, "Stream thread is not running"),
+            (True, "CLOSED", 0.0, "WebSocket connection is not open"),
+            (True, "OPEN", 91.0, "Stream event loop is unresponsive"),
+        ],
+    )
+    async def test_reports_unhealthy_for_broken_stream_state(
+        self,
+        dingtalk_channel,
+        thread_alive,
+        websocket_state,
+        watchdog_age,
+        expected_detail,
+    ):
+        """Broken stream states should not be reported as healthy."""
+        self._set_runtime_state(
+            dingtalk_channel,
+            thread_alive=thread_alive,
+            websocket_state=websocket_state,
+            watchdog_age=watchdog_age,
+        )
+
+        result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert expected_detail in result["detail"]
 
 
 # =============================================================================

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -30,6 +30,7 @@ import asyncio
 import json
 import threading
 import time
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2809,10 +2810,16 @@ class TestDingTalkFileDownload:
 class TestDingTalkStreamRequestTimeout:
     """Tests for bounded synchronous requests in the stream SDK."""
 
-    def test_stream_requests_add_default_timeout(self, monkeypatch):
-        """SDK HTTP calls should use bounded connect and read timeouts."""
+    def test_stream_and_chatbot_requests_use_default_timeout(
+        self,
+        dingtalk_channel,
+        monkeypatch,
+    ):
+        """Connection and chatbot ACK requests should share timeouts."""
         from qwenpaw.app.channels.dingtalk.channel import (
-            _DingTalkRequestsWithTimeout,
+            _DINGTALK_REQUESTS_WITH_TIMEOUT,
+            dingtalk_chatbot_module,
+            dingtalk_stream_module,
         )
 
         mock_post = MagicMock(return_value=MagicMock())
@@ -2820,15 +2827,45 @@ class TestDingTalkStreamRequestTimeout:
             "qwenpaw.app.channels.dingtalk.channel.requests.post",
             mock_post,
         )
-
-        _DingTalkRequestsWithTimeout.post(
-            "https://api.dingtalk.com/connection",
-            data=b"{}",
+        monkeypatch.setattr(
+            dingtalk_stream_module,
+            "requests",
+            MagicMock(),
+        )
+        monkeypatch.setattr(
+            dingtalk_chatbot_module,
+            "requests",
+            MagicMock(),
         )
 
+        dingtalk_channel._apply_stream_request_timeout()
+
+        assert (
+            dingtalk_stream_module.requests is _DINGTALK_REQUESTS_WITH_TIMEOUT
+        )
+        assert (
+            dingtalk_chatbot_module.requests is _DINGTALK_REQUESTS_WITH_TIMEOUT
+        )
+
+        incoming_message = MagicMock()
+        incoming_message.session_webhook = (
+            "https://api.dingtalk.com/session-webhook"
+        )
+        incoming_message.sender_staff_id = "user_123"
+        handler = dingtalk_chatbot_module.ChatbotHandler()
+
+        handler.reply_text(" ", incoming_message)
+
         mock_post.assert_called_once_with(
-            "https://api.dingtalk.com/connection",
-            data=b"{}",
+            "https://api.dingtalk.com/session-webhook",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "*/*",
+            },
+            data=(
+                '{"msgtype": "text", "text": {"content": " "}, '
+                '"at": {"atUserIds": ["user_123"]}}'
+            ),
             timeout=(10, 30),
         )
 
@@ -2901,41 +2938,52 @@ class TestDingTalkHealthCheck:
         *,
         thread_alive: bool = True,
         websocket_state: str = "OPEN",
-        watchdog_age: float = 0.0,
-    ) -> None:
+        stream_loop_running: bool = True,
+    ):
+        loop = asyncio.get_running_loop()
         websocket = MagicMock()
         websocket.state.name = websocket_state
+        websocket.ping = AsyncMock()
+        pong_waiter = loop.create_future()
+        pong_waiter.set_result(0.01)
+        websocket.ping.return_value = pong_waiter
         client = MagicMock()
         client.websocket = websocket
         channel._client = client
         channel._stream_thread = MagicMock()
         channel._stream_thread.is_alive.return_value = thread_alive
-        channel._stream_watchdog_at = time.time() - watchdog_age
+        if stream_loop_running:
+            channel._stream_event_loop = loop
+        else:
+            channel._stream_event_loop = MagicMock()
+            channel._stream_event_loop.is_running.return_value = False
         channel._http = MagicMock()
         channel._http.closed = False
+        return websocket
 
     async def test_reports_healthy_for_live_stream(
         self,
         dingtalk_channel,
     ):
         """A connected and responsive stream should be healthy."""
-        self._set_runtime_state(dingtalk_channel)
+        websocket = self._set_runtime_state(dingtalk_channel)
 
         result = await dingtalk_channel.health_check()
 
         assert result["status"] == "healthy"
+        websocket.ping.assert_awaited_once_with()
 
     @pytest.mark.parametrize(
         (
             "thread_alive",
             "websocket_state",
-            "watchdog_age",
+            "stream_loop_running",
             "expected_detail",
         ),
         [
-            (False, "OPEN", 0.0, "Stream thread is not running"),
-            (True, "CLOSED", 0.0, "WebSocket connection is not open"),
-            (True, "OPEN", 91.0, "Stream event loop is unresponsive"),
+            (False, "OPEN", True, "Stream thread is not running"),
+            (True, "CLOSED", True, "WebSocket connection is not open"),
+            (True, "OPEN", False, "Stream event loop is not running"),
         ],
     )
     async def test_reports_unhealthy_for_broken_stream_state(
@@ -2943,7 +2991,7 @@ class TestDingTalkHealthCheck:
         dingtalk_channel,
         thread_alive,
         websocket_state,
-        watchdog_age,
+        stream_loop_running,
         expected_detail,
     ):
         """Broken stream states should not be reported as healthy."""
@@ -2951,13 +2999,92 @@ class TestDingTalkHealthCheck:
             dingtalk_channel,
             thread_alive=thread_alive,
             websocket_state=websocket_state,
-            watchdog_age=watchdog_age,
+            stream_loop_running=stream_loop_running,
         )
 
         result = await dingtalk_channel.health_check()
 
         assert result["status"] == "unhealthy"
         assert expected_detail in result["detail"]
+
+    async def test_reports_unhealthy_when_pong_times_out(
+        self,
+        dingtalk_channel,
+    ):
+        """An open socket without a Pong response should be unhealthy."""
+        websocket = self._set_runtime_state(dingtalk_channel)
+        websocket.ping.return_value = (
+            asyncio.get_running_loop().create_future()
+        )
+
+        with patch(
+            "qwenpaw.app.channels.dingtalk.channel."
+            "_STREAM_HEALTH_PING_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert "WebSocket Ping timed out" in result["detail"]
+
+    async def test_reports_unhealthy_when_ping_fails(
+        self,
+        dingtalk_channel,
+    ):
+        """A Ping transport error should be reported as unhealthy."""
+        websocket = self._set_runtime_state(dingtalk_channel)
+        websocket.ping.side_effect = ConnectionError("socket closed")
+
+        result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert "WebSocket Ping failed: ConnectionError" in result["detail"]
+
+    async def test_reports_unhealthy_when_ping_is_cancelled(
+        self,
+        dingtalk_channel,
+    ):
+        """A Ping cancelled by Stream reconnect should be unhealthy."""
+        self._set_runtime_state(dingtalk_channel)
+
+        def cancel_probe(coro, _loop):
+            coro.close()
+            future = Future()
+            future.cancel()
+            return future
+
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=cancel_probe,
+        ):
+            result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert "WebSocket Ping was cancelled" in result["detail"]
+
+    async def test_reports_unhealthy_when_stream_loop_is_blocked(
+        self,
+        dingtalk_channel,
+    ):
+        """Health should time out if the Stream loop cannot run Ping."""
+        self._set_runtime_state(dingtalk_channel)
+
+        def leave_probe_pending(coro, _loop):
+            coro.close()
+            return Future()
+
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=leave_probe_pending,
+        ), patch(
+            "qwenpaw.app.channels.dingtalk.channel."
+            "_STREAM_HEALTH_PING_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            result = await dingtalk_channel.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert "WebSocket Ping timed out" in result["detail"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

DingTalk Stream WebSocket connections can become stale after system
sleep/wake cycles, network changes, or VPN route changes. In this state,
the connection may still appear open while no longer receiving messages.

The previous health check only verified that the client object and HTTP
session existed, so stale connections could still be reported as healthy.

Some synchronous HTTP requests in the DingTalk SDK also lacked timeouts.
A blocked connection request or Chatbot ACK request could therefore block
the Stream event loop indefinitely.

## Changes

- Actively send a WebSocket Ping and wait for the corresponding Pong in
  the DingTalk health check.
- Check the Stream thread, event loop, and WebSocket state before probing.
- Report the channel as unhealthy when Ping times out, fails, is cancelled,
  or cannot be executed because the Stream loop is blocked.
- Add connection and read timeouts to the SDK's synchronous HTTP requests,
  including connection setup and Chatbot ACK requests.
- Keep the watchdog's system sleep/wake detection. When a significant wall
  clock jump is detected, it closes the stale WebSocket and lets the SDK
  reconnect.
- Tighten the DingTalk Mock IM integration test to require an explicit
  `channel == "dingtalk"` and `status == "healthy"` response.

The health check only detects and reports connection health. It does not
restart the channel directly. The watchdog only handles clear
sleep/wake-related time jumps and does not use a local heartbeat to decide
whether the Stream loop is alive.

## Testing

- DingTalk unit and contract tests: `205 passed`
- DingTalk Mock IM integration tests: `7 passed`
- `pre-commit`: passed
- `git diff --check`: passed