### PR TITLE
fix(e2e): re-anchor approval level toggle selectors after #7334 component rebuild

### DIFF
--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -108,21 +108,31 @@ class ChatPage(BasePage):
     SESSION_DELETE_BTN = 'button:has(.spark-icon-spark-delete-line), button:has(.anticon-delete)'
 
     # --- Tool approval level toggle (composer / sender area) — upstream #5685 ---
-    # A single antd Tag whose text is one of the 4 levels; clicking it opens a
-    # dropdown of exactly 4 options. No CSS-module class or data-testid, so we
-    # anchor on the level texts (browser locale is en-US; ZH kept as fallback).
+    # Upstream #7334 rebuilt ApprovalLevelToggle from an antd Tag into a plain
+    # ``<button class="...trigger">`` (CSS-module hash class, not stable), so
+    # the old ``span.qwenpaw-tag`` anchor no longer exists. The button carries
+    # ``aria-label=<i18n toolExecutionLevelTitle>`` — the same handle upstream
+    # uses in its own unit test (ApprovalToggle.test.tsx) — so we anchor on it.
+    # Note: #7368 renamed that title from "Tool Execution Security" to
+    # "Tool Approval Mode" (zh: 工具审批模式). In non-compact desktop mode the
+    # button text also contains the current level label (e.g. "Strict Mode");
+    # in compact/mobile mode it is icon-only. Only one of ApprovalLevelToggle /
+    # HarnessApprovalToggle renders at a time (mutually exclusive in the
+    # composer), and the harness variant uses a different aria-label, so the
+    # locator below is unambiguous.
+    APPROVAL_TOGGLE = (
+        'button[aria-label="Tool Approval Mode"], '
+        'button[aria-label="工具审批模式"]'
+    )
     APPROVAL_LEVELS = {
         "STRICT": ("Strict Mode", "严格模式"),
         "SMART": ("Smart Mode", "智能模式"),
         "AUTO": ("Auto Mode", "自动模式"),
         "OFF": ("Off Mode", "关闭模式"),
     }
-    _APPROVAL_LABEL_RE = re.compile(
-        r"Strict Mode|Smart Mode|Auto Mode|Off Mode|"
-        r"严格模式|智能模式|自动模式|关闭模式"
-    )
     # Only items inside the currently-open dropdown (antd keeps closed menus in
-    # the DOM with a ``-hidden`` modifier).
+    # the DOM with a ``-hidden`` modifier). The #7334 rebuild kept the antd
+    # Dropdown for the menu itself, so this selector is unchanged.
     APPROVAL_MENU_ITEM = (
         '.qwenpaw-dropdown:not(.qwenpaw-dropdown-hidden) '
         '.qwenpaw-dropdown-menu-item'
@@ -1150,12 +1160,13 @@ class ChatPage(BasePage):
     # ========== Tool approval level toggle ==========
 
     def get_approval_toggle(self) -> Locator:
-        """Locate the approval-level Tag in the composer (matches any level)."""
-        return (
-            self.page.locator("span.qwenpaw-tag")
-            .filter(has_text=self._APPROVAL_LABEL_RE)
-            .first
-        )
+        """Locate the approval-level trigger button in the composer.
+
+        Upstream #7334 replaced the antd Tag with a ``<button>`` carrying an
+        ``aria-label`` (localized approval-mode title); we anchor on that
+        attribute, exactly like upstream's own ApprovalToggle.test.tsx.
+        """
+        return self.page.locator(self.APPROVAL_TOGGLE).first
 
     def open_approval_menu(self) -> "ChatPage":
         """Click the approval Tag and wait for its dropdown to render."""


### PR DESCRIPTION
## What this fixes

Since the 2026-08-28 nightly run, three E2E cases of the tool-approval family fail stably (retries do not help):

- `e2e/tests/test_chat.py::TestToolApproval::test_approval_toggle_renders_and_switches`
- `e2e/tests/test_chat.py::TestToolApproval::test_approval_level_persists_across_reload`
- `e2e/tests/test_chat.py::TestToolApproval::test_approval_level_cleared_on_session_delete`

This is test-side selector drift, not a product regression.

## Root cause

#7334 rebuilt `ApprovalLevelToggle` / `HarnessApprovalToggle` from an antd `Tag` into a plain `<button>` whose class name is a CSS-module build hash. The E2E page object still anchored on `span.qwenpaw-tag` (`e2e/pages/chat_page.py::get_approval_toggle`), which no longer exists in the DOM, so every interaction with the approval-level toggle failed (visibility assertion / 60s click timeout).

## Fix

Re-anchor the toggle on `button[aria-label]` — the localized approval-mode title — mirroring what upstream's own unit test (`console/src/pages/Chat/components/ApprovalToggle.test.tsx`) has been using since the rebuild:

- accepts both the en label (`Tool Approval Mode`, including the #7368 rename from "Tool Execution Security") and the zh label (`工具审批模式`);
- the level dropdown is still an antd Dropdown, so `APPROVAL_MENU_ITEM` stays unchanged;
- drops the now-dead `_APPROVAL_LABEL_RE`.

The two approval-toggle variants render mutually exclusively and carry different aria-labels, so the locator is unambiguous. Only `e2e/pages/chat_page.py` changes (+25/-14); no product code is touched.

## Verification

- Local run against a fresh build of `main` at 1a4f4d8a: the three approval cases pass, and the full `test_chat.py` file passes 14/14.
- Full E2E matrix on the fork branch (same three priority lanes as the nightly workflow): all green, zero failures — p0: 71 cases, p1: 105 cases, p2: 46 cases.

Signed-off-by: 李时珍·E2E@QPQAT
