### PR TITLE
fix(pawapp-sdk): make stream cleanup non-blocking

### DIFF
--- a/console/src/plugins/pawapp-sdk/api.ts
+++ b/console/src/plugins/pawapp-sdk/api.ts
@@ -265,6 +265,40 @@ async function* eventsForApp(
   const reader = res.body?.getReader();
   if (!reader) throw new Error("No response body for stream");
 
+  let readerFinalizePromise: Promise<void> | undefined;
+  const finalizeReaderOnce = () => {
+    if (!readerFinalizePromise) {
+      readerFinalizePromise = (async () => {
+        try {
+          await reader.cancel();
+        } catch {
+          // Best-effort cleanup; preserve the stream's original outcome.
+        } finally {
+          try {
+            reader.releaseLock();
+          } catch {
+            // The lock may already have been released by the stream runtime.
+          }
+        }
+      })();
+    }
+    return readerFinalizePromise;
+  };
+  const aborted = Symbol("aborted");
+  let notifyAbort!: () => void;
+  const abortPromise = new Promise<typeof aborted>((resolve) => {
+    notifyAbort = () => resolve(aborted);
+  });
+  const handleAbort = () => {
+    notifyAbort();
+    void finalizeReaderOnce();
+  };
+  if (opts.signal?.aborted) {
+    handleAbort();
+  } else {
+    opts.signal?.addEventListener("abort", handleAbort, { once: true });
+  }
+
   const decoder = new TextDecoder();
   let buffer = "";
   let eventName = "message";
@@ -309,7 +343,9 @@ async function* eventsForApp(
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const result = await Promise.race([reader.read(), abortPromise]);
+      if (result === aborted) break;
+      const { done, value } = result;
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
@@ -329,7 +365,8 @@ async function* eventsForApp(
     const event = flush();
     if (event) yield event;
   } finally {
-    await reader.cancel().catch(() => undefined);
+    opts.signal?.removeEventListener("abort", handleAbort);
+    void finalizeReaderOnce();
   }
 }
 

--- a/console/src/plugins/pawapp-sdk/streamLifecycle.test.ts
+++ b/console/src/plugins/pawapp-sdk/streamLifecycle.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { hostFetch } from "../hostSdk/fetch";
+import { forApp } from "./index";
+
+vi.mock("../hostSdk/fetch", () => ({
+  hostFetch: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(hostFetch);
+const encoder = new TextEncoder();
+
+function taskCreatedResponse() {
+  return new Response(JSON.stringify({ task_id: "task-1" }), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function streamResponse(reader: {
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: { getReader: () => reader },
+  } as unknown as Response;
+}
+
+async function settleWithin<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("result did not settle")),
+          100,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function failedResponse(status: number, cancel: () => Promise<void>) {
+  return {
+    ok: false,
+    status,
+    statusText: "Failed",
+    body: { cancel },
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("PawApp SDK stream lifecycle", () => {
+  it("cancels and releases an SSE reader once when the caller aborts", async () => {
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<ReadableStreamReadResult<Uint8Array>>(() => undefined),
+      ),
+      cancel: vi.fn(() => new Promise<void>(() => undefined)),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: { getReader: () => reader },
+    } as unknown as Response);
+
+    const controller = new AbortController();
+    const iterator = forApp("analysis-app").api.events("/events", {
+      method: "GET",
+      signal: controller.signal,
+    });
+    const completed = iterator.next();
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledOnce());
+
+    controller.abort();
+
+    await expect(completed).resolves.toEqual({ done: true, value: undefined });
+    expect(reader.cancel).toHaveBeenCalledOnce();
+    expect(reader.releaseLock).not.toHaveBeenCalled();
+  });
+
+  it("contains rejected SSE cleanup and releases the reader lock", async () => {
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<ReadableStreamReadResult<Uint8Array>>(() => undefined),
+      ),
+      cancel: vi.fn().mockRejectedValue(new Error("cleanup failed")),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch.mockResolvedValue(streamResponse(reader));
+    const controller = new AbortController();
+    const completed = forApp("analysis-app")
+      .api.events("/events", { method: "GET", signal: controller.signal })
+      .next();
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledOnce());
+
+    controller.abort();
+
+    await expect(completed).resolves.toEqual({ done: true, value: undefined });
+    await vi.waitFor(() => expect(reader.releaseLock).toHaveBeenCalledOnce());
+    expect(reader.cancel).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "done",
+      event: 'data: {"type":"done","data":{"ok":true}}\n',
+      assertion: "resolve" as const,
+    },
+    {
+      name: "error",
+      event: 'data: {"type":"error","message":"failed"}\n',
+      assertion: "reject" as const,
+    },
+  ])("finalizes a task once on $name", async ({ event, assertion }) => {
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode(event),
+      }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch
+      .mockResolvedValueOnce(taskCreatedResponse())
+      .mockResolvedValueOnce(streamResponse(reader));
+    const onDone = vi.fn();
+    const onError = vi.fn();
+    const task = forApp("analysis-app")
+      .api.task("/jobs", {})
+      .on("done", onDone)
+      .on("error", onError);
+
+    if (assertion === "resolve") {
+      await expect(task.result).resolves.toEqual({ ok: true });
+      expect(onDone).toHaveBeenCalledOnce();
+      expect(onError).not.toHaveBeenCalled();
+    } else {
+      await expect(task.result).rejects.toThrow("failed");
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onDone).not.toHaveBeenCalled();
+    }
+
+    task.cancel();
+    await vi.waitFor(() => expect(reader.cancel).toHaveBeenCalledOnce());
+    expect(reader.releaseLock).toHaveBeenCalledOnce();
+  });
+
+  it("settles cancellation immediately and finalizes its reader once", async () => {
+    let finishRead: (() => void) | undefined;
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+            finishRead = () => resolve({ done: true, value: undefined });
+          }),
+      ),
+      cancel: vi.fn(async () => {
+        finishRead?.();
+      }),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch
+      .mockResolvedValueOnce(taskCreatedResponse())
+      .mockResolvedValueOnce(streamResponse(reader));
+    const task = forApp("analysis-app").api.task("/jobs", {});
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledOnce());
+
+    task.cancel();
+
+    await expect(task.result).rejects.toThrow("Task cancelled");
+    await vi.waitFor(() => expect(reader.cancel).toHaveBeenCalledOnce());
+    expect(reader.releaseLock).toHaveBeenCalledOnce();
+    task.cancel();
+    expect(reader.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not delay a terminal result while reader cleanup is pending", async () => {
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode('data: {"type":"done","data":{"ok":true}}\n'),
+      }),
+      cancel: vi.fn(() => new Promise<void>(() => undefined)),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch
+      .mockResolvedValueOnce(taskCreatedResponse())
+      .mockResolvedValueOnce(streamResponse(reader));
+
+    const task = forApp("analysis-app").api.task("/jobs", {});
+
+    await expect(task.result).resolves.toEqual({ ok: true });
+    expect(reader.cancel).toHaveBeenCalledOnce();
+  });
+
+  it.each(["create", "stream"])(
+    "does not delay a %s failure while response cleanup is pending",
+    async (stage) => {
+      const cancel = vi.fn(() => new Promise<void>(() => undefined));
+      if (stage === "create") {
+        mockedFetch.mockResolvedValueOnce(failedResponse(500, cancel));
+      } else {
+        mockedFetch
+          .mockResolvedValueOnce(taskCreatedResponse())
+          .mockResolvedValueOnce(failedResponse(502, cancel));
+      }
+
+      const result = forApp("analysis-app").api.task("/jobs", {}).result;
+
+      await expect(settleWithin(result)).rejects.toThrow(
+        stage === "create" ? "Task creation failed" : "SSE connection failed",
+      );
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["create", "stream"])(
+    "settles cancellation while the %s request is pending",
+    async (stage) => {
+      const pending = new Promise<Response>(() => undefined);
+      if (stage === "create") {
+        mockedFetch.mockReturnValueOnce(pending);
+      } else {
+        mockedFetch
+          .mockResolvedValueOnce(taskCreatedResponse())
+          .mockReturnValueOnce(pending);
+      }
+      const task = forApp("analysis-app").api.task("/jobs", {});
+      await vi.waitFor(() =>
+        expect(mockedFetch).toHaveBeenCalledTimes(stage === "create" ? 1 : 2),
+      );
+
+      task.cancel();
+
+      await expect(settleWithin(task.result)).rejects.toThrow("Task cancelled");
+    },
+  );
+
+  it("does not dispatch later events from a batch after cancellation", async () => {
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode(
+          'data: {"type":"progress","data":{"step":1}}\n' +
+            'data: {"type":"progress","data":{"step":2}}\n',
+        ),
+      }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn(),
+    };
+    mockedFetch
+      .mockResolvedValueOnce(taskCreatedResponse())
+      .mockResolvedValueOnce(streamResponse(reader));
+    const onProgress = vi.fn();
+    const task = forApp("analysis-app").api.task("/jobs", {});
+    task.on("progress", (data) => {
+      onProgress(data);
+      task.cancel();
+    });
+
+    await expect(task.result).rejects.toThrow("Task cancelled");
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith({ step: 1 });
+  });
+});

--- a/console/src/plugins/pawapp-sdk/task.ts
+++ b/console/src/plugins/pawapp-sdk/task.ts
@@ -23,7 +23,10 @@ function createPawTaskWithScope(
 ): PawTaskHandle {
   const listeners = new Map<string, Set<PawTaskEventHandler>>();
   let taskId = "";
-  let abortController: AbortController | null = new AbortController();
+  const abortController = new AbortController();
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let readerFinalizePromise: Promise<void> | null = null;
+  let settled = false;
 
   // Promise that resolves with the final result
   let resolveResult!: (value: unknown) => void;
@@ -46,6 +49,40 @@ function createPawTaskWithScope(
     }
   }
 
+  function finalizeReaderOnce(): Promise<void> {
+    if (!activeReader) return Promise.resolve();
+    if (!readerFinalizePromise) {
+      const reader = activeReader;
+      readerFinalizePromise = (async () => {
+        try {
+          await reader.cancel();
+        } catch {
+          // Best-effort cleanup; preserve the task's original outcome.
+        } finally {
+          try {
+            reader.releaseLock();
+          } catch {
+            // The lock may already have been released by the stream runtime.
+          }
+        }
+      })();
+    }
+    return readerFinalizePromise;
+  }
+
+  function finalize(
+    outcome: "resolve" | "reject",
+    value: unknown,
+    terminalEvent?: { type: string; data: unknown },
+  ): boolean {
+    if (settled) return false;
+    settled = true;
+    if (terminalEvent) emit(terminalEvent.type, terminalEvent.data);
+    if (outcome === "resolve") resolveResult(value);
+    else rejectResult(value);
+    return true;
+  }
+
   // Start the task asynchronously
   (async () => {
     try {
@@ -61,10 +98,11 @@ function createPawTaskWithScope(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: params != null ? JSON.stringify(params) : undefined,
-        signal: abortController?.signal,
+        signal: abortController.signal,
       });
 
       if (!createRes.ok) {
+        void createRes.body?.cancel().catch(() => undefined);
         throw new Error(
           `Task creation failed: ${createRes.status} ${createRes.statusText}`,
         );
@@ -76,6 +114,7 @@ function createPawTaskWithScope(
       if (!taskId) {
         throw new Error("No task_id returned from backend");
       }
+      if (settled) return;
 
       // Connect to SSE stream using fetch-based approach
       // (EventSource doesn't support custom auth headers)
@@ -85,59 +124,74 @@ function createPawTaskWithScope(
           headers: {
             Accept: "text/event-stream",
           },
-          signal: abortController?.signal,
+          signal: abortController.signal,
         },
       );
 
       if (!sseRes.ok || !sseRes.body) {
+        void sseRes.body?.cancel().catch(() => undefined);
         throw new Error(`SSE connection failed: ${sseRes.status}`);
       }
 
       const reader = sseRes.body.getReader();
+      activeReader = reader;
       const decoder = new TextDecoder();
       let buffer = "";
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+      try {
+        while (!settled) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
 
-        for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            try {
-              const eventData = JSON.parse(line.slice(6));
-              const eventType = eventData.type ?? eventData.event ?? "message";
+          for (const line of lines) {
+            if (settled) break;
+            if (line.startsWith("data: ")) {
+              try {
+                const eventData = JSON.parse(line.slice(6));
+                const eventType =
+                  eventData.type ?? eventData.event ?? "message";
 
-              if (eventType === "done") {
-                emit("done", eventData.data ?? eventData);
-                resolveResult(eventData.data ?? eventData.result ?? null);
-                return;
-              } else if (eventType === "error") {
-                const err = new Error(eventData.message ?? "Task failed");
-                emit("error", eventData);
-                rejectResult(err);
-                return;
-              } else {
-                emit(eventType, eventData.data ?? eventData);
+                if (eventType === "done") {
+                  finalize(
+                    "resolve",
+                    eventData.data ?? eventData.result ?? null,
+                    { type: "done", data: eventData.data ?? eventData },
+                  );
+                } else if (eventType === "error") {
+                  finalize(
+                    "reject",
+                    new Error(eventData.message ?? "Task failed"),
+                    { type: "error", data: eventData },
+                  );
+                } else {
+                  emit(eventType, eventData.data ?? eventData);
+                }
+              } catch {
+                // Non-JSON line, emit as raw
+                emit("message", line.slice(6));
               }
-            } catch {
-              // Non-JSON line, emit as raw
-              emit("message", line.slice(6));
             }
           }
         }
+      } finally {
+        void finalizeReaderOnce();
+        activeReader = null;
       }
 
       // Stream ended without explicit done/error
-      resolveResult(null);
+      finalize("resolve", null);
     } catch (err) {
-      if ((err as Error).name === "AbortError") {
-        rejectResult(new Error("Task cancelled"));
+      if (
+        (err as Error).name === "AbortError" ||
+        abortController.signal.aborted
+      ) {
+        finalize("reject", new Error("Task cancelled"));
       } else {
-        rejectResult(err);
+        finalize("reject", err);
       }
     }
   })();
@@ -155,8 +209,9 @@ function createPawTaskWithScope(
       return handle;
     },
     cancel() {
-      abortController?.abort();
-      abortController = null;
+      if (!finalize("reject", new Error("Task cancelled"))) return;
+      abortController.abort();
+      void finalizeReaderOnce();
     },
     get result() {
       return resultPromise;


### PR DESCRIPTION
## Description

Make PawApp SDK stream cancellation and cleanup prompt, idempotent, and independent from a stalled reader.cancel promise.

The iterator races reads against abort, terminal task settlement happens once, reader cleanup is best-effort, active reader references are cleared, and late events from the same chunk are not dispatched after cancellation.

**Related Issue:** Fixes #7412

**Security Considerations:** No authentication or request-scope changes. Cleanup errors are contained and do not expose response bodies or credentials.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran pre-commit run --all-files locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: public SDK signatures are unchanged)
- [x] Ready for review

## Testing

    npm run test:run -- src/plugins/pawapp-sdk/streamLifecycle.test.ts src/plugins/pawapp-sdk/scoping.test.tsx
    # 2 files, 32 tests passed

    npx tsc -b --noEmit
    # passed

    npm run build
    # production build passed

    pre-commit run --files console/src/plugins/pawapp-sdk/api.ts console/src/plugins/pawapp-sdk/task.ts console/src/plugins/pawapp-sdk/streamLifecycle.test.ts
    # all applicable hooks passed

## Evidence

Tests cover pending and rejected reader.cancel, non-OK create/SSE cleanup, cancellation during request creation and stream setup, same-chunk cancellation, and exactly-once done/error/cancel settlement.

The production Console build completed successfully and the 8088 source instance served the built main asset with the same SHA256 as console/dist. The public initialization page rendered without console errors. Repository-wide pre-commit/full-pytest attempts are documented in the related backend PRs; failures are in unchanged upstream baseline files/test collection.

## Additional Notes

This PR does not add a second network SDK or change the PawApp public method signatures.