### PR TITLE
chore: bump the version to 2.2.0b5

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "2.2.0b4"
+__version__ = "2.2.0b5"


### PR DESCRIPTION
## Summary

- bump the QwenPaw version from `2.2.0b4` to `2.2.0b5`

## Verification

- `PYTHONPATH=src` version import check
- packaging version ordering check
- `pre-commit run --files src/qwenpaw/__version__.py`