### PR TITLE
perf(startup): make early readiness truly chat-ready

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -93,6 +93,28 @@ jobs:
           TAURI_UPDATER_ENDPOINTS: ${{ vars.TAURI_UPDATER_ENDPOINTS }}
         run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
 
+      - name: Benchmark packaged backend startup (Windows)
+        id: startup-benchmark-windows
+        timeout-minutes: 15
+        shell: pwsh
+        run: |
+          python scripts/benchmarks/desktop_startup/run_backend_benchmark.py `
+            --executable console/src-tauri/binaries/qwenpaw-backend/qwenpaw-backend.exe `
+            --runs 10 `
+            --warmup-runs 1 `
+            --timeout 60 `
+            --max-p50-ms 4000 `
+            --output dist/startup-benchmark-windows.json
+
+      - name: Upload backend startup benchmark (Windows)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-startup-benchmark-windows-${{ github.sha }}
+          path: dist/startup-benchmark-windows.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Stage Tauri Windows installer and updater assets
         shell: pwsh
         env:
@@ -234,6 +256,27 @@ jobs:
         run: |
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
+
+      - name: Benchmark packaged backend startup (macOS)
+        id: startup-benchmark-macos
+        timeout-minutes: 15
+        run: |
+          python scripts/benchmarks/desktop_startup/run_backend_benchmark.py \
+            --executable console/src-tauri/binaries/qwenpaw-backend/qwenpaw-backend \
+            --runs 10 \
+            --warmup-runs 1 \
+            --timeout 60 \
+            --max-p50-ms 4000 \
+            --output dist/startup-benchmark-macos.json
+
+      - name: Upload backend startup benchmark (macOS)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-startup-benchmark-macos-${{ github.sha }}
+          path: dist/startup-benchmark-macos.json
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Verify desktop (Tauri macOS)
         timeout-minutes: 10

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -47,6 +47,8 @@ import { languageApi } from "./api/modules/language";
 import { useUploadLimitStore } from "./stores/uploadLimitStore";
 import CloseWindowPrompt from "./tauri/CloseWindowPrompt";
 import BackendLoadingPage from "./tauri/BackendLoadingPage";
+import DesktopStartupShell from "./tauri/DesktopStartupShell";
+import { isDesktopApp } from "./tauri/backendRuntime";
 import {
   resolveAuthGate,
   resolveBackendInfo,
@@ -429,7 +431,7 @@ function BackendModeRouter() {
   }, [retryKey]);
 
   if (backendInfo === "loading") {
-    return null;
+    return isDesktopApp() ? <DesktopStartupShell /> : null;
   }
   if (backendInfo === "error") {
     return (

--- a/console/src/tauri/BackendReadyGate.tsx
+++ b/console/src/tauri/BackendReadyGate.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect } from "react";
 import BackendLoadingPage from "./BackendLoadingPage";
+import DesktopStartupShell from "./DesktopStartupShell";
 import useBackendReadyPolling from "./useBackendReadyPolling";
 import { withCacheBuster, withDesktopMarker } from "./backendRuntime";
 
@@ -27,6 +28,10 @@ export default function BackendReadyGate({ children }: Props) {
   // Browser mode, or Tauri after it has navigated to the backend-hosted console.
   if (!shouldGate) {
     return <>{children}</>;
+  }
+
+  if (status === "checking" || status === "ready") {
+    return <DesktopStartupShell />;
   }
 
   return (

--- a/console/src/tauri/DesktopStartupShell.module.css
+++ b/console/src/tauri/DesktopStartupShell.module.css
@@ -1,0 +1,270 @@
+.shell {
+  --startup-accent: #ba5b18;
+  --startup-border: #deded8;
+  --startup-muted: #686862;
+  --startup-sidebar: #f1f1ed;
+  --startup-surface: #fafaf8;
+  --startup-text: #20201d;
+  background: var(--startup-surface);
+  color: var(--startup-text);
+  display: grid;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  grid-template-columns: 224px minmax(0, 1fr);
+  min-height: 100dvh;
+}
+
+.sidebar {
+  background: var(--startup-sidebar);
+  border-right: 1px solid var(--startup-border);
+  padding: 20px 14px;
+}
+
+.brand {
+  align-items: center;
+  display: flex;
+  font-size: 15px;
+  font-weight: 650;
+  gap: 10px;
+  letter-spacing: -0.01em;
+  padding: 0 8px 22px;
+}
+
+.brand img {
+  height: 28px;
+  object-fit: contain;
+  width: 28px;
+}
+
+.navigation {
+  display: grid;
+  gap: 4px;
+}
+
+.navItem,
+.activeItem {
+  align-items: center;
+  border-radius: 8px;
+  display: flex;
+  font-size: 14px;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 10px;
+}
+
+.navItem {
+  color: var(--startup-muted);
+}
+
+.activeItem {
+  background: color-mix(in srgb, var(--startup-accent) 10%, transparent);
+  color: var(--startup-text);
+  font-weight: 600;
+}
+
+.main {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+}
+
+.header {
+  align-items: center;
+  border-bottom: 1px solid var(--startup-border);
+  display: flex;
+  justify-content: space-between;
+  min-height: 76px;
+  padding: 14px 28px;
+}
+
+.header h1,
+.intro h2 {
+  margin: 0;
+}
+
+.header h1 {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.eyebrow {
+  color: var(--startup-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.11em;
+  margin: 0 0 3px;
+  text-transform: uppercase;
+}
+
+.status {
+  border: 1px solid var(--startup-border);
+  border-radius: 999px;
+  color: var(--startup-muted);
+  font-size: 12px;
+  padding: 6px 10px;
+}
+
+.workspace {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 40px 24px;
+}
+
+.intro,
+.composer {
+  max-width: 760px;
+  width: 100%;
+}
+
+.intro {
+  margin-bottom: 28px;
+  text-align: center;
+}
+
+.intro h2 {
+  font-size: clamp(25px, 3vw, 34px);
+  font-weight: 620;
+  letter-spacing: -0.035em;
+}
+
+.intro p {
+  color: var(--startup-muted);
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 10px auto 0;
+  max-width: 580px;
+}
+
+.composer {
+  background: var(--startup-surface);
+  border: 1px solid var(--startup-border);
+  border-radius: 16px;
+  box-shadow: 0 14px 40px rgb(31 31 28 / 7%);
+  padding: 14px;
+}
+
+.composer > label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0 0 8px 2px;
+}
+
+.inputRow {
+  align-items: flex-end;
+  display: flex;
+  gap: 10px;
+}
+
+.inputRow textarea {
+  background: transparent;
+  border: 0;
+  color: var(--startup-text);
+  flex: 1;
+  font: inherit;
+  line-height: 1.5;
+  min-height: 58px;
+  outline: none;
+  padding: 8px;
+  resize: none;
+}
+
+.inputRow textarea::placeholder {
+  color: var(--startup-muted);
+}
+
+.inputRow button {
+  align-items: center;
+  background: var(--startup-text);
+  border: 0;
+  border-radius: 10px;
+  color: var(--startup-surface);
+  cursor: pointer;
+  display: inline-flex;
+  height: 42px;
+  justify-content: center;
+  transition: opacity 140ms ease;
+  width: 42px;
+}
+
+.inputRow button:focus-visible,
+.inputRow textarea:focus-visible {
+  outline: 2px solid var(--startup-accent);
+  outline-offset: 2px;
+}
+
+.inputRow button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.helper {
+  color: var(--startup-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 9px 2px 0;
+}
+
+@media (max-width: 720px) {
+  .shell {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .sidebar {
+    padding-inline: 10px;
+  }
+
+  .brand {
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  .brand span,
+  .navItem span,
+  .activeItem span {
+    display: none;
+  }
+
+  .navItem,
+  .activeItem {
+    justify-content: center;
+    padding: 0;
+  }
+
+  .header {
+    padding-inline: 18px;
+  }
+
+  .status {
+    display: none;
+  }
+
+  .workspace {
+    padding-inline: 16px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .shell {
+    --startup-accent: #e58a46;
+    --startup-border: #383834;
+    --startup-muted: #b4b4ad;
+    --startup-sidebar: #1b1b19;
+    --startup-surface: #222220;
+    --startup-text: #f2f2ee;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inputRow button {
+    transition: none;
+  }
+}

--- a/console/src/tauri/DesktopStartupShell.tsx
+++ b/console/src/tauri/DesktopStartupShell.tsx
@@ -1,0 +1,114 @@
+import { FormEvent, useState } from "react";
+import { MessageSquare, PanelLeft, Send, Settings } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useMessageQueueStore } from "../stores/messageQueueStore";
+import styles from "./DesktopStartupShell.module.css";
+
+const STARTUP_QUEUE_ID = "new";
+
+export default function DesktopStartupShell() {
+  const { t } = useTranslation();
+  const [message, setMessage] = useState("");
+  const [queued, setQueued] = useState(
+    () => useMessageQueueStore.getState().getQueue(STARTUP_QUEUE_ID).length > 0,
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const text = message.trim();
+    if (!text || queued) return;
+
+    useMessageQueueStore.getState().enqueue(STARTUP_QUEUE_ID, { text });
+    setMessage("");
+    setQueued(true);
+  };
+
+  return (
+    <div className={styles.shell}>
+      <aside
+        className={styles.sidebar}
+        aria-label={t("common.navigation", "Navigation")}
+      >
+        <div className={styles.brand}>
+          <img src="/qwenpaw.png" alt="QwenPaw" />
+          <span>QwenPaw</span>
+        </div>
+        <nav className={styles.navigation}>
+          <div className={styles.activeItem} aria-current="page">
+            <MessageSquare size={17} aria-hidden="true" />
+            <span>{t("menu.chat", "Chat")}</span>
+          </div>
+          <div className={styles.navItem}>
+            <PanelLeft size={17} aria-hidden="true" />
+            <span>{t("menu.workspace", "Workspace")}</span>
+          </div>
+          <div className={styles.navItem}>
+            <Settings size={17} aria-hidden="true" />
+            <span>{t("menu.settings", "Settings")}</span>
+          </div>
+        </nav>
+      </aside>
+
+      <main className={styles.main}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.eyebrow}>QwenPaw</p>
+            <h1>{t("chat.newConversation", "New conversation")}</h1>
+          </div>
+          <span className={styles.status} role="status">
+            {queued
+              ? t("startup.messageQueued", "Message queued")
+              : t("startup.preparing", "Preparing assistant")}
+          </span>
+        </header>
+
+        <section className={styles.workspace}>
+          <div className={styles.intro}>
+            <h2>{t("startup.beginNow", "What would you like to do?")}</h2>
+            <p>
+              {t(
+                "startup.beginNowHint",
+                "You can begin now. Your first message will be sent as soon as the assistant is ready.",
+              )}
+            </p>
+          </div>
+
+          <form className={styles.composer} onSubmit={submit}>
+            <label htmlFor="desktop-startup-message">
+              {t("startup.firstMessage", "First message")}
+            </label>
+            <div className={styles.inputRow}>
+              <textarea
+                id="desktop-startup-message"
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder={t("chat.inputPlaceholder", "Ask QwenPaw anything")}
+                rows={2}
+                disabled={queued}
+                autoFocus
+              />
+              <button
+                type="submit"
+                disabled={queued || message.trim().length === 0}
+                aria-label={t("chat.send", "Send message")}
+              >
+                <Send size={18} aria-hidden="true" />
+              </button>
+            </div>
+            <p className={styles.helper} aria-live="polite">
+              {queued
+                ? t(
+                    "startup.messageQueuedHint",
+                    "Your message is safe and will send automatically.",
+                  )
+                : t(
+                    "startup.backgroundHint",
+                    "Optional capabilities continue preparing in the background.",
+                  )}
+            </p>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/console/src/test/DesktopStartupShell.test.tsx
+++ b/console/src/test/DesktopStartupShell.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "./common_setup";
+import { useMessageQueueStore } from "../stores/messageQueueStore";
+import DesktopStartupShell from "../tauri/DesktopStartupShell";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+describe("DesktopStartupShell", () => {
+  beforeEach(() => {
+    useMessageQueueStore.getState().clear("new");
+  });
+
+  it("persists one startup message in the existing chat queue", () => {
+    renderWithProviders(<DesktopStartupShell />);
+
+    fireEvent.change(screen.getByLabelText("First message"), {
+      target: { value: "Summarize my unread work" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    const queue = useMessageQueueStore.getState().getQueue("new");
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      text: "Summarize my unread work",
+      status: "pending",
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("Message queued");
+    expect(screen.getByLabelText("First message")).toBeDisabled();
+  });
+});

--- a/scripts/benchmarks/desktop_startup/run_backend_benchmark.py
+++ b/scripts/benchmarks/desktop_startup/run_backend_benchmark.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Benchmark packaged QwenPaw desktop backend startup milestones."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import queue
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from typing import Any, TextIO
+import urllib.error
+import urllib.request
+from uuid import uuid4
+
+
+METRIC_PREFIX = "QWENPAW_STARTUP_METRIC "
+BACKEND_READY_PREFIX = "QWENPAW_BACKEND_READY "
+CHAT_READY_TARGET = "console_chat_http_200"
+METRICS_ENV = "QWENPAW_DESKTOP_STARTUP_METRICS"
+SHUTDOWN_TOKEN_ENV = "QWENPAW_DESKTOP_SHUTDOWN_TOKEN"
+SHUTDOWN_TOKEN_HEADER = "X-QwenPaw-Desktop-Shutdown-Token"
+
+
+def parse_metric_line(line: str) -> dict[str, Any] | None:
+    """Parse a structured metric embedded in one process output line."""
+    marker_index = line.find(METRIC_PREFIX)
+    if marker_index < 0:
+        return None
+    raw_payload = line[marker_index + len(METRIC_PREFIX) :].strip()
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or not payload.get("event"):
+        return None
+    return payload
+
+
+def parse_backend_port(line: str) -> int | None:
+    """Parse the port from the sidecar's stable ready announcement."""
+    marker_index = line.find(BACKEND_READY_PREFIX)
+    if marker_index < 0:
+        return None
+    raw_payload = line[marker_index + len(BACKEND_READY_PREFIX) :].strip()
+    try:
+        payload = json.loads(raw_payload)
+        port = int(payload["port"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    return port if 0 < port <= 65535 else None
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    """Return a linearly interpolated percentile for non-empty values."""
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(ordered) - 1)
+    fraction = position - lower_index
+    lower = ordered[lower_index]
+    upper = ordered[upper_index]
+    return lower + (upper - lower) * fraction
+
+
+def summarize_runs(
+    runs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Summarize successful true Chat API readiness timings."""
+    successful = [run for run in runs if run.get("success")]
+    wall_values = [float(run["wall_elapsed_ms"]) for run in successful]
+
+    def _stats(values: list[float]) -> dict[str, float]:
+        return {
+            "min": round(min(values), 3),
+            "p50": round(percentile(values, 0.50), 3),
+            "p90": round(percentile(values, 0.90), 3),
+            "p95": round(percentile(values, 0.95), 3),
+            "max": round(max(values), 3),
+        }
+
+    result: dict[str, Any] = {
+        "requested_runs": len(runs),
+        "successful_runs": len(successful),
+        "failed_runs": len(runs) - len(successful),
+    }
+    if successful:
+        result["wall_elapsed_ms"] = _stats(wall_values)
+    return result
+
+
+def _forward_stream(
+    name: str,
+    stream: TextIO,
+    output_queue: queue.Queue[tuple[str, str | None]],
+) -> None:
+    try:
+        for line in stream:
+            output_queue.put((name, line.rstrip("\r\n")))
+    finally:
+        output_queue.put((name, None))
+
+
+def _shutdown_backend(port: int | None, token: str) -> None:
+    if port is None:
+        return
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/desktop/shutdown",
+        method="POST",
+        headers={SHUTDOWN_TOKEN_HEADER: token},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2):
+            pass
+    except (OSError, urllib.error.URLError):
+        pass
+
+
+def _probe_console_chat(port: int, session_id: str) -> bool:
+    """Return whether the production Console Chat route accepts a request."""
+    payload = json.dumps(
+        {
+            "channel": "console",
+            "user_id": "default",
+            "session_id": session_id,
+            "input": [
+                {
+                    "role": "user",
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "readiness probe",
+                        },
+                    ],
+                },
+            ],
+            "stream": True,
+            "reconnect": True,
+        },
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/console/chat",
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Agent-Id": "default",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=0.5) as response:
+            response.read()
+            return response.status == 200
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def _force_stop(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            [
+                "taskkill",
+                "/PID",
+                f"{process.pid}",
+                "/T",
+                "/F",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+# pylint: disable=too-many-branches,too-many-statements
+def run_once(
+    executable: Path,
+    working_dir: Path,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Launch the backend and wait for a real Console Chat HTTP 200."""
+    shutdown_token = uuid4().hex
+    probe_session_id = f"startup-probe-{uuid4().hex}"
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "PYTHONUTF8": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUNBUFFERED": "1",
+            "QWENPAW_DESKTOP_APP": "1",
+            "QWENPAW_WORKING_DIR": str(working_dir),
+            METRICS_ENV: "1",
+            SHUTDOWN_TOKEN_ENV: shutdown_token,
+        },
+    )
+    creation_flags = 0
+    if os.name == "nt":
+        creation_flags = subprocess.CREATE_NO_WINDOW
+    started_ns = time.perf_counter_ns()
+    process = subprocess.Popen(  # pylint: disable=consider-using-with
+        [str(executable)],
+        cwd=str(executable.parent),
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        creationflags=creation_flags,
+        start_new_session=os.name != "nt",
+    )
+    if process.stdout is None or process.stderr is None:
+        raise RuntimeError("backend output pipes were not created")
+
+    output_queue: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    threads = [
+        threading.Thread(
+            target=_forward_stream,
+            args=("stdout", process.stdout, output_queue),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_forward_stream,
+            args=("stderr", process.stderr, output_queue),
+            daemon=True,
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+
+    metrics: dict[str, dict[str, Any]] = {}
+    captured_output: list[dict[str, str]] = []
+    deadline = time.monotonic() + timeout_seconds
+    target_seen_ns: int | None = None
+    open_streams = len(threads)
+    port: int | None = None
+    next_probe_at = 0.0
+
+    try:
+        while time.monotonic() < deadline and open_streams:
+            try:
+                stream_name, line = output_queue.get(timeout=0.1)
+            except queue.Empty:
+                now = time.monotonic()
+                if port is not None and now >= next_probe_at:
+                    next_probe_at = now + 0.05
+                    if _probe_console_chat(port, probe_session_id):
+                        target_seen_ns = time.perf_counter_ns()
+                        break
+                if process.poll() is not None:
+                    continue
+                continue
+            if line is None:
+                open_streams -= 1
+                continue
+            captured_output.append({"stream": stream_name, "line": line})
+            metric = parse_metric_line(line)
+            if metric is not None:
+                event = str(metric["event"])
+                metrics[event] = metric
+                if event == "port_bound" and metric.get("port") is not None:
+                    port = int(metric["port"])
+            announced_port = parse_backend_port(line)
+            if announced_port is not None:
+                port = announced_port
+
+            now = time.monotonic()
+            if port is not None and now >= next_probe_at:
+                next_probe_at = now + 0.05
+                if _probe_console_chat(port, probe_session_id):
+                    target_seen_ns = time.perf_counter_ns()
+                    break
+        if target_seen_ns is None and port is not None:
+            while time.monotonic() < deadline:
+                if _probe_console_chat(port, probe_session_id):
+                    target_seen_ns = time.perf_counter_ns()
+                    break
+                time.sleep(0.05)
+                if process.poll() is not None:
+                    break
+    finally:
+        _shutdown_backend(port, shutdown_token)
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            _force_stop(process)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    if target_seen_ns is None:
+        return {
+            "success": False,
+            "exit_code": process.poll(),
+            "metrics": metrics,
+            "output_tail": captured_output[-80:],
+            "error": f"target {CHAT_READY_TARGET} was not reached",
+        }
+    return {
+        "success": True,
+        "exit_code": process.poll(),
+        "wall_elapsed_ms": round(
+            (target_seen_ns - started_ns) / 1_000_000,
+            3,
+        ),
+        "metrics": metrics,
+        "output_tail": captured_output[-20:],
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark packaged desktop backend startup",
+    )
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--runs", type=int, default=20)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--max-p50-ms", type=float)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run warmups and measured launches, then write a JSON report."""
+    args = _parse_args()
+    executable = args.executable.resolve()
+    if not executable.is_file():
+        raise FileNotFoundError(
+            f"backend executable not found: {executable}",
+        )
+    if args.runs < 1 or args.warmup_runs < 0:
+        raise ValueError("run counts must be positive")
+
+    with tempfile.TemporaryDirectory(
+        prefix="qwenpaw-desktop-startup-",
+    ) as temporary_dir:
+        working_dir = Path(temporary_dir)
+        warmups = [
+            run_once(
+                executable,
+                working_dir,
+                args.timeout,
+            )
+            for _ in range(args.warmup_runs)
+        ]
+        runs = [
+            run_once(
+                executable,
+                working_dir,
+                args.timeout,
+            )
+            for _ in range(args.runs)
+        ]
+
+    summary = summarize_runs(runs)
+    acceptance = None
+    if args.max_p50_ms is not None:
+        measured_p50 = summary.get("wall_elapsed_ms", {}).get("p50")
+        acceptance = {
+            "max_p50_ms": args.max_p50_ms,
+            "measured_p50_ms": measured_p50,
+            "passed": (
+                measured_p50 is not None and measured_p50 <= args.max_p50_ms
+            ),
+        }
+
+    report = {
+        "schema_version": 2,
+        "executable": str(executable),
+        "platform": os.name,
+        "target": CHAT_READY_TARGET,
+        "warmups": warmups,
+        "runs": runs,
+        "summary": summary,
+    }
+    if acceptance is not None:
+        report["acceptance"] = acceptance
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        f"{json.dumps(report, indent=2, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote startup benchmark to {args.output}")
+    print(f"{json.dumps(report['summary'], indent=2, sort_keys=True)}")
+    all_runs_succeeded = summary["successful_runs"] == args.runs
+    threshold_passed = acceptance is None or acceptance["passed"]
+    return 0 if all_runs_succeeded and threshold_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -135,6 +135,18 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     app: FastAPI,
 ):
     startup_start_time = time.time()
+    startup_coordinator = getattr(
+        app.state,
+        "startup_coordinator",
+        None,
+    )
+    desktop_startup_metric = getattr(
+        app.state,
+        "desktop_startup_metric",
+        None,
+    )
+    if desktop_startup_metric is not None:
+        desktop_startup_metric("lifespan_started")
     add_project_file_handler(LOG_FILE_PATH)
 
     # ================================================================
@@ -210,6 +222,7 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
         workspace_registry = WorkspaceRegistry(
             app_services=app_services,
+            defer_optional_services=startup_coordinator is not None,
         )
         app.state.workspace_registry = workspace_registry
         logger.debug("Runtime infrastructure initialized")
@@ -358,11 +371,18 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         prime_bridge_token()
     except Exception:
         logger.warning("Bridge token priming failed", exc_info=True)
+    if startup_coordinator is not None:
+        startup_coordinator.mark_ready("browser_ready")
 
     fast_elapsed = time.time() - startup_start_time
     logger.info(
         f"Server ready in {fast_elapsed:.3f}s (agents loading in background)",
     )
+    if desktop_startup_metric is not None:
+        desktop_startup_metric(
+            "core_ready",
+            lifespan_elapsed_ms=round(fast_elapsed * 1000, 3),
+        )
 
     # ================================================================
     # Background heavy initialization
@@ -375,6 +395,14 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     startup_display = AgentStartupDisplay(read_last_api()).start()
 
     async def _background_startup():  # pylint: disable=too-many-statements
+        if startup_coordinator is not None:
+            for phase_name in (
+                "background_ready",
+                "plugins_ready",
+                "channels_ready",
+                "memory_ready",
+            ):
+                startup_coordinator.mark_running(phase_name)
         try:
             # ---- Plugin System (phase 1: channel plugins) ----
             # Load channel-type plugins *before* agents start so that
@@ -414,8 +442,45 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             def _mark_core_agents_ready(_results: dict[str, bool]) -> None:
                 """Publish readiness after the core agent phase."""
                 core_elapsed = time.time() - startup_start_time
-                startup_display.mark_core_ready(core_elapsed)
                 app.state.startup_ready.set()
+                if startup_coordinator is not None:
+                    for phase_name in (
+                        "chat_core_ready",
+                        "memory_ready",
+                    ):
+                        startup_coordinator.mark_ready(phase_name)
+
+                    async def _wait_for_background_services() -> None:
+                        default_agent = workspace_registry.get_loaded_agent(
+                            "default",
+                        )
+                        if default_agent is None:
+                            raise RuntimeError(
+                                "Default agent missing after startup",
+                            )
+                        await default_agent.wait_for_deferred_services()
+
+                    startup_coordinator.start_worker(
+                        "channels_ready",
+                        _wait_for_background_services,
+                    )
+                    ready_elapsed = (
+                        startup_coordinator.snapshot()["elapsed_ms"] / 1000
+                    )
+                    startup_display.complete(
+                        ready_elapsed,
+                        background_pending=True,
+                    )
+                else:
+                    startup_display.mark_core_ready(core_elapsed)
+                if desktop_startup_metric is not None:
+                    desktop_startup_metric(
+                        "console_chat_ready",
+                        lifespan_elapsed_ms=round(
+                            core_elapsed * 1000,
+                            3,
+                        ),
+                    )
 
             startup_results = (
                 await workspace_registry.start_all_configured_agents(
@@ -427,6 +492,14 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 startup_display.mark_failed(
                     "Default agent failed to start",
                 )
+                if startup_coordinator is not None:
+                    error = "Default agent failed to start"
+                    for phase_name in (
+                        "chat_core_ready",
+                        "channels_ready",
+                        "memory_ready",
+                    ):
+                        startup_coordinator.mark_failed(phase_name, error)
             elif app.state.startup_ready.is_set():
                 startup_display.mark_finalizing()
 
@@ -539,6 +612,9 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                         exc_info=True,
                     )
 
+            if startup_coordinator is not None:
+                startup_coordinator.mark_ready("plugins_ready")
+
             # ---- Approval Service ----
             try:
                 default_agent = await workspace_registry.get_agent(
@@ -568,19 +644,50 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                     exc_info=True,
                 )
 
+            loaded_agents = [
+                workspace_registry.get_loaded_agent(agent_id)
+                for agent_id in workspace_registry.list_loaded_agents()
+            ]
+            await asyncio.gather(
+                *(
+                    agent.wait_for_deferred_services()
+                    for agent in loaded_agents
+                    if agent is not None
+                ),
+            )
+            if startup_coordinator is not None:
+                startup_coordinator.mark_ready("background_ready")
+
             startup_elapsed = time.time() - startup_start_time
             logger.info(
                 "Background startup completed in "
                 f"{startup_elapsed:.3f} seconds",
             )
             if app.state.startup_ready.is_set():
-                startup_display.complete(startup_elapsed)
+                if startup_coordinator is not None:
+                    background_elapsed = (
+                        startup_coordinator.snapshot()["elapsed_ms"] / 1000
+                    )
+                    startup_display.complete_background(background_elapsed)
+                else:
+                    startup_display.complete(startup_elapsed)
 
-        except Exception:
+        except Exception as exc:
             logger.error(
                 "Background startup encountered an error",
                 exc_info=True,
             )
+            if startup_coordinator is not None:
+                if app.state.startup_ready.is_set():
+                    startup_display.fail_background()
+                for phase_name in (
+                    "background_ready",
+                    "chat_core_ready",
+                    "channels_ready",
+                    "memory_ready",
+                    "plugins_ready",
+                ):
+                    startup_coordinator.mark_failed(phase_name, exc)
 
     _bg_task = asyncio.create_task(_background_startup())
 

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -22,9 +22,10 @@ from typing import (
 from .base import BaseChannel, ContentType, ProcessHandler, TextContent
 from .renderer import ChannelDisplayConfig
 from .command_registry import CommandRegistry
-from .registry import get_channel_registry
+from .registry import get_channel_class, get_channel_registry
 from .unified_queue_manager import UnifiedQueueManager
 from ...config import get_available_channels
+from ...config.utils import get_startup_channel_keys
 
 if TYPE_CHECKING:
     from ...config.config import Config
@@ -129,15 +130,13 @@ class ChannelManager:
             on_last_dispatch: Callback for dispatch events
             workspace_dir: Agent workspace directory for channel state files
         """
-        available = get_available_channels()
+        available = get_startup_channel_keys()
         ch = config.channels
         show_tool_details = getattr(config, "show_tool_details", True)
         extra = getattr(ch, "__pydantic_extra__", None) or {}
 
         channels: list[BaseChannel] = []
-        for key, ch_cls in get_channel_registry().items():
-            if key not in available:
-                continue
+        for key in available:
             ch_cfg = getattr(ch, key, None)
             if ch_cfg is None and key in extra:
                 ch_cfg = extra[key]
@@ -159,6 +158,10 @@ class ChannelManager:
             else:
                 enabled = getattr(ch_cfg, "enabled", False)
             if not enabled:
+                continue
+
+            ch_cls = get_channel_class(key)
+            if ch_cls is None:
                 continue
 
             no_text_debounce = getattr(ch_cfg, "no_text_debounce", True)

--- a/src/qwenpaw/app/channels/registry.py
+++ b/src/qwenpaw/app/channels/registry.py
@@ -39,60 +39,73 @@ _BUILTIN_SPECS: dict[str, tuple[str, str]] = {
 # Required channels must load; failures are raised, not skipped.
 _REQUIRED_CHANNEL_KEYS: frozenset[str] = frozenset({"console"})
 
-_BUILTIN_CHANNEL_CACHE: dict[str, type[BaseChannel]] | None = None
+_BUILTIN_CHANNEL_CACHE: dict[str, type[BaseChannel] | None] = {}
 _BUILTIN_CHANNEL_CACHE_LOCK = threading.Lock()
 
 
-def _load_builtin_channels() -> dict[str, type[BaseChannel]]:
-    """Load built-in channels safely.
-
-    A single optional dependency failure should not break CLI startup.
-    """
-    out: dict[str, type[BaseChannel]] = {}
-    for key, (module_name, class_name) in _BUILTIN_SPECS.items():
-        try:
-            mod = importlib.import_module(module_name, package=__package__)
-            cls = getattr(mod, class_name)
-            if not (
-                isinstance(cls, type)
-                and issubclass(cls, BaseChannel)
-                and cls is not BaseChannel
-            ):
-                raise TypeError(
-                    f"{module_name}.{class_name} is not a BaseChannel subtype",
-                )
-        except Exception:
-            if key in _REQUIRED_CHANNEL_KEYS:
-                logger.error(
-                    'failed to load required built-in channel "%s"',
-                    key,
-                    exc_info=True,
-                )
-                raise
-            logger.debug(
-                "built-in channel unavailable: %s",
+def _load_builtin_channel(key: str) -> type[BaseChannel] | None:
+    """Load one built-in channel without importing unrelated transports."""
+    module_name, class_name = _BUILTIN_SPECS[key]
+    try:
+        module = importlib.import_module(module_name, package=__package__)
+        channel_class = getattr(module, class_name)
+        if not (
+            isinstance(channel_class, type)
+            and issubclass(channel_class, BaseChannel)
+            and channel_class is not BaseChannel
+        ):
+            raise TypeError(
+                f"{module_name}.{class_name} is not a BaseChannel subtype",
+            )
+    except Exception:
+        if key in _REQUIRED_CHANNEL_KEYS:
+            logger.error(
+                'failed to load required built-in channel "%s"',
                 key,
                 exc_info=True,
             )
-            continue
-        out[key] = cls
-    return out
+            raise
+        logger.debug(
+            "built-in channel unavailable: %s",
+            key,
+            exc_info=True,
+        )
+        return None
+    return channel_class
+
+
+def get_channel_class(key: str) -> type[BaseChannel] | None:
+    """Return one channel class, importing only the requested built-in."""
+    if key in _BUILTIN_SPECS:
+        with _BUILTIN_CHANNEL_CACHE_LOCK:
+            if key not in _BUILTIN_CHANNEL_CACHE:
+                _BUILTIN_CHANNEL_CACHE[key] = _load_builtin_channel(key)
+            return _BUILTIN_CHANNEL_CACHE[key]
+    return _get_plugin_channels().get(key)
+
+
+def get_channel_keys() -> tuple[str, ...]:
+    """Return discoverable keys without importing built-in channel modules."""
+    plugin_keys = tuple(
+        key for key in _get_plugin_channels() if key not in _BUILTIN_SPECS
+    )
+    return (*_BUILTIN_SPECS, *plugin_keys)
 
 
 def _get_cached_builtin_channels() -> dict[str, type[BaseChannel]]:
-    """Return cached built-in channels (loaded once per process)."""
-    global _BUILTIN_CHANNEL_CACHE
-    with _BUILTIN_CHANNEL_CACHE_LOCK:
-        if _BUILTIN_CHANNEL_CACHE is None:
-            _BUILTIN_CHANNEL_CACHE = _load_builtin_channels()
-        return dict(_BUILTIN_CHANNEL_CACHE)
+    """Return every available built-in channel for discovery commands."""
+    channels = {key: get_channel_class(key) for key in _BUILTIN_SPECS}
+    return {
+        key: channel_class
+        for key, channel_class in channels.items()
+        if channel_class is not None
+    }
 
 
 def clear_builtin_channel_cache() -> None:
     """Reset built-in channel cache. Primarily for tests."""
-    global _BUILTIN_CHANNEL_CACHE
     with _BUILTIN_CHANNEL_CACHE_LOCK:
-        _BUILTIN_CHANNEL_CACHE = None
+        _BUILTIN_CHANNEL_CACHE.clear()
 
 
 BUILTIN_CHANNEL_KEYS = frozenset(_BUILTIN_SPECS.keys())

--- a/src/qwenpaw/app/deferred_app.py
+++ b/src/qwenpaw/app/deferred_app.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Shared lightweight ASGI entry point with deferred full-app loading."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import time
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from ..__version__ import __version__
+from .startup_coordinator import StartupCoordinator
+
+
+STARTUP_PHASES = (
+    "api_ready",
+    "chat_core_ready",
+    "browser_ready",
+    "memory_ready",
+    "channels_ready",
+    "plugins_ready",
+    "background_ready",
+)
+
+
+def load_full_app() -> FastAPI:
+    """Import and return the complete QwenPaw application."""
+    module = importlib.import_module("qwenpaw.app._app")
+    return module.app
+
+
+class DeferredRuntime:
+    """Own the complete app lifespan outside the server critical path."""
+
+    def __init__(self, app_loader: Callable[[], FastAPI]) -> None:
+        self.coordinator = StartupCoordinator(STARTUP_PHASES)
+        self.full_app: FastAPI | None = None
+        self.load_error: str | None = None
+        self.ready = asyncio.Event()
+        self._stop_requested = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._app_loader = app_loader
+
+    def start(self, shell_app: FastAPI) -> None:
+        """Start importing and initializing the complete app."""
+        self.coordinator.mark_ready("api_ready")
+        self._mark(shell_app, "api_ready")
+        self.coordinator.mark_running("chat_core_ready")
+        self._task = asyncio.create_task(
+            self._run(shell_app),
+            name="startup:full-app",
+        )
+
+    async def stop(self) -> None:
+        """Exit the complete app lifespan and readiness monitors."""
+        self._stop_requested.set()
+        if self._task is not None:
+            await asyncio.gather(self._task, return_exceptions=True)
+        await self.coordinator.stop()
+
+    async def _run(self, shell_app: FastAPI) -> None:
+        try:
+            self._mark(shell_app, "full_app_import_started")
+            full_app = await asyncio.to_thread(self._app_loader)
+            self._mark(shell_app, "full_app_import_done")
+            self._copy_state(shell_app, full_app)
+            full_app.state.startup_coordinator = self.coordinator
+            async with full_app.router.lifespan_context(full_app):
+                self.full_app = full_app
+                self.ready.set()
+                self.coordinator.start_worker(
+                    "chat_core_ready",
+                    lambda: self._wait_for_chat_core(full_app),
+                )
+                await self._stop_requested.wait()
+        except Exception as exc:  # noqa: BLE001 - startup boundary
+            self.load_error = str(exc)
+            self.coordinator.mark_failed("chat_core_ready", exc)
+            self.ready.set()
+
+    @staticmethod
+    def _mark(shell_app: FastAPI, event: str) -> None:
+        metric = getattr(shell_app.state, "desktop_startup_metric", None)
+        if metric is not None:
+            metric(event)
+
+    @staticmethod
+    def _copy_state(shell_app: FastAPI, full_app: FastAPI) -> None:
+        """Copy state installed by an outer process entry point."""
+        for name in ("desktop_startup_metric", "uvicorn_server"):
+            value = getattr(shell_app.state, name, None)
+            if value is not None:
+                setattr(full_app.state, name, value)
+
+    @staticmethod
+    async def _wait_for_chat_core(full_app: FastAPI) -> None:
+        """Wait for the existing default-agent readiness primitive."""
+        ready = getattr(full_app.state, "startup_ready", None)
+        if ready is None:
+            raise RuntimeError("Full app did not publish startup_ready")
+        await ready.wait()
+
+
+class DeferredApp:
+    """Dispatch early readiness requests before the full app is ready."""
+
+    def __init__(
+        self,
+        app_loader: Callable[[], FastAPI] = load_full_app,
+    ) -> None:
+        self.runtime = DeferredRuntime(app_loader)
+        self.shell_app = self._create_shell_app()
+        self.state = self.shell_app.state
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[..., Any],
+        send: Callable[..., Any],
+    ) -> None:
+        """Dispatch one ASGI request to the shell or complete app."""
+        if scope["type"] == "lifespan" or self._is_shell_request(scope):
+            await self.shell_app(scope, receive, send)
+            return
+
+        await self.runtime.ready.wait()
+        if self.runtime.full_app is None:
+            response = JSONResponse(
+                status_code=503,
+                content={
+                    "status": "failed",
+                    "detail": self.runtime.load_error
+                    or "QwenPaw runtime failed to start",
+                },
+            )
+            await response(scope, receive, send)
+            return
+
+        required_phase = self._required_phase(scope)
+        phase = await self.runtime.coordinator.wait_for_terminal(
+            required_phase,
+        )
+        if phase.status != "ready":
+            response = JSONResponse(
+                status_code=503,
+                content={
+                    "status": "failed",
+                    "detail": phase.error
+                    or f"Startup phase failed: {required_phase}",
+                },
+            )
+            await response(scope, receive, send)
+            return
+        await self.runtime.full_app(scope, receive, send)
+
+    @staticmethod
+    def _required_phase(scope: dict[str, Any]) -> str:
+        """Choose the smallest safe readiness boundary for one request."""
+        if scope["type"] == "http":
+            method = scope.get("method", "GET").upper()
+            path = scope.get("path", "")
+            if method in {"GET", "HEAD", "OPTIONS"}:
+                return "chat_core_ready"
+            if path in {
+                "/api/console/chat",
+                "/api/console/chat/stop",
+                "/api/console/chat/task",
+            }:
+                return "chat_core_ready"
+        return "background_ready"
+
+    @staticmethod
+    def _is_shell_request(scope: dict[str, Any]) -> bool:
+        if scope["type"] != "http":
+            return False
+        return scope.get("path", "") in {
+            "/api/healthz",
+            "/api/startup/status",
+            "/api/version",
+        }
+
+    def _create_shell_app(self) -> FastAPI:
+        @asynccontextmanager
+        async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+            self.runtime.start(shell_app)
+            try:
+                yield
+            finally:
+                await self.runtime.stop()
+
+        shell_app = FastAPI(lifespan=lifespan)
+
+        @shell_app.get("/api/version")
+        def get_version() -> dict[str, str]:
+            return {"version": __version__}
+
+        @shell_app.get("/api/startup/status")
+        def get_startup_status() -> dict[str, Any]:
+            return self.runtime.coordinator.snapshot()
+
+        @shell_app.get("/api/healthz")
+        def get_healthz() -> Any:
+            snapshot = self.runtime.coordinator.snapshot()
+            chat_phase = snapshot["phases"]["chat_core_ready"]
+            if chat_phase["status"] != "ready":
+                status = "failed" if self.runtime.load_error else "starting"
+                detail = self.runtime.load_error or (
+                    "Background startup in progress"
+                )
+                return JSONResponse(
+                    status_code=503,
+                    content={"status": status, "detail": detail},
+                )
+
+            full_app = self.runtime.full_app
+            registry = (
+                getattr(full_app.state, "multi_agent_manager", None)
+                if full_app is not None
+                else None
+            )
+            agents = registry.list_loaded_agents() if registry else []
+            start_time = (
+                getattr(full_app.state, "startup_time", None)
+                if full_app is not None
+                else None
+            )
+            uptime = (
+                round(time.time() - start_time, 2)
+                if start_time is not None
+                else None
+            )
+            return {
+                "status": "ok",
+                "agents_loaded": agents,
+                "uptime_seconds": uptime,
+            }
+
+        return shell_app
+
+
+app = DeferredApp()

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -880,14 +880,15 @@ class MultiAgentManager:
         on_core_ready: Callable[[dict[str, bool]], None] | None = None,
         startup_display: AgentStartupDisplay | None = None,
     ) -> dict[str, bool]:
-        """Start core agents, then custom agents with bounded concurrency.
+        """Start the default agent, then all deferred agents.
 
         Only agents with enabled=True will be started.
         Disabled agents are skipped to save resources.
 
-        The default and built-in QA agents form the concurrent core phase.
-        Remaining custom agents start only after that phase and are bounded
-        by ``QWENPAW_CUSTOM_AGENT_STARTUP_CONCURRENCY``.
+        The default agent is the chat-readiness critical path. The built-in QA
+        agent and custom agents start only after default readiness. Custom
+        agents remain bounded by
+        ``QWENPAW_CUSTOM_AGENT_STARTUP_CONCURRENCY``.
 
         Returns:
             dict[str, bool]: Mapping of agent_id to success status
@@ -939,15 +940,16 @@ class MultiAgentManager:
                 )
                 return (agent_id, False)
 
-        core_agent_ids = [
-            agent_id
-            for agent_id in ("default", BUILTIN_QA_AGENT_ID)
-            if agent_id in enabled_agents
-        ]
+        core_agent_ids = ["default"] if "default" in enabled_agents else []
+        deferred_builtin_ids = (
+            [BUILTIN_QA_AGENT_ID]
+            if BUILTIN_QA_AGENT_ID in enabled_agents
+            else []
+        )
         custom_agent_ids = [
             agent_id
             for agent_id in agent_ids
-            if agent_id not in core_agent_ids
+            if agent_id not in {*core_agent_ids, *deferred_builtin_ids}
         ]
 
         core_results = await asyncio.gather(
@@ -966,15 +968,19 @@ class MultiAgentManager:
                 )
 
         if core_result_map.get("default") is False:
-            custom_result_map = {
+            deferred_result_map = {
                 agent_id: agent_id in self.agents
-                for agent_id in custom_agent_ids
+                for agent_id in (
+                    *deferred_builtin_ids,
+                    *custom_agent_ids,
+                )
             }
             logger.error(
-                "Default agent failed to start; skipping %d custom agent(s)",
-                len(custom_agent_ids),
+                "Default agent failed to start; skipping %d deferred "
+                "agent(s)",
+                len(deferred_result_map),
             )
-            return {**core_result_map, **custom_result_map}
+            return {**core_result_map, **deferred_result_map}
 
         if startup_display is not None and custom_agent_ids:
             startup_display.start_custom_agents(len(custom_agent_ids))
@@ -990,12 +996,16 @@ class MultiAgentManager:
                 if startup_display is not None:
                     startup_display.advance(agent_id)
 
-        custom_results = await asyncio.gather(
+        deferred_results = await asyncio.gather(
+            *(
+                start_single_agent(agent_id)
+                for agent_id in deferred_builtin_ids
+            ),
             *(start_custom_agent(agent_id) for agent_id in custom_agent_ids),
             return_exceptions=False,
         )
 
-        results = [*core_results, *custom_results]
+        results = [*core_results, *deferred_results]
 
         # Build result mapping
         result_map = dict(results)

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -77,6 +77,23 @@ def _resolve_effective_stream_task_timeout(
     return resolve_stream_task_timeout(raw_timeout, field_name="timeout")
 
 
+async def _get_console_channel(workspace: Any) -> Any:
+    """Return the local console channel or a stable readiness error."""
+    manager = workspace.channel_manager
+    if manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel Console not ready",
+        )
+    console_channel = await manager.get_channel("console")
+    if console_channel is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel Console not found",
+        )
+    return console_channel
+
+
 def _background_task_cancel_error(
     *,
     timed_out: bool,
@@ -376,12 +393,7 @@ async def post_console_chat(
     Stop via POST /console/chat/stop. Reconnect with body.reconnect=true.
     """
     workspace = await get_agent_for_request(request)
-    console_channel = await workspace.channel_manager.get_channel("console")
-    if console_channel is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Channel Console not found",
-        )
+    console_channel = await _get_console_channel(workspace)
     try:
         native_payload = _extract_session_and_payload(request_data)
     except ValueError as e:
@@ -530,12 +542,7 @@ async def post_console_upload(
     """Save to console channel media_dir."""
 
     workspace = await get_agent_for_request(request)
-    console_channel = await workspace.channel_manager.get_channel("console")
-    if console_channel is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Channel Console not found",
-        )
+    console_channel = await _get_console_channel(workspace)
     media_dir = console_channel.media_dir
     media_dir.mkdir(parents=True, exist_ok=True)
     data = await file.read()
@@ -826,12 +833,7 @@ async def post_console_chat_task(
     ``GET /console/chat/task/{task_id}``.
     """
     workspace = await get_agent_for_request(request)
-    console_channel = await workspace.channel_manager.get_channel("console")
-    if console_channel is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Channel Console not found",
-        )
+    console_channel = await _get_console_channel(workspace)
 
     # Single validation path for task timeout — always HTTP 400 on error.
     try:

--- a/src/qwenpaw/app/startup_coordinator.py
+++ b/src/qwenpaw/app/startup_coordinator.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Readiness and failure tracking for application startup phases."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+_PENDING = "pending"
+_RUNNING = "running"
+_READY = "ready"
+_FAILED = "failed"
+
+
+@dataclass
+class StartupPhase:
+    """Mutable state for one independently observable startup phase."""
+
+    status: str = _PENDING
+    started_ms: float | None = None
+    finished_ms: float | None = None
+    error: str | None = None
+
+
+class StartupCoordinator:
+    """Supervise startup tasks and publish monotonic readiness."""
+
+    def __init__(self, phase_names: tuple[str, ...]) -> None:
+        self._started_at = time.monotonic()
+        self._phases = {
+            phase_name: StartupPhase() for phase_name in phase_names
+        }
+        self._terminal_events = {
+            phase_name: asyncio.Event() for phase_name in phase_names
+        }
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    def mark_running(self, phase_name: str) -> None:
+        """Mark a phase as running without resetting its timestamp."""
+        phase = self._phase(phase_name)
+        if phase.status in {_READY, _FAILED}:
+            return
+        phase.status = _RUNNING
+        if phase.started_ms is None:
+            phase.started_ms = self._elapsed_ms()
+
+    def mark_ready(self, phase_name: str) -> None:
+        """Mark a phase as ready."""
+        phase = self._phase(phase_name)
+        if phase.status == _FAILED:
+            return
+        if phase.started_ms is None:
+            phase.started_ms = self._elapsed_ms()
+        phase.status = _READY
+        phase.finished_ms = self._elapsed_ms()
+        phase.error = None
+        self._terminal_events[phase_name].set()
+
+    def mark_failed(self, phase_name: str, error: BaseException | str) -> None:
+        """Mark a phase as failed without raising into sibling workers."""
+        phase = self._phase(phase_name)
+        if phase.status == _READY:
+            return
+        if phase.started_ms is None:
+            phase.started_ms = self._elapsed_ms()
+        phase.status = _FAILED
+        phase.finished_ms = self._elapsed_ms()
+        phase.error = str(error)
+        self._terminal_events[phase_name].set()
+
+    async def wait_for_terminal(self, phase_name: str) -> StartupPhase:
+        """Wait until one phase is ready or failed, then return its state."""
+        self._phase(phase_name)
+        await self._terminal_events[phase_name].wait()
+        return self._phase(phase_name)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-safe snapshot of every startup phase."""
+        return {
+            "elapsed_ms": round(self._elapsed_ms(), 3),
+            "phases": {
+                phase_name: asdict(phase)
+                for phase_name, phase in self._phases.items()
+            },
+        }
+
+    def start_worker(
+        self,
+        phase_name: str,
+        worker: Callable[[], Awaitable[None]],
+    ) -> asyncio.Task[Any]:
+        """Start and supervise one readiness worker."""
+
+        async def _run() -> None:
+            self.mark_running(phase_name)
+            try:
+                await worker()
+            except Exception as exc:  # noqa: BLE001 - worker isolation
+                self.mark_failed(phase_name, exc)
+            else:
+                self.mark_ready(phase_name)
+
+        task = asyncio.create_task(
+            _run(),
+            name=f"startup:{phase_name}",
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def stop(self) -> None:
+        """Cancel and retrieve every active worker task."""
+        tasks = list(self._tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _phase(self, phase_name: str) -> StartupPhase:
+        try:
+            return self._phases[phase_name]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown startup phase: {phase_name}",
+            ) from exc
+
+    def _elapsed_ms(self) -> float:
+        return (time.monotonic() - self._started_at) * 1000

--- a/src/qwenpaw/app/workspace/service_manager.py
+++ b/src/qwenpaw/app/workspace/service_manager.py
@@ -188,15 +188,39 @@ class ServiceManager:
         sequential service, the event loop is yielded so HTTP requests can
         be served during background startup.
         """
+        await self._start_priorities(
+            sorted(self._group_by_priority()),
+        )
+
+    async def start_through(self, maximum_priority: int) -> None:
+        """Start services up to and including one priority boundary."""
+        priorities = [
+            priority
+            for priority in sorted(self._group_by_priority())
+            if priority <= maximum_priority
+        ]
+        await self._start_priorities(priorities)
+
+    async def start_after(self, minimum_priority: int) -> None:
+        """Start services strictly after one priority boundary."""
+        priorities = [
+            priority
+            for priority in sorted(self._group_by_priority())
+            if priority > minimum_priority
+        ]
+        await self._start_priorities(priorities)
+
+    async def _start_priorities(self, priorities: List[int]) -> None:
+        """Start selected priority groups in their declared order."""
         t0 = time.perf_counter()
         logger.debug(
-            f"Starting {len(self.descriptors)} services "
+            f"Starting service priorities {priorities} "
             f"({len(self.reused_services)} reused)",
         )
 
         priority_groups = self._group_by_priority()
 
-        for priority in sorted(priority_groups.keys()):
+        for priority in priorities:
             descriptors = priority_groups[priority]
 
             # Separate concurrent and sequential services
@@ -216,7 +240,7 @@ class ServiceManager:
 
         elapsed = time.perf_counter() - t0
         logger.debug(
-            "All services started for "
+            f"Service priorities {priorities} started for "
             f"{sanitize_log_value(self.workspace.agent_id)} "
             f"in {elapsed:.3f}s",
         )

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -54,12 +54,18 @@ class Workspace:
     to ``Runtime.run()``.
     """
 
-    def __init__(self, agent_id: str, workspace_dir: str):
+    def __init__(
+        self,
+        agent_id: str,
+        workspace_dir: str,
+        defer_optional_services: bool = False,
+    ):
         """Initialize agent instance.
 
         Args:
             agent_id: Unique agent identifier
             workspace_dir: Path to agent's workspace directory
+            defer_optional_services: Start non-chat services in background.
         """
         self.agent_id = agent_id
         self.workspace_dir = Path(workspace_dir).expanduser()
@@ -83,6 +89,9 @@ class Workspace:
         self._config_mtime: float | None = None
         self._started = False
         self._start_attempted = False
+        self._defer_optional_services = defer_optional_services
+        self._deferred_start_task: asyncio.Task[None] | None = None
+        self._deferred_start_error: str | None = None
         self._manager = None  # Reference to MultiAgentManager
         self._task_tracker = TaskTracker()
         self._app_services: Any = None
@@ -454,7 +463,8 @@ class Workspace:
             ),
         )
 
-        # Priority 30: Channel manager
+        # Priority 20: Console chat transport. External channel connections
+        # are started as background tasks by ChannelManager.start_all().
         sm.register(
             ServiceDescriptor(
                 name="channel_manager",
@@ -462,8 +472,8 @@ class Workspace:
                 post_init=create_channel_service,
                 start_method="start_all",
                 stop_method="stop_all",
-                priority=30,
-                concurrent_init=False,
+                priority=20,
+                concurrent_init=True,
             ),
         )
 
@@ -603,10 +613,20 @@ class Workspace:
             # start so ChatManager / Runner see the canonical layout.
             self._migrate_legacy_weixin_data()
 
-            # 3. Start all services via ServiceManager
-            await self._service_manager.start_all()
+            # 3. Start chat-critical services before optional desktop workers.
+            if self._defer_optional_services:
+                await self._service_manager.start_through(20)
+            else:
+                await self._service_manager.start_all()
+
+            await self._require_console_chat_ready()
 
             self._started = True
+            if self._defer_optional_services:
+                self._deferred_start_task = asyncio.create_task(
+                    self._start_deferred_services(),
+                    name=f"workspace-deferred:{self.agent_id}",
+                )
             logger.info(
                 "Workspace started successfully: "
                 f"{sanitize_log_value(self.agent_id)}",
@@ -636,6 +656,35 @@ class Workspace:
                     f"{sanitize_log_value(cleanup_error)}",
                 )
             raise
+
+    async def _require_console_chat_ready(self) -> None:
+        """Fail startup unless the local console chat path is usable."""
+        if self.chat_manager is None:
+            raise RuntimeError("ChatManager is not ready")
+        manager = self.channel_manager
+        if manager is None:
+            raise RuntimeError("ChannelManager is not ready")
+        if await manager.get_channel("console") is None:
+            raise RuntimeError("Console channel is not ready")
+
+    async def _start_deferred_services(self) -> None:
+        """Start channel and maintenance services without blocking chat."""
+        try:
+            await self._service_manager.start_after(20)
+        except Exception as exc:  # noqa: BLE001 - worker isolation
+            self._deferred_start_error = str(exc)
+            logger.error(
+                "Deferred services failed for %s",
+                sanitize_log_value(self.agent_id),
+                exc_info=True,
+            )
+
+    async def wait_for_deferred_services(self) -> None:
+        """Wait until deferred services either complete or fail."""
+        if self._deferred_start_task is not None:
+            await self._deferred_start_task
+        if self._deferred_start_error is not None:
+            raise RuntimeError(self._deferred_start_error)
 
     def _migrate_legacy_weixin_data(self) -> None:
         """Eagerly migrate legacy weixin -> wechat data on workspace start.
@@ -719,6 +768,15 @@ class Workspace:
             "Stopping agent instance: "
             f"{sanitize_log_value(self.agent_id)} (final={final})",
         )
+
+        if self._deferred_start_task is not None:
+            if not self._deferred_start_task.done():
+                self._deferred_start_task.cancel()
+            await asyncio.gather(
+                self._deferred_start_task,
+                return_exceptions=True,
+            )
+            self._deferred_start_task = None
 
         # Stop all services via ServiceManager (handles reuse automatically)
         await self._service_manager.stop_all(

--- a/src/qwenpaw/app/workspace_registry.py
+++ b/src/qwenpaw/app/workspace_registry.py
@@ -29,16 +29,22 @@ class WorkspaceRegistry(MultiAgentManager):
         *,
         app_services: Any = None,
         bootstrap_plugins_kwargs: dict[str, Any] | None = None,
+        defer_optional_services: bool = False,
     ) -> None:
         super().__init__()
         self.app_services = app_services
         self._bootstrap_kwargs = bootstrap_plugins_kwargs or {}
+        self._defer_optional_services = defer_optional_services
 
     def _create_workspace(self, agent_id: str, workspace_dir: str) -> Any:
         """Override to run bootstrap_plugins after creation."""
         from .workspace import Workspace
 
-        workspace = Workspace(agent_id=agent_id, workspace_dir=workspace_dir)
+        workspace = Workspace(
+            agent_id=agent_id,
+            workspace_dir=workspace_dir,
+            defer_optional_services=self._defer_optional_services,
+        )
         if self._bootstrap_kwargs:
             workspace.bootstrap_plugins(**self._bootstrap_kwargs)
         if self.app_services is not None:

--- a/src/qwenpaw/cli/app_cmd.py
+++ b/src/qwenpaw/cli/app_cmd.py
@@ -158,7 +158,7 @@ def app_cmd(
     _warn_if_auth_off_non_loopback_bind(host, port)
 
     uvicorn.run(
-        "qwenpaw.app._app:app",
+        "qwenpaw.app.deferred_app:app",
         host=host,
         port=port,
         reload=reload,

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -396,8 +396,18 @@ def get_available_channels() -> Tuple[str, ...]:
     """
     from ..app.channels.registry import get_channel_registry
 
-    registry = get_channel_registry()
-    all_keys = tuple(registry.keys())
+    return _filter_channel_keys(tuple(get_channel_registry()))
+
+
+def get_startup_channel_keys() -> Tuple[str, ...]:
+    """Return enabled keys without importing every built-in channel."""
+    from ..app.channels.registry import get_channel_keys
+
+    return _filter_channel_keys(get_channel_keys())
+
+
+def _filter_channel_keys(all_keys: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Apply process channel allow/deny environment filters."""
 
     raw_enabled = EnvVarLoader.get_str("QWENPAW_ENABLED_CHANNELS", "").strip()
     if raw_enabled:

--- a/src/qwenpaw/local_models/__init__.py
+++ b/src/qwenpaw/local_models/__init__.py
@@ -1,10 +1,25 @@
 # -*- coding: utf-8 -*-
 """Local model management and inference."""
 
-from .manager import LocalModelManager
-from .manager import LocalModelConfig
-from .model_manager import ModelManager, LocalModelInfo, DownloadSource
-from .llamacpp import LlamaCppBackend
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .llamacpp import LlamaCppBackend
+    from .manager import LocalModelConfig, LocalModelManager
+    from .model_manager import DownloadSource, LocalModelInfo, ModelManager
+
+
+_EXPORT_MODULES = {
+    "DownloadSource": ".model_manager",
+    "LlamaCppBackend": ".llamacpp",
+    "LocalModelConfig": ".manager",
+    "LocalModelInfo": ".model_manager",
+    "LocalModelManager": ".manager",
+    "ModelManager": ".model_manager",
+}
 
 __all__ = [
     "DownloadSource",
@@ -14,3 +29,13 @@ __all__ = [
     "ModelManager",
     "LlamaCppBackend",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Load public local-model exports only when callers request them."""
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value

--- a/src/qwenpaw/providers/__init__.py
+++ b/src/qwenpaw/providers/__init__.py
@@ -1,8 +1,22 @@
 # -*- coding: utf-8 -*-
 """Provider management — models, registry + persistent store."""
 
-from .provider import Provider, ProviderInfo, ModelInfo
-from .provider_manager import ProviderManager
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .provider import ModelInfo, Provider, ProviderInfo
+    from .provider_manager import ProviderManager
+
+
+_EXPORT_MODULES = {
+    "ModelInfo": ".provider",
+    "Provider": ".provider",
+    "ProviderInfo": ".provider",
+    "ProviderManager": ".provider_manager",
+}
 
 __all__ = [
     "ModelInfo",
@@ -10,3 +24,13 @@ __all__ = [
     "ProviderManager",
     "ProviderInfo",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Load public provider exports only when callers request them."""
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -7,11 +7,9 @@ import json
 import logging
 import time
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import httpx
-from agentscope.model import ChatModelBase
-import anthropic
 from pydantic import Field
 
 from qwenpaw.providers.multimodal_prober import (
@@ -33,6 +31,11 @@ from qwenpaw.providers.provider import (
 from ..utils.logging import sanitize_log_value
 from .capping_formatter import _CappingAnthropicFormatter
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
+
+if TYPE_CHECKING:
+    import anthropic
+
+    from agentscope.model import ChatModelBase
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +112,8 @@ class AnthropicProvider(Provider):
         return self._strip_http_client
 
     def _client(self, timeout: float = 5) -> anthropic.AsyncAnthropic:
+        import anthropic
+
         default_headers = self._build_default_headers()
         if self.auth_mode == "auth_token":
             return anthropic.AsyncAnthropic(
@@ -182,6 +187,8 @@ class AnthropicProvider(Provider):
         call so that custom proxies that only expose the messages API still
         pass the connection test.
         """
+        import anthropic
+
         client = self._client(timeout=timeout)
         try:
             await client.models.list()
@@ -208,6 +215,8 @@ class AnthropicProvider(Provider):
         client: anthropic.AsyncAnthropic,
     ) -> tuple[bool, str]:
         """Fallback: check reachability via messages.create."""
+        import anthropic
+
         model = self.models[0].id if self.models else "claude-opus-4-5"
         try:
             await client.messages.create(
@@ -246,6 +255,8 @@ class AnthropicProvider(Provider):
         timeout: float = 5,
     ) -> ModelConnectionResult:
         """Check if a specific model is reachable/usable."""
+        import anthropic
+
         target = (model_id or "").strip()
         if not target:
             return ModelConnectionResult(
@@ -477,6 +488,8 @@ class AnthropicProvider(Provider):
         error summary is appended to help callers log the
         actual rejection reason.
         """
+        import anthropic
+
         log_model = sanitize_log_value(model_id)
         client = self._client(timeout=timeout)
         try:
@@ -574,8 +587,10 @@ class AnthropicProvider(Provider):
            image by asking for the dominant color of a solid-red PNG.
            Some providers silently accept image payloads without
            processing them, so a pure API-error check would produce
-           false positives.
+        false positives.
         """
+        import anthropic
+
         log_model = sanitize_log_value(model_id)
         logger.info(
             "Image probe start: model=%s url=%s",
@@ -653,6 +668,8 @@ class _AnthropicChatModelCompat:
     """
 
     def __new__(cls, **kwargs: Any) -> Any:
+        import anthropic
+
         from agentscope.model import AnthropicChatModel
 
         default_headers = kwargs.pop("default_headers", None)

--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -13,21 +13,21 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, List
-
-from agentscope.model import ChatModelBase
+from typing import TYPE_CHECKING, Any, Dict, List
 from pydantic import Field
 
 from .provider import ModelInfo
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .capping_formatter import _CappingDashScopeFormatter
-from .openai_chat_model_compat import _sanitize_nullable_tool_schemas
 from .openai_provider import (
     CODING_DASHSCOPE_BASE_URL,
     DASHSCOPE_BASE_URLS,
     TOKEN_PLAN_BASE_URL,
     OpenAIProvider,
 )
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
 
 logger = logging.getLogger(__name__)
 
@@ -303,6 +303,9 @@ class _DashScopeChatModelCompat:
 
     def __new__(cls, **kwargs: Any) -> Any:
         from agentscope.model import DashScopeChatModel
+        from .openai_chat_model_compat import (
+            _sanitize_nullable_tool_schemas,
+        )
 
         default_headers = kwargs.pop("default_headers", None)
         thinking_explicitly_set = kwargs.pop(

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -7,12 +7,8 @@ from __future__ import annotations
 import copy
 import logging
 import time
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 
-from agentscope.model import ChatModelBase
-from google import genai
-from google.genai import errors as genai_errors
-from google.genai import types as genai_types
 from pydantic import Field
 
 from qwenpaw.providers.multimodal_prober import (
@@ -31,6 +27,9 @@ from qwenpaw.providers.provider import (
 from ..utils.logging import sanitize_log_value
 from .capping_formatter import _CappingGeminiFormatter
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +187,9 @@ class GeminiProvider(Provider):
         return dict(self.custom_headers) if self.custom_headers else {}
 
     def _client(self, timeout: float = 10) -> Any:
+        from google import genai
+        from google.genai import types as genai_types
+
         headers = self._build_default_headers() or None
         return genai.Client(
             api_key=self.api_key,
@@ -240,6 +242,8 @@ class GeminiProvider(Provider):
 
     async def check_connection(self, timeout: float = 10) -> tuple[bool, str]:
         """Check if Google Gemini provider is reachable."""
+        from google.genai import errors as genai_errors
+
         client = None
         response = None
         try:
@@ -267,6 +271,8 @@ class GeminiProvider(Provider):
 
     async def fetch_models(self, timeout: float = 10) -> List[ModelInfo]:
         """Fetch available models from Gemini API."""
+        from google.genai import errors as genai_errors
+
         client = None
         response = None
         try:
@@ -292,6 +298,8 @@ class GeminiProvider(Provider):
         timeout: float = 10,
     ) -> ModelConnectionResult:
         """Check if a specific Gemini model is reachable/usable."""
+        from google.genai import errors as genai_errors
+
         target = (model_id or "").strip()
         if not target:
             return ModelConnectionResult(
@@ -443,6 +451,8 @@ class GeminiProvider(Provider):
         Sends a solid-red 16x16 PNG and asks the model to name the colour.
         """
         import base64
+        from google.genai import errors as genai_errors
+        from google.genai import types as genai_types
 
         log_model = sanitize_log_value(model_id)
         logger.info(
@@ -508,6 +518,9 @@ class GeminiProvider(Provider):
 
         Asks the model whether the video contains moving content.
         """
+        from google.genai import errors as genai_errors
+        from google.genai import types as genai_types
+
         log_model = sanitize_log_value(model_id)
         logger.info(
             "Video probe start: model=%s url=%s",
@@ -591,6 +604,7 @@ class _GeminiChatModelCompat:
 
     def __new__(cls, **kwargs: Any) -> Any:
         from agentscope.model import GeminiChatModel
+        from google.genai import types as genai_types
 
         default_headers = kwargs.pop("default_headers", None)
         extra_config_kwargs = kwargs.pop("extra_config_kwargs", None) or {}

--- a/src/qwenpaw/providers/ollama_provider.py
+++ b/src/qwenpaw/providers/ollama_provider.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 """An Ollama provider implementation."""
 
-import os
-from typing import Any
+from __future__ import annotations
 
-from agentscope.model import ChatModelBase
-from openai import AsyncOpenAI
+import os
+from typing import TYPE_CHECKING, Any
 
 from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.openai_provider import OpenAIProvider
 from qwenpaw.providers.provider import ModelConnectionResult
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+    from openai import AsyncOpenAI
 
 
 class OllamaProvider(OpenAIProvider):
@@ -44,6 +47,8 @@ class OllamaProvider(OpenAIProvider):
         self.base_url = self._normalize_base_url(self.base_url)
 
     def _client(self, timeout: float = 5) -> AsyncOpenAI:
+        from openai import AsyncOpenAI
+
         kwargs: dict = {
             "base_url": self._openai_compatible_base_url(),
             "api_key": self.api_key,

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -13,9 +13,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, List
 from urllib.parse import urlparse
 
 import httpx
-
-from agentscope.model import ChatModelBase
-from openai import APIError
 from pydantic import Field
 
 from qwenpaw.providers.provider import (
@@ -29,6 +26,9 @@ from ..utils.logging import sanitize_log_value
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES, _CappingOpenAIFormatter
 
 if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+    from openai import AsyncOpenAI
+
     from qwenpaw.providers.multimodal_prober import ProbeResult
 
 logger = logging.getLogger(__name__)
@@ -125,17 +125,22 @@ def _token_limit_kwargs(model_id: str, limit: int) -> dict[str, int]:
     return {"max_tokens": limit}
 
 
-if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec(
-    "langfuse",
-):
-    from langfuse.openai import AsyncOpenAI  # type: ignore[import]
-else:
+def _get_async_openai_class() -> type[AsyncOpenAI]:
+    """Resolve the configured OpenAI client only when it is first used."""
+    if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec(
+        "langfuse",
+    ):
+        from langfuse.openai import AsyncOpenAI
+
+        return AsyncOpenAI
     if os.environ.get("LANGFUSE_SECRET_KEY"):
         logger.warning(
             "LANGFUSE_SECRET_KEY is set but langfuse is not installed; "
             "install with `pip install langfuse` to enable tracing",
         )
-    from openai import AsyncOpenAI  # pylint: disable=ungrouped-imports
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI
 
 
 class OpenAIProvider(Provider):
@@ -165,7 +170,7 @@ class OpenAIProvider(Provider):
         headers = self._build_default_headers()
         if headers:
             kwargs["default_headers"] = headers
-        return AsyncOpenAI(**kwargs)
+        return _get_async_openai_class()(**kwargs)
 
     @staticmethod
     async def _close_client(client: AsyncOpenAI) -> None:
@@ -213,6 +218,8 @@ class OpenAIProvider(Provider):
 
     async def check_connection(self, timeout: float = 5) -> tuple[bool, str]:
         """Check if OpenAI provider is reachable with current configuration."""
+        from openai import APIError
+
         client = self._client(timeout=timeout)
         try:
             await client.models.list(timeout=timeout)
@@ -236,6 +243,8 @@ class OpenAIProvider(Provider):
 
     async def fetch_models(self, timeout: float = 5) -> List[ModelInfo]:
         """Fetch available models."""
+        from openai import APIError
+
         client = self._client(timeout=timeout)
         try:
             payload = await client.models.list(timeout=timeout)
@@ -254,6 +263,8 @@ class OpenAIProvider(Provider):
         timeout: float = 5,
     ) -> ModelConnectionResult:
         """Check that a model can complete a basic chat request."""
+        from openai import APIError
+
         model_id = (model_id or "").strip()
         if not model_id:
             return ModelConnectionResult(
@@ -620,6 +631,7 @@ class OpenAIProvider(Provider):
             _is_media_keyword_error,
             evaluate_image_probe_answer,
         )
+        from openai import APIError
 
         log_model = sanitize_log_value(model_id)
         logger.info(
@@ -742,6 +754,8 @@ class OpenAIProvider(Provider):
         start_time: float,
     ) -> tuple[bool, str] | None:
         """Try a single video URL format. Return None to try next."""
+        from openai import APIError
+
         from .multimodal_prober import (
             _PROBE_VIDEO_URL,
             _is_media_keyword_error,
@@ -945,6 +959,8 @@ class GitHubModelsProvider(OpenAIProvider):
 
     async def check_connection(self, timeout: float = 5) -> tuple[bool, str]:
         """Check connectivity via a tiny chat completion request."""
+        from openai import APIError
+
         # Prefer a built-in model; fall back to a well-known GitHub Models id.
         model_id = ""
         for candidate in ("openai/gpt-4o-mini", "gpt-4o-mini"):

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
-
-from agentscope.model import ChatModelBase, OpenAIResponseModel
+from typing import TYPE_CHECKING, Any
 
 from .capping_formatter import _CappingOpenAIResponseFormatter
 from .openai_provider import OpenAIProvider
 from .provider import ModelConnectionResult
 from ..utils.logging import sanitize_log_value
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ def _extract_reasoning_text(response: Any) -> str:
     return " ".join(parts)
 
 
-class OpenAIResponseModelCompat(OpenAIResponseModel):
+class OpenAIResponseModelCompat:
     """OpenAIResponseModel with extra-kwargs injection and tool schema
     sanitization.
 
@@ -83,59 +84,66 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
       providers reject (same fix as ``OpenAIChatModelCompat``).
     """
 
-    def __init__(
-        self,
+    def __new__(
+        cls,
         *,
         extra_generate_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> None:
-        self._extra_generate_kwargs = extra_generate_kwargs or {}
-        super().__init__(**kwargs)
-
-    async def _call_api(
-        self,
-        model_name: str,
-        messages: Any,
-        tools: list[dict] | None = None,
-        tool_choice: Any | None = None,
-        **generate_kwargs: Any,
     ) -> Any:
-        max_tokens = generate_kwargs.pop("max_tokens", None)
-        if (
-            max_tokens is not None
-            and "max_output_tokens" not in generate_kwargs
-        ):
-            generate_kwargs["max_output_tokens"] = max_tokens
-        merged = {**self._extra_generate_kwargs, **generate_kwargs}
-        disable_thinking = merged.pop("disable_thinking", False)
-        inherited_max_tokens = merged.pop("max_tokens", None)
-        if (
-            inherited_max_tokens is not None
-            and "max_output_tokens" not in merged
-        ):
-            merged["max_output_tokens"] = inherited_max_tokens
-        if disable_thinking:
-            merged.pop("reasoning", None)
-            if _supports_none_reasoning_effort(model_name):
-                merged["reasoning"] = {"effort": "none"}
-        return await super()._call_api(
-            model_name,
-            messages,
-            tools,
-            tool_choice,
-            **merged,
-        )
+        from agentscope.model import OpenAIResponseModel
 
-    def _format_tools(
-        self,
-        tools: list[dict] | None,
-        tool_choice: Any | None,
-    ) -> tuple[list[dict] | None, Any]:
-        from .openai_chat_model_compat import _sanitize_tool_schemas
+        class _Compat(OpenAIResponseModel):
+            async def _call_api(
+                self,
+                model_name: str,
+                messages: Any,
+                tools: list[dict] | None = None,
+                tool_choice: Any | None = None,
+                **generate_kwargs: Any,
+            ) -> Any:
+                max_tokens = generate_kwargs.pop("max_tokens", None)
+                if (
+                    max_tokens is not None
+                    and "max_output_tokens" not in generate_kwargs
+                ):
+                    generate_kwargs["max_output_tokens"] = max_tokens
+                merged = {
+                    **self._qp_extra_generate_kwargs,
+                    **generate_kwargs,
+                }
+                disable_thinking = merged.pop("disable_thinking", False)
+                inherited_max_tokens = merged.pop("max_tokens", None)
+                if (
+                    inherited_max_tokens is not None
+                    and "max_output_tokens" not in merged
+                ):
+                    merged["max_output_tokens"] = inherited_max_tokens
+                if disable_thinking:
+                    merged.pop("reasoning", None)
+                    if _supports_none_reasoning_effort(model_name):
+                        merged["reasoning"] = {"effort": "none"}
+                return await super()._call_api(
+                    model_name,
+                    messages,
+                    tools,
+                    tool_choice,
+                    **merged,
+                )
 
-        if tools:
-            tools = _sanitize_tool_schemas(tools)
-        return super()._format_tools(tools, tool_choice)
+            def _format_tools(
+                self,
+                tools: list[dict] | None,
+                tool_choice: Any | None,
+            ) -> tuple[list[dict] | None, Any]:
+                from .openai_chat_model_compat import _sanitize_tool_schemas
+
+                if tools:
+                    tools = _sanitize_tool_schemas(tools)
+                return super()._format_tools(tools, tool_choice)
+
+        model = _Compat(**kwargs)
+        model._qp_extra_generate_kwargs = extra_generate_kwargs or {}
+        return model
 
 
 class OpenAIResponseProvider(OpenAIProvider):
@@ -382,6 +390,7 @@ class OpenAIResponseProvider(OpenAIProvider):
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from agentscope.credential import OpenAICredential
+        from agentscope.model import OpenAIResponseModel
 
         credential = OpenAICredential(
             id=f"qwenpaw-{self.id}",

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -4,10 +4,8 @@
 from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
-from agentscope.model import ChatModelBase
-from openai import APIError, AsyncOpenAI
 from pydantic import Field
 
 from qwenpaw.exceptions import ProviderError
@@ -20,6 +18,10 @@ from qwenpaw.providers.provider import (
 from .capping_formatter import _CappingOpenAIFormatter
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .multimodal_prober import ProbeResult
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+    from openai import AsyncOpenAI
 
 
 class OpenRouterProvider(Provider):
@@ -52,6 +54,8 @@ class OpenRouterProvider(Provider):
         return {**self._DEFAULT_HEADERS, **self.custom_headers}
 
     def _client(self, timeout: float = 30) -> AsyncOpenAI:
+        from openai import AsyncOpenAI
+
         return AsyncOpenAI(
             base_url=self.base_url,
             api_key=self.api_key,
@@ -227,6 +231,8 @@ class OpenRouterProvider(Provider):
 
     async def check_connection(self, timeout: float = 30) -> tuple[bool, str]:
         """Check if OpenRouter provider is reachable."""
+        from openai import APIError
+
         client = self._client()
         try:
             await client.models.list(timeout=timeout)
@@ -251,6 +257,8 @@ class OpenRouterProvider(Provider):
         Returns:
             List of ModelInfo (or ExtendedModelInfo if include_extended=True)
         """
+        from openai import APIError
+
         client = self._client(timeout=timeout)
         try:
             payload = await client.models.list(timeout=timeout)
@@ -298,6 +306,8 @@ class OpenRouterProvider(Provider):
         must raise so the provider manager does not persist false capability
         flags over previously known values.
         """
+        from openai import APIError
+
         try:
             client = self._client(timeout=timeout)
             payload = await client.models.list(timeout=timeout)

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -10,7 +10,6 @@ import re
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Type
 
-from agentscope.model import ChatModelBase
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from qwenpaw.exceptions import ProviderError
@@ -18,6 +17,8 @@ from qwenpaw.exceptions import ProviderError
 from .context_windows import DEFAULT_CONTEXT_WINDOW, resolve_context_window
 
 if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+
     from .multimodal_prober import ProbeResult
 
 

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -4,13 +4,13 @@ It provides a unified interface to manage providers, such as listing available
 providers, adding/removing custom providers, and fetching provider details."""
 # pylint: disable=unused-import
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
-
-from agentscope.model import ChatModelBase
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from qwenpaw.exceptions import ModelNotFoundException
 
@@ -49,6 +49,9 @@ from .provider_update_fields import (
 )
 from .plugin_provider_registry import PluginProviderRegistry
 from .provider_annotations import ProviderAnnotationService
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/qwenpaw/tauri/deferred_app.py
+++ b/src/qwenpaw/tauri/deferred_app.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Desktop ASGI shell built on the shared deferred application runtime."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from ..app.deferred_app import DeferredApp
+
+
+_INDEX_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
+
+def _load_full_app() -> FastAPI:
+    """Configure desktop browser state and load the complete application."""
+    from ..browser.runtime.managed_playwright import (
+        configure_desktop_playwright_cache,
+    )
+
+    configure_desktop_playwright_cache()
+    from ..app.deferred_app import load_full_app
+
+    return load_full_app()
+
+
+def _resolve_console_dir() -> Path:
+    """Resolve packaged console assets without importing the full app."""
+    configured = os.environ.get("QWENPAW_CONSOLE_STATIC_DIR", "").strip()
+    if configured:
+        return Path(configured)
+
+    package_dir = Path(__file__).resolve().parent.parent
+    candidates = (
+        package_dir / "console",
+        package_dir.parent.parent / "console" / "dist",
+        Path.cwd() / "console" / "dist",
+        Path.cwd() / "console_dist",
+    )
+    for candidate in candidates:
+        if (candidate / "index.html").is_file():
+            return candidate
+    return candidates[0]
+
+
+class DeferredDesktopApp(DeferredApp):
+    """Serve the desktop console while the complete app starts."""
+
+    def __init__(
+        self,
+        app_loader: Callable[[], FastAPI] = _load_full_app,
+        console_dir: Path | None = None,
+    ) -> None:
+        super().__init__(app_loader=app_loader)
+        self._install_console_routes(
+            console_dir or _resolve_console_dir(),
+        )
+
+    @staticmethod
+    def _is_shell_request(scope: dict[str, Any]) -> bool:
+        if scope["type"] != "http":
+            return False
+        path = scope.get("path", "")
+        return not path.startswith("/api/") or path in {
+            "/api/healthz",
+            "/api/startup/status",
+            "/api/version",
+        }
+
+    def _install_console_routes(self, console_dir: Path) -> None:
+        index_path = console_dir / "index.html"
+        assets_dir = console_dir / "assets"
+        if assets_dir.is_dir():
+            self.shell_app.mount(
+                "/assets",
+                StaticFiles(directory=str(assets_dir)),
+                name="desktop-assets",
+            )
+
+        def serve_index() -> FileResponse:
+            if not index_path.is_file():
+                raise HTTPException(status_code=404, detail="Not Found")
+            return FileResponse(index_path, headers=_INDEX_HEADERS)
+
+        @self.shell_app.get("/console")
+        @self.shell_app.get("/console/")
+        @self.shell_app.get("/console/{full_path:path}")
+        def get_console(full_path: str = "") -> FileResponse:
+            _ = full_path
+            return serve_index()
+
+        @self.shell_app.get("/{full_path:path}")
+        def get_static_or_index(full_path: str) -> FileResponse:
+            if full_path and ".." not in full_path:
+                candidate = console_dir / full_path
+                if not Path(full_path).is_absolute() and candidate.is_file():
+                    return FileResponse(candidate)
+            return serve_index()
+
+
+app = DeferredDesktopApp()

--- a/src/qwenpaw/tauri/entry.py
+++ b/src/qwenpaw/tauri/entry.py
@@ -20,8 +20,10 @@ from qwenpaw.tauri.env import (
     ensure_desktop_cors_origins,
 )
 from qwenpaw.tauri.sidecar_logging import install_sidecar_logging
+from qwenpaw.tauri.startup_metrics import mark
 
 logger = logging.getLogger(__name__)
+mark("python_entry")
 
 
 def _is_frozen_desktop() -> bool:
@@ -223,16 +225,10 @@ def _install_certifi_env() -> None:
 
 def _install_desktop_runtime() -> None:
     os.environ.setdefault(DESKTOP_APP_ENV, "1")
-    # Must run before importing the FastAPI app: it applies CORS middleware
-    # from qwenpaw.constant.CORS_ORIGINS at import time.
+    # CORS must be set before the deferred worker imports the full app.
     _ensure_qwenpaw_app_not_loaded()
     ensure_desktop_cors_origins()
     _sync_loaded_qwenpaw_constant_cors_origins()
-    from qwenpaw.browser.runtime.managed_playwright import (
-        configure_desktop_playwright_cache,
-    )
-
-    configure_desktop_playwright_cache()
 
 
 def _run_click_command(
@@ -264,6 +260,7 @@ def _emit_backend_ready(port: int) -> None:
 
 
 def _run_backend_server(log_level: str) -> None:
+    mark("backend_server_imports_started")
     import uvicorn
 
     from qwenpaw.browser.control_link.chrome.protocol import (
@@ -312,9 +309,13 @@ def _run_backend_server(log_level: str) -> None:
     port_file = str(WORKING_DIR / "desktop_port")
     port, reused_socket = get_stable_port(port_file, host)
 
-    # Import the app instance (instead of the import string) so the desktop
-    # shutdown endpoint can reach the uvicorn server via app.state.
-    from qwenpaw.app._app import app as fastapi_app
+    # The lightweight shell serves the console while the complete app imports
+    # and initializes in its supervised background runtime.
+    mark("desktop_shell_import_started")
+    from qwenpaw.tauri.deferred_app import app as fastapi_app
+
+    mark("desktop_shell_import_done")
+    fastapi_app.state.desktop_startup_metric = mark
 
     config = uvicorn.Config(
         fastapi_app,
@@ -338,6 +339,7 @@ def _run_backend_server(log_level: str) -> None:
 
     try:
         port = _socket_port(backend_socket)
+        mark("port_bound", port=port)
         write_port_file(port_file, port)
         write_last_api(host, port)
         server = uvicorn.Server(config)
@@ -364,11 +366,13 @@ def main() -> None:
     _ensure_utf8_stdio()
     _install_subprocess_guard()
     _install_desktop_runtime()
+    mark("desktop_runtime_installed")
 
     from qwenpaw.constant import LOG_LEVEL_ENV, WORKING_DIR
 
     install_sidecar_logging(WORKING_DIR / "desktop.log")
     _install_certifi_env()
+    mark("sidecar_logging_installed")
 
     # Auto-initialize if no config exists
     config_path = WORKING_DIR / "config.json"

--- a/src/qwenpaw/tauri/startup_metrics.py
+++ b/src/qwenpaw/tauri/startup_metrics.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Dependency-light startup metrics for the packaged desktop backend."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+
+STARTUP_METRIC_ENV = "QWENPAW_DESKTOP_STARTUP_METRICS"
+STARTUP_METRIC_PREFIX = "QWENPAW_STARTUP_METRIC "
+
+_ORIGIN_NS = time.perf_counter_ns()
+
+
+def enabled() -> bool:
+    """Return whether structured desktop startup metrics are enabled."""
+    value = os.environ.get(STARTUP_METRIC_ENV, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def mark(event: str, **fields: Any) -> None:
+    """Emit one machine-readable startup event to standard output."""
+    if not enabled():
+        return
+    elapsed_ns = time.perf_counter_ns() - _ORIGIN_NS
+    payload = {
+        "event": event,
+        "elapsed_ms": round(elapsed_ns / 1_000_000, 3),
+        "pid": os.getpid(),
+        **fields,
+    }
+    print(
+        f"{STARTUP_METRIC_PREFIX}"
+        f"{json.dumps(payload, separators=(',', ':'), sort_keys=True)}",
+        flush=True,
+    )

--- a/src/qwenpaw/utils/startup_display.py
+++ b/src/qwenpaw/utils/startup_display.py
@@ -16,6 +16,7 @@ from rich.progress import (
     TaskProgressColumn,
     TextColumn,
 )
+from rich.text import Text
 from rich.tree import Tree
 
 
@@ -48,6 +49,8 @@ class AgentStartupDisplay:
         self._phase = "Starting core agents"
         self._failed = False
         self._elapsed_seconds: float | None = None
+        self._background_status: str | None = None
+        self._background_elapsed_seconds: float | None = None
         self._redirected_handlers: list[
             tuple[logging.StreamHandler, object]
         ] = []
@@ -81,10 +84,11 @@ class AgentStartupDisplay:
 
     def start_custom_agents(self, total: int) -> None:
         """Add the bounded custom-agent progress bar."""
-        self._phase = "Starting custom agents"
+        if self._phase != "Ready":
+            self._phase = "Starting custom agents"
         if total > 0 and self._task_id is None:
             self._task_id = self._progress.add_task(
-                "Waiting for custom agents",
+                "Starting custom agents",
                 total=total,
             )
         self._refresh()
@@ -97,15 +101,16 @@ class AgentStartupDisplay:
             self._progress.update(
                 self._task_id,
                 advance=1,
-                description=f"Starting custom agents: {agent_id}",
             )
+            _ = agent_id
             self._refresh()
         except OSError:
             self.stop()
 
     def mark_finalizing(self) -> None:
         """Show that agent startup finished and services are finalizing."""
-        self._phase = "Finalizing services"
+        if self._phase != "Ready":
+            self._phase = "Finalizing services"
         self._refresh()
 
     def mark_failed(self, status: str) -> None:
@@ -114,15 +119,45 @@ class AgentStartupDisplay:
         self._failed = True
         self._refresh()
 
-    def complete(self, elapsed_seconds: float) -> None:
+    def complete(
+        self,
+        elapsed_seconds: float,
+        *,
+        background_pending: bool = False,
+    ) -> None:
         """Keep a ready panel live, or print one for non-TTY output."""
         self._failed = False
         self._phase = "Ready"
         self._elapsed_seconds = elapsed_seconds
+        self._background_status = "Loading" if background_pending else None
+        self._background_elapsed_seconds = None
+        if not background_pending:
+            self._task_id = None
         if self._live is None:
-            print_ready_banner(self._api_info, elapsed_seconds)
+            if self._background_status is None:
+                print_ready_banner(self._api_info, elapsed_seconds)
+            else:
+                print_ready_banner(
+                    self._api_info,
+                    elapsed_seconds,
+                    background_status=self._background_status,
+                )
         else:
             self._refresh()
+
+    def complete_background(self, elapsed_seconds: float) -> None:
+        """Record background completion without changing ready time."""
+        self._background_status = "Ready"
+        self._background_elapsed_seconds = elapsed_seconds
+        self._task_id = None
+        self._refresh()
+
+    def fail_background(self) -> None:
+        """Show a background failure without regressing chat readiness."""
+        self._background_status = "Failed"
+        self._background_elapsed_seconds = None
+        self._task_id = None
+        self._refresh()
 
     def stop(self) -> None:
         """Stop rendering and restore redirected terminal log handlers."""
@@ -151,22 +186,24 @@ class AgentStartupDisplay:
 
     def _renderable(self) -> Group:
         """Build the current fixed startup panel and optional progress."""
-        renderables = [
-            _build_startup_panel(
-                self._api_info,
-                self._elapsed_seconds,
-                status=self._phase,
-                ready=self._phase == "Ready",
-                failed=self._failed,
-            ),
-        ]
-        if (
-            self._task_id is not None
-            and self._phase != "Ready"
-            and not self._failed
-        ):
-            renderables.append(self._progress)
-        return Group(*renderables)
+        progress_slot: Progress | Text = (
+            self._progress
+            if self._task_id is not None and not self._failed
+            else Text(" ")
+        )
+        panel_width = max(40, min(64, self._console.width - 2))
+        panel = _build_startup_panel(
+            self._api_info,
+            self._elapsed_seconds,
+            status=self._phase,
+            ready=self._phase == "Ready",
+            failed=self._failed,
+            background_status=self._background_status,
+            background_elapsed_seconds=self._background_elapsed_seconds,
+            progress=progress_slot,
+            width=panel_width,
+        )
+        return Group(panel)
 
     def _refresh(self) -> None:
         """Refresh the live region without affecting startup on I/O errors."""
@@ -244,6 +281,10 @@ def _build_startup_panel(
     status: str,
     ready: bool,
     failed: bool = False,
+    background_status: str | None = None,
+    background_elapsed_seconds: float | None = None,
+    progress: Progress | Text | None = None,
+    width: int | None = None,
 ) -> Panel:
     """Build a startup status panel shared by Live and final output."""
     status_color = "red" if failed else "green" if ready else "yellow"
@@ -263,22 +304,53 @@ def _build_startup_panel(
         tree.add(
             f"[dim]Address:[/dim] [blue underline]{url}[/blue underline]",
         )
-    if elapsed_seconds is not None:
+    if elapsed_seconds is None:
+        tree.add("[dim]Startup:[/dim] [yellow]Measuring[/yellow]")
+    else:
         tree.add(
             f"[dim]Startup:[/dim] [yellow]" f"{elapsed_seconds:.3f}s[/yellow]",
         )
+    if background_status is None:
+        background_status = "Ready" if ready else "Pending"
+    background_color = {
+        "Failed": "red",
+        "Ready": "green",
+    }.get(background_status, "yellow")
+    background_value = background_status
+    if background_elapsed_seconds is not None:
+        background_value = (
+            f"{background_value} {background_elapsed_seconds:.3f}s"
+        )
+        if elapsed_seconds is not None:
+            additional_elapsed = max(
+                0.0,
+                background_elapsed_seconds - elapsed_seconds,
+            )
+            background_value = (
+                f"{background_value} (+{additional_elapsed:.3f}s)"
+            )
+    tree.add(
+        f"[dim]Background:[/dim] "
+        f"[{background_color}]{background_value}"
+        f"[/{background_color}]",
+    )
+    content = Group(tree, progress) if progress is not None else tree
     return Panel(
-        tree,
+        content,
         border_style=status_color,
         box=box.ROUNDED,
         padding=(1, 2),
-        expand=False,
+        expand=width is not None,
+        width=width,
     )
 
 
 def print_ready_banner(
     api_info: Optional[Tuple[str, int]] = None,
     elapsed_seconds: Optional[float] = None,
+    *,
+    background_status: str | None = None,
+    background_elapsed_seconds: float | None = None,
 ) -> None:
     """Print a fancy QwenPaw ready banner with rich formatting.
 
@@ -286,6 +358,8 @@ def print_ready_banner(
         api_info: Optional tuple of (host, port) for the server URL.
                  If None, displays a generic ready message.
         elapsed_seconds: Optional startup time in seconds to display.
+        background_status: Optional state for deferred startup work.
+        background_elapsed_seconds: Optional deferred completion time.
 
     Example:
         >>> print_ready_banner(("127.0.0.1", 8088), 2.345)
@@ -303,6 +377,8 @@ def print_ready_banner(
         elapsed_seconds,
         status="Ready",
         ready=True,
+        background_status=background_status,
+        background_elapsed_seconds=background_elapsed_seconds,
     )
 
     _safe_print(console, panel)

--- a/tests/unit/app/channels/test_registry_lazy.py
+++ b/tests/unit/app/channels/test_registry_lazy.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Tests for selective built-in channel imports."""
+
+from __future__ import annotations
+
+from qwenpaw.app.channels import registry
+
+
+def test_channel_keys_do_not_import_builtin_modules(monkeypatch) -> None:
+    monkeypatch.setattr(registry, "_get_plugin_channels", lambda: {})
+
+    def fail_import(*_args, **_kwargs):
+        raise AssertionError("built-in channel module was imported")
+
+    monkeypatch.setattr(registry.importlib, "import_module", fail_import)
+
+    keys = registry.get_channel_keys()
+
+    assert "console" in keys
+    assert "dingtalk" in keys
+
+
+def test_channel_class_imports_only_requested_builtin(monkeypatch) -> None:
+    registry.clear_builtin_channel_cache()
+    imported: list[str] = []
+    original_import = registry.importlib.import_module
+
+    def record_import(name: str, package: str | None = None):
+        imported.append(name)
+        return original_import(name, package=package)
+
+    monkeypatch.setattr(registry.importlib, "import_module", record_import)
+
+    channel_class = registry.get_channel_class("console")
+
+    assert channel_class is not None
+    assert imported == [".console"]

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,6 +23,17 @@ from fastapi.testclient import TestClient
 from qwenpaw.app.routers.console import _extract_session_and_payload
 from qwenpaw.app.task_tracker import TaskTracker
 from qwenpaw.schemas import AgentRequest, Message, Role, TextContent
+
+
+@pytest.mark.asyncio
+async def test_console_route_reports_not_ready_without_channel_manager():
+    from qwenpaw.app.routers.console import _get_console_channel
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _get_console_channel(SimpleNamespace(channel_manager=None))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Channel Console not ready"
 
 
 @pytest.fixture

--- a/tests/unit/app/test_multi_agent_manager_startup.py
+++ b/tests/unit/app/test_multi_agent_manager_startup.py
@@ -371,7 +371,7 @@ def test_custom_startup_concurrency_supports_legacy_env() -> None:
 
 
 @pytest.mark.asyncio
-async def test_core_agents_overlap_before_custom_agents(
+async def test_default_agent_finishes_before_deferred_agents(
     monkeypatch,
 ) -> None:
     manager = MultiAgentManager()
@@ -381,17 +381,17 @@ async def test_core_agents_overlap_before_custom_agents(
         lambda: config,
     )
 
-    core_started = set()
-    both_core_started = asyncio.Event()
-    release_core = asyncio.Event()
+    default_started = asyncio.Event()
+    release_default = asyncio.Event()
+    qa_started = asyncio.Event()
     custom_started = asyncio.Event()
 
     async def get_agent(agent_id: str):
-        if agent_id in {"default", BUILTIN_QA_AGENT_ID}:
-            core_started.add(agent_id)
-            if len(core_started) == 2:
-                both_core_started.set()
-            await release_core.wait()
+        if agent_id == "default":
+            default_started.set()
+            await release_default.wait()
+        elif agent_id == BUILTIN_QA_AGENT_ID:
+            qa_started.set()
         else:
             custom_started.set()
         return SimpleNamespace()
@@ -404,9 +404,11 @@ async def test_core_agents_overlap_before_custom_agents(
         ),
     )
 
-    await asyncio.wait_for(both_core_started.wait(), timeout=1)
+    await asyncio.wait_for(default_started.wait(), timeout=1)
+    assert not qa_started.is_set()
     assert not custom_started.is_set()
-    release_core.set()
+    callback.assert_not_called()
+    release_default.set()
     result = await asyncio.wait_for(task, timeout=1)
 
     assert result == {
@@ -415,11 +417,13 @@ async def test_core_agents_overlap_before_custom_agents(
         "custom": True,
     }
     callback.assert_called_once()
+    assert qa_started.is_set()
+    assert custom_started.is_set()
 
 
 @pytest.mark.asyncio
-async def test_core_ready_waits_for_enabled_qa(monkeypatch) -> None:
-    """Ready is published only after both enabled core agents finish."""
+async def test_core_ready_does_not_wait_for_enabled_qa(monkeypatch) -> None:
+    """Default readiness is published before the deferred QA agent."""
     manager = MultiAgentManager()
     config = _config("default", BUILTIN_QA_AGENT_ID)
     monkeypatch.setattr(
@@ -440,17 +444,23 @@ async def test_core_ready_waits_for_enabled_qa(monkeypatch) -> None:
 
     manager.get_agent = AsyncMock(side_effect=get_agent)
     callback = MagicMock()
+    callback_called = asyncio.Event()
+
+    def on_core_ready(results: dict[str, bool]) -> None:
+        callback(results)
+        callback_called.set()
+
     task = asyncio.create_task(
-        manager.start_all_configured_agents(on_core_ready=callback),
+        manager.start_all_configured_agents(on_core_ready=on_core_ready),
     )
 
     await asyncio.wait_for(default_done.wait(), timeout=1)
+    await asyncio.wait_for(callback_called.wait(), timeout=1)
+    callback.assert_called_once_with({"default": True})
     await asyncio.wait_for(qa_started.wait(), timeout=1)
-    callback.assert_not_called()
 
     release_qa.set()
     await asyncio.wait_for(task, timeout=1)
-    callback.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/test_shared_deferred_app.py
+++ b/tests/unit/app/test_shared_deferred_app.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Tests for the shared deferred application entry point."""
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.deferred_app import DeferredApp
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected"),
+    [
+        ("GET", "/api/chats", "chat_core_ready"),
+        ("POST", "/api/console/chat", "chat_core_ready"),
+        ("POST", "/api/console/chat/task", "chat_core_ready"),
+        ("POST", "/api/cron/jobs", "background_ready"),
+        ("PUT", "/api/config", "background_ready"),
+    ],
+)
+def test_request_readiness_boundary(
+    method: str,
+    path: str,
+    expected: str,
+) -> None:
+    assert (
+        DeferredApp._required_phase(
+            {
+                "type": "http",
+                "method": method,
+                "path": path,
+            },
+        )
+        == expected
+    )
+
+
+def test_healthz_is_immediately_available_during_import() -> None:
+    release = threading.Event()
+    full_app = FastAPI()
+
+    @asynccontextmanager
+    async def full_lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.startup_ready = asyncio.Event()
+        app.state.startup_ready.set()
+        yield
+
+    full_app.router.lifespan_context = full_lifespan
+
+    def load_app() -> FastAPI:
+        release.wait(timeout=2)
+        return full_app
+
+    deferred = DeferredApp(app_loader=load_app)
+    with TestClient(deferred) as client:
+        response = client.get("/api/healthz")
+        assert response.status_code == 503
+        assert response.json()["status"] == "starting"
+        assert client.get("/api/version").status_code == 200
+        release.set()
+
+
+def test_healthz_becomes_ready_with_default_agent() -> None:
+    full_app = FastAPI()
+
+    class Registry:
+        @staticmethod
+        def list_loaded_agents() -> list[str]:
+            return ["default"]
+
+    @asynccontextmanager
+    async def full_lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.startup_ready = asyncio.Event()
+        app.state.multi_agent_manager = Registry()
+        app.state.startup_time = 1.0
+        app.state.startup_ready.set()
+        yield
+
+    full_app.router.lifespan_context = full_lifespan
+    deferred = DeferredApp(app_loader=lambda: full_app)
+
+    with TestClient(deferred) as client:
+        response = client.get("/api/healthz")
+
+    assert response.status_code == 200
+    assert response.json()["agents_loaded"] == ["default"]
+
+
+def test_application_routes_wait_for_true_chat_readiness() -> None:
+    release_chat = threading.Event()
+    full_app = FastAPI()
+
+    @full_app.get("/api/probe")
+    def get_probe() -> dict[str, bool]:
+        return {"chat": True}
+
+    @asynccontextmanager
+    async def full_lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.startup_ready = asyncio.Event()
+
+        async def publish_chat_ready() -> None:
+            await asyncio.to_thread(release_chat.wait)
+            app.state.startup_ready.set()
+
+        task = asyncio.create_task(publish_chat_ready())
+        try:
+            yield
+        finally:
+            release_chat.set()
+            await task
+
+    full_app.router.lifespan_context = full_lifespan
+    deferred = DeferredApp(app_loader=lambda: full_app)
+
+    with TestClient(deferred) as client:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            response_future = executor.submit(client.get, "/api/probe")
+            assert not response_future.done()
+            release_chat.set()
+            response = response_future.result(timeout=2)
+
+    assert response.status_code == 200
+    assert response.json() == {"chat": True}

--- a/tests/unit/app/test_startup_coordinator.py
+++ b/tests/unit/app/test_startup_coordinator.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Tests for shared startup phase supervision."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from qwenpaw.app.startup_coordinator import StartupCoordinator
+
+
+def test_phase_transitions_are_exposed() -> None:
+    coordinator = StartupCoordinator(("api_ready",))
+
+    coordinator.mark_running("api_ready")
+    coordinator.mark_ready("api_ready")
+
+    phase = coordinator.snapshot()["phases"]["api_ready"]
+    assert phase["status"] == "ready"
+    assert phase["started_ms"] is not None
+    assert phase["finished_ms"] is not None
+    assert phase["error"] is None
+
+
+def test_terminal_phase_does_not_regress() -> None:
+    coordinator = StartupCoordinator(("chat_core_ready",))
+
+    coordinator.mark_ready("chat_core_ready")
+    coordinator.mark_failed("chat_core_ready", "late worker failure")
+
+    phase = coordinator.snapshot()["phases"]["chat_core_ready"]
+    assert phase["status"] == "ready"
+    assert phase["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_is_isolated() -> None:
+    coordinator = StartupCoordinator(("plugins_ready",))
+
+    async def fail() -> None:
+        raise RuntimeError("plugin failed")
+
+    task = coordinator.start_worker("plugins_ready", fail)
+    await task
+
+    phase = coordinator.snapshot()["phases"]["plugins_ready"]
+    assert phase["status"] == "failed"
+    assert phase["error"] == "plugin failed"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_tracks_real_phase_completion() -> None:
+    coordinator = StartupCoordinator(("chat_core_ready",))
+    waiter = asyncio.create_task(
+        coordinator.wait_for_terminal("chat_core_ready"),
+    )
+
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    coordinator.mark_ready("chat_core_ready")
+    phase = await waiter
+
+    assert phase.status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_active_workers() -> None:
+    coordinator = StartupCoordinator(("browser_ready",))
+    started = asyncio.Event()
+
+    async def wait_forever() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = coordinator.start_worker("browser_ready", wait_forever)
+    await started.wait()
+    await coordinator.stop()
+
+    assert task.cancelled()

--- a/tests/unit/app/workspace/test_service_manager.py
+++ b/tests/unit/app/workspace/test_service_manager.py
@@ -31,6 +31,11 @@ def workspace(monkeypatch, tmp_path) -> Workspace:
         lambda _agent_id: SimpleNamespace(),
     )
     monkeypatch.setattr(instance, "_migrate_legacy_weixin_data", lambda: None)
+    monkeypatch.setattr(
+        instance,
+        "_require_console_chat_ready",
+        AsyncMock(),
+    )
     return instance
 
 
@@ -47,6 +52,40 @@ def _register(
             **kwargs,
         ),
     )
+
+
+def test_console_channel_manager_is_chat_critical(tmp_path) -> None:
+    workspace = Workspace("agent-1", str(tmp_path))
+    descriptor = workspace._service_manager.descriptors["channel_manager"]
+
+    assert descriptor.priority == 20
+    assert descriptor.concurrent_init is True
+
+
+@pytest.mark.asyncio
+async def test_chat_ready_requires_console_channel(tmp_path) -> None:
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager.services["chat_manager"] = object()
+    workspace._service_manager.services["channel_manager"] = SimpleNamespace(
+        get_channel=AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(RuntimeError, match="Console channel is not ready"):
+        await workspace._require_console_chat_ready()
+
+
+@pytest.mark.asyncio
+async def test_chat_ready_accepts_initialized_console_path(tmp_path) -> None:
+    workspace = Workspace("agent-1", str(tmp_path))
+    workspace._service_manager.services["chat_manager"] = object()
+    get_channel = AsyncMock(return_value=object())
+    workspace._service_manager.services["channel_manager"] = SimpleNamespace(
+        get_channel=get_channel,
+    )
+
+    await workspace._require_console_chat_ready()
+
+    get_channel.assert_awaited_once_with("console")
 
 
 @pytest.mark.asyncio
@@ -131,6 +170,51 @@ async def test_workspace_cleans_up_after_partial_start_failure(workspace):
     closed.assert_awaited_once_with()
     assert not workspace._started
     assert not workspace._start_attempted
+
+
+@pytest.mark.asyncio
+async def test_desktop_workspace_defers_services_after_chat_core(
+    workspace,
+) -> None:
+    core_started = asyncio.Event()
+    deferred_started = asyncio.Event()
+    release_deferred = asyncio.Event()
+
+    class Core:
+        async def start(self):
+            core_started.set()
+
+    class Deferred:
+        async def start(self):
+            deferred_started.set()
+            await release_deferred.wait()
+
+    workspace._defer_optional_services = True
+    _register(
+        workspace,
+        "core",
+        Core,
+        start_method="start",
+        priority=20,
+    )
+    _register(
+        workspace,
+        "deferred",
+        Deferred,
+        start_method="start",
+        priority=30,
+    )
+
+    await workspace.start()
+
+    assert core_started.is_set()
+    await asyncio.wait_for(deferred_started.wait(), timeout=1)
+    assert workspace._started
+    assert workspace._deferred_start_task is not None
+    assert not workspace._deferred_start_task.done()
+
+    release_deferred.set()
+    await workspace.wait_for_deferred_services()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_hub_cmd.py
+++ b/tests/unit/cli/test_hub_cmd.py
@@ -70,6 +70,14 @@ def test_app_rejects_removed_pro_option() -> None:
     assert "--pro" in result.output
 
 
+def test_app_uses_shared_deferred_entry_point() -> None:
+    with patch("qwenpaw.cli.app_cmd.uvicorn.run") as run_server:
+        result = CliRunner().invoke(app_cmd, ["--port", "9088"])
+
+    assert result.exit_code == 0
+    assert run_server.call_args.args[0] == ("qwenpaw.app.deferred_app:app")
+
+
 def test_hub_is_registered_at_root() -> None:
     result = CliRunner().invoke(cli, ["hub", "--help"])
 

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -6,6 +6,8 @@ import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import anthropic
+
 import qwenpaw.providers.anthropic_provider as anthropic_provider_module
 from qwenpaw.providers.anthropic_provider import AnthropicProvider
 
@@ -137,7 +139,7 @@ async def test_check_connection_api_error_returns_false(monkeypatch) -> None:
     fake_client = SimpleNamespace(models=FakeModels(), close=close)
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
     monkeypatch.setattr(
-        anthropic_provider_module.anthropic,
+        anthropic,
         "APIError",
         Exception,
     )
@@ -334,7 +336,7 @@ async def test_check_model_connection_api_error_returns_false(
     fake_client = SimpleNamespace(messages=FakeMessages())
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
     monkeypatch.setattr(
-        anthropic_provider_module.anthropic,
+        anthropic,
         "APIError",
         Exception,
     )
@@ -489,7 +491,7 @@ async def test_try_video_source_400_returns_none(
     provider = _make_provider()
 
     class Fake400Error(
-        anthropic_provider_module.anthropic.APIError,
+        anthropic.APIError,
     ):
         def __init__(self):
             self.status_code = 400

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -7,10 +7,10 @@ import copy
 from types import SimpleNamespace
 
 import pytest
+from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
-import qwenpaw.providers.gemini_provider as gemini_provider_module
 from qwenpaw.providers.gemini_provider import GeminiProvider
 
 
@@ -38,7 +38,7 @@ def test_chat_model_configures_persistent_client_headers(monkeypatch) -> None:
         captured.append(kwargs)
         return fake_client
 
-    monkeypatch.setattr(gemini_provider_module.genai, "Client", create_client)
+    monkeypatch.setattr(genai, "Client", create_client)
 
     model = _make_provider(
         custom_headers={"X-QwenPaw-Test": "enabled"},
@@ -65,7 +65,7 @@ async def test_summary_limit_is_adapted_without_mutating_thinking(
         aio=SimpleNamespace(models=FakeModels()),
     )
     monkeypatch.setattr(
-        gemini_provider_module.genai,
+        genai,
         "Client",
         lambda **kwargs: fake_client,
     )
@@ -115,7 +115,7 @@ async def test_summary_thinking_override_is_concurrency_safe(
         aio=SimpleNamespace(models=FakeModels()),
     )
     monkeypatch.setattr(
-        gemini_provider_module.genai,
+        genai,
         "Client",
         lambda **kwargs: fake_client,
     )

--- a/tests/unit/providers/test_lazy_imports.py
+++ b/tests/unit/providers/test_lazy_imports.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Tests for startup-sensitive provider import boundaries."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from importlib import import_module
+
+
+def test_provider_manager_does_not_import_unused_sdk_modules() -> None:
+    code = """
+import json
+import sys
+
+import qwenpaw.providers.provider_manager
+
+names = ("anthropic", "google.genai", "openai", "agentscope.model")
+print(json.dumps([name for name in names if name in sys.modules]))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []
+
+
+def test_package_exports_remain_available_after_lazy_loading() -> None:
+    local_models = import_module("qwenpaw.local_models")
+    providers = import_module("qwenpaw.providers")
+
+    assert providers.Provider.__name__ == "Provider"
+    assert providers.ProviderManager.__name__ == "ProviderManager"
+    assert local_models.LocalModelManager.__name__ == "LocalModelManager"
+    assert local_models.ModelManager.__name__ == "ModelManager"

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -89,7 +89,7 @@ def test_client_uses_single_v1_suffix(monkeypatch, base_url: str) -> None:
             captured["timeout"] = timeout
 
     monkeypatch.setattr(
-        "qwenpaw.providers.ollama_provider.AsyncOpenAI",
+        "openai.AsyncOpenAI",
         FakeAsyncOpenAI,
     )
 

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from agentscope.model import OpenAIChatModel
+import openai
 import pytest
 
 import qwenpaw.providers.openai_provider as openai_provider_module
@@ -60,7 +61,7 @@ async def test_check_connection_api_error_returns_false(monkeypatch) -> None:
     close = AsyncMock()
     fake_client = SimpleNamespace(models=FakeModels(), close=close)
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
-    monkeypatch.setattr(openai_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     ok, msg = await provider.check_connection(timeout=1)
 
@@ -197,7 +198,7 @@ async def test_list_model_api_error_returns_empty(monkeypatch) -> None:
     close = AsyncMock()
     fake_client = SimpleNamespace(models=FakeModels(), close=close)
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
-    monkeypatch.setattr(openai_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     models = await provider.fetch_models(timeout=3)
 
@@ -568,7 +569,7 @@ async def test_check_model_connection_api_error_returns_false(
         chat=SimpleNamespace(completions=FakeCompletions()),
     )
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
-    monkeypatch.setattr(openai_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     ok, msg = await provider.check_model_connection("gpt-4o-mini", timeout=4)
 
@@ -869,7 +870,7 @@ async def test_check_model_connection_api_type_mismatch_treated_as_ok(
         chat=SimpleNamespace(completions=FakeCompletions()),
     )
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
-    monkeypatch.setattr(openai_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     # A generation model whose id does not match the non-chat patterns
     ok, msg = await provider.check_model_connection("my-video-gen", timeout=4)
@@ -890,7 +891,7 @@ async def test_connection_error_redacts_credentials(monkeypatch) -> None:
 
     fake_client = SimpleNamespace(models=FakeModels())
     monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
-    monkeypatch.setattr(openai_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     ok, message = await provider.check_connection()
 

--- a/tests/unit/providers/test_openai_tool_schema_compat.py
+++ b/tests/unit/providers/test_openai_tool_schema_compat.py
@@ -145,17 +145,15 @@ def test_sanitize_tool_schemas_removes_nullable_builtin_tool_branches() -> (
     read_file_params = _schema_by_name(sanitized, "read_file")
     assert read_file_params["required"] == ["file_path"]
     start_line = read_file_params["properties"]["start_line"]
-    assert start_line == {
-        "anyOf": [
-            {"type": "integer"},
-            {"type": "string"},
-        ],
-        "description": (
-            "First line to read (1-based, inclusive). Decimal strings are\n"
-            "accepted for tool-call compatibility."
-        ),
-        "default": None,
+    assert {item["type"] for item in start_line["anyOf"]} == {
+        "integer",
+        "string",
     }
+    assert start_line["description"] == (
+        "First line to read (1-based, inclusive). Decimal strings are\n"
+        "accepted for tool-call compatibility."
+    )
+    assert start_line["default"] is None
 
     shell_params = _schema_by_name(sanitized, "execute_shell_command")
     assert shell_params["required"] == ["command"]

--- a/tests/unit/providers/test_openrouter_provider.py
+++ b/tests/unit/providers/test_openrouter_provider.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import qwenpaw.providers.openrouter_provider as openrouter_provider_module
+import openai
+
 from qwenpaw.providers.openrouter_provider import OpenRouterProvider
 from qwenpaw.providers.provider_manager import ProviderManager
 
@@ -42,7 +43,7 @@ async def test_fetch_models_closes_client_on_api_error(monkeypatch) -> None:
     models = SimpleNamespace(list=AsyncMock(side_effect=RuntimeError("boom")))
     client = SimpleNamespace(models=models, close=close)
     monkeypatch.setattr(provider, "_client", lambda timeout=30: client)
-    monkeypatch.setattr(openrouter_provider_module, "APIError", Exception)
+    monkeypatch.setattr(openai, "APIError", Exception)
 
     result = await provider.fetch_models(timeout=2)
 

--- a/tests/unit/tauri/test_deferred_app.py
+++ b/tests/unit/tauri/test_deferred_app.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""Tests for the lightweight desktop ASGI shell."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.tauri.deferred_app import DeferredDesktopApp
+
+
+def _wait_for_status(
+    client: TestClient,
+    phase_name: str,
+    expected: str,
+) -> None:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        response = client.get("/api/startup/status")
+        phase = response.json()["phases"][phase_name]
+        if phase["status"] == expected:
+            return
+        time.sleep(0.01)
+    raise AssertionError(
+        f"Startup phase {phase_name} did not become {expected}",
+    )
+
+
+def test_shell_serves_before_full_app_is_ready(tmp_path) -> None:
+    release = threading.Event()
+    full_app = FastAPI()
+
+    @asynccontextmanager
+    async def full_lifespan(app: FastAPI) -> AsyncIterator[None]:
+        await asyncio.to_thread(release.wait)
+        app.state.startup_ready = asyncio.Event()
+        app.state.startup_ready.set()
+        yield
+
+    full_app.router.lifespan_context = full_lifespan
+
+    @full_app.get("/api/full")
+    def get_full() -> dict[str, bool]:
+        return {"ready": True}
+
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    (console_dir / "index.html").write_text(
+        "<html>shell</html>",
+        encoding="utf-8",
+    )
+    deferred = DeferredDesktopApp(
+        app_loader=lambda: full_app,
+        console_dir=console_dir,
+    )
+
+    with TestClient(deferred) as client:
+        assert client.get("/api/version").status_code == 200
+        assert client.get("/console").text == "<html>shell</html>"
+        status = client.get("/api/startup/status").json()
+        assert status["phases"]["api_ready"]["status"] == "ready"
+        assert status["phases"]["chat_core_ready"]["status"] == "running"
+
+        release.set()
+        assert client.get("/api/full").json() == {"ready": True}
+        _wait_for_status(client, "chat_core_ready", "ready")
+
+
+def test_full_app_failure_returns_service_unavailable(tmp_path) -> None:
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    (console_dir / "index.html").write_text(
+        "<html>shell</html>",
+        encoding="utf-8",
+    )
+
+    def fail() -> FastAPI:
+        raise RuntimeError("full app failed")
+
+    deferred = DeferredDesktopApp(
+        app_loader=fail,
+        console_dir=console_dir,
+    )
+
+    with TestClient(deferred) as client:
+        response = client.get("/api/private")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "full app failed"

--- a/tests/unit/tauri/test_startup_metrics.py
+++ b/tests/unit/tauri/test_startup_metrics.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tests for structured desktop startup metrics."""
+
+import json
+
+from qwenpaw.tauri import startup_metrics
+
+
+def test_mark_is_silent_when_metrics_are_disabled(monkeypatch, capsys):
+    monkeypatch.delenv(startup_metrics.STARTUP_METRIC_ENV, raising=False)
+
+    startup_metrics.mark("ready")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_mark_emits_structured_metric(monkeypatch, capsys):
+    monkeypatch.setenv(startup_metrics.STARTUP_METRIC_ENV, "true")
+
+    startup_metrics.mark("port_bound", port=12345)
+
+    output = capsys.readouterr().out.strip()
+    assert output.startswith(startup_metrics.STARTUP_METRIC_PREFIX)
+    payload = json.loads(
+        output.removeprefix(
+            startup_metrics.STARTUP_METRIC_PREFIX,
+        ),
+    )
+    assert payload["event"] == "port_bound"
+    assert payload["port"] == 12345
+    assert payload["pid"] > 0
+    assert payload["elapsed_ms"] >= 0

--- a/tests/unit/test_desktop_startup_benchmark.py
+++ b/tests/unit/test_desktop_startup_benchmark.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Tests for the packaged desktop startup benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmarks"
+    / "desktop_startup"
+    / "run_backend_benchmark.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "desktop_startup_benchmark",
+    _SCRIPT_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(benchmark)
+
+
+def _run(value: float) -> dict[str, Any]:
+    return {
+        "success": True,
+        "wall_elapsed_ms": value,
+        "metrics": {},
+    }
+
+
+def test_parse_metric_line_accepts_embedded_metric() -> None:
+    line = (
+        "prefix QWENPAW_STARTUP_METRIC "
+        '{"elapsed_ms":12.5,"event":"python_entry","pid":7}'
+    )
+
+    assert benchmark.parse_metric_line(line) == {
+        "elapsed_ms": 12.5,
+        "event": "python_entry",
+        "pid": 7,
+    }
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "ordinary output",
+        "QWENPAW_STARTUP_METRIC invalid",
+        "QWENPAW_STARTUP_METRIC []",
+        'QWENPAW_STARTUP_METRIC {"elapsed_ms":1}',
+    ],
+)
+def test_parse_metric_line_rejects_invalid_payload(line: str) -> None:
+    assert benchmark.parse_metric_line(line) is None
+
+
+def test_parse_backend_port_accepts_ready_announcement() -> None:
+    line = 'QWENPAW_BACKEND_READY {"port":8088}'
+
+    assert benchmark.parse_backend_port(line) == 8088
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "ordinary output",
+        "QWENPAW_BACKEND_READY invalid",
+        'QWENPAW_BACKEND_READY {"port":0}',
+        'QWENPAW_BACKEND_READY {"port":70000}',
+    ],
+)
+def test_parse_backend_port_rejects_invalid_payload(line: str) -> None:
+    assert benchmark.parse_backend_port(line) is None
+
+
+def test_percentile_interpolates_values() -> None:
+    assert benchmark.percentile([100.0, 200.0, 300.0], 0.5) == 200.0
+    assert benchmark.percentile([100.0, 200.0], 0.95) == 195.0
+
+
+def test_summarize_runs_ignores_failures() -> None:
+    runs = [
+        _run(100.0),
+        _run(200.0),
+        {"success": False},
+    ]
+
+    summary = benchmark.summarize_runs(runs)
+
+    assert summary == {
+        "requested_runs": 3,
+        "successful_runs": 2,
+        "failed_runs": 1,
+        "wall_elapsed_ms": {
+            "min": 100.0,
+            "p50": 150.0,
+            "p90": 190.0,
+            "p95": 195.0,
+            "max": 200.0,
+        },
+    }

--- a/tests/unit/utils/test_startup_display.py
+++ b/tests/unit/utils/test_startup_display.py
@@ -31,7 +31,7 @@ def test_startup_display_renders_progress_on_terminal() -> None:
         display.stop()
         console.print(display._renderable())
         rendered = output.getvalue()
-        assert "Starting custom agents: research" in rendered
+        assert "Starting custom agents" in rendered
         assert "1/1" in rendered
         assert "http://127.0.0.1:8088" in rendered
     finally:
@@ -61,6 +61,86 @@ def test_startup_display_prints_final_banner_without_tty() -> None:
         display.complete(2.0)
 
     print_banner.assert_called_once_with(None, 2.0)
+
+
+def test_ready_time_is_stable_while_background_work_finishes() -> None:
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=True,
+        color_system=None,
+        width=100,
+    )
+    display = AgentStartupDisplay(
+        ("127.0.0.1", 8088),
+        console=console,
+    )
+
+    with patch(
+        "qwenpaw.utils.startup_display.print_ready_banner",
+    ):
+        console.print(display._renderable())
+        initial = output.getvalue()
+
+        output.seek(0)
+        output.truncate(0)
+        display.complete(1.25, background_pending=True)
+        console.print(display._renderable())
+        loading = output.getvalue()
+
+        output.seek(0)
+        output.truncate(0)
+        display.complete_background(4.5)
+        console.print(display._renderable())
+        completed = output.getvalue()
+
+    assert "Status:  Ready" in loading
+    assert "Startup: 1.250s" in loading
+    assert "Background: Loading" in loading
+    assert "Startup: 1.250s" in completed
+    assert "Background: Ready 4.500s (+3.250s)" in completed
+    assert len(initial.splitlines()) == len(loading.splitlines())
+    assert len(loading.splitlines()) == len(completed.splitlines())
+
+
+def test_ready_state_does_not_regress_and_progress_is_cleared() -> None:
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=True,
+        color_system=None,
+        width=100,
+    )
+    display = AgentStartupDisplay(
+        ("127.0.0.1", 8088),
+        console=console,
+    )
+
+    with patch(
+        "qwenpaw.utils.startup_display.print_ready_banner",
+    ):
+        display.complete(1.25, background_pending=True)
+        display.start_custom_agents(1)
+        display.advance("research")
+        display.mark_finalizing()
+        console.print(display._renderable())
+        loading = output.getvalue()
+
+        output.seek(0)
+        output.truncate(0)
+        display.complete_background(4.5)
+        console.print(display._renderable())
+        completed = output.getvalue()
+
+    assert "Status:  Ready" in loading
+    assert "Background: Loading" in loading
+    assert "Starting custom agents" in loading
+    assert "1/1" in loading
+    assert "Finalizing services" not in loading
+    assert "Status:  Ready" in completed
+    assert "Background: Ready 4.500s (+3.250s)" in completed
+    assert "Starting custom agents" not in completed
+    assert len(loading.splitlines()) == len(completed.splitlines())
 
 
 def test_startup_display_preserves_file_logging(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- serve a lightweight desktop/API shell while the full Python application initializes
- define Ready as an actually usable Default Agent chat path, including ChatManager, ChannelManager, and Console Channel
- keep custom agents, external services, plugins, and maintenance work in the background
- lazily import only configured channel implementations instead of importing all built-in channels
- share the deferred startup path between the desktop sidecar and `qwenpaw app`
- keep the startup panel height stable while reporting foreground and background timings separately

## Readiness contract

`Ready` now means that a real `POST /api/console/chat` request can be accepted. Read-only and Chat APIs may run after Chat Ready; non-Chat mutations wait for Background Ready so Cron/config/plugin operations cannot race unfinished services.

The packaged benchmark no longer trusts an internal event. It repeatedly sends a reconnect request through the production Console Chat route and records the first HTTP 200 without invoking a model.

## Local measurements

Using the same machine and configuration:

- true Chat Ready before selective Channel imports: 4.241s
- true Chat Ready after selective Channel imports: 1.682s
- reduction: about 60%

A controlled startup gate also verified:

- `chat_core_ready=ready`
- background services still `running`
- production Console Chat endpoint returned HTTP 200

## Verification

- Python unit suite: 10077 passed, 18 skipped
- focused readiness tests: 100 passed
- ACP integration regression: passed
- DesktopStartupShell frontend test: passed
- pre-commit: passed

## Packaged benchmark

Windows and macOS desktop builds are running in CI. Both jobs probe the production Chat API for 10 measured runs and fail when p50 exceeds 4000ms.

CI: https://github.com/rayrayraykk/CoPaw/actions/runs/33164768334

## Status

Draft until packaged Windows/macOS Chat Ready numbers and desktop verification are available.