### PR TITLE
fix(pawapp): fail closed when chat runtime is unavailable

### DIFF
--- a/src/qwenpaw/pawapp/context.py
+++ b/src/qwenpaw/pawapp/context.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
+from qwenpaw.exceptions import ConfigurationException
+
 logger = logging.getLogger(__name__)
 
 
@@ -227,7 +229,7 @@ class PawAppContext:
         """
         workspace = await self._get_workspace()
         if workspace is None:
-            raise RuntimeError("No workspace available for chat")
+            raise self._chat_runtime_unavailable()
 
         chunks: List[Any] = []
         async for event in self._stream_query(
@@ -262,9 +264,7 @@ class PawAppContext:
         """
         workspace = await self._get_workspace()
         if workspace is None:
-            raise RuntimeError(
-                "No workspace available for chat_stream",
-            )
+            raise self._chat_runtime_unavailable()
 
         async for event in self._stream_query(
             workspace,
@@ -609,12 +609,16 @@ class PawAppContext:
             async for event in workspace.stream_query(request):
                 yield event
         else:
-            # Fallback: try direct agent call
-            logger.warning("Workspace has no stream_query; using fallback")
-            yield {
-                "type": "text",
-                "content": f"[PawApp ctx.chat fallback] {message}",
-            }
+            raise self._chat_runtime_unavailable()
+
+    @staticmethod
+    def _chat_runtime_unavailable() -> ConfigurationException:
+        """Return the standard structured error for a missing chat runtime."""
+        return ConfigurationException(
+            "Agent chat runtime is unavailable",
+            config_key="agent_runtime",
+            error_code="AGENT_CHAT_RUNTIME_UNAVAILABLE",
+        )
 
     # ─── Cached sub-objects ────────────────────────────────────────
 

--- a/tests/unit/pawapp/test_app_contract.py
+++ b/tests/unit/pawapp/test_app_contract.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -498,6 +499,49 @@ def test_chat_reports_missing_model_as_actionable_unavailable() -> None:
                 "path": "/models",
             },
         },
+    }
+
+
+def test_chat_routes_report_the_same_runtime_unavailable_error() -> None:
+    class MissingRuntimeContext:
+        app_id = "fixture"
+
+        @staticmethod
+        def _error() -> ConfigurationException:
+            return ConfigurationException(
+                "Agent chat runtime is unavailable",
+                config_key="agent_runtime",
+                error_code="AGENT_CHAT_RUNTIME_UNAVAILABLE",
+            )
+
+        async def chat(self, *_args, **_kwargs):
+            raise self._error()
+
+        async def chat_stream(self, *_args, **_kwargs):
+            for item in ():
+                yield item
+            raise self._error()
+
+    fixture = FastAPI()
+    fixture.include_router(_build_capability_router())
+    fixture.dependency_overrides[get_scoped_ctx] = MissingRuntimeContext
+    client = TestClient(fixture)
+    expected = {
+        "code": "AGENT_CHAT_RUNTIME_UNAVAILABLE",
+        "message": "Agent chat runtime is unavailable",
+        "config_key": "agent_runtime",
+    }
+
+    response = client.post("/chat", json={"message": "run"})
+    stream = client.post("/chat/stream", json={"message": "run"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": expected}
+    assert stream.status_code == 200
+    assert '"type": "error"' in stream.text
+    assert json.loads(stream.text.removeprefix("data: ").strip()) == {
+        "type": "error",
+        "error": expected,
     }
 
 

--- a/tests/unit/pawapp/test_context_sessions.py
+++ b/tests/unit/pawapp/test_context_sessions.py
@@ -8,6 +8,7 @@ import pytest
 from qwenpaw.app.chats.manager import ChatManager
 from qwenpaw.app.chats.models import ChatSpec
 from qwenpaw.app.chats.repo import JsonChatRepository
+from qwenpaw.exceptions import ConfigurationException
 from qwenpaw.pawapp.context import PawAppContext
 
 
@@ -18,6 +19,28 @@ class _WorkspaceRegistry:
     async def get_agent(self, agent_id: str):
         assert agent_id == "qwenpaw-data"
         return self.workspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("workspace", [None, SimpleNamespace()])
+async def test_pawapp_chat_fails_closed_without_runtime(workspace) -> None:
+    context = PawAppContext(
+        app_id="qwenpaw-data",
+        agent_id="qwenpaw-data",
+        _workspace_registry=_WorkspaceRegistry(workspace),
+    )
+
+    with pytest.raises(ConfigurationException) as chat_error:
+        await context.chat("do not fake this reply")
+
+    assert chat_error.value.error_code == "AGENT_CHAT_RUNTIME_UNAVAILABLE"
+    assert chat_error.value.config_key == "agent_runtime"
+
+    with pytest.raises(ConfigurationException) as stream_error:
+        await anext(context.chat_stream("do not fake this reply"))
+
+    assert stream_error.value.error_code == "AGENT_CHAT_RUNTIME_UNAVAILABLE"
+    assert stream_error.value.config_key == "agent_runtime"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Remove the synthetic PawApp chat fallback when the host agent runtime is unavailable.

Both HTTP chat and SSE chat-stream now fail closed with the same structured AGENT_CHAT_RUNTIME_UNAVAILABLE error instead of returning text that can be mistaken for a real model response.

**Related Issue:** Fixes #7411

**Security Considerations:** The public error contains only a stable code, fixed message, and fixed configuration key. Internal workspace paths, exceptions, and runtime objects are not exposed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran pre-commit run --all-files locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: this corrects invalid fallback behavior)
- [x] Ready for review

## Testing

    pytest tests/unit/pawapp -q
    # 124 passed, 1 skipped, 1 warning

    pre-commit run --files src/qwenpaw/pawapp/context.py tests/unit/pawapp/test_context_sessions.py tests/unit/pawapp/test_app_contract.py
    # all applicable hooks passed

## Evidence

Contract tests verify that missing workspace/runtime capability fails closed and that HTTP 503 and SSE error events expose the same stable structured detail without internal information.

Repository-wide pre-commit was attempted and reported unrelated current-baseline failures in src/qwenpaw/cli/shutdown_cmd.py and existing test-only pylint warnings. Full pytest stops during collection on the existing duplicate test_backup.py module names. None of those files are changed by this PR.

## Additional Notes

No DaxiaWork or other product-specific semantics are included.