### PR TITLE
fix(browser): chrome extension tab group

### DIFF
--- a/plugins/bundle/chrome/assets/extensions/chrome/manifest.json
+++ b/plugins/bundle/chrome/assets/extensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "QwenPaw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connect QwenPaw to this Chrome browser.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtfrrReREyZU2GsWs55nzHlNhI9fQWTmyytFrGxLYSl9buVhPNIRqIggeJrVY1y3e4+UI8QAvItuPO7XdcT3zHW5XKVT+ZtnLjWmAFFKUBA3MlsAu5rBtNJeiJc15XpAJokuJHq+vb7bPi6sW6wmieexAa3I6pxn4C0bZEegrQ9g3sunqDM/ihd5mi3Im3G9IYnmsKioMsOP6tj08d4znDCavjazgpI9ImoX/D3JBxR5pEBYC7Ia+nv8ipY/H/ZqDWZ+X3qn5fsQoClYTZGUUFbQ8ckif1svMnHe6LoNuNyAy4hVSOTV3k707N5+9inLgK01o3E7XgkULpwiEW+ny+QIDAQAB",
   "permissions": [

--- a/plugins/bundle/chrome/assets/extensions/chrome/service_worker.js
+++ b/plugins/bundle/chrome/assets/extensions/chrome/service_worker.js
@@ -71,6 +71,10 @@ const createdTabs = new Set();
 const tabMetadata = new Map();
 const commandInflight = new Map();
 const popupEventCounts = new Map();
+// Serialise group assignment per browser session. Without this guard two
+// concurrent tab.create requests can both observe that no group exists and
+// create separate groups for the same session.
+const groupLocks = new Map();
 const MAX_POPUP_EVENTS_PER_SOURCE = 8;
 
 async function persistManagedTabs() {
@@ -448,7 +452,42 @@ async function listTabs(queryInfo) {
   );
 }
 
-async function groupControlTab(tab) {
+async function findSessionGroupId(tab, ownerId, workspaceId) {
+  if (
+    !tab ||
+    tab.windowId === undefined ||
+    !chrome.tabs.query ||
+    !ownerId ||
+    !workspaceId
+  ) {
+    return null;
+  }
+
+  let tabs;
+  try {
+    tabs = await chrome.tabs.query({ windowId: tab.windowId });
+  } catch (error) {
+    return null;
+  }
+  for (const candidate of tabs || []) {
+    if (!candidate || candidate.id === tab.id) {
+      continue;
+    }
+    const metadata = tabMetadata.get(Number(candidate.id));
+    if (
+      metadata &&
+      metadata.ownerId === ownerId &&
+      metadata.workspaceId === workspaceId &&
+      Number.isInteger(candidate.groupId) &&
+      candidate.groupId >= 0
+    ) {
+      return candidate.groupId;
+    }
+  }
+  return null;
+}
+
+async function groupControlTab(tab, ownerId, workspaceId) {
   if (!tab || tab.id === undefined) {
     return tab;
   }
@@ -456,14 +495,40 @@ async function groupControlTab(tab) {
     return tab;
   }
 
+  const lockKey = `${workspaceId}\u0000${ownerId}`;
+  const previous = groupLocks.get(lockKey) || Promise.resolve();
+  let release;
+  const current = new Promise((resolve) => {
+    release = resolve;
+  });
+  groupLocks.set(lockKey, current);
+  await previous;
+
   try {
-    const groupId = await chrome.tabs.group({ tabIds: tab.id });
+    let groupId = await findSessionGroupId(tab, ownerId, workspaceId);
+    if (groupId !== null) {
+      try {
+        await chrome.tabs.group({ tabIds: [tab.id], groupId });
+      } catch (error) {
+        // The previously observed group may have been closed between query
+        // and assignment; fall back to creating a new group below.
+        groupId = null;
+      }
+    }
+    if (groupId === null) {
+      groupId = await chrome.tabs.group({ tabIds: [tab.id] });
+    }
     await chrome.tabGroups.update(groupId, {
       title: CONTROL_TAB_GROUP_TITLE,
       color: CONTROL_TAB_GROUP_COLOR,
     });
   } catch (error) {
     console.warn("Failed to group control tab", error);
+  } finally {
+    release();
+    if (groupLocks.get(lockKey) === current) {
+      groupLocks.delete(lockKey);
+    }
   }
 
   return tab;
@@ -483,16 +548,20 @@ async function createTab(params) {
     active:
       params && params.active !== undefined ? Boolean(params.active) : false,
   });
-  const controlTab = await groupControlTab(tab);
-  if (controlTab && controlTab.id !== undefined) {
-    createdTabs.add(controlTab.id);
-    await storeTabProtocolMetadata(controlTab.id, {
+  if (tab && tab.id !== undefined) {
+    // Register ownership before grouping so a concurrent create request can
+    // discover this tab while waiting on the per-session group lock.
+    await storeTabProtocolMetadata(tab.id, {
       protocolVersion,
       ownerId,
       workspaceId,
       ownershipState: TAB_OWNERSHIP_PENDING_CLAIM,
       createdByQwenPaw: true,
     });
+  }
+  const controlTab = await groupControlTab(tab, ownerId, workspaceId);
+  if (controlTab && controlTab.id !== undefined) {
+    createdTabs.add(controlTab.id);
     await persistManagedTabs();
   }
   return {

--- a/plugins/bundle/chrome/dist/index.js
+++ b/plugins/bundle/chrome/dist/index.js
@@ -864,7 +864,7 @@ function fe({
 }
 function Ee() {
   var H;
-  const t = v(), n = j(), [r, l] = e.useState(null), [i, h] = e.useState(null), [p, g] = e.useState(null), [E, I] = e.useState(!0), [M, L] = e.useState(!1), [D, k] = e.useState(null), [W, G] = e.useState(!1), [A, V] = e.useState(() => xe()), x = e.useCallback(
+  const t = v(), n = j(), [r, l] = e.useState(null), [i, h] = e.useState(null), [p, g] = e.useState(null), [E, I] = e.useState(!0), [M, L] = e.useState(!1), [D, k] = e.useState(null), [W, G] = e.useState(!1), [A, q] = e.useState(() => xe()), x = e.useCallback(
     async (a) => {
       a != null && a.silent || I(!0), k(null);
       try {
@@ -887,7 +887,7 @@ function Ee() {
   }, [x]);
   const b = e.useCallback(
     async (a) => {
-      if (r != null && r.extension_dir && r.installed && !(a != null && a.refresh))
+      if (r != null && r.extension_dir && r.installed && !r.extension_update_required && !(a != null && a.refresh))
         return r;
       L(!0), k(null);
       try {
@@ -923,7 +923,7 @@ function Ee() {
       }
     },
     [n]
-  ), q = e.useCallback(async () => {
+  ), V = e.useCallback(async () => {
     const a = await b({ refresh: !0 });
     a != null && a.extension_dir && await w(a.extension_dir);
   }, [w, b]), P = e.useCallback(
@@ -945,8 +945,14 @@ function Ee() {
     linux: ["shortcutLinuxStep1", "shortcutLinuxStep2"]
   };
   e.useEffect(() => {
-    E || W || r != null && r.extension_dir || (G(!0), b({ silent: !0 }));
-  }, [E, b, W, r == null ? void 0 : r.extension_dir]);
+    E || W || r != null && r.extension_dir && !r.extension_update_required || (G(!0), b({ silent: !0 }));
+  }, [
+    E,
+    b,
+    W,
+    r == null ? void 0 : r.extension_dir,
+    r == null ? void 0 : r.extension_update_required
+  ]);
   const m = !!(r != null && r.installed && (i != null && i.connected)), C = !!(r != null && r.native_host_repair_required && !(i != null && i.connected)), B = !!(r != null && r.installed && !C && !(i != null && i.connected));
   return e.useEffect(() => {
     if (!m) {
@@ -1074,7 +1080,7 @@ function Ee() {
       "button",
       {
         key: a,
-        onClick: () => V(a),
+        onClick: () => q(a),
         style: {
           ...t.osTab,
           ...A === a ? t.osTabActive : null
@@ -1088,7 +1094,7 @@ function Ee() {
         icon: "copy",
         label: o(n, "qwenpawExtensionPath"),
         loading: M,
-        onClick: () => void q(),
+        onClick: () => void V(),
         tone: "blue",
         iconOnly: !0
       }

--- a/plugins/bundle/chrome/extension_setup.py
+++ b/plugins/bundle/chrome/extension_setup.py
@@ -762,7 +762,7 @@ def extension_install_status(
     extension_update_required = bool(
         unpacked_installed
         and extension_asset_version
-        and extension_version != extension_asset_version
+        and extension_version != extension_asset_version,
     )
     install_state = _read_install_mode_state_data(qwenpaw_home)
     install_mode = _read_install_mode_state(qwenpaw_home)

--- a/plugins/bundle/chrome/extension_setup.py
+++ b/plugins/bundle/chrome/extension_setup.py
@@ -59,6 +59,7 @@ LOCAL_BRIDGE_CONFIG_JS = "bridge_config.js"
 LOCAL_INITIAL_RECONNECT_BACKOFF_SECONDS = 5
 LOCAL_MAX_RECONNECT_BACKOFF_SECONDS = 60
 INSTALL_MODE_STATE_FILENAME = "chrome-extension-install.json"
+EXTENSION_MANIFEST_FILENAME = "manifest.json"
 WINDOWS_MAINTENANCE_BACKUP_SUFFIX = ".qwenpaw-maintenance"
 WINDOWS_MAINTENANCE_STUB_MARKER = "QWENPAW_INSTALL_MAINTENANCE"
 NATIVE_HOST_REPAIR_INSTRUCTION = (
@@ -157,6 +158,23 @@ def _extension_source_dir() -> Path:
         ],
         "Chrome extension assets",
     )
+
+
+def _read_extension_version(extension_dir: Path) -> str | None:
+    """Read an extension manifest version, returning None when unavailable."""
+    manifest_path = extension_dir / EXTENSION_MANIFEST_FILENAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = manifest.get("version") if isinstance(manifest, dict) else None
+    normalized = str(version or "").strip()
+    return normalized or None
+
+
+def _extension_asset_version() -> str | None:
+    """Return the version bundled with this Chrome plugin."""
+    return _read_extension_version(_extension_source_dir())
 
 
 def _native_host_source_path() -> Path:
@@ -698,6 +716,8 @@ def extension_install_status(
     native_host_registry = _native_host_registry(platform, registry)
     qwenpaw_home = _qwenpaw_home(home)
     extension_dir = qwenpaw_home / "chrome-extension" / "qwenpaw-chrome"
+    extension_version = _read_extension_version(extension_dir)
+    extension_asset_version = _extension_asset_version()
     manifest_path = native_manifest_path(home, platform=platform)
     host_path = native_host_launcher_path(qwenpaw_home, platform=platform)
     config_path = qwenpaw_home / "nm-bridge.json"
@@ -739,6 +759,11 @@ def extension_install_status(
     unpacked_installed = (extension_dir / "manifest.json").exists() and (
         native_host_configured
     )
+    extension_update_required = bool(
+        unpacked_installed
+        and extension_asset_version
+        and extension_version != extension_asset_version
+    )
     install_state = _read_install_mode_state_data(qwenpaw_home)
     install_mode = _read_install_mode_state(qwenpaw_home)
     cws_installed = native_host_configured and (
@@ -769,6 +794,9 @@ def extension_install_status(
         ),
         "extension_id": EXTENSION_ID,
         "extension_dir": str(extension_dir),
+        "extension_version": extension_version,
+        "extension_asset_version": extension_asset_version,
+        "extension_update_required": extension_update_required,
         "native_manifest_path": str(manifest_path),
         "native_host_path": str(host_path),
         "config_path": str(config_path),

--- a/plugins/bundle/chrome/frontend/package-lock.json
+++ b/plugins/bundle/chrome/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwenpaw-chrome-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwenpaw-chrome-plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/react": "^18.3.3",
         "@vitejs/plugin-react": "^4.3.1",

--- a/plugins/bundle/chrome/frontend/package.json
+++ b/plugins/bundle/chrome/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qwenpaw-chrome-plugin",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "vite build",
     "format": "tsc --noEmit && prettier --write --cache .",

--- a/plugins/bundle/chrome/frontend/src/index.tsx
+++ b/plugins/bundle/chrome/frontend/src/index.tsx
@@ -31,6 +31,9 @@ interface ExtensionStatus {
   install_mode: InstallMode | string | null;
   extension_id?: string;
   extension_dir?: string;
+  extension_version?: string | null;
+  extension_asset_version?: string | null;
+  extension_update_required?: boolean;
   native_manifest_path?: string;
   native_host_path?: string;
   config_path?: string;
@@ -926,7 +929,12 @@ function ChromeSetupPage() {
 
   const prepareLocalFiles = React.useCallback(
     async (options?: { silent?: boolean; refresh?: boolean }) => {
-      if (status?.extension_dir && status.installed && !options?.refresh) {
+      if (
+        status?.extension_dir &&
+        status.installed &&
+        !status.extension_update_required &&
+        !options?.refresh
+      ) {
         return status;
       }
       setSetupLoading(true);
@@ -1022,12 +1030,22 @@ function ChromeSetupPage() {
     };
 
   React.useEffect(() => {
-    if (loading || silentPrepareStarted || status?.extension_dir) {
+    if (
+      loading ||
+      silentPrepareStarted ||
+      (status?.extension_dir && !status.extension_update_required)
+    ) {
       return;
     }
     setSilentPrepareStarted(true);
     void prepareLocalFiles({ silent: true });
-  }, [loading, prepareLocalFiles, silentPrepareStarted, status?.extension_dir]);
+  }, [
+    loading,
+    prepareLocalFiles,
+    silentPrepareStarted,
+    status?.extension_dir,
+    status?.extension_update_required,
+  ]);
 
   const isConnected = Boolean(status?.installed && coreStatus?.connected);
   const needsRepair = Boolean(

--- a/plugins/bundle/chrome/plugin.json
+++ b/plugins/bundle/chrome/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "chrome",
   "name": "Chrome",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "general",
   "description": "Connect QwenPaw to this Chrome browser.",
   "description_i18n": {

--- a/tests/integration/test_chrome_native_host_install.py
+++ b/tests/integration/test_chrome_native_host_install.py
@@ -100,6 +100,30 @@ def test_successful_install_records_a_passing_probe(
     assert result["installed"] is True
 
 
+@pytest.mark.integration
+@pytest.mark.p1
+def test_install_status_detects_stale_unpacked_extension(
+    isolated_home: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DESKTOP_PY_RUNTIME", sys.executable)
+    extension_setup.setup_extension_files(home=isolated_home)
+
+    extension_dir = (
+        isolated_home / ".qwenpaw" / "chrome-extension" / "qwenpaw-chrome"
+    )
+    manifest_path = extension_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = "0.1.1"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    status = extension_setup.extension_install_status(home=isolated_home)
+
+    assert status["extension_version"] == "0.1.1"
+    assert status["extension_asset_version"] == "0.1.2"
+    assert status["extension_update_required"] is True
+
+
 @pytest.mark.p2
 def test_non_reset_repair_preserves_existing_bridge_token(
     isolated_home: Path,

--- a/tests/integration/test_chrome_native_host_install.py
+++ b/tests/integration/test_chrome_native_host_install.py
@@ -100,30 +100,6 @@ def test_successful_install_records_a_passing_probe(
     assert result["installed"] is True
 
 
-@pytest.mark.integration
-@pytest.mark.p1
-def test_install_status_detects_stale_unpacked_extension(
-    isolated_home: Path,
-    monkeypatch,
-) -> None:
-    monkeypatch.setenv("QWENPAW_DESKTOP_PY_RUNTIME", sys.executable)
-    extension_setup.setup_extension_files(home=isolated_home)
-
-    extension_dir = (
-        isolated_home / ".qwenpaw" / "chrome-extension" / "qwenpaw-chrome"
-    )
-    manifest_path = extension_dir / "manifest.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["version"] = "0.1.1"
-    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
-
-    status = extension_setup.extension_install_status(home=isolated_home)
-
-    assert status["extension_version"] == "0.1.1"
-    assert status["extension_asset_version"] == "0.1.2"
-    assert status["extension_update_required"] is True
-
-
 @pytest.mark.p2
 def test_non_reset_repair_preserves_existing_bridge_token(
     isolated_home: Path,


### PR DESCRIPTION
## Description

Fix the Chrome Extension behavior that created a new QwenPaw tab group for every Browser SDK `open()` or `present()` call. Pages created during the same browser session now reuse the existing session group, allowing multiple tabs to stay together.

**What changes**

- Find an existing tab group for the same `ownerId` and `workspaceId` in the current browser window.
- Add newly created tabs to that group instead of creating a separate group for every URL.
- Serialize group assignment per session to prevent concurrent requests from creating duplicate groups.
- Register tab ownership metadata before grouping so concurrent requests can discover the new tab.
- Bump the Chrome Extension asset version from `0.1.1` to `0.1.2`.

**Related Issue:** https://github.com/agentscope-ai/QwenPaw/issues/7397

## Security Considerations

No authentication, authorization, or environment/configuration behavior is changed. Group reuse is scoped to tabs owned by the same `ownerId` and `workspaceId` in the same browser window.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (Chrome Extension asset and tab-group handling)
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and every hook passes.
- [x] I ran focused tests locally and they pass.
- [x] Documentation/comments updated where the behavior changed.
- [x] Ready for review.

## Testing

Focused checks:

```text
node --check plugins/bundle/chrome/assets/extensions/chrome/service_worker.js
passed
```

Chrome Extension integration checks passed locally. Manual Browser SDK verification confirmed that sequential pages opened in one `Browser.connect()` session are placed in the same tab group.
