### PR TITLE
fix(console): link Daily Paper to QwenPaw docs

### DIFF
--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
@@ -590,10 +590,7 @@ describe("long-term memory defaults", () => {
       screen.getByRole("link", {
         name: "agentConfig.dailyPaperDocumentation",
       }),
-    ).toHaveAttribute(
-      "href",
-      "https://github.com/agentscope-ai/ReMe/blob/main/cookbook/daily_paper/README_ZH.md",
-    );
+    ).toHaveAttribute("href", "https://qwenpaw.agentscope.io/docs/memory");
 
     fireEvent.click(sourceToggle);
 

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
@@ -49,7 +49,7 @@ export function isValidDreamCronShape(value?: string) {
 }
 
 export function ReMeLightMemoryCard() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { message, modal } = useAppMessage();
   const form = Form.useFormInstance();
   const { selectedAgent } = useAgentStore();
@@ -159,12 +159,6 @@ export function ReMeLightMemoryCard() {
   const dailyPaperCronEnabled = remeConfig?.daily_paper_cron_enabled ?? false;
   const autoSearchEnabled =
     remeConfig?.auto_memory_search_config?.enabled ?? false;
-  const dailyPaperDocsUrl = (i18n?.resolvedLanguage || i18n?.language || "en")
-    .toLowerCase()
-    .startsWith("zh")
-    ? "https://github.com/agentscope-ai/ReMe/blob/main/cookbook/daily_paper/README_ZH.md"
-    : "https://github.com/agentscope-ai/ReMe/blob/main/cookbook/daily_paper/README.md";
-
   const toggleAutoMemory = (enabled: boolean) => {
     form.setFieldValue(
       ["reme_light_memory_config", "auto_memory_interval"],
@@ -375,7 +369,11 @@ export function ReMeLightMemoryCard() {
                 </span>
               </button>
               <div className={styles.memorySourceActions}>
-                <a href={dailyPaperDocsUrl} target="_blank" rel="noreferrer">
+                <a
+                  href="https://qwenpaw.agentscope.io/docs/memory"
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   {t("agentConfig.dailyPaperDocumentation")}
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>


### PR DESCRIPTION
## Description

Update the Daily Paper guide link in the Console memory settings to point to QwenPaw's own Memory documentation instead of the upstream ReMe cookbook.

This keeps the guide aligned with QwenPaw's wrapped behavior and configuration, and makes it consistent with the existing Memory documentation link in the same card.

**Related Issue:** None

**Security Considerations:** None; this only changes a documentation URL in the Console.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit locally on the changed files and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; the target Memory documentation already covers Daily Paper)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

Not applicable: this Console change does not modify a channel integration.

## Testing

- `npm run test:run -- src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx`
- `npx tsc -b --noEmit`
- `npx prettier --check src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx`
- `pre-commit run --files console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx`

## Evidence

```text
Test Files  1 passed (1)
Tests       30 passed (30)

Checking formatting...
All matched files use Prettier code style!

pre-commit (changed files):
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
```

TypeScript project checking completed successfully with no errors.

## Additional Notes

The existing QwenPaw Memory documentation already includes the Daily Paper workflow and its configuration fields.
