### PR TITLE
fix(tools): return 404 when updating config for an unknown tool

### DIFF
--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -542,7 +542,10 @@ async def update_tool_config(
             not agent_config.tools
             or tool_name not in agent_config.tools.builtin_tools
         ):
-            raise ValueError(f"Tool '{tool_name}' not found in agent")
+            raise HTTPException(
+                status_code=404,
+                detail=f"Tool '{tool_name}' not found",
+            )
 
         tool_config = agent_config.tools.builtin_tools[tool_name]
         existing_config = tool_config.config or {}
@@ -566,8 +569,8 @@ async def update_tool_config(
         persisted_config = dict(
             agent_config.tools.builtin_tools[tool_name].config,
         )
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -459,7 +459,8 @@ async def update_tool_config(
         Success response
 
     Raises:
-        HTTPException: If update fails
+        HTTPException: 404 if the tool is not found, 500 if the
+            update fails for an unexpected reason
     """
     from ...plugins.registry import PluginRegistry
     from ..agent_context import get_agent_for_request
@@ -565,6 +566,8 @@ async def update_tool_config(
         persisted_config = dict(
             agent_config.tools.builtin_tools[tool_name].config,
         )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -56,16 +56,16 @@ def test_tools_list_returns_array(app_server) -> None:
 
 @pytest.mark.integration
 @pytest.mark.p0
-def test_tools_config_update_unknown_returns_500(app_server) -> None:
+def test_tools_config_update_unknown_returns_404(app_server) -> None:
     """Test purpose:
     - Verify POST /api/agents/{agentId}/tools/{name}/config with an
-      unknown tool name returns 500 because the PluginRegistry rejects
-      config writes for non-existent tools.
+      unknown tool name returns 404 because the builtin_tools
+      membership check rejects config writes for missing tools.
 
     Test flow:
     1. Create agent.
     2. POST /{bogus_tool}/config.
-    3. Assert 500 and detail mentions ``not found``.
+    3. Assert 404 and detail is ``Tool 'integ-nosuch-tool' not found``.
 
     API endpoints:
     - POST /api/agents/{agentId}/tools/{tool_name}/config
@@ -79,8 +79,10 @@ def test_tools_config_update_unknown_returns_500(app_server) -> None:
             json={"config": {"api_key": "test"}},
             timeout=_HTTP_TIMEOUT,
         )
-        assert resp.status_code == 500, app_server.logs_tail()
-        assert "not found" in resp.json().get("detail", "").lower()
+        assert resp.status_code == 404, app_server.logs_tail()
+        assert (
+            resp.json().get("detail") == "Tool 'integ-nosuch-tool' not found"
+        )
     finally:
         delete_agent_quietly(app_server, agent_id)
 

--- a/tests/unit/app/routers/test_tools_router.py
+++ b/tests/unit/app/routers/test_tools_router.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from fastapi import HTTPException
+from pydantic import BaseModel, ValidationError
 import pytest
 
 import qwenpaw.app.agent_context as agent_context_module
@@ -251,4 +252,74 @@ async def test_update_tool_config_unknown_tool_returns_404(
         )
 
     assert exc_info.value.status_code == 404
-    assert "integ-unknown-xyz" in str(exc_info.value.detail)
+    assert exc_info.value.detail == "Tool 'integ-unknown-xyz' not found"
+
+
+@pytest.mark.asyncio
+async def test_update_tool_config_transaction_value_error_stays_500(
+    monkeypatch,
+) -> None:
+    """Load/save ValueError is an internal failure, not a missing tool."""
+    _patch_workspace(monkeypatch)
+    registry = SimpleNamespace(
+        get_plugin_id_for_tool=lambda _tool_name: None,
+    )
+
+    async def update_config(_agent_id, _updater):
+        raise ValueError("invalid cron expression")
+
+    monkeypatch.setattr(registry_module, "PluginRegistry", lambda: registry)
+    monkeypatch.setattr(
+        tools_router_module,
+        "update_agent_config_async",
+        update_config,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_tool_config(
+            tool_name="read_file",
+            body=ToolConfigUpdate(config={}),
+            request=SimpleNamespace(),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "invalid cron expression" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_tool_config_validation_error_stays_500(
+    monkeypatch,
+) -> None:
+    """Pydantic ValidationError subclasses ValueError and must stay 500."""
+
+    class _ProfileStub(BaseModel):
+        timeout: int
+
+    with pytest.raises(ValidationError) as verr:
+        _ProfileStub.model_validate({"timeout": "broken"})
+    validation_error = verr.value
+
+    _patch_workspace(monkeypatch)
+    registry = SimpleNamespace(
+        get_plugin_id_for_tool=lambda _tool_name: None,
+    )
+
+    async def update_config(_agent_id, _updater):
+        raise validation_error
+
+    monkeypatch.setattr(registry_module, "PluginRegistry", lambda: registry)
+    monkeypatch.setattr(
+        tools_router_module,
+        "update_agent_config_async",
+        update_config,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_tool_config(
+            tool_name="read_file",
+            body=ToolConfigUpdate(config={}),
+            request=SimpleNamespace(),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert isinstance(validation_error, ValueError)

--- a/tests/unit/app/routers/test_tools_router.py
+++ b/tests/unit/app/routers/test_tools_router.py
@@ -9,6 +9,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from fastapi import HTTPException
 import pytest
 
 import qwenpaw.app.agent_context as agent_context_module
@@ -215,3 +216,39 @@ async def test_get_tool_config_reads_off_event_loop(monkeypatch) -> None:
     assert read_task.done() is False
     assert await read_task == {"region": "test"}
     assert read_threads and read_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_update_tool_config_unknown_tool_returns_404(
+    monkeypatch,
+) -> None:
+    """A missing tool name is a client 404, not an internal 500."""
+    _patch_workspace(monkeypatch)
+    agent_config = _agent_config("read_file", {})
+    registry = SimpleNamespace(
+        get_plugin_id_for_tool=lambda _tool_name: None,
+    )
+
+    async def update_config(_agent_id, updater):
+        def update_sync():
+            updater(agent_config)
+            return agent_config
+
+        return await run_sync_io(update_sync)
+
+    monkeypatch.setattr(registry_module, "PluginRegistry", lambda: registry)
+    monkeypatch.setattr(
+        tools_router_module,
+        "update_agent_config_async",
+        update_config,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_tool_config(
+            tool_name="integ-unknown-xyz",
+            body=ToolConfigUpdate(config={}),
+            request=SimpleNamespace(),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert "integ-unknown-xyz" in str(exc_info.value.detail)


### PR DESCRIPTION
## Description

`POST /api/tools/{tool_name}/config` mapped a missing tool name to HTTP 500 because `apply_tool_config` raises `ValueError("Tool '…' not found in agent")` and the handler's broad `except Exception` rewrote every failure as an internal error.

This PR only changes the HTTP translation layer: `ValueError` (resource not found) becomes 404; unexpected failures stay 500. Request-body validation is unchanged (missing body is still 422; `{}` remains a valid empty update for an existing tool). Sibling write endpoints (`PATCH /{tool_name}/toggle`, `PATCH /{tool_name}/async-execution`) already return 404 for the same condition.

**Security Considerations:** None. Path and body handling are unchanged; this is status-code mapping only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Unknown tool + empty body `{}`:
   `curl -sS -o /tmp/out -w "%{http_code}" -X POST http://127.0.0.1:<port>/api/tools/integ-unknown-xyz/config -H "Content-Type: application/json" -d '{}'`
   Expect **404** with `Tool 'integ-unknown-xyz' not found in agent`.
2. Unknown tool + no body: expect **422** (validation unchanged).
3. Unknown tool + `{"config":{"a":1}}`: expect **404**.
4. Existing tool (e.g. `read_file`) + `{}`: expect **200**.
5. Unit: `pytest tests/unit/app/routers/test_tools_router.py tests/unit/app/routers/test_tools_router_web_search_config.py -q`

## Evidence

Changed-file pre-commit (`pre-commit run` on the staged router + unit test) and targeted pytest:

```text
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

pytest tests/unit/app/routers/test_tools_router.py \
       tests/unit/app/routers/test_tools_router_web_search_config.py -q
...................                                                      [100%]
19 passed in 1.34s
```

`test_update_tool_config_unknown_tool_returns_404` covers the missing-tool path. Existing web_search tests still assert unexpected write failures remain 500.

## Additional Notes

No docs or channel contract updates. Behavior change is limited to the status code for a missing `tool_name` (500 → 404); success and validation paths are unchanged.