### PR TITLE
fix(yuanbao): restore protobuf decoding on protobuf 6+

### DIFF
--- a/src/qwenpaw/app/channels/yuanbao/codec.py
+++ b/src/qwenpaw/app/channels/yuanbao/codec.py
@@ -293,7 +293,6 @@ def decode_pb(type_name: str, data: bytes) -> Optional[dict]:
         return json_format.MessageToDict(
             msg,
             preserving_proto_field_name=True,
-            including_default_value_fields=False,
         )
     except Exception:
         return None

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -648,6 +648,40 @@ class TestSendMedia:
 class TestCodecHelpers:
     """P1: Codec encode/decode helpers."""
 
+    @pytest.mark.parametrize(
+        ("type_name", "payload", "expected"),
+        [
+            (
+                "AUTH_BIND_RSP",
+                {"code": 41101, "message": "already", "connectId": "cid"},
+                {"code": 41101, "message": "already", "connectId": "cid"},
+            ),
+            (
+                "PING_RSP",
+                {"heartInterval": 42},
+                {"heartInterval": 42},
+            ),
+            (
+                "KICKOUT_MSG",
+                {"status": 1, "reason": "another device"},
+                {"status": 1, "reason": "another device"},
+            ),
+            (
+                "AUTH_BIND_RSP",
+                {"code": 0},
+                {},
+            ),
+        ],
+    )
+    def test_pb_roundtrip(self, type_name, payload, expected):
+        from qwenpaw.app.channels.yuanbao import codec
+
+        message_type = getattr(codec, type_name)
+        encoded = codec.encode_pb(message_type, payload)
+
+        assert encoded is not None
+        assert codec.decode_pb(message_type, encoded) == expected
+
     def test_to_proto_msg_body_text(self):
         from qwenpaw.app.channels.yuanbao.codec import _to_proto_msg_body
 


### PR DESCRIPTION
## Summary

Fix Yuanbao protobuf decoding failure with newer protobuf versions.

## Root Cause

`decode_pb()` passed the removed `including_default_value_fields`
keyword argument to `json_format.MessageToDict()`.

With protobuf 6.x and 7.x, this raises `TypeError`. The exception was
silently caught, causing every otherwise valid protobuf payload to return
`None`.

## Changes

- Remove the obsolete `including_default_value_fields` argument.
- Add protobuf encode/decode round-trip regression tests covering:
  - `AuthBindRsp`
  - `PingRsp`
  - `KickoutMsg`
  - Empty/default-valued responses

Removing the argument preserves the existing behavior: fields without
presence and default values remain omitted because that is the API default.

## Impact

This restores decoding of Yuanbao response fields such as:

- Auth response fields, including `connectId`
- Negotiated heartbeat interval
- Kickout reason
- Business response fields

No protobuf wire format, encoding logic, authentication flow, heartbeat
flow, or regular JSON inbound-message flow was changed.

## Verification

- `conda run -n base pytest -q tests/unit/channels/test_yuanbao.py`
  - `100 passed`
- Round-trip checks passed with protobuf `6.33.6`
- Round-trip checks passed with protobuf `7.35.1`
- Python compilation check passed
- `git diff --check` passed