### PR TITLE
fix(pack): bundle reme-ai Python core in PyInstaller onedir (#7446)

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -215,6 +215,13 @@ a = Analysis(
         *collect_submodules("agentscope.workspace._mcp_gateway"),
         *collect_submodules("whisper"),
         *collect_submodules("chromadb"),
+        # ReMe light-memory core (reme-ai) is lazily imported by
+        # ReMeLightMemoryManager._initialize_reme, so PyInstaller's static
+        # analysis misses it. Without the module tree the bundled backend has
+        # an empty _internal/reme/ (data files only), _reme stays None and
+        # "Rebuild Memory Index" fails (#7446).
+        "reme",
+        *collect_submodules("reme"),
     ],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary

Fix #7446: "Rebuild Memory Index" returns 500 because the bundled Windows backend ships an empty `_internal/reme/` (data files only, 0 `.py`/`.pyd`) — `_reme` stays `None` at runtime and the reindex path hits `'NoneType' object has no attribute 'update_component'`.

## Root cause

`ReMeLightMemoryManager._initialize_reme()` lazily imports `reme` (`from reme import ReMe`), which PyInstaller's static analysis cannot see. `qwenpaw.spec` only collected `reme`'s **data files** (`collect_data_files("reme")`), never its Python module tree, so the onedir bundle had no ReMe core to import.

## Changes

`scripts/pack-tauri/qwenpaw.spec`:
- Add `"reme"` anchor + `*collect_submodules("reme")` to `hiddenimports`, so the ReMe light-memory core is bundled alongside its data files.

## Verification

- Spec syntax validated (`ast.parse`).
- Full PyInstaller rebuild requires a CI/desktop packaging run; the spec change is the documented fix for the missing-module symptom (empty `_internal/reme/`).

## Type of Change

Bug fix
