### PR TITLE
fix(plugins): preserve prerelease minimum ordering

### DIFF
--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -46,12 +46,6 @@ def check_plugin_version_compat(
 
     current = Version(current_version_str)
 
-    # Pre-release versions (e.g. 2.0.0b2) should be treated as their base
-    # release for compatibility purposes — developers on a pre-release build
-    # must be able to load plugins targeting the upcoming release.
-    if current.pre is not None:
-        current = Version(f"{current.major}.{current.minor}.{current.micro}")
-
     qv = manifest.qwenpaw_version
     if qv is not None:
         min_v = Version(qv.min)
@@ -63,6 +57,12 @@ def check_plugin_version_compat(
             if manifest.max_version
             else _derive_exclusive_max(manifest.min_version)
         )
+
+    # A stable minimum accepts development builds of that same base release,
+    # preserving the existing developer workflow. A pre-release minimum is an
+    # exact capability boundary and must retain normal PEP 440 ordering.
+    if current.pre is not None and min_v.pre is None:
+        current = Version(f"{current.major}.{current.minor}.{current.micro}")
 
     # Temporary: only enforce >= min.  Original full-range check:
     # if current < min_v or current >= max_v:

--- a/tests/unit/plugins/test_version_compat.py
+++ b/tests/unit/plugins/test_version_compat.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw._version_compat import check_plugin_version_compat
+
+version_module = importlib.import_module("qwenpaw.__version__")
+
+
+def _manifest(min_version: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        qwenpaw_version=SimpleNamespace(min=min_version, max="3.0.0"),
+        min_version="0.0.0",
+        max_version="",
+    )
+
+
+@pytest.mark.parametrize(
+    ("current", "compatible"),
+    [
+        ("2.1.1a1", False),
+        ("2.1.1b1", False),
+        ("2.1.1b2", True),
+        ("2.1.1rc1", True),
+        ("2.1.1", True),
+    ],
+)
+def test_prerelease_minimum_preserves_pep440_ordering(
+    monkeypatch: pytest.MonkeyPatch,
+    current: str,
+    compatible: bool,
+) -> None:
+    monkeypatch.setattr(version_module, "__version__", current)
+
+    result, _ = check_plugin_version_compat(_manifest("2.1.1b2"))
+
+    assert result is compatible
+
+
+def test_stable_minimum_still_accepts_same_release_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(version_module, "__version__", "2.1.1a1")
+
+    result, _ = check_plugin_version_compat(_manifest("2.1.1"))
+
+    assert result is True


### PR DESCRIPTION
## Description

Preserve PEP 440 ordering when a plugin declares a pre-release minimum QwenPaw version, while retaining the existing behavior that lets development builds satisfy a stable minimum for the same base release.

## What Problem This Solves

The compatibility check currently normalizes every running pre-release (for example `2.1.1b1`) to its stable base (`2.1.1`) before it reads the plugin minimum. That makes `2.1.1b1` appear compatible with a plugin requiring `2.1.1b2`, even though the running build predates the declared capability boundary.

This patch defers normalization until the minimum is known:

- stable minimum `2.1.1`: `2.1.1a1` remains accepted, preserving the documented developer workflow;
- pre-release minimum `2.1.1b2`: normal PEP 440 ordering is retained, so alpha/beta builds below `b2` are rejected.

**Security Considerations:** This is a compatibility gate correction. It prevents loading plugins that explicitly require a newer pre-release contract; it does not change permissions or data handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: existing semantics are clarified in code)
- [x] Ready for review

## Testing

Validated on upstream `main` (`81116f42`):

```text
python -m pytest tests/unit/plugins/test_version_compat.py -q
6 passed in 0.14s

python -m pre_commit run --files src/qwenpaw/_version_compat.py tests/unit/plugins/test_version_compat.py
all applicable hooks passed, including mypy, black, flake8, and pylint

git diff --check
passed
```

## Evidence

The parameterized regression verifies `a1 < b1 < b2 <= rc1 < final` for a `2.1.1b2` plugin minimum. A separate regression proves that a stable `2.1.1` minimum still accepts the same-base development build `2.1.1a1`, so the existing pre-release developer workflow is not regressed.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor reviewed the compatibility semantics against `packaging.version.Version`, limited the change to the minimum-version decision point, and independently ran the focused tests and changed-file hooks above.

## Additional Notes

Upper-bound enforcement remains intentionally unchanged and disabled, matching the current upstream implementation.