### PR TITLE
test(providers): add regression guard for Aliyun Coding Plan catalog alignment (#6551)

### DIFF
--- a/tests/unit/providers/test_model_catalog.py
+++ b/tests/unit/providers/test_model_catalog.py
@@ -127,6 +127,44 @@ def test_packaged_catalog_snapshot() -> None:
     }
 
 
+def test_aliyun_codingplan_catalog_alignment() -> None:
+    """Regression guard for #6551.
+
+    The Aliyun Coding Plan model list must stay aligned with the official
+    DashScope coding-plan catalog. A previous misalignment exposed models
+    that are not actually offered on the coding plan, which surfaced as
+    ``Model 'unknown' execution failed ... model `glm-5.2` is not supported``
+    when a user picked one. Lock the set so future catalog refreshes cannot
+    silently re-introduce unsupported models into this catalog key.
+    """
+    catalog = model_catalog.load_model_catalog()
+    ids = [model.id for model in catalog["ALIYUN_CODINGPLAN_MODELS"]]
+    id_set = set(ids)
+
+    # Models the official Aliyun Coding Plan site exposes must remain present.
+    expected = {
+        "qwen3.7-plus",
+        "qwen3.6-plus",
+        "qwen3.5-plus",
+        "qwen3-max-2026-01-23",
+        "qwen3-coder-next",
+        "qwen3-coder-plus",
+        "glm-5",
+        "glm-4.7",
+        "MiniMax-M2.5",
+        "kimi-k2.5",
+    }
+    assert expected.issubset(id_set)
+
+    # These were reported as unsupported on the coding plan (issue #6551) and
+    # must never be re-added to this catalog key.
+    assert "glm-5.2" not in id_set
+    assert "glm-5.1" not in id_set
+
+    # No duplicate model ids within the catalog key.
+    assert len(ids) == len(id_set)
+
+
 def test_catalog_overlays_merge_fields_in_priority_order(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What Problem This Solves

Issue #6551 reports that the Aliyun Coding Plan model list in `src/qwenpaw/providers/data/model_catalog.json` drifted out of sync with the official DashScope coding-plan catalog. Mismatched entries (e.g. `glm-5.2`, `glm-5.1`) were offered in the model picker even though they are not actually served on the coding plan. Selecting one produced a hard runtime failure for the user:

```text
Model 'unknown' execution failed ... model `glm-5.2` is not supported
```

The reporter explicitly pointed at the provider catalog as the root cause. The concrete operational problem is that a catalog/data refresh can silently re-introduce a model id that the plan does not serve, and nothing in the test suite catches it — the user only discovers it at request time, as a confusing "not supported" error on a model the UI offered them.

## Solution

The underlying data was realigned with the official catalog in #7277. This PR adds a focused, low-cost **regression test** (`test_aliyun_codingplan_catalog_alignment`) that locks that alignment so future catalog refreshes cannot silently re-introduce unsupported models into the `ALIYUN_CODINGPLAN_MODELS` key. The test encodes the exact failure mode from the issue:

- asserts the official-site models remain present,
- asserts the previously-unsupported `glm-5.2` / `glm-5.1` stay absent,
- asserts there are no duplicate model ids.

## Changes

- `tests/unit/providers/test_model_catalog.py`: +38 lines, one new test function.
- No source / runtime changes. No new dependencies. No architectural change. Diff is confined to a single test file.

## Testing

- Added `test_aliyun_codingplan_catalog_alignment` (happy path: expected models present; boundary: unsupported `glm-5.2`/`glm-5.1` absent + duplicate-id check).
- Verified it passes against the current packaged catalog, and the existing `test_packaged_catalog_snapshot` still passes.
- Command and local result:

  ```bash
  $ QWENPAW_WORKING_DIR=$(mktemp -d) pytest tests/unit/providers/test_model_catalog.py -q
  .................                                                        [100%]
  17 passed
  ```

- Negative control (proves the test actually guards the reported symptom): injecting `glm-5.2` back into `ALIYUN_CODINGPLAN_MODELS` makes the new test fail on the "unsupported model must stay absent" assertion.

## Notes for Reviewer

- Scope: this PR adds a test only; it does not modify runtime behavior. The data fix itself landed in #7277.
- Conflict check with my prior PRs in this repo (#7214, #7269, #7255 — all README / loop-engineering docs): **zero file overlap**. This PR touches only `tests/unit/providers/test_model_catalog.py`, which is not modified by any open PR (verified against the open-PR file sets).
- References #6551.
