### PR TITLE
fix(console): handle CRLF replay event boundaries

### DIFF
--- a/console/src/pages/Chat/replayFastForward.ts
+++ b/console/src/pages/Chat/replayFastForward.ts
@@ -33,7 +33,7 @@ const isMarker = (event: string): boolean => event.trim() === REPLAY_END_EVENT;
 
 /** Split buffered text into complete SSE events and the partial tail. */
 function splitEvents(buf: string): { events: string[]; rest: string } {
-  const parts = buf.split("\n\n");
+  const parts = buf.split(/\r?\n\r?\n/);
   const rest = parts.pop() ?? "";
   return { events: parts.filter((e) => e.length > 0), rest };
 }

--- a/console/src/pages/Chat/tests/replayFastForward.test.ts
+++ b/console/src/pages/Chat/tests/replayFastForward.test.ts
@@ -88,6 +88,21 @@ describe("wrapReplayFastForward", () => {
     expect(chunks.join("")).not.toContain("replay_end");
   });
 
+  it("accepts CRLF event boundaries from Windows fixtures", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 5000);
+
+    push("data: one\r\n\r\n");
+    push('data: {"type": "replay_end"}\r\n\r\n');
+    push("data: live\r\n\r\n");
+    close();
+
+    const chunks = await readAllChunks(wrapped);
+    expect(chunks[0]).toBe("data: one\n\n");
+    expect(chunks.slice(1)).toEqual(["data: live\n\n"]);
+    expect(chunks.join("")).not.toContain("replay_end");
+  });
+
   it("falls back to an idle-timeout flush when no marker is sent", async () => {
     const { response, push, close } = makeSseResponse();
     const wrapped = wrapReplayFastForward(response, 20);


### PR DESCRIPTION
## Description

Accept both LF (`\n\n`) and CRLF (`\r\n\r\n`) event boundaries while buffering Chat replay SSE events.

## What Problem This Solves

`wrapReplayFastForward` currently splits replay events only on `\n\n`. SSE fixtures or proxies that preserve Windows-style CRLF delimiters are therefore treated as one unterminated event: the replay marker is not recognized at the expected boundary and replay/live handoff can be delayed or malformed.

The parser now uses `\r?\n\r?\n`, preserving existing LF behavior while accepting standards-compatible CRLF framing.

**Security Considerations:** No authentication, authorization, or data-exposure changes. The patch only normalizes SSE record boundaries.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: internal parser bug fix)
- [x] Ready for review

## Testing

Validated on upstream `main` (`81116f42`):

```text
vitest run src/pages/Chat/tests/replayFastForward.test.ts
Test Files  1 passed (1)
Tests       8 passed (8)

prettier --check src/pages/Chat/replayFastForward.ts src/pages/Chat/tests/replayFastForward.test.ts
All matched files use Prettier code style!

git diff --check
passed
```

## Evidence

The regression feeds replay, marker, and live events with `\r\n\r\n` boundaries. It verifies that replay content is flushed, the replay marker is removed, and the following live event is emitted as a separate normalized SSE chunk. All existing LF, split-marker, timeout, end-of-stream, and partial-event cases remain passing.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor reviewed the parser against the current upstream implementation and independently ran the focused regression and formatting checks above.

## Additional Notes

The production change is one line and does not alter the public API or emitted event payloads.