### PR TITLE
fix(memory): start ReMe before model configuration

### DIFF
--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install packaging helper dependencies
         run: python -m pip install packaging

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -53,6 +53,7 @@ from ...config.config import (
     EmbeddingModelConfig,
     RerankerConfig,
 )
+from ...exceptions import ProviderError
 from ...utils.io_utils import run_sync_io
 
 if TYPE_CHECKING:
@@ -202,7 +203,19 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if self._reme is None:
             return
 
-        await self._update_qwenpaw_model()
+        try:
+            await self._update_qwenpaw_model()
+        except ProviderError as exc:
+            # A fresh installation has no active model until onboarding is
+            # complete.  ReMe's provider-free jobs (for example BM25 reindex)
+            # must still be available in that state.  Jobs that require an
+            # LLM refresh the injected model immediately before execution.
+            logger.info(
+                "ReMe starting without an active QwenPaw model for agent "
+                "'%s': %s",
+                self.agent_id,
+                exc,
+            )
         try:
             await self._reme.start()
             logger.info(

--- a/tests/integration/test_qq_mock_im.py
+++ b/tests/integration/test_qq_mock_im.py
@@ -258,14 +258,40 @@ def test_qq_outbound_send_carries_msg_id_reply_context(
         msg_seq for c2c passive replies.
 
     Test flow:
-      1. Push a C2C message with a distinctive msg_id.
-      2. Wait for the outbound send; inspect the recorded body.
+      1. Register the mock model and wait for the QQ channel to reconnect
+         when first-time model activation schedules an agent reload.
+      2. Push a C2C message with a distinctive msg_id.
+      3. Wait for the outbound send; inspect the recorded body.
     """
     srv, mock_url = mock_llm
     srv.force_tool_call = False
     unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+
+    # Global model activation copies the model into an agent that does not
+    # have one yet, then schedules a zero-downtime reload asynchronously.
+    # Waiting for the replacement QQ connection prevents this message from
+    # being consumed by the old workspace just before it is stopped.  When
+    # the full module runs, an earlier test may already have initialized the
+    # model, in which case activation does not reload and no wait is needed.
+    agent = app_server.api_request(
+        "GET",
+        "/api/agents/default",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert agent.status_code == 200, app_server.logs_tail()
+    active_model = agent.json().get("active_model") or {}
+    reload_expected = not active_model.get("provider_id")
+    if reload_expected:
+        qq_channel_up.reset_identified()
+
     provider_id = register_mock_provider(app_server, mock_url)
     try:
+        if reload_expected:
+            assert qq_channel_up.wait_identified(timeout=60.0), (
+                "QQ channel did not reconnect after initial model "
+                "activation: " + app_server.logs_tail()[-3000:]
+            )
+
         marker_msg_id = "integ-qq-msgid-ctx"
         before = len(qq_channel_up.api_calls)
         qq_channel_up.push_c2c_message(

--- a/tests/unit/agents/memory/test_reme_start.py
+++ b/tests/unit/agents/memory/test_reme_start.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Focused tests for the embedded ReMe startup lifecycle."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qwenpaw.agents.memory.reme_light_memory_manager import (
+    ReMeLightMemoryManager,
+)
+from qwenpaw.exceptions import ProviderError
+
+
+@pytest.mark.asyncio
+async def test_start_without_active_model_keeps_provider_free_reme() -> None:
+    """A fresh install must retain ReMe before model onboarding completes."""
+    reme = SimpleNamespace(start=AsyncMock())
+    manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
+    manager.agent_id = "default"
+    manager._reme = reme
+    manager._update_qwenpaw_model = AsyncMock(
+        side_effect=ProviderError("No active model configured."),
+    )
+
+    await manager.start()
+
+    manager._update_qwenpaw_model.assert_awaited_once_with()
+    reme.start.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_start_propagates_unexpected_model_injection_failure() -> None:
+    """Only expected provider configuration failures may be degraded."""
+    reme = SimpleNamespace(start=AsyncMock())
+    manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
+    manager.agent_id = "default"
+    manager._reme = reme
+    manager._update_qwenpaw_model = AsyncMock(
+        side_effect=RuntimeError("unexpected injection failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected injection failure"):
+        await manager.start()
+
+    reme.start.assert_not_awaited()

--- a/tests/unit/tauri/test_desktop_workflows.py
+++ b/tests/unit/tauri/test_desktop_workflows.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for desktop packaging workflows."""
+
+from pathlib import Path
+import tomllib
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_fork_desktop_build_uses_supported_python() -> None:
+    """Both platform builders must bootstrap a project-supported Python."""
+    project = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"),
+    )
+    supported = SpecifierSet(project["project"]["requires-python"])
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/fork-verify-desktop.yml").read_text(
+            encoding="utf-8"
+        ),
+    )
+
+    for job_name in ("tauri-macos", "tauri-windows"):
+        setup_python = next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if step.get("uses", "").startswith("actions/setup-python@")
+        )
+        version = Version(str(setup_python["with"]["python-version"]))
+        assert version in supported, (
+            f"{job_name} bootstraps unsupported Python {version}; "
+            f"project requires {supported}"
+        )

--- a/tests/unit/tauri/test_desktop_workflows.py
+++ b/tests/unit/tauri/test_desktop_workflows.py
@@ -20,7 +20,7 @@ def test_fork_desktop_build_uses_supported_python() -> None:
     supported = SpecifierSet(project["project"]["requires-python"])
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github/workflows/fork-verify-desktop.yml").read_text(
-            encoding="utf-8"
+            encoding="utf-8",
         ),
     )
 


### PR DESCRIPTION
## Description

A fresh desktop installation has no active model until onboarding completes. `ReMeLightMemoryManager.start()` currently injects the active QwenPaw model before starting ReMe, and lets `ProviderError` escape when no model is configured. Because the workspace memory service is optional, ServiceManager then removes it entirely.

This caused both desktop release jobs in run #33484573427 to fail the provider-free BM25 check added by #7458 with:

```text
HTTP 503: {"detail":"Memory manager is not available"}
```

This change treats model configuration errors as a supported startup state: ReMe starts with its placeholder LLM component so provider-free jobs such as BM25 reindex remain available. Jobs that need an LLM already refresh the injected QwenPaw model immediately before execution. Unexpected model injection errors still propagate.

Follow-up to #7458.

## Testing

```bash
.venv/bin/python -m pytest \
  tests/unit/agents/memory/test_reme_start.py \
  tests/unit/agents/memory/test_reme_embedding_update.py \
  tests/unit/app/routers/test_agents_router.py -q
# 79 passed

uvx pre-commit run --files \
  src/qwenpaw/agents/memory/reme_light_memory_manager.py \
  tests/unit/agents/memory/test_reme_start.py
# all passed
```

## Security Considerations

No security-sensitive behavior changes. The change only keeps the local memory runtime available before model onboarding.