### PR TITLE
fix(desktop): bundle ReMe entry-point plugins

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -71,8 +71,13 @@ datas.append(
     ),
 )
 
-# Include reme package data files (configs, tool yamls, etc.)
+# Include ReMe package data files (configs, tool yamls, plugin manifests, etc.).
+# The plugin packages are discovered through importlib.metadata entry points,
+# so PyInstaller cannot infer either their modules or their data files from
+# QwenPaw's static imports.
 datas += collect_data_files("reme")
+datas += collect_data_files("reme_auto_fin")
+datas += collect_data_files("reme_daily_paper")
 datas += collect_data_files("whisper")
 datas += collect_data_files("agentscope")
 datas += collect_data_files(
@@ -148,6 +153,9 @@ _metadata_pkgs = [
     "tiktoken",
     "agentscope",
     "agentscope-runtime",
+    "reme-ai",
+    "reme-auto-fin",
+    "reme-daily-paper",
     "huggingface_hub",
     "modelscope",
     "openai-whisper",
@@ -201,6 +209,10 @@ a = Analysis(
         # Backup modules are exposed through qwenpaw.backup.__getattr__, which
         # PyInstaller cannot discover from static imports.
         *collect_submodules("qwenpaw.backup"),
+        # ReMe loads these plugin backends from plugin.yaml targets exposed by
+        # distribution entry points, which are invisible to static analysis.
+        *collect_submodules("reme_auto_fin"),
+        *collect_submodules("reme_daily_paper"),
         # Third-party packages that use dynamic imports. Use
         # collect_submodules() for packages that load many submodules by name;
         # keep the bare package string when runtime code imports only the

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -6,13 +6,15 @@ tauri-win / tauri-mac) end-to-end:
 
 1. ``GET /api/version`` — health + version match.
 2. ``GET /``           — frontend HTML served.
-3. ``PUT /api/models/<provider>/config``            — install API key.
-4. ``POST /api/models/<provider>/models``           — register the chat model
+3. ``POST /api/agents/default/memory/reindex?scope=bm25`` — prove the packaged
+   ReMe runtime starts.
+4. ``PUT /api/models/<provider>/config``            — install API key.
+5. ``POST /api/models/<provider>/models``           — register the chat model
                                                        (newer aliases like
                                                        qwen3.6-plus aren't in
                                                        the built-in catalogue).
-5. ``PUT /api/models/active``                       — mark it active globally.
-6. **UI single-round factual Q&A**                  — drive the real SPA:
+6. ``PUT /api/models/active``                       — mark it active globally.
+7. **UI single-round factual Q&A**                  — drive the real SPA:
    - Open the page and wait for the chat input to render.
    - Send "What is the tallest mountain in the world?" via the
      input box.
@@ -158,6 +160,33 @@ def verify_frontend(base_url: str) -> None:
             "Frontend HTML does not mention QwenPaw — wrong bundle?",
         )
     print("PASS  GET / -> frontend HTML served")
+
+
+def verify_reme_runtime(base_url: str) -> None:
+    """Run a provider-free job against the packaged ReMe runtime."""
+    body = _http(
+        "POST",
+        f"{base_url}/api/agents/default/memory/reindex?scope=bm25",
+        timeout=120,
+    )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Memory reindex returned non-JSON: {body[:200]}",
+        ) from exc
+    if payload.get("status") != "completed" or payload.get("scope") != "bm25":
+        raise RuntimeError(
+            f"Memory reindex returned an unexpected response: {body[:300]}",
+        )
+    print("PASS  packaged ReMe runtime completed BM25 reindex")
+
+
+def verify_packaged_api(base_url: str) -> None:
+    """Verify the desktop's basic API, frontend, and embedded ReMe runtime."""
+    health_check(base_url)
+    verify_frontend(base_url)
+    verify_reme_runtime(base_url)
 
 
 def configure_provider(
@@ -909,8 +938,7 @@ def main() -> int:
     driver: UIDriver | None = None
     try:
         # ---- API-level checks (always run, no key needed) ----
-        health_check(base_url)
-        verify_frontend(base_url)
+        verify_packaged_api(base_url)
 
         # ---- UI load (always run unless --skip-ui, no key needed) ----
         # This catches broken Vite bundles, missing assets, CSP issues,

--- a/src/qwenpaw/agents/memory/reme_embedding.py
+++ b/src/qwenpaw/agents/memory/reme_embedding.py
@@ -118,6 +118,9 @@ class ReMeEmbedding:
             self.runtime._reindex_lock,
             self.runtime._exclusive_reme_lifecycle("reindex"),
         ):
+            reme = self.runtime._reme
+            if reme is None or not getattr(reme, "is_started", False):
+                return None
             fingerprint = None
             if rebuilds_embedding:
                 agent_config = await self.load_agent_config(

--- a/tests/unit/agents/memory/test_reme_embedding_update.py
+++ b/tests/unit/agents/memory/test_reme_embedding_update.py
@@ -254,6 +254,26 @@ async def test_all_reindex_rejects_disabled_embedding() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reme", [None, SimpleNamespace(is_started=False)])
+async def test_reindex_returns_unavailable_when_reme_is_not_started(
+    reme,
+) -> None:
+    config = _config()
+    manager, _wrapper, _store = _manager(config)
+    manager._reme = reme
+
+    with patch(
+        "qwenpaw.agents.memory.reme_light_memory_manager."
+        "load_agent_config_async",
+    ) as load_config:
+        response = await manager.rebuild_index("embedding")
+
+    assert response is None
+    load_config.assert_not_awaited()
+    manager._run_reme_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_reindex_cancellation_after_persist_still_closes_live_gate() -> (
     None
 ):

--- a/tests/unit/tauri/test_pyinstaller_spec.py
+++ b/tests/unit/tauri/test_pyinstaller_spec.py
@@ -28,6 +28,43 @@ def _collected_submodule_packages() -> set[str]:
     return packages
 
 
+def _called_packages(function_name: str) -> set[str]:
+    tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
+    packages = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != function_name or not node.args:
+            continue
+        package = node.args[0]
+        if isinstance(package, ast.Constant) and isinstance(
+            package.value,
+            str,
+        ):
+            packages.add(package.value)
+    return packages
+
+
+def _metadata_packages() -> set[str]:
+    tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_metadata_pkgs"
+            for target in node.targets
+        ):
+            continue
+        return {
+            item.value
+            for item in node.value.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        }
+    return set()
+
+
 def _data_directories() -> set[tuple[str, str]]:
     tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
     for node in tree.body:
@@ -82,3 +119,12 @@ def test_desktop_spec_collects_provider_catalog_data():
         "providers/data",
         "qwenpaw/providers/data",
     ) in _data_directories()
+
+
+def test_desktop_spec_collects_reme_entry_point_plugins():
+    plugin_modules = {"reme_auto_fin", "reme_daily_paper"}
+    plugin_distributions = {"reme-auto-fin", "reme-daily-paper"}
+
+    assert plugin_modules <= _collected_submodule_packages()
+    assert plugin_modules <= _called_packages("collect_data_files")
+    assert {"reme-ai", *plugin_distributions} <= _metadata_packages()


### PR DESCRIPTION
## Description

QwenPaw 2.2.0b5 enables the independently distributed `auto-fin` and `daily-paper` ReMe plugins, but the desktop PyInstaller spec only collected data from the core `reme` package. Because ReMe discovers those plugins through `importlib.metadata` entry points and imports their manifest targets dynamically, the frozen desktop bundle omitted their Python modules, `plugin.yaml` resources, and distribution metadata. ReMe initialization consequently failed, left the manager's `_reme` instance unset, and embedding reindex surfaced a secondary `NoneType.update_component` error.

This PR:

- collects both ReMe plugin packages, their data files, and their distribution metadata in the desktop bundle;
- returns the existing unavailable result when reindex is requested before ReMe has started, so the API responds with a meaningful 503 instead of an `AttributeError`;
- adds PyInstaller-spec regression coverage for all three entry-point requirements;
- extends the installed-desktop verifier with a provider-free BM25 reindex, proving that the packaged ReMe runtime can start and execute a job.

**Related Issue:** Fixes #7446

**Security Considerations:** No security-sensitive behavior changes. The desktop verifier only rebuilds the empty/default test workspace's local BM25 index.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; packaging/runtime-only fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable.

## Testing

```bash
.venv/bin/python -m pytest \
  tests/unit/tauri/test_pyinstaller_spec.py \
  tests/unit/agents/memory/test_reme_embedding_update.py \
  tests/unit/app/routers/test_agents_router.py -q
```

The desktop release verifier will exercise the real frozen artifact through:

```text
POST /api/agents/default/memory/reindex?scope=bm25
```

## Evidence

```text
........................................................................ [ 88%]
.........                                                                [100%]
81 passed, 1 warning in 1.54s
```

```text
uvx pre-commit run --files <five changed files>
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

The actual PyInstaller hook helpers were also run against the pinned ReMe/plugin distributions:

```text
reme_auto_fin modules=6 data=[merge.yaml, plugin.yaml, topic.yaml]
reme_daily_paper modules=10 data=[analyze.yaml, digest.yaml, plugin.yaml, select.yaml]
reme-ai metadata=1
reme-auto-fin metadata=1
reme-daily-paper metadata=1
```

## Additional Notes

The absence of loose `.py`/`.pyc` files under `_internal/reme` is expected for a PyInstaller PYZ archive. The regression was specifically the omitted dynamically discovered plugin packages and metadata.
