### PR TITLE
fix: save screenshots in active project directory

### DIFF
--- a/src/qwenpaw/agents/tools/desktop_screenshot.py
+++ b/src/qwenpaw/agents/tools/desktop_screenshot.py
@@ -2,16 +2,16 @@
 """Desktop/screen screenshot tool."""
 
 import json
+import mimetypes
 import os
 import platform
 import time
-import mimetypes
+from pathlib import Path
 from agentscope.message import DataBlock, TextBlock, URLSource
 from agentscope.tool import ToolChunk
 from agentscope.message import ToolResultState
 
-from ...config.context import get_current_workspace_dir
-from ...constant import WORKING_DIR
+from ...config.context import get_tool_base_dir
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.io_utils import run_sync_io
 from .file_io import _path_to_file_url
@@ -163,7 +163,7 @@ async def desktop_screenshot(
     Args:
         path (`str`):
             Optional path to save the screenshot. If empty, saves under
-            the current workspace directory. Should end in .png for PNG output.
+            the current project directory. Should end in .png for PNG output.
         capture_window (`bool`):
             If True on macOS, the user can click a window to capture just
             that window. On Windows/Linux, only full-screen is supported
@@ -175,9 +175,16 @@ async def desktop_screenshot(
             or "error".
     """
     path = (path or "").strip()
+    # User-facing file tools resolve relative paths from the effective project
+    # directory (falling back to the workspace/working directory when unset).
+    base_dir = get_tool_base_dir()
     if not path:
-        base_dir = get_current_workspace_dir() or WORKING_DIR
         path = str(base_dir / f"desktop_screenshot_{int(time.time())}.png")
+    else:
+        output_path = Path(path).expanduser()
+        if not output_path.is_absolute():
+            output_path = base_dir / output_path
+        path = str(output_path.resolve())
     if not path.lower().endswith(".png"):
         path = path.rstrip("/\\") + ".png"
 

--- a/src/qwenpaw/browser/control_link/cdp_verbs.py
+++ b/src/qwenpaw/browser/control_link/cdp_verbs.py
@@ -11,8 +11,7 @@ import time
 from pathlib import Path
 from typing import Any, Mapping
 
-from ...config.context import get_current_workspace_dir
-from ...constant import WORKING_DIR
+from ...config.context import get_tool_base_dir
 from ...utils.io_utils import make_dirs_async, write_bytes_async
 from ..errors import BrowserError, ErrorCause, ErrorCategory
 from .identity import require_owner
@@ -164,10 +163,8 @@ def _key_event_frames(key: str) -> list[dict[str, Any]]:
 
 
 async def persist_screenshot_async(image: bytes) -> dict[str, str]:
-    """Write browser PNG bytes to the active workspace and return its path."""
-    directory = get_current_workspace_dir() or (
-        WORKING_DIR / "workspaces" / "default"
-    )
+    """Write browser PNG bytes to the active project and return its path."""
+    directory = get_tool_base_dir()
     directory = Path(directory).expanduser()
     await make_dirs_async(directory)
     digest = hashlib.sha256(image).hexdigest()


### PR DESCRIPTION
## Description
In current version, instruct QwenPaw to screen shot would get preview error like this:
<img width="1014" height="334" alt="image" src="https://github.com/user-attachments/assets/a28c34bf-8903-478b-a483-f26d8d1a512b" />
This pr fix screenshot output paths so user-facing screenshots are saved in the active project directory and returned as absolute paths. This prevents preview URLs from pointing to a missing relative path. Browser SDK screenshots now follow the same project-directory rule.

**Related Issue:** N/A

**Security Considerations:** No security behavior changed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or the `--changed` variant) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the focused screenshot tool tests with the source tree on `PYTHONPATH`.

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
PYTHONPATH="$PWD/src" pytest -q \
  tests/unit/agents/tools/test_desktop_screenshot.py
# 2 passed
```

## Additional Notes

The existing test file was intentionally left unchanged per request.
