### PR TITLE
fix(privacy): keep host paths out of chat-visible text

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -6,6 +6,7 @@ This module handles:
 - Message content manipulation
 - Message validation
 """
+
 import asyncio
 import json
 import logging
@@ -126,12 +127,14 @@ def _format_uploaded_file_hint(
     filename: object,
     language: str,
 ) -> str:
-    """Build a localized upload hint with optional filename metadata."""
+    """Build a localized upload hint without exposing the host path."""
     display_name = _quote_display_filename(filename)
-    name_suffix = f" {display_name}" if display_name else ""
+    if display_name is None:
+        basename = os.path.basename(local_path.replace("\\", "/")) or "file"
+        display_name = _quote_display_filename(basename) or '"file"'
     if language == "zh":
-        return f"用户上传文件{name_suffix}，已经下载到 {local_path}"
-    return f"User uploaded a file{name_suffix}, downloaded to {local_path}"
+        return f"用户上传文件，已保存为 {display_name}"
+    return f"User uploaded a file, saved as {display_name}"
 
 
 def _media_type_from_path(path: str) -> str:

--- a/src/qwenpaw/hooks/error/error_hook.py
+++ b/src/qwenpaw/hooks/error/error_hook.py
@@ -57,7 +57,6 @@ class ErrorNormalizeHook(LifecycleHook):
                 {"agent": ctx.agent},
             )
             if dump_path:
-                error_text += f" [dump: {dump_path}]"
                 logger.info("error_normalize: dump written to %s", dump_path)
         except Exception:
             logger.debug(

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -6,6 +6,7 @@ Covers:
 - prepend_to_message_content
 - process_file_and_media_blocks_in_message
 """
+
 # pylint: disable=redefined-outer-name
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -232,7 +233,7 @@ class TestProcessAudioDataBlock:
         assert msg.content[0].text == "[Voice message]: hello from voice"
 
     @pytest.mark.asyncio
-    async def test_failed_transcription_keeps_local_path_hint(
+    async def test_failed_transcription_hides_local_path_hint(
         self,
         tmp_path,
         _audio_config,
@@ -247,7 +248,10 @@ class TestProcessAudioDataBlock:
         assert isinstance(msg.content[0], TextBlock)
         assert msg.content[0].text == "[Voice message]: (audio file received)"
         assert isinstance(msg.content[1], TextBlock)
-        assert str(audio_path.resolve()) in msg.content[1].text
+        assert msg.content[1].text == (
+            'User uploaded a file, saved as "voice.opus"'
+        )
+        assert str(audio_path.resolve()) not in msg.content[1].text
 
     @pytest.mark.asyncio
     async def test_native_audio_remains_data_block(
@@ -346,9 +350,8 @@ class TestProcessFileAndMediaBlocks:
 
         await process_file_and_media_blocks_in_message(msg)
 
-        assert msg.content[1].text == (
-            f'用户上传文件 "项目方案.docx"，已经下载到 {local_path}'
-        )
+        assert msg.content[1].text == '用户上传文件，已保存为 "项目方案.docx"'
+        assert str(local_path) not in msg.content[1].text
 
     @pytest.mark.asyncio
     async def test_data_block_hint_normalizes_and_escapes_filename(
@@ -366,10 +369,10 @@ class TestProcessFileAndMediaBlocks:
         await process_file_and_media_blocks_in_message(msg)
 
         assert msg.content[1].text == (
-            "User uploaded a file "
-            '"会议\\n记\\u0085录\\u2028划\\u2029.docx", '
-            f"downloaded to {local_path}"
+            "User uploaded a file, saved as "
+            '"会议\\n记\\u0085录\\u2028划\\u2029.docx"'
         )
+        assert str(local_path) not in msg.content[1].text
 
     @pytest.mark.asyncio
     async def test_data_block_hint_bounds_display_filename(
@@ -385,12 +388,12 @@ class TestProcessFileAndMediaBlocks:
 
         expected_name = "a" * 200
         assert msg.content[1].text == (
-            f'User uploaded a file "{expected_name}", '
-            f"downloaded to {local_path}"
+            f'User uploaded a file, saved as "{expected_name}"'
         )
+        assert str(local_path) not in msg.content[1].text
 
     @pytest.mark.asyncio
-    async def test_file_hint_without_name_keeps_existing_wording(
+    async def test_file_hint_without_name_uses_local_basename(
         self,
         monkeypatch,
         tmp_path,
@@ -402,5 +405,6 @@ class TestProcessFileAndMediaBlocks:
         await process_file_and_media_blocks_in_message(msg)
 
         assert msg.content[1].text == (
-            f"User uploaded a file, downloaded to {local_path}"
+            'User uploaded a file, saved as "stored.bin"'
         )
+        assert str(local_path) not in msg.content[1].text

--- a/tests/unit/hooks/error/test_error_hook.py
+++ b/tests/unit/hooks/error/test_error_hook.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Error normalization privacy contract tests."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.app.chats import query_error_dump
+from qwenpaw.hooks.error.error_hook import ErrorNormalizeHook
+
+
+@pytest.mark.asyncio
+async def test_error_dump_path_is_logged_but_not_exposed_to_chat(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO)
+    private_path = (
+        r"C:\Users\example\AppData\Local\Temp\qwenpaw_query_error.json"
+    )
+    monkeypatch.setattr(
+        query_error_dump,
+        "write_query_error_dump",
+        lambda *_args, **_kwargs: private_path,
+    )
+    context = SimpleNamespace(
+        error=RuntimeError("provider failed"),
+        agent=None,
+        request={"input": []},
+        extras={},
+    )
+
+    await ErrorNormalizeHook().run(context)
+
+    assert "provider failed" in context.extras["_error_text"]
+    assert private_path not in context.extras["_error_text"]
+    assert "[dump:" not in context.extras["_error_text"]
+    assert private_path in caplog.text


### PR DESCRIPTION
## Description

Keep host absolute paths out of two chat-visible surfaces while preserving the useful diagnostic and file-identification information:

1. provider error dumps remain logged server-side but are no longer appended to the normalized chat error;
2. uploaded-file hints sent through message processing show a bounded basename instead of the downloaded host path.

## What Problem This Solves

QwenPaw currently appends the full error-dump path to the response error text and includes the downloaded local path in uploaded-file hints. On desktop and self-hosted deployments, those values can expose usernames, home directories, temporary directories, or workspace layout to chat users and model-visible message content.

The patch keeps the operational behavior intact:

- error dumps are still written and their path remains in server logs for operators;
- uploaded files are still downloaded and processed from the same local path;
- the model still receives a safe, bounded, escaped filename so it can refer to the attachment;
- when filename metadata is absent, the hint derives only the basename from either POSIX or Windows path syntax.

**Security Considerations:** This is a privacy hardening change. It reduces disclosure of host filesystem structure without weakening logging, file processing, authorization, or path validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: no public API change)
- [x] Ready for review

## Testing

Validated on upstream `main` (`81116f42`):

```text
python -m pytest tests/unit/agents/utils/test_message_processing.py tests/unit/hooks/error/test_error_hook.py -q
26 passed in 0.79s

python -m pre_commit run --files src/qwenpaw/agents/utils/message_processing.py src/qwenpaw/hooks/error/error_hook.py tests/unit/agents/utils/test_message_processing.py tests/unit/hooks/error/test_error_hook.py
all applicable hooks passed, including mypy, black, flake8, and pylint

git diff --check
passed
```

## Evidence

The updated message-processing regressions cover Chinese and English hints, Windows-style names, control-character escaping, bounded long filenames, missing filename metadata, and failed audio transcription. Every case asserts that the host path is absent.

The new error-hook regression verifies that the dump path is absent from `_error_text` and the `[dump: ...]` suffix, while the same path remains present in captured server logs.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor reviewed both values' data flow to chat/model-visible text, preserved the existing diagnostic log path, and independently ran the focused tests and changed-file hooks above.

## Additional Notes

No file URLs, stored paths, or operator log formats are changed. Only the human/model-facing hint text stops carrying absolute host paths.