### PR TITLE
fix(console): name language and theme toggle buttons

### DIFF
--- a/console/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
+++ b/console/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
@@ -52,7 +52,9 @@ describe("LanguageSwitcher", () => {
 
   it("renders the language switcher button", () => {
     renderWithProviders(<LanguageSwitcher />);
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "sidebar.settings.language" }),
+    ).toHaveAttribute("title", "sidebar.settings.language");
   });
 
   it("shows all supported language options", () => {

--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -36,7 +36,7 @@ interface LanguageSwitcherProps {
 export default function LanguageSwitcher({
   persistRemotely = true,
 }: LanguageSwitcherProps) {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
 
   const currentLanguage = i18n.resolvedLanguage || i18n.language;
   const currentLangKey = KNOWN_LANG_KEYS.has(currentLanguage)
@@ -72,7 +72,12 @@ export default function LanguageSwitcher({
       placement="bottomRight"
       overlayClassName={styles.languageDropdown}
     >
-      <Button icon={iconMap[currentLangKey]} type="text" />
+      <Button
+        aria-label={t("sidebar.settings.language")}
+        title={t("sidebar.settings.language")}
+        icon={iconMap[currentLangKey]}
+        type="text"
+      />
     </Dropdown>
   );
 }

--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -21,7 +21,9 @@ function renderWithTheme(mode: "light" | "dark" | "system" = "light") {
 describe("ThemeToggleButton", () => {
   it("renders the theme toggle button", () => {
     renderWithTheme("light");
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "sidebar.settings.theme" }),
+    ).toHaveAttribute("title", "sidebar.settings.theme");
   });
 
   it("shows sun icon when light mode is active", () => {

--- a/console/src/components/ThemeToggleButton/index.tsx
+++ b/console/src/components/ThemeToggleButton/index.tsx
@@ -43,7 +43,13 @@ export default function ThemeToggleButton() {
       placement="bottomRight"
       overlayClassName={styles.themeDropdown}
     >
-      <Button className={styles.toggleBtn} type="text" icon={icon} />
+      <Button
+        aria-label={t("sidebar.settings.theme")}
+        title={t("sidebar.settings.theme")}
+        className={styles.toggleBtn}
+        type="text"
+        icon={icon}
+      />
     </Dropdown>
   );
 }


### PR DESCRIPTION
## Description

Give the shared language and theme icon buttons localized accessible names and matching hover titles by reusing the existing `sidebar.settings.language` and `sidebar.settings.theme` translations.

## What Problem This Solves

Both controls are icon-only Ant Design buttons. Without an explicit accessible name, screen readers and role-based automation can receive only an implementation-oriented icon name or no stable user-facing label. Sighted users also lack a native title explaining the control before opening its menu.

The patch adds `aria-label` and `title` from the current locale. It does not add new translation keys or change either dropdown's behavior.

**Security Considerations:** No security-sensitive behavior changes. This is an accessibility and discoverability fix.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed: no API or configuration change)
- [x] Ready for review

## Testing

Validated on upstream `main` (`81116f42`):

```text
vitest run src/components/LanguageSwitcher/LanguageSwitcher.test.tsx src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
Test Files  2 passed (2)
Tests       10 passed (10)

prettier --check <the four changed TSX files>
All matched files use Prettier code style!

locale contract check
all locale files contain sidebar.settings.language/theme

git diff --check
passed
```

## Evidence

The component regressions now query each control by its accessible role and localized name, then verify the matching `title`. Existing icon state, dropdown options, language persistence, remote update, and theme-mode tests remain passing. A JSON check confirms both reused translation keys exist in every current locale file.

The LanguageSwitcher suite emits its existing mocked-icon React warning but completes all five tests successfully; this patch does not change icon imports.

## AI-Assisted Development Disclosure

This contribution was AI-assisted. The contributor verified that the labels reuse existing locale keys across every current locale and independently ran the focused component and formatting checks above.

## Additional Notes

No locale files, styles, dropdown contents, or persisted settings are changed.