### PR TITLE
fix(memory): normalize backend-specific embedding dimensions

### DIFF
--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
@@ -7,7 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { agentsApi, api } from "@/api";
 import { useAgentStore } from "@/stores/agentStore";
@@ -64,6 +64,19 @@ const memoryStatus = {
 const unknownRuntime = { type: "unknown" as const };
 const unknownDiagnostics = { type: "unknown" as const };
 const noopStatusCheck = async () => {};
+const persistedDashScopeEmbeddingConfig = {
+  backend: "dashscope" as const,
+  model_name: "text-embedding-v4",
+  api_key: "secret",
+  base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+  dimensions: 1024,
+  enable_cache: true,
+  use_dimensions: true,
+  max_cache_size: 1000,
+  max_input_length: 8192,
+  max_batch_size: 10,
+  health_check_timeout: 15,
+};
 
 function RuntimeProvider({ children }: { children: ReactNode }) {
   const [localReindexing, setLocalReindexing] = useState(false);
@@ -216,6 +229,40 @@ function PersistedEmbeddingForm() {
       }}
     >
       <ConfiguredEmbeddingForm />
+    </MemoryMaintenanceContext.Provider>
+  );
+}
+
+function PersistedDashScopeEmbeddingForm() {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    form.setFieldsValue({
+      reme_light_memory_config: {
+        embedding_model_config: persistedDashScopeEmbeddingConfig,
+      },
+    });
+  }, [form]);
+
+  return (
+    <MemoryMaintenanceContext.Provider
+      value={{
+        needsReindex: false,
+        setNeedsReindex: vi.fn(),
+        reindexing: false,
+        setReindexing: vi.fn(),
+        persistedEmbeddingFingerprint: getEmbeddingConfigFingerprint(
+          persistedDashScopeEmbeddingConfig,
+        ),
+        openMemorySettings: vi.fn(),
+        runtimeStatus: unknownRuntime,
+        diagnosticsStatus: unknownDiagnostics,
+        checkMemoryStatus: noopStatusCheck,
+      }}
+    >
+      <Form form={form}>
+        <EmbeddingModelCard />
+      </Form>
     </MemoryMaintenanceContext.Provider>
   );
 }
@@ -878,6 +925,22 @@ describe("embedding card separation", () => {
       }),
     ).toBeDisabled();
   });
+
+  it("enables reindex for a freshly loaded DashScope config", async () => {
+    renderWithProviders(<PersistedDashScopeEmbeddingForm />);
+
+    expect(
+      await screen.findByDisplayValue("text-embedding-v4"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("agentConfig.embeddingIndexAvailable"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "agentConfig.rebuildEmbeddingIndex",
+      }),
+    ).toBeEnabled();
+  });
 });
 
 describe("isValidDreamCronShape", () => {
@@ -992,6 +1055,36 @@ describe("getEmbeddingServiceFingerprint", () => {
         max_cache_size: 20,
         max_input_length: 200,
         max_batch_size: 4,
+      }),
+    );
+  });
+
+  it("ignores use_dimensions outside the OpenAI backend", () => {
+    const dashscope = {
+      ...base,
+      backend: "dashscope" as const,
+    };
+
+    expect(
+      getEmbeddingServiceFingerprint({
+        ...dashscope,
+        use_dimensions: true,
+      }),
+    ).toBe(
+      getEmbeddingServiceFingerprint({
+        ...dashscope,
+        use_dimensions: false,
+      }),
+    );
+    expect(
+      getEmbeddingConfigFingerprint({
+        ...dashscope,
+        use_dimensions: true,
+      }),
+    ).toBe(
+      getEmbeddingConfigFingerprint({
+        ...dashscope,
+        use_dimensions: false,
       }),
     );
   });

--- a/console/src/pages/Agent/Config/components/embeddingUtils.ts
+++ b/console/src/pages/Agent/Config/components/embeddingUtils.ts
@@ -7,6 +7,10 @@ const OPENAI_COMPAT_EMBEDDING_BACKENDS = new Set([
   "dashscope_multimodal",
 ]);
 
+function effectiveUseDimensions(config: Partial<EmbeddingModelConfig>) {
+  return config.backend === "openai" && !!config.use_dimensions;
+}
+
 export function isEmbeddingEnabled(config?: Partial<EmbeddingModelConfig>) {
   if (!config?.model_name?.trim()) {
     return false;
@@ -32,7 +36,7 @@ export function getEmbeddingServiceFingerprint(
     config.base_url?.trim().replace(/\/+$/, "") || "",
     config.model_name?.trim() || "",
     config.dimensions || 0,
-    !!config.use_dimensions,
+    effectiveUseDimensions(config),
   ]);
 }
 
@@ -47,7 +51,7 @@ export function getEmbeddingConfigFingerprint(
     config.model_name?.trim() || "",
     config.dimensions || 0,
     !!config.enable_cache,
-    !!config.use_dimensions,
+    effectiveUseDimensions(config),
     config.max_cache_size || 0,
     config.max_input_length || 0,
     config.max_batch_size || 0,

--- a/src/qwenpaw/agents/memory/embedding_model.py
+++ b/src/qwenpaw/agents/memory/embedding_model.py
@@ -32,6 +32,11 @@ _CREDENTIAL_TYPES = {
 _TEST_TEXT = "QwenPaw embedding connection test"
 
 
+def _effective_use_dimensions(config: EmbeddingModelConfig) -> bool:
+    """Return whether dimensions are sent to the selected provider."""
+    return config.backend == "openai" and config.use_dimensions
+
+
 @dataclass(frozen=True)
 class EmbeddingTestResult:
     """Result of one real embedding provider request."""
@@ -138,7 +143,7 @@ def embedding_config_fingerprint(
         config.base_url.strip().rstrip("/"),
         config.model_name.strip(),
         config.dimensions,
-        config.use_dimensions,
+        _effective_use_dimensions(config),
     )
 
 
@@ -151,5 +156,5 @@ def embedding_vector_space_fingerprint(
         config.base_url.strip().rstrip("/"),
         config.model_name.strip(),
         config.dimensions,
-        config.use_dimensions,
+        _effective_use_dimensions(config),
     )

--- a/tests/unit/agents/memory/test_embedding_model.py
+++ b/tests/unit/agents/memory/test_embedding_model.py
@@ -126,3 +126,33 @@ def test_tested_config_fingerprint_ignores_reme_store_settings() -> None:
     assert module.embedding_config_fingerprint(
         first,
     ) == module.embedding_config_fingerprint(second)
+
+
+@pytest.mark.parametrize(
+    "fingerprint",
+    [
+        module.embedding_config_fingerprint,
+        module.embedding_vector_space_fingerprint,
+    ],
+)
+def test_fingerprints_ignore_inapplicable_dashscope_use_dimensions(
+    fingerprint,
+) -> None:
+    first = _config(backend="dashscope", use_dimensions=False)
+    second = _config(backend="dashscope", use_dimensions=True)
+
+    assert fingerprint(first) == fingerprint(second)
+
+
+@pytest.mark.parametrize(
+    "fingerprint",
+    [
+        module.embedding_config_fingerprint,
+        module.embedding_vector_space_fingerprint,
+    ],
+)
+def test_fingerprints_keep_openai_use_dimensions(fingerprint) -> None:
+    first = _config(backend="openai", use_dimensions=False)
+    second = _config(backend="openai", use_dimensions=True)
+
+    assert fingerprint(first) != fingerprint(second)


### PR DESCRIPTION
## Description

The Console fingerprinted `use_dimensions` for every embedding backend even though the field is only registered and applied for the OpenAI backend. A persisted DashScope configuration with a stale `use_dimensions=true` was therefore compared against a watched form value that omitted the hidden field, permanently marking the form as unsaved and disabling manual embedding reindex.

The backend service and vector-space fingerprints had the same semantic mismatch: they treated `use_dimensions` as meaningful for DashScope even though model construction only passes it to OpenAI.

This PR:

- normalizes `use_dimensions` to its effective value in Console service/config fingerprints;
- applies the same normalization to backend staged-service and vector-space fingerprints;
- preserves distinct fingerprints for OpenAI configurations where the option is effective;
- adds a Console regression covering a freshly loaded DashScope config with persisted `use_dimensions=true`;
- adds backend regression coverage for both DashScope equivalence and OpenAI distinction.

Fixes #7464

## Security Considerations

No security-sensitive behavior changes.

## Testing

- `.venv/bin/python -m pytest tests/unit/agents/memory/test_embedding_model.py -q` — 10 passed
- `npm run test:run -- src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx` — 32 passed
- `npx tsc -b --noEmit`
- targeted ESLint and Prettier checks
- `uvx pre-commit run --files <changed files>`