### PR TITLE
fix(runtime): preserve state when stream generator closes

### DIFF
--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -178,6 +178,13 @@ class Runtime:
             ):
                 yield ev
             raise
+        except GeneratorExit:
+            # Closing an async response stream is normal generator control
+            # flow.  It must not run error hooks or emit an error envelope;
+            # persist any interrupted turn before the ``finally`` block
+            # performs lifecycle cleanup.
+            await self._try_save_on_cancel(ctx)
+            raise
         except BaseException as e:
             await self._try_save_on_cancel(ctx)
 

--- a/tests/unit/runtime/test_runtime_generator_close.py
+++ b/tests/unit/runtime/test_runtime_generator_close.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Runtime lifecycle behavior when a streaming consumer closes early."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.runtime.hooks import HookResult
+from qwenpaw.runtime.phases import Phase
+from qwenpaw.runtime.runtime import Runtime
+from qwenpaw.schemas import AgentRequest
+
+
+class _HookRegistry:
+    def __init__(self) -> None:
+        self.calls: list[Phase] = []
+
+    async def run(self, phase: Phase, _ctx: object) -> HookResult:
+        self.calls.append(phase)
+        return HookResult()
+
+
+class _SlashCommandRegistry:
+    async def dispatch(self, _text: str, _ctx: object) -> None:
+        return None
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_not_reported_as_runtime_error(monkeypatch) -> None:
+    hooks = _HookRegistry()
+    agent = _Agent()
+    save_calls = 0
+    error_envelope_calls = 0
+    workspace = SimpleNamespace(
+        agent_id="default",
+        workspace_dir=None,
+        plugins=SimpleNamespace(
+            hook_registry=hooks,
+            slash_command_registry=_SlashCommandRegistry(),
+            modes=[],
+        ),
+    )
+
+    async def build(_builder: object, _ctx: object) -> _Agent:
+        return agent
+
+    async def save_on_cancel(_ctx: object) -> None:
+        nonlocal save_calls
+        save_calls += 1
+
+    async def error_envelope(_envelope: object, *_args: object):
+        nonlocal error_envelope_calls
+        error_envelope_calls += 1
+        for item in ():
+            yield item
+
+    monkeypatch.setattr(
+        "qwenpaw.runtime.runtime.AgentBuilder.build",
+        build,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.runtime.runtime.Envelope.error_envelope",
+        error_envelope,
+    )
+
+    runtime = Runtime(workspace=workspace, app_services=None)
+    monkeypatch.setattr(runtime, "_try_save_on_cancel", save_on_cancel)
+    stream = runtime.run(
+        AgentRequest(session_id="session-close"),
+    )
+    await anext(stream)
+    await stream.aclose()
+
+    assert save_calls == 1
+    assert error_envelope_calls == 0
+    assert Phase.ON_ERROR not in hooks.calls
+    assert hooks.calls.count(Phase.FINALLY) == 1
+    assert agent.close_calls == 1


### PR DESCRIPTION
## Description

Preserve interrupted runtime state when an async response generator is closed through `GeneratorExit`.

The close path saves cancellation state exactly once, re-raises `GeneratorExit`, avoids `ON_ERROR` and error-envelope emission, and still closes the agent and runs `FINALLY` exactly once.

## What Problem This Solves

When a streaming client disconnects and Python closes the async generator, `GeneratorExit` is not caught by the existing `except Exception` path. Without a dedicated close path, partial runtime state can be lost and a resumed request may repeat already-started work or tool side effects.

This patch treats generator closure as interruption rather than failure: it reuses the existing cancellation-state persistence helper and preserves normal generator-close semantics.

**Related Issue:** Fixes #7410

**Security Considerations:** This reduces the risk of losing partial tool/output state and unintentionally repeating side effects after a disconnect. It does not change authorization, trust boundaries, or data exposure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: no user-facing contract change)
- [x] Ready for review

## Testing

Revalidated on 2026-09-02 against current upstream `main` (`81116f42`):

```text
python -m pytest tests/unit/runtime/test_runtime_generator_close.py -q
1 passed in 0.62s

python -m pre_commit run --files src/qwenpaw/runtime/runtime.py tests/unit/runtime/test_runtime_generator_close.py
all applicable hooks passed
```

## Evidence

The regression test closes the async generator and verifies that cancellation-state saving, agent close, and `FINALLY` each run exactly once, while `ON_ERROR` and the error envelope are not invoked. GitHub's `Real behavior proof` check is also passing.

Repository-wide pre-commit was previously attempted. The upstream baseline reported unrelated errors in `src/qwenpaw/cli/shutdown_cmd.py` (mypy) and existing unused test arguments (pylint); neither file is changed by this PR. Full pytest also stopped during collection because two existing test modules shared the basename `test_backup.py`. The focused changed-file gates above pass.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor reviewed the current upstream diff, mapped the behavior to issue #7410, and independently reran the focused regression test and all applicable changed-file pre-commit hooks before requesting review.

## Additional Notes

This is intentionally a small runtime lifecycle fix with no API expansion.