### PR TITLE
ci: skip test runs on draft PRs until marked ready

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,10 @@ name: CodeQL
 
 on:
   pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the scan really runs
+    # right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, dev, develop]
     paths:
       - 'src/**'
@@ -46,6 +50,12 @@ concurrency:
 jobs:
   analyze:
     name: CodeQL (${{ matrix.shard }})
+    # Draft PRs skip the scan entirely: CodeQL is not part of the
+    # required-check set, so no placeholder context is needed. The
+    # ready_for_review trigger above re-runs it once the PR is ready.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/creator-app-tests.yml
+++ b/.github/workflows/creator-app-tests.yml
@@ -7,6 +7,10 @@ on:
       - "plugins/apps/qwenpaw-creator/**"
       - ".github/workflows/creator-app-tests.yml"
   pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the checks really run
+    # right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, dev, develop, "dev/**"]
     paths:
       - "plugins/apps/qwenpaw-creator/**"
@@ -25,7 +29,8 @@ jobs:
     needs: [spam-gate]
     if: |
       always() &&
-      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +60,8 @@ jobs:
     needs: [spam-gate]
     if: |
       always() &&
-      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -2,6 +2,10 @@ name: E2E Smoke Tests
 
 on:
   pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the smoke run really
+    # happens right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, dev, develop]
     paths:
       - 'console/**'
@@ -17,6 +21,12 @@ on:
 jobs:
   e2e-smoke:
     name: Playwright UI Smoke
+    # Draft PRs skip the smoke run entirely: this check is not part of
+    # the required-check set, so no placeholder context is needed. The
+    # ready_for_review trigger above re-runs it once the PR is ready.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -7,6 +7,10 @@ on:
       - 'console/**'
       - '.github/workflows/frontend-tests.yml'
   pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so vitest really runs right
+    # after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, dev, develop]
 
 jobs:
@@ -45,11 +49,15 @@ jobs:
     # cancelled its `code` output is empty and this job would silently skip,
     # which a ruleset cannot distinguish from a bypass. The frontend-summary
     # job below turns that detection failure into a hard red.
+    # Draft PRs defer the real run: the summary reports an explicit green
+    # placeholder (GitHub forbids merging drafts), and the ready_for_review
+    # trigger re-runs everything when the PR is marked ready.
     if: |
       always() &&
       needs.changes.result == 'success' &&
       needs.changes.outputs.code == 'true' &&
-      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -86,10 +94,13 @@ jobs:
     needs: [changes, spam-gate, vitest]
     # Fail-closed gate. This job ALWAYS runs (no path condition) so the
     # required-check context can never be satisfied by an accidental skip.
-    # Three-state decision, mirroring `Test Summary` in tests.yml:
+    # Four-state decision, mirroring `Test Summary` in tests.yml:
     #   1. change detection did not succeed -> red;
     #   2. detection succeeded, no console changes -> explicit green;
-    #   3. console change -> vitest must be strictly `success`.
+    #   3. draft PR with console changes -> explicit green placeholder
+    #      (the real run resumes automatically once the PR is marked
+    #      ready via the ready_for_review trigger);
+    #   4. console change -> vitest must be strictly `success`.
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -107,6 +118,12 @@ jobs:
 
           if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
             echo "✅ No console changes — vitest not required"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "✅ Draft PR — vitest deferred until the PR is marked ready for review"
             exit 0
           fi
 

--- a/.github/workflows/npm-format.yml
+++ b/.github/workflows/npm-format.yml
@@ -1,6 +1,12 @@
 name: NPM Format (website & console)
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the checks really run
+    # right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   spam-gate:
@@ -21,14 +27,32 @@ jobs:
       run:
         working-directory: website
     steps:
+      # Draft PRs defer the real run: this job still reports a green
+      # placeholder so the required-check context stays present (GitHub
+      # forbids merging drafts), and the ready_for_review trigger
+      # re-runs everything once the PR is marked ready.
+      - name: Detect draft PR
+        id: draft
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.draft.outputs.value != 'true'
 
       - name: Setup pnpm
+        if: steps.draft.outputs.value != 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node
+        if: steps.draft.outputs.value != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -36,10 +60,17 @@ jobs:
           cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: steps.draft.outputs.value != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run format check
+        if: steps.draft.outputs.value != 'true'
         run: pnpm run format:check
+
+      - name: Report draft placeholder
+        if: steps.draft.outputs.value == 'true'
+        shell: bash
+        run: echo "✅ Draft PR — website format check deferred until the PR is marked ready for review"
 
   console:
     name: console format check
@@ -52,9 +83,22 @@ jobs:
       run:
         working-directory: console
     steps:
+      - name: Detect draft PR
+        id: draft
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.draft.outputs.value != 'true'
 
       - name: Setup Node
+        if: steps.draft.outputs.value != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -62,7 +106,14 @@ jobs:
           cache-dependency-path: console/package-lock.json
 
       - name: Install dependencies
+        if: steps.draft.outputs.value != 'true'
         run: npm ci
 
       - name: Run format check
+        if: steps.draft.outputs.value != 'true'
         run: npm run format:check
+
+      - name: Report draft placeholder
+        if: steps.draft.outputs.value == 'true'
+        shell: bash
+        run: echo "✅ Draft PR — console format check deferred until the PR is marked ready for review"

--- a/.github/workflows/npm-format.yml
+++ b/.github/workflows/npm-format.yml
@@ -33,6 +33,10 @@ jobs:
       # re-runs everything once the PR is marked ready.
       - name: Detect draft PR
         id: draft
+        # Override the job-level working-directory: the website/console
+        # subdirectories only exist after checkout, and this step must run
+        # before checkout to decide whether the real steps run at all.
+        working-directory: .
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ] && \
@@ -69,6 +73,9 @@ jobs:
 
       - name: Report draft placeholder
         if: steps.draft.outputs.value == 'true'
+        # Same override as the draft-detection step: the subdirectory does
+        # not exist before checkout, which never runs on draft PRs.
+        working-directory: .
         shell: bash
         run: echo "✅ Draft PR — website format check deferred until the PR is marked ready for review"
 
@@ -85,6 +92,10 @@ jobs:
     steps:
       - name: Detect draft PR
         id: draft
+        # Override the job-level working-directory: the website/console
+        # subdirectories only exist after checkout, and this step must run
+        # before checkout to decide whether the real steps run at all.
+        working-directory: .
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ] && \
@@ -115,5 +126,8 @@ jobs:
 
       - name: Report draft placeholder
         if: steps.draft.outputs.value == 'true'
+        # Same override as the draft-detection step: the subdirectory does
+        # not exist before checkout, which never runs on draft PRs.
+        working-directory: .
         shell: bash
         run: echo "✅ Draft PR — console format check deferred until the PR is marked ready for review"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,12 @@
 name: Pre-commit Checks
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the checks really run
+    # right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   spam-gate:
@@ -23,26 +29,47 @@ jobs:
       OS: ubuntu-latest
       PYTHON: "3.11"
     steps:
+      # Draft PRs defer the real run: this job still reports a green
+      # placeholder so the required-check context stays present (GitHub
+      # forbids merging drafts), and the ready_for_review trigger
+      # re-runs everything once the PR is marked ready.
+      - name: Detect draft PR
+        id: draft
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.draft.outputs.value != 'true'
 
       - name: Setup Python
+        if: steps.draft.outputs.value != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Update setuptools and wheel
+        if: steps.draft.outputs.value != 'true'
         run: |
           pip install setuptools==68.2.2 wheel==0.41.2
 
       - name: Install QwenPaw with dev dependencies
+        if: steps.draft.outputs.value != 'true'
         run: |
           pip install -q -e ".[dev]"
 
       - name: Install pre-commit hooks
+        if: steps.draft.outputs.value != 'true'
         run: |
           pre-commit install
 
       - name: Run pre-commit
+        if: steps.draft.outputs.value != 'true'
         run: |
           pre-commit run --all-files 2>&1 | tee pre-commit.log || true
           if grep -q Failed pre-commit.log; then
@@ -50,3 +77,8 @@ jobs:
             exit 1
           fi
           echo -e "\e[46m  ********************************Passed******************************** \e[0m"
+
+      - name: Report draft placeholder
+        if: steps.draft.outputs.value == 'true'
+        shell: bash
+        run: echo "✅ Draft PR — pre-commit checks deferred until the PR is marked ready for review"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ on:
       - 'deploy/Dockerfile'
       - '.github/workflows/tests.yml'
   pull_request:
+    # Default types plus ready_for_review: converting a draft PR to
+    # ready must re-trigger this workflow so the real tiers run on the
+    # current head right after the author leaves draft state.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, dev, develop]
   workflow_dispatch:
     inputs:
@@ -68,7 +72,8 @@ jobs:
     if: |
       always() &&
       needs.changes.outputs.code == 'true' &&
-      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     environment: maintainer-approved
     steps:
@@ -648,14 +653,19 @@ jobs:
     needs: [changes, approval-gate, unit-tests, contract-tests, integrated-tests, coverage-report]
     # Fail-closed gate. This job ALWAYS runs (no path condition) so the
     # required-check context can never be satisfied by an accidental skip.
-    # Three-state decision:
+    # Four-state decision:
     #   1. change detection did not succeed -> red (its `code` output is
     #      unreliable when the detection job fails/is cancelled, so the
     #      gate must close rather than open);
     #   2. detection succeeded and reported a docs-only PR -> explicit
     #      green (instead of skipping, which a ruleset cannot distinguish
     #      from a bypass);
-    #   3. code change -> approval plus EVERY test tier must be strictly
+    #   3. draft PR with code changes -> explicit green placeholder: the
+    #      real tiers are deferred while the PR is a draft (GitHub forbids
+    #      merging drafts, so the placeholder cannot smuggle anything in),
+    #      and the `ready_for_review` trigger re-runs the whole workflow
+    #      the moment the author marks the PR ready;
+    #   4. code change -> approval plus EVERY test tier must be strictly
     #      `success`; failure/cancelled/skipped are all rejected.
     # coverage-report is intentionally observed, not enforced: a coverage
     # tooling outage must not block an otherwise green PR.
@@ -679,6 +689,12 @@ jobs:
 
           if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
             echo "✅ Docs-only change — no test tiers required"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "✅ Draft PR — test tiers deferred until the PR is marked ready for review"
             exit 0
           fi
 


### PR DESCRIPTION
## Description

Developer request: draft/WIP PRs currently burn full test suites before the code is final. Measured on the current open PR list, 14 of the 15 draft PRs are running the real tests. This PR defers the real runs while a PR is a draft and re-runs everything automatically the moment it is marked ready for review.

### What changed (7 workflow files)

1. **`ready_for_review` added to every `pull_request` trigger** — converting a draft to ready re-triggers all workflows, so the real checks run on the current head immediately, with no manual re-push needed.
2. **The five required-check contexts stay present on drafts with an explicit green placeholder** — `Test Summary` / `Frontend Summary` report an explicit "draft deferred" success instead of failing; `Pre-commit` and both format checks print the placeholder and skip their real steps. Rationale: GitHub never allows merging a draft, so the placeholder cannot let untested code in; and if the contexts were absent on drafts, the merge box would show them as missing right after converting to ready (the checks would never have been produced), forcing a needless re-push.
3. **Non-required workflows (`E2E Smoke Tests`, `CodeQL`, `Creator App Tests`) skip their jobs entirely on drafts** — they are outside the required-check set, so a plain skip is safe; `ready_for_review` re-runs them once the PR is ready.
4. **Fail-closed semantics are fully preserved** — a change-detection failure still turns `Test Summary` / `Frontend Summary` red, and every real tier must be strictly `success` once the PR leaves draft state.

### Verification (real evidence, fork yutai78786/QwenPaw PR #50 on this exact branch, closed after verification)

| Phase | Evidence |
|---|---|
| Draft state | All real test tiers skipped (no unit/contract/integrated/vitest/format execution); all five required-check contexts present and green |
| Convert to ready | All workflows re-triggered automatically: E2E smoke really ran for 111s (it was `skipped` in the draft state), NPM Format and Creator tests really ran, `Tests` entered the queue |

One bug was caught and fixed during this verification: the `website`/`console` jobs set a job-level `working-directory` that only exists after checkout, which broke the draft-detection step itself (and would have gone red for every PR, draft or not). Fixed by overriding the affected steps back to the workspace root (commit bec3e178).

## Type of Change

- [x] Refactoring (no functional changes, improves code maintainability or structure)

## Component(s) Affected

- [x] CI/CD and build system

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Testing

- Fork verification PR on this exact branch: draft state showed zero real test execution with all five required contexts green; converting to ready re-triggered every workflow and the smoke/format/creator tests really ran (111s Playwright run, format and creator jobs executed).
- Fail-closed paths unchanged: change-detection failure still closes the gate; ready PRs require every tier strictly `success`.

## Evidence

- Fork branch: `yutai78786:ci/skip-draft-pr-tests` (head bec3e178, rebased on main 1a4f4d8a)
- Fork verification PR: yutai78786/QwenPaw#50 (draft placeholder green verified, ready_for_review re-trigger verified, then closed)

## Additional Notes

- Trade-off acknowledged by the team: while a PR is a draft the author no longer gets test feedback until it is marked ready; a manual-trigger escape hatch was intentionally deferred (out of scope for this round).
- No test or product code touched — workflow orchestration only.
