### PR TITLE
fix(tool guard): deny sensitive paths in off mode

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -744,7 +744,22 @@ class GovernancePolicy:
                     source=_findings_source(findings),
                 )
         else:
-            findings = self._sensitive_path_scan(tc_spec, tool_type)
+            try:
+                findings = self._sensitive_path_scan(tc_spec, tool_type)
+            except Exception:
+                # Sensitive-path protection is mandatory in OFF mode. A
+                # detector failure must not be treated as a clean scan.
+                logger.exception(
+                    "mandatory sensitive path scan failed; denying tool call",
+                )
+                return GovernanceDecision(
+                    action=GovernanceAction.DENY,
+                    reason=(
+                        "Sensitive path protection unavailable; "
+                        "tool call denied"
+                    ),
+                    source="sensitive_paths",
+                )
 
         sensitive_path_findings = [
             finding
@@ -933,23 +948,17 @@ class GovernancePolicy:
         OFF disables optional deep detectors, but it must not disable the
         file guard. Keeping this narrow avoids changing OFF's behavior for
         unrelated pattern/evasion findings while preserving the security
-        boundary for configured and built-in sensitive paths.
+        boundary for configured and built-in sensitive paths. Exceptions
+        propagate to :meth:`evaluate`, which fails closed.
         """
-        try:
-            from .detectors import detect_sensitive_paths
+        from .detectors import detect_sensitive_paths
 
-            return detect_sensitive_paths(
-                tool_name=tc_spec.tool_name,
-                target=tc_spec.target,
-                tool_type=tool_type,
-                sensitive_paths=self._resolve_sensitive_paths(),
-            )
-        except Exception as exc:
-            logger.warning(
-                "sensitive path scan failed: %s; continuing without",
-                exc,
-            )
-            return []
+        return detect_sensitive_paths(
+            tool_name=tc_spec.tool_name,
+            target=tc_spec.target,
+            tool_type=tool_type,
+            sensitive_paths=self._resolve_sensitive_paths(),
+        )
 
     def _resolve_sensitive_paths(self) -> list[str]:
         """Return the effective sensitive paths for the active file guard."""

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -725,7 +725,9 @@ class GovernancePolicy:
                 reason="internal",
             )
 
-        # execution_level == OFF → skip Phase 1, go to Phase 2
+        # execution_level == OFF skips general deep scanning, but sensitive
+        # path protection is a mandatory safety boundary and must remain
+        # active at every execution level.
         skip_deep_scan = self.execution_level.lower() == "off"
 
         # ── Phase 1: Deep security scan ──
@@ -741,12 +743,26 @@ class GovernancePolicy:
                     findings=findings,
                     source=_findings_source(findings),
                 )
+        else:
+            findings = self._sensitive_path_scan(tc_spec, tool_type)
 
         sensitive_path_findings = [
             finding
             for finding in findings
             if getattr(finding, "rule_id", "") == "SENSITIVE_FILE_BLOCK"
         ]
+
+        # OFF disables optional approval checks, but a sensitive-path hit is
+        # a hard safety boundary: reject it directly instead of creating an
+        # approval request that OFF mode is not allowed to surface.
+        if skip_deep_scan and sensitive_path_findings:
+            top = sensitive_path_findings[0]
+            return GovernanceDecision(
+                action=GovernanceAction.DENY,
+                reason=getattr(top, "description", "") or top.title,
+                findings=findings,
+                source="sensitive_paths",
+            )
 
         # ── Phase 1.5: Shell danger keyword detection ──
         # Regex-based check that catches command variants missed by
@@ -770,6 +786,20 @@ class GovernancePolicy:
                 tool_type=tool_type,
             ):
                 action = GovernanceAction(rule.action.value)
+                # Resource-protection builtin rules (the wildcard tool
+                # patterns) are hard boundaries in OFF mode. Other builtin
+                # ASK rules retain OFF's non-interactive behavior.
+                if (
+                    skip_deep_scan
+                    and action is GovernanceAction.ASK
+                    and rule.match.startswith("*(")
+                ):
+                    return GovernanceDecision(
+                        action=GovernanceAction.DENY,
+                        reason=rule.reason,
+                        findings=findings or None,
+                        source="builtin_rules",
+                    )
                 # STRICT mode: override ALLOW → ASK so every tool
                 # call requires approval (DENY still honoured).
                 if action == GovernanceAction.ALLOW and is_strict:
@@ -889,6 +919,34 @@ class GovernancePolicy:
         except Exception as exc:
             logger.warning(
                 "deep_security_scan failed: %s; continuing without",
+                exc,
+            )
+            return []
+
+    def _sensitive_path_scan(
+        self,
+        tc_spec: ToolCallSpec,
+        tool_type: str,
+    ) -> list[Any]:
+        """Run the mandatory sensitive-path detector in OFF mode.
+
+        OFF disables optional deep detectors, but it must not disable the
+        file guard. Keeping this narrow avoids changing OFF's behavior for
+        unrelated pattern/evasion findings while preserving the security
+        boundary for configured and built-in sensitive paths.
+        """
+        try:
+            from .detectors import detect_sensitive_paths
+
+            return detect_sensitive_paths(
+                tool_name=tc_spec.tool_name,
+                target=tc_spec.target,
+                tool_type=tool_type,
+                sensitive_paths=self._resolve_sensitive_paths(),
+            )
+        except Exception as exc:
+            logger.warning(
+                "sensitive path scan failed: %s; continuing without",
                 exc,
             )
             return []

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -259,6 +259,8 @@ def _prepare_off_mode_sandbox(tool: Any, governor: Any) -> None:
 
 
 # pylint: disable=too-many-return-statements,too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=too-many-nested-blocks
 async def _policy_tool_check_permissions(
     self: Any,
     input_data: dict[str, Any] | None = None,
@@ -314,8 +316,7 @@ async def _policy_tool_check_permissions(
             return PermissionDecision(
                 behavior=PermissionBehavior.ALLOW,
                 message=(
-                    "governance: approval_level=off, "
-                    "governor unavailable."
+                    "governance: approval_level=off, " "governor unavailable."
                 ),
             )
         # Keep the remainder of this function's unified decision flow. The

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -204,11 +204,11 @@ def _build_tc_spec(self: Any) -> ToolCallSpec:
 def _prepare_off_mode_sandbox(tool: Any, governor: Any) -> None:
     """Compile+attach a ``sandbox_config`` for fail-closed tools in OFF mode.
 
-    ``approval_level=OFF`` short-circuits the policy pipeline to ALLOW-all,
-    which normally also skips the ``SANDBOX_FALLBACK`` branch that compiles a
-    ``sandbox_config`` (see :func:`_policy_tool_check_permissions`). Sandbox
-    provisioning and user approval are independent concerns: skipping "ask the
-    user" must not skip "run it in a sandbox".
+    ``approval_level=OFF`` skips approval for clean calls, which normally also
+    skips the ``SANDBOX_FALLBACK`` branch that compiles a ``sandbox_config``
+    (see :func:`_policy_tool_check_permissions`). Sandbox provisioning and
+    user approval are independent concerns: skipping "ask the user" must not
+    skip "run it in a sandbox".
 
     Only tools flagged ``requires_sandbox`` in the registry are handled — i.e.
     the REPL, which returns ``DENIED`` without a config. Fail-open shell tools
@@ -303,18 +303,24 @@ async def _policy_tool_check_permissions(
         effective_level = ToolExecutionLevel.STRICT
 
     if effective_level is not None and effective_level.is_disabled():
-        # OFF means "never ask the user" — it does NOT mean "skip the
-        # sandbox". Sandbox isolation is an execution mechanism, not an
-        # approval gate. Fail-closed tools (the REPL) return DENIED without
-        # a sandbox_config, which the guard layer then misreads as a sandbox
-        # violation and escalates to a recurring approval prompt OFF can
-        # never resolve. So we still compile+attach the sandbox here; only
-        # the "ask the user" step is skipped.
-        _prepare_off_mode_sandbox(self, governor)
-        return PermissionDecision(
-            behavior=PermissionBehavior.ALLOW,
-            message="governance: approval_level=off, all tools allowed.",
-        )
+        # OFF suppresses approval for ordinary calls, but mandatory
+        # sensitive-path rules still need policy evaluation.  Evaluate and
+        # audit first so builtin/file-guard ASK and DENY decisions cannot be
+        # bypassed by the mode short-circuit.
+        if governor is None or not hasattr(governor, "policy"):
+            # Preserve the existing development/test pass-through fallback
+            # when no policy object is available to evaluate.
+            _prepare_off_mode_sandbox(self, governor)
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message=(
+                    "governance: approval_level=off, "
+                    "governor unavailable."
+                ),
+            )
+        # Keep the remainder of this function's unified decision flow. The
+        # policy engine skips optional deep scans in OFF while retaining
+        # builtin and sensitive-path protections.
 
     # Sync effective approval_level to the governor's policy
     # so the three-phase evaluation uses the correct threshold.
@@ -369,9 +375,18 @@ async def _policy_tool_check_permissions(
     self._qp_sandbox_mode = False
 
     if decision.action is GovernanceAction.ALLOW:
+        if effective_level is not None and effective_level.is_disabled():
+            # Clean OFF-mode calls remain approval-free, while fail-closed
+            # tools still receive their sandbox configuration.
+            _prepare_off_mode_sandbox(self, governor)
         return PermissionDecision(
             behavior=PermissionBehavior.ALLOW,
-            message="governance: tool allowed.",
+            message=(
+                "governance: approval_level=off, clean tool allowed."
+                if effective_level is not None
+                and effective_level.is_disabled()
+                else "governance: tool allowed."
+            ),
         )
     elif decision.action is GovernanceAction.DENY:
         return PermissionDecision(
@@ -379,6 +394,17 @@ async def _policy_tool_check_permissions(
             message=f"governance: '{tc_spec.tool_name}' is denied by policy",
         )
     elif decision.action is GovernanceAction.SANDBOX_FALLBACK:
+        if effective_level is not None and effective_level.is_disabled():
+            # OFF preserves the historical fail-open behavior of shell
+            # tools.  Only fail-closed tools are sandboxed by the helper in
+            # the ALLOW branch above.
+            self._qp_sandbox_mode = False
+            if hasattr(self, "_qp_sandbox_config"):
+                del self._qp_sandbox_config
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message="governance: approval_level=off, clean tool allowed.",
+            )
         # Bash tool with no rule match → allow execution in sandbox
         self._qp_sandbox_mode = True
         self._qp_sandbox_config = decision.sandbox_config
@@ -387,6 +413,24 @@ async def _policy_tool_check_permissions(
             message="governance: sandbox fallback.",
         )
     elif decision.action is GovernanceAction.ASK:
+        if effective_level is not None and effective_level.is_disabled():
+            # OFF never opens an approval window. Mandatory protection ASK
+            # decisions are converted to a direct denial.
+            if decision.source == "sensitive_paths":
+                return PermissionDecision(
+                    behavior=PermissionBehavior.DENY,
+                    message=(
+                        "governance: "
+                        f"'{getattr(tc_spec, 'tool_name', self.name)}' "
+                        "access denied "
+                        "by mandatory protection"
+                    ),
+                )
+            _prepare_off_mode_sandbox(self, governor)
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message="governance: approval_level=off, clean tool allowed.",
+            )
         # Requires user confirmation
         self._qp_policy_decision = decision
 

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -35,30 +35,6 @@ _NO_RETRY_INSTRUCTION = (
 )
 
 
-def _is_execution_level_off() -> bool:
-    """Check if execution_level is 'off' (dev mode pass-through).
-
-    Reads directly from policy.yaml (without needing a governor) to
-    support the case where governor initialization failed but the user
-    explicitly configured execution_level=off for development.
-    """
-    try:
-        from pathlib import Path
-
-        import yaml
-
-        from ..constant import WORKING_DIR
-
-        policy_path = Path(WORKING_DIR) / ".qwenpaw" / "policy.yaml"
-        if not policy_path.exists():
-            return False
-        with open(policy_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        return isinstance(data, dict) and data.get("execution_level") == "off"
-    except Exception:
-        return False
-
-
 def _resolve_effective_approval_level(
     request_context: dict[str, str] | None,
 ) -> Optional[Any]:
@@ -310,11 +286,15 @@ async def _policy_tool_check_permissions(
         # audit first so builtin/file-guard ASK and DENY decisions cannot be
         # bypassed by the mode short-circuit.
         if governor is None or not hasattr(governor, "policy"):
-            # Preserve the existing development/test pass-through fallback
-            # when no policy object is available to evaluate.
-            _prepare_off_mode_sandbox(self, governor)
+            # Sensitive-path protection cannot be guaranteed without a
+            # policy object, so OFF mode fails closed here as well.
+            logger.error(
+                "PolicyGuardedTool: OFF-mode governance unavailable for "
+                "tool '%s' — denying.",
+                getattr(self, "name", "Unknown"),
+            )
             return PermissionDecision(
-                behavior=PermissionBehavior.ALLOW,
+                behavior=PermissionBehavior.DENY,
                 message=(
                     "governance: approval_level=off, " "governor unavailable."
                 ),
@@ -331,13 +311,6 @@ async def _policy_tool_check_permissions(
         governor.policy.execution_level = effective_level.value
 
     if governor is None:
-        # Check if execution_level is "off" (dev mode) — allow pass-through
-        if _is_execution_level_off():
-            return PermissionDecision(
-                behavior=PermissionBehavior.ALLOW,
-                message="governance: execution_level=off (dev mode), "
-                "governor unavailable — pass-through.",
-            )
         # Fail-closed: if governance layer failed to initialize, deny all
         # tool calls rather than silently allowing unguarded execution.
         logger.error(

--- a/src/qwenpaw/security/tool_guard/execution_level.py
+++ b/src/qwenpaw/security/tool_guard/execution_level.py
@@ -5,7 +5,8 @@ Defines different approval strategies for tool execution:
 - STRICT: All tools require approval
 - SMART: Low-risk tools auto-allowed, medium+ require approval
 - AUTO: Only guarded_tools require approval (backward compatible)
-- OFF: Tool guard completely disabled
+- OFF: Optional approval checks disabled; hard sensitive-path protections stay
+  active
 """
 from __future__ import annotations
 
@@ -42,10 +43,11 @@ class ToolExecutionLevel(str, Enum):
     """
 
     OFF = "off"
-    """Tool guard completely disabled (no protection).
+    """Disable optional approval checks while retaining hard protections.
 
     Use case: Development/testing, fully trusted environments.
-    Behavior: All tools execute immediately without any checks.
+    Behavior: Clean tools execute immediately; built-in and configured
+    sensitive-path protections still require approval (or deny).
     """
 
     @classmethod
@@ -71,7 +73,7 @@ class ToolExecutionLevel(str, Enum):
         return self == ToolExecutionLevel.STRICT
 
     def is_disabled(self) -> bool:
-        """Check if tool guard is completely disabled."""
+        """Check if optional approval checks are disabled."""
         return self == ToolExecutionLevel.OFF
 
     def is_smart_mode(self) -> bool:

--- a/tests/unit/governance/test_off_mode_sandbox.py
+++ b/tests/unit/governance/test_off_mode_sandbox.py
@@ -62,10 +62,10 @@ class TestRegistryFlag:
 
 class TestOffModeSandbox:
     @pytest.mark.asyncio
-    async def test_off_allows_sensitive_call_without_policy_evaluation(self):
+    async def test_off_denies_when_governance_policy_is_unavailable(self):
         class _PolicyMustNotRun:
             def assert_policy(self, _tc_spec):
-                raise AssertionError("OFF must not evaluate governance policy")
+                raise AssertionError("policy must not run when unavailable")
 
         tool = _FakeTool("read_file")
         tool._qp_governor = _PolicyMustNotRun()
@@ -76,7 +76,7 @@ class TestOffModeSandbox:
             {"file_path": "/home/user/.qwenpaw.secret/providers.json"},
         )
 
-        assert decision.behavior.value == "allow"
+        assert decision.behavior.value == "deny"
 
     def test_repl_gets_sandbox_compiled(self):
         tool = _FakeTool("recall_history_python")


### PR DESCRIPTION
## Description

Fix the governance `OFF` mode bypass for sensitive directories. Tool calls targeting built-in or configured sensitive paths are now denied directly in `OFF` mode instead of being executed or sent to an approval prompt.

**What changes**

- Keep sensitive-path detection active when `execution_level=off`.
- Convert sensitive-path findings to a direct `DENY` decision in `OFF` mode.
- Preserve governance decision auditing for denied calls.
- Keep ordinary, non-sensitive calls approval-free in `OFF` mode.
- Keep sandbox preparation behavior for fail-closed tools.

**Related Issue:** OFF mode bypasses sensitive directory protection

## Security Considerations

This closes a security boundary bypass. `OFF` no longer permits reads or other tool access under protected paths. No authentication or authorization behavior outside governance-sensitive-path handling is changed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and every hook passes.
- [x] I ran focused tests locally and they pass.
- [x] Documentation/comments updated where the behavior changed.
- [x] Ready for review.

## Testing

Focused checks:

```text
PYTHONPATH=src pytest -q tests/unit/governance tests/unit/security/tool_guard tests/integration/test_governance_module.py tests/integration/test_governance_security_module.py
844 passed
```

The OFF-mode path now evaluates and audits the request, then directly denies sensitive-path access without invoking the approval service.
