### PR TITLE
feat(chat): copy assistant text without reasoning

### DIFF
--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -22,6 +22,7 @@ const {
   mockSelectedAgent,
   mockSetSelectedAgent,
   mockGetTranscriptionProviderType,
+  mockCopyText,
 } = vi.hoisted(() => ({
   mockListProviders: vi.fn(),
   mockGetActiveModels: vi.fn(),
@@ -31,6 +32,7 @@ const {
   mockSelectedAgent: vi.fn(() => "default"),
   mockSetSelectedAgent: vi.fn(),
   mockGetTranscriptionProviderType: vi.fn(),
+  mockCopyText: vi.fn().mockResolvedValue(undefined),
 }));
 
 let capturedOptions: any = null;
@@ -488,6 +490,7 @@ vi.mock("./utils", async () => {
   const actual = await vi.importActual("./utils");
   return {
     ...actual,
+    copyText: mockCopyText,
     getActiveSenderTextarea: vi.fn(() => null),
     getSenderTextareaFromTarget: vi.fn(() => null),
     setTextareaValue: vi.fn(),
@@ -502,6 +505,7 @@ describe("ChatPage coverage", () => {
   beforeEach(() => {
     chatExtensions.__resetForTests();
     capturedOptions = null;
+    mockCopyText.mockClear();
     mockListProviders.mockResolvedValue([
       {
         id: "openai",
@@ -950,24 +954,34 @@ describe("ChatPage coverage", () => {
   });
 
   // ── actions list: copy onClick ─────────────────────────────────────────
-  it("actions list copy onClick invokes copyText", async () => {
+  it("actions list copies only the assistant text message", async () => {
     renderWithProviders(<ChatPage />, {
       initialEntries: ["/chat/test-session"],
     });
     await screen.findByTestId("chat-ui");
 
-    const actionsList = capturedOptions?.actions?.list;
-    if (actionsList && actionsList.length > 0 && actionsList[0].onClick) {
-      // The first action is copy — invoke it with mock data
-      await actionsList[0].onClick({
-        data: {
-          content: [{ type: "text", text: "copyable text" }],
-          role: "assistant",
-        },
-      });
-      // Should not throw
-      expect(true).toBe(true);
-    }
+    const copyAction = capturedOptions?.actions?.list?.[0];
+    expect(copyAction?.onClick).toBeTypeOf("function");
+
+    await copyAction.onClick({
+      data: {
+        output: [
+          {
+            type: "reasoning",
+            role: "assistant",
+            content: [{ type: "text", text: "private reasoning" }],
+          },
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "text", text: "copyable text" }],
+          },
+        ],
+      },
+    });
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith("copyable text");
+    });
   });
 
   // ── actions list: timestamp render ─────────────────────────────────────

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2505,14 +2505,17 @@ export default function ChatPage() {
 
   const copyResponse = useCallback(
     async (response: CopyableResponse) => {
+      const text = extractCopyableText(response);
+      if (!text) return;
+
       try {
-        await copyText(extractCopyableText(response));
+        await copyText(text);
         message.success(t("common.copied"));
       } catch {
         message.error(t("common.copyFailed"));
       }
     },
-    [t],
+    [message, t],
   );
 
   const customFetch = useCallback(

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -27,7 +27,11 @@ describe("extractCopyableText", () => {
     const response: CopyableResponse = {
       output: [
         { role: "user", content: "你好" },
-        { role: "assistant", content: "你好，有什么可以帮你？" },
+        {
+          role: "assistant",
+          type: "message",
+          content: "你好，有什么可以帮你？",
+        },
       ],
     };
     expect(extractCopyableText(response)).toBe("你好，有什么可以帮你？");
@@ -38,6 +42,7 @@ describe("extractCopyableText", () => {
       output: [
         {
           role: "assistant",
+          type: "message",
           content: [
             { type: "text", text: "第一段" },
             { type: "text", text: "第二段" },
@@ -53,6 +58,7 @@ describe("extractCopyableText", () => {
       output: [
         {
           role: "assistant",
+          type: "message",
           content: [{ type: "refusal", refusal: "无法回答此问题" }],
         },
       ],
@@ -60,16 +66,16 @@ describe("extractCopyableText", () => {
     expect(extractCopyableText(response)).toBe("无法回答此问题");
   });
 
-  it("falls back to JSON.stringify when no assistant message is present", () => {
+  it("returns empty text when no assistant message is present", () => {
     const response: CopyableResponse = {
       output: [{ role: "user", content: "仅用户消息" }],
     };
-    expect(extractCopyableText(response)).toBe(JSON.stringify(response));
+    expect(extractCopyableText(response)).toBe("");
   });
 
-  it("returns JSON serialization when output is empty", () => {
+  it("returns empty text when output is empty", () => {
     const response: CopyableResponse = { output: [] };
-    expect(extractCopyableText(response)).toBe(JSON.stringify(response));
+    expect(extractCopyableText(response)).toBe("");
   });
 
   it("does not throw when output is undefined", () => {
@@ -79,11 +85,62 @@ describe("extractCopyableText", () => {
   it("merges multiple assistant messages with double newlines", () => {
     const response: CopyableResponse = {
       output: [
-        { role: "assistant", content: "第一句" },
-        { role: "assistant", content: "第二句" },
+        { role: "assistant", type: "message", content: "第一句" },
+        { role: "assistant", type: "message", content: "第二句" },
       ],
     };
     expect(extractCopyableText(response)).toBe("第一句\n\n第二句");
+  });
+
+  it("copies only ordinary assistant messages, excluding reasoning and tools", () => {
+    const response: CopyableResponse = {
+      output: [
+        {
+          role: "assistant",
+          type: "reasoning",
+          content: [{ type: "text", text: "内部推理" }],
+        },
+        {
+          role: "assistant",
+          type: "tool_call_output",
+          content: [{ type: "text", text: "工具结果" }],
+        },
+        {
+          role: "assistant",
+          type: "message",
+          content: [{ type: "text", text: "最终回答" }],
+        },
+        {
+          role: "assistant",
+          type: "thinking",
+          content: "另一种 thinking 格式",
+        },
+      ],
+    };
+
+    expect(extractCopyableText(response)).toBe("最终回答");
+  });
+
+  it("does not serialize a reasoning-only response as a fallback", () => {
+    const response: CopyableResponse = {
+      output: [
+        {
+          role: "assistant",
+          type: "reasoning",
+          content: [{ type: "text", text: "不应复制" }],
+        },
+      ],
+    };
+
+    expect(extractCopyableText(response)).toBe("");
+  });
+
+  it("does not copy an untyped assistant item", () => {
+    const response: CopyableResponse = {
+      output: [{ role: "assistant", content: "无法确认其消息类型" }],
+    };
+
+    expect(extractCopyableText(response)).toBe("");
   });
 });
 

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -10,6 +10,7 @@ export type CopyableContent = {
 
 export type CopyableMessage = {
   role?: string;
+  type?: string;
   content?: string | CopyableContent[];
 };
 
@@ -28,35 +29,35 @@ export type RuntimeLoadingBridgeApi = {
 
 /** Extract copyable text from assistant response. */
 export function extractCopyableText(response: CopyableResponse): string {
-  const collectText = (assistantOnly: boolean) => {
-    const chunks = (response.output || []).flatMap((item: CopyableMessage) => {
-      if (assistantOnly && item.role !== "assistant") return [];
+  const chunks = (response.output || []).flatMap((item: CopyableMessage) => {
+    if (item.role !== "assistant") return [];
 
-      if (typeof item.content === "string") {
-        return [item.content];
+    // Runtime reasoning, tool calls, and tool results also use the assistant
+    // role. Only ordinary assistant messages belong on the clipboard.
+    if (item.type !== "message") return [];
+
+    if (typeof item.content === "string") {
+      return [item.content];
+    }
+
+    if (!Array.isArray(item.content)) {
+      return [];
+    }
+
+    return item.content.flatMap((content: CopyableContent) => {
+      if (content.type === "text" && typeof content.text === "string") {
+        return [content.text];
       }
 
-      if (!Array.isArray(item.content)) {
-        return [];
+      if (content.type === "refusal" && typeof content.refusal === "string") {
+        return [content.refusal];
       }
 
-      return item.content.flatMap((content: CopyableContent) => {
-        if (content.type === "text" && typeof content.text === "string") {
-          return [content.text];
-        }
-
-        if (content.type === "refusal" && typeof content.refusal === "string") {
-          return [content.refusal];
-        }
-
-        return [];
-      });
+      return [];
     });
+  });
 
-    return chunks.filter(Boolean).join("\n\n").trim();
-  };
-
-  return collectText(true) || JSON.stringify(response);
+  return chunks.filter(Boolean).join("\n\n").trim();
 }
 
 /** Extract plain text from user message content. */


### PR DESCRIPTION
## Description

Update the assistant response copy action to copy only ordinary assistant text messages. Reasoning/thinking entries, tool messages, and raw response fallbacks are excluded. Empty text results no longer clear the clipboard or show a false success message.

**Related Issue:** None

**Security Considerations:** Prevents internal reasoning and tool output from being copied unintentionally.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran pre-commit run --all-files locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (as relevant) and they pass
- [x] Documentation updated (not needed for this UI behavior change)
- [x] Ready for review

## Testing

- Ran the focused Chat utility and Chat page coverage suites.
- Ran the TypeScript project check with no emit.
- Ran Prettier checks for all changed files.
- Confirmed git diff whitespace checks pass.
- Did not run npm run build per repository instructions.

## Evidence

Focused tests:

    Test Files  2 passed (2)
    Tests       112 passed (112)

Additional checks:

    npx tsc -b --noEmit
    npx prettier --check src/pages/Chat/utils.ts src/pages/Chat/utils.test.ts src/pages/Chat/index.tsx src/pages/Chat/ChatPage.coverage.test.tsx
    git diff --check

All commands completed successfully.

## Additional Notes

The copy filter requires runtime message type message, so reasoning/thinking and untyped assistant items are not copied.