### PR TITLE
chore(deps): exclude optional Pylint runtime provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "orjson>=3.9",
     # Coding Mode — Python LSP server bundled as a zero-config fallback
     # so the `lsp` tool always works for .py files (see PROPOSAL §3.4).
-    "python-lsp-server[all]>=1.10",
+    "python-lsp-server[autopep8,flake8,mccabe,pycodestyle,pydocstyle,pyflakes,rope,yapf]>=1.10",
     # Coding Mode — multi-language AST pattern matcher used by ast_search.
     # Pure-Python wrapper around a prebuilt Rust binary; PyPI distributes
     # wheels for all three OSes.


### PR DESCRIPTION
## Description

Fixes #7428. Replace `python-lsp-server[all]` with the same non-Pylint provider extras. The development-only Pylint entry in `e2e/requirements.txt` remains unchanged.

## What Problem This Solves

`python-lsp-server[all]` installs the optional GPL-2.0-or-later Pylint provider in the distributed runtime even though Pylint is disabled by default. This creates an avoidable copyleft distribution-compliance concern without providing default product behavior.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Testing

- `python -m uv lock --check`
- `python -m uv tree --no-dev`
- `python -m uv run --no-dev pylsp --help`
- Runtime module probe
- `git diff --check`

## Evidence

```text
python -m uv lock --check
Resolved 357 packages

python -m uv tree --no-dev
selected providers: autopep8, flake8, mccabe, pycodestyle,
pydocstyle, pyflakes, rope, yapf
pylint matches: 0

python -m uv run --no-dev pylsp --help
Python Language Server usage printed; exit code 0

runtime module probe
pylsp=True
pylint=False

git diff --check
exit code: 0
```

## Security Considerations

This is a license/supply-chain scope reduction, not a vulnerability claim. LSP completion, linting, formatting, and refactoring providers remain available; only the disabled optional Pylint runtime provider is excluded.