### PR TITLE
fix(desktop): preserve PyInstaller multiprocessing runtime hook

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -169,11 +169,12 @@ for _pkg in _metadata_pkgs:
     except Exception:
         pass
 
+BACKEND_ENTRY = SRC / "tauri" / "entry.py"
+CLI_ENTRY = SRC / "tauri" / "cli_entry.py"
+ENTRY_SCRIPTS = (BACKEND_ENTRY, CLI_ENTRY)
+
 a = Analysis(
-    [
-        str(SRC / "tauri" / "entry.py"),
-        str(SRC / "tauri" / "cli_entry.py"),
-    ],
+    [str(path) for path in ENTRY_SCRIPTS],
     pathex=[str(REPO_ROOT), str(REPO_ROOT / "src"), str(MAIL_MCP_SRC)],
     binaries=[*qoder_binaries, *codex_binaries],
     datas=datas,
@@ -241,16 +242,40 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
-def script_entry(file_name):
-    for item in a.scripts:
-        if Path(item[1]).name == file_name:
-            return [item]
-    raise SystemExit(f"script entry not found: {file_name}")
+
+def executable_scripts(scripts, selected_entry, entry_scripts):
+    """Keep every non-entry Analysis script plus one application entry."""
+    selected_path = Path(selected_entry).resolve()
+    entry_paths = {Path(path).resolve() for path in entry_scripts}
+    if selected_path not in entry_paths:
+        raise SystemExit(f"unknown script entry: {selected_entry}")
+
+    selected_scripts = []
+    selected_entry_count = 0
+    for item in scripts:
+        source_path = Path(item[1]).resolve()
+        if source_path in entry_paths:
+            if source_path == selected_path:
+                selected_scripts.append(item)
+                selected_entry_count += 1
+            continue
+        selected_scripts.append(item)
+
+    if selected_entry_count != 1:
+        raise SystemExit(
+            "script entry must appear exactly once: "
+            f"{selected_entry} (found {selected_entry_count})"
+        )
+    return selected_scripts
+
+
+backend_scripts = executable_scripts(a.scripts, BACKEND_ENTRY, ENTRY_SCRIPTS)
+cli_scripts = executable_scripts(a.scripts, CLI_ENTRY, ENTRY_SCRIPTS)
 
 
 backend_exe = EXE(
     pyz,
-    script_entry("entry.py"),
+    backend_scripts,
     [],
     name="qwenpaw-backend",
     debug=False,
@@ -268,7 +293,7 @@ backend_exe = EXE(
 
 cli_exe = EXE(
     pyz,
-    script_entry("cli_entry.py"),
+    cli_scripts,
     [],
     name="qwenpaw",
     debug=False,

--- a/src/qwenpaw/tauri/entry.py
+++ b/src/qwenpaw/tauri/entry.py
@@ -48,6 +48,28 @@ def _looks_like_python_invocation(args: Sequence[str]) -> bool:
     return len(first) >= 2 and first[0] == "-" and first[1] != "-"
 
 
+def _abort_unhandled_multiprocessing_child(args: Sequence[str]) -> None:
+    """Stop a frozen multiprocessing child that escaped its runtime hook.
+
+    PyInstaller's multiprocessing runtime hook consumes this private flag and
+    dispatches ``spawn_main()`` before the application entry point runs.  If
+    the flag reaches this function, the packaged executable is missing or did
+    not execute that hook.  Never let such a child continue into backend
+    singleton reconciliation, where it could terminate its parent backend.
+    """
+    if not bool(getattr(sys, "frozen", False)):
+        return
+    if "--multiprocessing-fork" not in args:
+        return
+    if sys.stderr is not None:
+        print(
+            "qwenpaw-backend multiprocessing runtime hook did not handle "
+            "the child process",
+            file=sys.stderr,
+        )
+    raise SystemExit(2)
+
+
 def _bundled_python() -> str:
     """Path to the bundled standalone CPython, or ``""`` if missing."""
     python = (os.environ.get("QWENPAW_DESKTOP_PY_RUNTIME") or "").strip()
@@ -358,6 +380,11 @@ def _socket_port(sock: socket.socket) -> int:
 
 
 def main() -> None:
+    # PyInstaller replaces this function on every platform. It must run before
+    # application initialization so multiprocessing workers and resource
+    # trackers do not re-enter the backend entry point.
+    mp.freeze_support()
+    _abort_unhandled_multiprocessing_child(sys.argv[1:])
     if _is_frozen_desktop() and _looks_like_python_invocation(sys.argv[1:]):
         _reexec_as_bundled_python(sys.argv[1:])
         return
@@ -391,5 +418,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    mp.freeze_support()
     main()

--- a/tests/unit/tauri/test_entry.py
+++ b/tests/unit/tauri/test_entry.py
@@ -138,6 +138,41 @@ def test_socket_port_returns_bound_port():
         assert entry._socket_port(sock) == sock.getsockname()[1]
 
 
+def test_main_aborts_unhandled_frozen_multiprocessing_child(
+    monkeypatch,
+    capsys,
+):
+    calls = []
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "qwenpaw-backend",
+            "--multiprocessing-fork",
+            "tracker_fd=6",
+            "pipe_handle=8",
+        ],
+    )
+    monkeypatch.setattr(
+        entry.mp,
+        "freeze_support",
+        lambda: calls.append("freeze-support"),
+    )
+    monkeypatch.setattr(
+        entry,
+        "_install_desktop_runtime",
+        lambda: calls.append("desktop-runtime"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        entry.main()
+
+    assert exc_info.value.code == 2
+    assert calls == ["freeze-support"]
+    assert "multiprocessing runtime hook" in capsys.readouterr().err
+
+
 def test_main_supports_frozen_entry_without_package_context(
     monkeypatch,
     tmp_path,
@@ -150,6 +185,11 @@ def test_main_supports_frozen_entry_without_package_context(
     monkeypatch.setattr(entry, "__spec__", None)
     monkeypatch.setattr(entry, "__name__", "__main__")
     monkeypatch.setattr(entry, "_is_frozen_desktop", lambda: False)
+    monkeypatch.setattr(
+        entry.mp,
+        "freeze_support",
+        lambda: calls.append("freeze-support"),
+    )
     monkeypatch.setattr(entry, "_ensure_utf8_stdio", lambda: None)
     monkeypatch.setattr(entry, "_install_subprocess_guard", lambda: None)
     monkeypatch.setattr(entry, "_install_desktop_runtime", lambda: None)
@@ -165,4 +205,4 @@ def test_main_supports_frozen_entry_without_package_context(
 
     entry.main()
 
-    assert calls == ["sandbox-check", "info"]
+    assert calls == ["freeze-support", "sandbox-check", "info"]

--- a/tests/unit/tauri/test_pyinstaller_spec.py
+++ b/tests/unit/tauri/test_pyinstaller_spec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SPEC_PATH = REPO_ROOT / "scripts" / "pack-tauri" / "qwenpaw.spec"
@@ -105,6 +107,21 @@ def _analysis_path_names() -> set[str]:
     return {node.id for node in ast.walk(pathex) if isinstance(node, ast.Name)}
 
 
+def _load_spec_function(name: str):
+    tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    module = ast.fix_missing_locations(
+        ast.Module(body=[function], type_ignores=[]),
+    )
+    namespace = {"Path": Path}
+    exec(compile(module, SPEC_PATH, "exec"), namespace)  # noqa: S102
+    return namespace[name]
+
+
 def test_desktop_spec_collects_pawapp_sdk_for_runtime_loaded_plugins():
     assert "qwenpaw.pawapp" in _collected_submodule_packages()
 
@@ -128,3 +145,62 @@ def test_desktop_spec_collects_reme_entry_point_plugins():
     assert plugin_modules <= _collected_submodule_packages()
     assert plugin_modules <= _called_packages("collect_data_files")
     assert {"reme-ai", *plugin_distributions} <= _metadata_packages()
+
+
+def test_executable_scripts_preserves_runtime_hooks_and_selected_entry(
+    tmp_path,
+):
+    executable_scripts = _load_spec_function("executable_scripts")
+    backend_entry = tmp_path / "entry.py"
+    cli_entry = tmp_path / "cli_entry.py"
+    inspect_hook = tmp_path / "pyi_rth_inspect.py"
+    multiprocessing_hook = tmp_path / "pyi_rth_multiprocessing.py"
+    future_hook = tmp_path / "future_runtime_hook.py"
+    scripts = [
+        ("pyi_rth_inspect", str(inspect_hook), "PYSOURCE"),
+        (
+            "pyi_rth_multiprocessing",
+            str(multiprocessing_hook),
+            "PYSOURCE",
+        ),
+        ("future_runtime_hook", str(future_hook), "PYSOURCE"),
+        ("entry", str(backend_entry), "PYSOURCE"),
+        ("cli_entry", str(cli_entry), "PYSOURCE"),
+    ]
+    entry_scripts = (backend_entry, cli_entry)
+
+    backend_scripts = executable_scripts(
+        scripts,
+        backend_entry,
+        entry_scripts,
+    )
+    cli_scripts = executable_scripts(scripts, cli_entry, entry_scripts)
+
+    assert backend_scripts == [*scripts[:3], scripts[3]]
+    assert cli_scripts == [*scripts[:3], scripts[4]]
+
+
+@pytest.mark.parametrize("entry_count", [0, 2])
+def test_executable_scripts_requires_exactly_one_selected_entry(
+    tmp_path,
+    entry_count,
+):
+    executable_scripts = _load_spec_function("executable_scripts")
+    backend_entry = tmp_path / "entry.py"
+    cli_entry = tmp_path / "cli_entry.py"
+    runtime_hook = tmp_path / "runtime_hook.py"
+    scripts = [
+        ("runtime_hook", str(runtime_hook), "PYSOURCE"),
+        *[
+            ("entry", str(backend_entry), "PYSOURCE")
+            for _ in range(entry_count)
+        ],
+        ("cli_entry", str(cli_entry), "PYSOURCE"),
+    ]
+
+    with pytest.raises(SystemExit, match="must appear exactly once"):
+        executable_scripts(
+            scripts,
+            backend_entry,
+            (backend_entry, cli_entry),
+        )


### PR DESCRIPTION
## Description

Fix the packaged Desktop backend restarting when a StdIO MCP server spawns a multiprocessing helper on macOS.

The shared PyInstaller `Analysis` contains both application entry scripts and its generated runtime hooks. The previous per-executable selection kept only the chosen application entry, which also dropped `pyi_rth_multiprocessing.py`. As a result, a frozen child launched with `--multiprocessing-fork` re-entered the normal backend entry point and could terminate the active parent through singleton reconciliation.

This change:

- preserves every non-entry `Analysis` script in its original order while selecting only the intended backend or CLI application entry;
- enforces the structural invariant that the selected application entry appears exactly once, without depending on PyInstaller's private runtime-hook filenames;
- calls `multiprocessing.freeze_support()` before Desktop initialization; and
- adds a fail-safe that stops an unhandled frozen multiprocessing child before it can reach singleton reconciliation.

**Related Issue:** Fixes #7481

**Security Considerations:** No new permissions, dependencies, network access, or user-controlled execution paths are introduced. The fallback is limited to frozen processes carrying PyInstaller's `--multiprocessing-fork` marker and fails closed before backend initialization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; this corrects internal packaging behavior)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
uv run --extra test pytest tests/unit/tauri -q
# 24 passed in 0.25s

uv run --with black==23.3.0 black --check --line-length 79 \
  tests/unit/tauri/test_pyinstaller_spec.py
# 1 file would be left unchanged

uv run --with flake8==6.1.0 flake8 --extend-ignore=E203 \
  tests/unit/tauri/test_pyinstaller_spec.py
# passed
```

The non-reusable `QwenPaw Desktop Build` workflow was dispatched for the updated branch with `upload_to_oss=false`: https://github.com/jinglinpeng/CoPaw/actions/runs/33598794295

## Evidence

The regression suite exercises both sides of the fix:

```text
tests/unit/tauri/test_pyinstaller_spec.py
- preserves known and future runtime hooks in their original order
- includes only the selected application entry
- rejects zero or multiple occurrences of the selected entry

tests/unit/tauri/test_entry.py
- verifies freeze_support runs before Desktop initialization
- verifies an unhandled frozen --multiprocessing-fork child exits before the Desktop runtime

24 passed in 0.25s
```

Desktop packaging evidence: https://github.com/jinglinpeng/CoPaw/actions/runs/33598794295

## Additional Notes

The singleton backend guard remains unchanged and continues to clean up genuinely orphaned top-level backends. The script partitioning deliberately avoids checking PyInstaller's private runtime-hook filenames; `pyi_rth_multiprocessing.py` remains only as a concrete regression-test fixture for #7481.
