### PR TITLE
fix(console): revive dead dark-mode overrides and rename Marketplace …

### DIFF
--- a/console/src/components/AgentSelector/index.module.less
+++ b/console/src/components/AgentSelector/index.module.less
@@ -660,17 +660,17 @@
     );
     border-color: rgba(245, 160, 90, 0.2);
     color: #f5a05a;
+  }
 
-    .agentOption:hover & {
-      background: linear-gradient(
-        135deg,
-        rgba(240, 126, 38, 0.3) 0%,
-        rgba(240, 126, 38, 0.15) 100%
-      );
-      border-color: rgba(245, 160, 90, 0.4);
-      color: #f5b87a;
-      box-shadow: 0 2px 8px rgba(240, 126, 38, 0.3);
-    }
+  .agentOption:hover .agentOptionIcon {
+    background: linear-gradient(
+      135deg,
+      rgba(240, 126, 38, 0.3) 0%,
+      rgba(240, 126, 38, 0.15) 100%
+    );
+    border-color: rgba(245, 160, 90, 0.4);
+    color: #f5b87a;
+    box-shadow: 0 2px 8px rgba(240, 126, 38, 0.3);
   }
 
   .agentOptionName {

--- a/console/src/components/SessionItem/sessionItem.module.less
+++ b/console/src/components/SessionItem/sessionItem.module.less
@@ -546,11 +546,14 @@
     color: rgba(255, 255, 255, 0.5);
   }
 
-  .channelTag {
-    .drawer & {
-      color: rgba(255, 255, 255, 0.65);
-      background: rgba(255, 255, 255, 0.1);
-    }
+  .drawer .channelTag {
+    color: rgba(255, 255, 255, 0.65);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .sourceTag {
+    color: #f5a05a;
+    background: rgba(240, 126, 38, 0.16);
   }
 
   .pinButton {

--- a/console/src/layouts/registry/builtinMenu.ts
+++ b/console/src/layouts/registry/builtinMenu.ts
@@ -68,7 +68,7 @@ export const BUILTIN_MENU: MenuItem[] = [
   {
     id: "core.marketplace",
     location: "primary.agentScoped",
-    label: navLabel("nav.marketplace", "Marketplace"),
+    label: navLabel("nav.marketplace", "Extension"),
     icon: SparkMyApplicationLine,
     route: "core.marketplace",
     order: 15,

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -132,7 +132,7 @@
     "workspace": "Files",
     "skills": "Skills",
     "skillPool": "Skill Pool",
-    "marketplace": "Marketplace",
+    "marketplace": "Extension",
     "market": "Skill Market",
     "tools": "Tools",
     "mcp": "MCP",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -130,7 +130,7 @@
     "workspace": "File",
     "skills": "Skill",
     "skillPool": "Kumpulan Skill",
-    "marketplace": "Pasar",
+    "marketplace": "Ekstensi",
     "tools": "Tool",
     "mcp": "MCP",
     "acp": "ACP",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -128,7 +128,7 @@
     "workspace": "ファイル",
     "skills": "スキル",
     "skillPool": "スキルプール",
-    "marketplace": "マーケット",
+    "marketplace": "拡張機能",
     "mcp": "MCP",
     "agentConfig": "設定",
     "settings": "設定",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -130,7 +130,7 @@
     "workspace": "Arquivos",
     "skills": "Skills",
     "skillPool": "Pool de Skills",
-    "marketplace": "Mercado",
+    "marketplace": "Extensões",
     "tools": "Ferramentas",
     "mcp": "MCP",
     "acp": "ACP",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -128,7 +128,7 @@
     "workspace": "Файлы",
     "skills": "Навыки",
     "skillPool": "Пул навыков",
-    "marketplace": "Маркетплейс",
+    "marketplace": "Расширения",
     "tools": "Инструменты",
     "mcp": "MCP",
     "agentConfig": "Конфигурация",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -131,7 +131,7 @@
     "workspace": "Không gian làm việc",
     "skills": "Kỹ năng",
     "skillPool": "Kho kỹ năng",
-    "marketplace": "Thị trường",
+    "marketplace": "Tiện ích mở rộng",
     "market": "Chợ kỹ năng",
     "tools": "Công cụ",
     "mcp": "MCP",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -132,7 +132,7 @@
     "workspace": "文件",
     "skills": "技能",
     "skillPool": "技能池",
-    "marketplace": "市场",
+    "marketplace": "扩展",
     "market": "技能市场",
     "tools": "工具",
     "mcp": "MCP",

--- a/console/src/os/osApps.ts
+++ b/console/src/os/osApps.ts
@@ -16,7 +16,7 @@ import {
   Wifi,
   Inbox,
   Store,
-  ShoppingBag,
+  Blocks,
   Settings,
   Puzzle,
   History,
@@ -218,15 +218,15 @@ export const STORE_APP: OsAppDef = {
 };
 
 /**
- * Marketplace — a route-backed system app. It is always available in the
+ * Extension — a route-backed system app. It is always available in the
  * Desktop OS, but intentionally lives outside OS_APPS so it cannot be
  * installed or uninstalled through the simulated App Store catalog.
  */
 export const MARKETPLACE_APP: OsAppDef = {
   routeId: "core.marketplace",
   labelKey: "nav.marketplace",
-  fallback: "Marketplace",
-  Icon: ShoppingBag,
+  fallback: "Extension",
+  Icon: Blocks,
   accent: "#0ea5e9",
   defaultW: 1180,
   defaultH: 720,

--- a/console/src/pages/Market/components/MarketplaceHeader/index.tsx
+++ b/console/src/pages/Market/components/MarketplaceHeader/index.tsx
@@ -43,7 +43,7 @@ export function MarketplaceHeader({
 
   return (
     <PageHeader
-      current={t("nav.marketplace", "Marketplace")}
+      current={t("nav.marketplace", "Extension")}
       center={
         <Tabs
           className={styles.sectionSwitch}

--- a/console/src/pages/Settings/Environments/index.module.less
+++ b/console/src/pages/Settings/Environments/index.module.less
@@ -479,11 +479,11 @@
     color: rgba(255, 255, 255, 0.4);
     border-right-color: rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.04);
+  }
 
-    .inputGroup:focus-within & {
-      color: #ff7f16;
-      background: rgba(97, 92, 237, 0.1);
-    }
+  .inputGroup:focus-within .inputLabel {
+    color: #ff7f16;
+    background: rgba(97, 92, 237, 0.1);
   }
 
   /* Input field inside group */


### PR DESCRIPTION
Less `&` nesting inside the dark-mode block expanded to `.x :global(.dark-mode) .y`, which can never match because the dark-mode class lives on <html>. Flatten the three affected rules so the overrides apply again:

- SessionItem drawer channel tag (near-black text on a dark card)
- AgentSelector option icon on hover
- Environments Key/Value label on focus-within

Also give .sourceTag an explicit dark palette; without it the rule fell back to the light --colorPrimaryBg value, which is never defined.

Rename the nav.marketplace label to Extension across all seven locales plus the in-code fallbacks, and swap the desktop icon to Blocks so it no longer reads as a shopping bag. Route ids and component names are untouched to keep persisted window state and deep links working.
<img width="2560" height="1293" alt="image" src="https://github.com/user-attachments/assets/ba421023-217d-4d3c-bc22-0a646888e1e0" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
