### PR TITLE
fix(providers): migrate discovered model output limits

### DIFF
--- a/src/qwenpaw/providers/provider_model_state.py
+++ b/src/qwenpaw/providers/provider_model_state.py
@@ -57,7 +57,11 @@ def migrate_provider_snapshot(data: dict[str, Any]) -> bool:
     ):
         return False
 
-    for collection_name in ("models", "extra_models"):
+    for collection_name in (
+        "models",
+        "extra_models",
+        "discovered_models",
+    ):
         models = data.get(collection_name)
         if not isinstance(models, list):
             continue

--- a/tests/unit/providers/test_provider_model_state.py
+++ b/tests/unit/providers/test_provider_model_state.py
@@ -97,7 +97,7 @@ def test_migration_applies_to_extra_models_and_is_idempotent() -> None:
 
 
 def test_discovered_model_migration_preserves_secret() -> None:
-    snapshot = {
+    snapshot: dict[str, Any] = {
         "api_key": "ENC:encrypted-provider-key",
         "discovered_models": [
             {

--- a/tests/unit/providers/test_provider_model_state.py
+++ b/tests/unit/providers/test_provider_model_state.py
@@ -96,7 +96,7 @@ def test_migration_applies_to_extra_models_and_is_idempotent() -> None:
     assert snapshot == migrated
 
 
-def test_migration_applies_to_discovered_models_and_preserves_secret() -> None:
+def test_discovered_model_migration_preserves_secret() -> None:
     snapshot = {
         "api_key": "ENC:encrypted-provider-key",
         "discovered_models": [

--- a/tests/unit/providers/test_provider_model_state.py
+++ b/tests/unit/providers/test_provider_model_state.py
@@ -94,3 +94,23 @@ def test_migration_applies_to_extra_models_and_is_idempotent() -> None:
     migrated = deepcopy(snapshot)
     assert migrate_provider_snapshot(snapshot) is False
     assert snapshot == migrated
+
+
+def test_migration_applies_to_discovered_models_and_preserves_secret() -> None:
+    snapshot = {
+        "api_key": "ENC:encrypted-provider-key",
+        "discovered_models": [
+            {
+                "id": "discovered-model",
+                "name": "Discovered Model",
+                "max_tokens": 4096,
+            },
+        ],
+    }
+
+    assert migrate_provider_snapshot(snapshot) is True
+
+    model = snapshot["discovered_models"][0]
+    assert "max_tokens" not in model
+    assert model["generate_kwargs"]["max_tokens"] == 4096
+    assert snapshot["api_key"] == "ENC:encrypted-provider-key"


### PR DESCRIPTION
## Summary

- migrate legacy per-model `max_tokens` values in `discovered_models`
- keep provider snapshots loadable so encrypted credentials are restored
- add regression coverage for discovery migration and secret preservation

## Root cause

PR #7337 migrated legacy model output limits in `models` and
`extra_models`, but omitted `discovered_models`. A provider snapshot with
legacy discovery entries then failed `ModelInfo` validation as a whole, so
the provider fell back to its built-in defaults and appeared to lose its API
key even though the encrypted key remained valid on disk.

## Tests

- `tests/unit/providers/test_provider_model_state.py`: 5 passed
- `tests/unit/providers/test_provider_manager.py`: 145 passed, 1 skipped
- verified a real legacy DashScope snapshot migrates 183 discovery entries,
  preserves the decrypted API key, and returns the masked key from
  `/api/models`
