### PR TITLE
fix(windows): fall back when CPU architecture is missing

### DIFF
--- a/src/qwenpaw/utils/system_info.py
+++ b/src/qwenpaw/utils/system_info.py
@@ -9,6 +9,7 @@ import platform
 import re
 import subprocess
 import sys
+import sysconfig
 from collections.abc import Mapping
 from typing import Any
 
@@ -54,12 +55,27 @@ def get_os_name() -> str:
 
 def get_architecture() -> str:
     """Return the CPU architecture as x64/arm64 when recognized."""
-    machine = platform.machine().lower()
+    machine = platform.machine().strip().lower()
+    if not machine and get_os_name() == "windows":
+        # ``platform.machine()`` depends on PROCESSOR_ARCHITECTURE on
+        # Windows. Minimal process environments may omit it even though
+        # Python still knows its target platform.
+        machine = (
+            (
+                os.environ.get("PROCESSOR_ARCHITEW6432")
+                or os.environ.get("PROCESSOR_ARCHITECTURE")
+                or sysconfig.get_platform()
+            )
+            .strip()
+            .lower()
+        )
     mapping = {
         "x86_64": "x64",
         "amd64": "x64",
+        "win-amd64": "x64",
         "arm64": "arm64",
         "aarch64": "arm64",
+        "win-arm64": "arm64",
     }
     return mapping.get(machine, machine)
 

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 
 import qwenpaw.utils.system_info as system_info_module
-from qwenpaw.utils.system_info import get_system_info, get_vram_size_gb
+from qwenpaw.utils.system_info import (
+    get_architecture,
+    get_system_info,
+    get_vram_size_gb,
+)
 
 _NVIDIA_SMI_HEADER = (
     "NVIDIA-SMI 560.94    Driver Version: 560.94    CUDA Version: 12.6\n"
@@ -26,6 +30,65 @@ def _fake_run_command(
         return None
 
     return _runner
+
+
+# ---------------------------------------------------------------------------
+# get_architecture
+# ---------------------------------------------------------------------------
+
+
+def test_get_architecture_uses_python_target_when_windows_env_is_minimal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(system_info_module.platform, "machine", lambda: "")
+    monkeypatch.setattr(
+        system_info_module.platform,
+        "system",
+        lambda: "Windows",
+    )
+    monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+    monkeypatch.delenv("PROCESSOR_ARCHITECTURE", raising=False)
+    monkeypatch.setattr(
+        system_info_module.sysconfig,
+        "get_platform",
+        lambda: "win-amd64",
+    )
+
+    assert get_architecture() == "x64"
+
+
+def test_get_architecture_prefers_wow64_process_architecture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(system_info_module.platform, "machine", lambda: "")
+    monkeypatch.setattr(
+        system_info_module.platform,
+        "system",
+        lambda: "Windows",
+    )
+    monkeypatch.setenv("PROCESSOR_ARCHITEW6432", "ARM64")
+    monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+    monkeypatch.setattr(
+        system_info_module.sysconfig,
+        "get_platform",
+        lambda: "win-amd64",
+    )
+
+    assert get_architecture() == "arm64"
+
+
+def test_get_architecture_does_not_infer_python_target_outside_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(system_info_module.platform, "machine", lambda: "")
+    monkeypatch.setattr(system_info_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        system_info_module.sysconfig,
+        "get_platform",
+        lambda: "linux-x86_64",
+    )
+
+    assert get_architecture() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Add a Windows-only fallback for CPU architecture detection when `platform.machine()` returns an empty string in a minimal process environment.

The fallback prefers `PROCESSOR_ARCHITEW6432`, then `PROCESSOR_ARCHITECTURE`, then Python's target platform from `sysconfig.get_platform()`.

## What Problem This Solves

On Windows, `platform.machine()` depends on processor environment variables. Launchers, service wrappers, or reduced development environments can omit those variables, causing QwenPaw to return an empty architecture. Local-model selection then cannot choose an architecture-specific asset even though Python still knows its target platform.

The fallback is deliberately Windows-only:

- normal non-empty `platform.machine()` behavior is unchanged;
- WOW64's native architecture variable takes precedence;
- `win-amd64` and `win-arm64` Python platform identifiers map to the existing `x64` and `arm64` values;
- an empty result on non-Windows platforms remains empty rather than guessing.

**Security Considerations:** No trust-boundary or authorization changes. Environment values are used only for local architecture classification, with Python's target platform as the final fallback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: internal platform detection fix)
- [x] Ready for review

## Testing

Validated on upstream `main` (`81116f42`):

```text
python -m pytest tests/unit/utils/test_system_info.py -q
8 passed in 0.16s

python -m pre_commit run --files src/qwenpaw/utils/system_info.py tests/unit/utils/test_system_info.py
all applicable hooks passed, including mypy, black, flake8, and pylint

git diff --check
passed
```

## Evidence

The regression tests simulate three independent cases: a minimal Windows environment falling back to `win-amd64`, a WOW64 environment preferring native `ARM64` over process `AMD64`, and a non-Windows empty architecture that must not infer from `sysconfig`. The existing system information tests remain passing.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor reviewed the Windows fallback precedence, kept it isolated to the empty-machine case, and independently ran the focused tests and changed-file hooks above.

## Additional Notes

No launcher or local-model API changes are included; this PR only makes the existing architecture helper return a stable value when Windows omits processor variables.