### PR TITLE
fix(webui): add dark-mode overrides for MCP section containers

### DIFF
--- a/console/src/pages/Agent/MCP/index.module.less
+++ b/console/src/pages/Agent/MCP/index.module.less
@@ -946,6 +946,41 @@
     border-color: rgba(255, 255, 255, 0.08);
   }
 
+  .mcpSection {
+    background: #2d2d2d;
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .sectionHeader {
+    p {
+      color: rgba(255, 255, 255, 0.65);
+    }
+  }
+
+  .sectionEmpty {
+    color: rgba(255, 255, 255, 0.55);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .providerCard {
+    background: #2d2d2d;
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .providerCardHeader strong {
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .providerDisabled {
+    color: rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .providerMeta span {
+    color: rgba(255, 255, 255, 0.55);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
   .mcpDescription {
     color: rgba(255, 255, 255, 0.65);
   }


### PR DESCRIPTION
## Description

Fix the MCP clients page rendering a large white rounded-rectangle container around the MCP server cards in dark mode.

`.mcpSection` used `background: var(--color-bg-base, #fff)` and `.providerCard` used `background: var(--color-bg-container, #faf9f7)`. Neither custom property is defined anywhere in the frontend source (only `var(...)` usage points exist, no `--color-bg-*` definition and no runtime JS injection), so they always resolve to their white fallback in both light and dark mode. The `:global(.dark-mode)` block overrode `.mcpCard` and many other selectors but missed these two containers, leaving a white block that strongly contrasts with the dark theme.

This PR adds matching dark-mode overrides (`#2d2d2d`) for `.mcpSection` and `.providerCard`, consistent with the existing `.mcpCard` override.

**Related Issue:** Fixes #7471

**Security Considerations:** N/A (pure frontend CSS change)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- Verified the modified LESS file compiles cleanly with `lessc 4.9.0` (exit 0).
- Confirmed the generated CSS contains the new dark-mode rules:

```less
:global(.dark-mode) .mcpSection {
  background: #2d2d2d;
  border-color: rgba(255, 255, 255, 0.08);
}
:global(.dark-mode) .providerCard {
  background: #2d2d2d;
  border-color: rgba(255, 255, 255, 0.08);
}
```

- Visual behavior: in dark mode the MCP page section/provider containers now match the dark card background (`#2d2d2d`) instead of the previous white fallback.

## Evidence

<!-- The modified LESS file compiles without errors and emits the new dark-mode rules. -->

```bash
$ /tmp/lessc/node_modules/.bin/lessc console/src/pages/Agent/MCP/index.module.less /tmp/mcp-test.css
# exit 0, no errors

$ grep -A2 'dark-mode' /tmp/mcp-test.css | grep -E '2d2d2d|mcpSection|providerCard'
:global(.dark-mode) .mcpSection {
  background: #2d2d2d;
:global(.dark-mode) .providerCard {
  background: #2d2d2d;
  background: #2d2d2d;
```

Full compile output:

```css
/* excerpt from generated CSS */
:global(.dark-mode) .mcpSection {
  background: #2d2d2d;
  border-color: rgba(255, 255, 255, 0.08);
}
:global(.dark-mode) .providerCard {
  background: #2d2d2d;
  border-color: rgba(255, 255, 255, 0.08);
}
```

The buggy behavior (white container around MCP server cards in dark mode) is documented with screenshots in issue #7471.

## Additional Notes

- Scope is intentionally limited to the MCP page module (`console/src/pages/Agent/MCP/index.module.less`). A separate follow-up could formally define `--color-bg-base` / `--color-bg-container` in the global theme or migrate these usages to the antd `--ant-color-bg-container` token, but that is out of scope here.
