### PR TITLE
fix(plugins): avoid full module sweep after each load

### DIFF
--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -537,6 +537,7 @@ class PluginLoader:
                 f"Failed to load module spec for {backend_entry_file}",
             )
 
+        modules_before = dict(sys.modules)
         module = importlib.util.module_from_spec(spec)
 
         # Redirect the plugin's bare absolute imports (``import utils``)
@@ -620,7 +621,7 @@ class PluginLoader:
             # or a data-directory fallthrough during load can cache a
             # bare name rooted in this plugin's tree, which would keep
             # serving later plugins even with sys.path clean.
-            sweep_bare_tree_modules(source_path)
+            sweep_bare_tree_modules(source_path, modules_before)
 
         return plugin_def
 

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -61,7 +61,7 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 
 class _NamespaceLoader:
@@ -188,7 +188,10 @@ def strip_plugin_sys_path(source_path: Any) -> None:
     sys.path[:] = [p for p in sys.path if _keep(p)]
 
 
-def sweep_bare_tree_modules(source_path: Any) -> None:
+def sweep_bare_tree_modules(
+    source_path: Any,
+    previous_modules: Optional[Mapping[str, Any]] = None,
+) -> None:
     """Pop non-namespaced ``sys.modules`` entries rooted in *source_path*.
 
     Redirected plugin imports live under ``plugin_<id>`` and are exempt
@@ -198,15 +201,35 @@ def sweep_bare_tree_modules(source_path: Any) -> None:
     data-directory fallthrough; left in place, the ``sys.modules``
     cache would keep serving it to later imports even after the
     plugin's ``sys.path`` entries are swept.
+
+    When *previous_modules* is provided, bindings unchanged since that
+    snapshot are skipped.  Changed bindings rooted in the plugin tree are
+    removed, or restored when they replaced an existing binding.  This keeps
+    load-end cleanup proportional to modules imported by that plugin instead
+    of filesystem-normalizing the entire process module table.
     """
     root = _norm(source_path)
     prefix = root + os.sep
+    missing = object()
 
     def _under(path: Any) -> bool:
         resolved = _norm(path)
         return resolved == root or resolved.startswith(prefix)
 
+    def _remove_or_restore(name: str, mod: Any, previous: Any) -> None:
+        if sys.modules.get(name, missing) is not mod:
+            return
+        if previous is missing:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
     for name, mod in list(sys.modules.items()):
+        previous = missing
+        if previous_modules is not None:
+            previous = previous_modules.get(name, missing)
+            if previous is mod:
+                continue
         top = name.partition(".")[0]
         if _finder is not None and _finder.is_registered(top):
             continue
@@ -214,7 +237,7 @@ def sweep_bare_tree_modules(source_path: Any) -> None:
             mod_file = getattr(mod, "__file__", None)
             if mod_file is not None:
                 if _under(mod_file):
-                    sys.modules.pop(name, None)
+                    _remove_or_restore(name, mod, previous)
                 continue
             # Namespace packages have no __file__; match by __path__.
             # Accessing __path__ recomputes _NamespacePath, which can
@@ -223,10 +246,10 @@ def sweep_bare_tree_modules(source_path: Any) -> None:
             try:
                 portions = list(getattr(mod, "__path__", None) or [])
             except KeyError:
-                sys.modules.pop(name, None)
+                _remove_or_restore(name, mod, previous)
                 continue
             if portions and any(_under(p) for p in portions):
-                sys.modules.pop(name, None)
+                _remove_or_restore(name, mod, previous)
         except Exception:  # pylint: disable=broad-except
             # Best-effort cleanup: lazy-module proxies or broken path
             # hooks must not turn a sweep into a load failure.

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -73,6 +73,7 @@ def validate_plugin_module(
             f"Cannot create module spec for {backend_entry}",
         )
 
+    modules_before = dict(sys.modules)
     module = importlib.util.module_from_spec(spec)
     # Register in sys.modules BEFORE exec_module so that
     # relative imports can resolve the parent package.
@@ -111,4 +112,4 @@ def validate_plugin_module(
         # time, and any bare sys.modules entries rooted in its tree,
         # so validation leaves no residue in the CLI process.
         strip_plugin_sys_path(plugin_path)
-        sweep_bare_tree_modules(plugin_path)
+        sweep_bare_tree_modules(plugin_path, modules_before)

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -835,6 +835,64 @@ class TestFallthroughIsolation:
         assert "only_a_owns_this" not in sys.modules
 
     @pytest.mark.asyncio
+    async def test_load_end_sweep_skips_unchanged_module_locations(
+        self,
+        loader,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Load-end cleanup must not normalize every preloaded module."""
+        from qwenpaw.plugins import module_isolation
+
+        plugin_dir = tmp_path / "incremental-sweep"
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        stable_name = "_qwenpaw_unchanged_module_probe"
+        stable_module = types.ModuleType(stable_name)
+        stable_path = str(tmp_path.parent / "stable_module.py")
+        stable_module.__file__ = stable_path
+        sys.modules[stable_name] = stable_module
+
+        normalized = []
+        real_norm = module_isolation._norm
+
+        def _record_norm(path):
+            normalized.append(str(path))
+            return real_norm(path)
+
+        monkeypatch.setattr(module_isolation, "_norm", _record_norm)
+        try:
+            await _load(loader, plugin_dir)
+        finally:
+            sys.modules.pop(stable_name, None)
+
+        assert stable_path not in normalized
+
+    def test_incremental_sweep_restores_replaced_binding(self, tmp_path):
+        """A plugin-local replacement must not erase an older binding."""
+        from qwenpaw.plugins.module_isolation import sweep_bare_tree_modules
+
+        plugin_dir = tmp_path / "restore-binding"
+        plugin_dir.mkdir()
+        module_name = "_qwenpaw_replaced_module_probe"
+        previous = types.ModuleType(module_name)
+        replacement = types.ModuleType(module_name)
+        replacement.__file__ = str(plugin_dir / "replacement.py")
+        sys.modules[module_name] = previous
+        modules_before = dict(sys.modules)
+        sys.modules[module_name] = replacement
+
+        try:
+            sweep_bare_tree_modules(plugin_dir, modules_before)
+            assert sys.modules[module_name] is previous
+        finally:
+            sys.modules.pop(module_name, None)
+
+    @pytest.mark.asyncio
     async def test_bare_namespace_residue_swept_at_load_end(
         self,
         loader,


### PR DESCRIPTION
## Description

Plugin load cleanup currently canonicalizes the filesystem location of nearly
every entry in `sys.modules` after each plugin loads. On Windows this repeatedly
enters `nt._getfinalpathname` and can dominate Desktop startup.

This change snapshots `sys.modules` before plugin execution and limits the
load-end sweep to bindings changed by that plugin. New plugin-tree residue is
removed, replaced bindings are restored, and the existing full sweep remains
available for uncommon unload cleanup. CLI validation uses the same semantics.

**Related Issue:** Fixes #7360

**Security Considerations:** None. This only narrows plugin import-residue
cleanup candidates while preserving location checks and namespace isolation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```powershell
$env:PYTHONPATH = (Resolve-Path 'src').Path
python -m pytest tests/unit/plugins/test_plugin_namespace_isolation.py -q
# 25 passed

python -m pytest tests/unit/plugins/test_plugin_api_extensions.py::TestPluginValidatorImports::test_cli_validate_path_with_relative_import tests/unit/plugins/test_plugin_api_extensions.py::TestPluginValidatorImports::test_cli_validate_cleans_sys_modules_on_error -q
# 2 passed

python -m pytest tests/unit/plugins/test_plugin_load_isolation.py tests/unit/plugins/test_plugin_api_extensions.py::TestPluginValidatorImports -q
# 12 passed

python -m pytest tests/unit/plugins -q --ignore=tests/unit/plugins/test_plugin_lifecycle_lock.py
# 228 passed; two environment-only failures: Windows symlink privilege and
# missing optional qwenpawmail_mcp. The ignored lifecycle file also requires
# qwenpawmail_mcp during collection.
```

`flake8`, `compileall`, and `git diff --check` pass for the changed files.
`mypy` is not installed in the local runner. Black 23.3 `--check` hung without
output and was stopped; no formatter rewrites were applied.

## Evidence

Same-process Windows A/B benchmark, Python 3.12.10, 3,205 loaded modules,
five repetitions per side:

```text
v2.2.0-beta.1 full sweep median:       1568.606 ms
incremental snapshot + sweep median:      0.782 ms
```

The regression test also asserts that load-end cleanup does not normalize the
location of an unchanged preloaded module. Existing successful-load,
failed-load, and PEP 420 namespace-residue tests remain green.

## Additional Notes

- Origin non-reusable Desktop packaging verification:
  https://github.com/jinglinpeng/CoPaw/actions/runs/33157978072 (passed on
  attempt 2; Windows and macOS artifacts uploaded).
- No release or OSS upload is requested.
