### PR TITLE
fix(console): unify nav and theme-toggle icons with Spark line series (#7376)

### DIFF
--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -38,9 +38,11 @@ describe("ThemeToggleButton", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows sun-moon icon when system mode is active", () => {
+  it("shows computer icon when system mode is active", () => {
     renderWithTheme("system");
-    expect(document.querySelector(".lucide-sun-moon")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-icon="SparkComputerLine"]'),
+    ).toBeInTheDocument();
   });
 
   it("renders without crashing", () => {

--- a/console/src/components/ThemeToggleButton/index.tsx
+++ b/console/src/components/ThemeToggleButton/index.tsx
@@ -1,6 +1,9 @@
 import { Dropdown, Button, type MenuProps } from "antd";
-import { SparkMoonLine, SparkSunLine } from "@agentscope-ai/icons";
-import { SunMoon } from "lucide-react";
+import {
+  SparkComputerLine,
+  SparkMoonLine,
+  SparkSunLine,
+} from "@agentscope-ai/icons";
 import { useTheme, type ThemeMode } from "../../contexts/ThemeContext";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
@@ -9,7 +12,7 @@ import styles from "./index.module.less";
 const ICONS: Record<ThemeMode, ReactNode> = {
   light: <SparkSunLine />,
   dark: <SparkMoonLine />,
-  system: <SunMoon size="1em" />,
+  system: <SparkComputerLine />,
 };
 
 export default function ThemeToggleButton() {

--- a/console/src/layouts/Sidebar.test.tsx
+++ b/console/src/layouts/Sidebar.test.tsx
@@ -26,6 +26,8 @@ vi.mock("@agentscope-ai/icons", () => {
     SparkDateLine: stub,
     SparkDebugLine: stub,
     SparkEmailLine: stub,
+    SparkFile2Line: stub,
+    SparkHistoryLine: stub,
     SparkInternetLine: stub,
     SparkMagicWandLine: stub,
     SparkMcpMcpLine: stub,

--- a/console/src/layouts/registry/builtinMenu.ts
+++ b/console/src/layouts/registry/builtinMenu.ts
@@ -29,6 +29,8 @@ import {
   SparkDateLine,
   SparkDebugLine,
   SparkEmailLine,
+  SparkFile2Line,
+  SparkHistoryLine,
   SparkInternetLine,
   SparkMagicWandLine,
   SparkMcpMcpLine,
@@ -44,9 +46,7 @@ import {
   SparkVoiceChat01Line,
   SparkWifiLine,
 } from "@agentscope-ai/icons";
-import { GitBranch } from "lucide-react";
 import i18next from "i18next";
-import { Files } from "lucide-react";
 import { menuRegistry } from "../../plugins/registry/store";
 import type { MenuItem } from "../../plugins/registry/types";
 
@@ -132,7 +132,7 @@ export const BUILTIN_MENU: MenuItem[] = [
     location: "primary.agentScoped",
     parentId: "core.workspace-group",
     label: navLabel("nav.files"),
-    icon: Files,
+    icon: SparkFile2Line,
     route: "core.files",
     order: 5,
   },
@@ -195,7 +195,7 @@ export const BUILTIN_MENU: MenuItem[] = [
     location: "primary.agentScoped",
     parentId: "core.agent-group",
     label: navLabel("checkpoints.nav"),
-    icon: GitBranch,
+    icon: SparkHistoryLine,
     route: "core.checkpoints",
     order: 80,
   },

--- a/console/src/test/icons-mock.ts
+++ b/console/src/test/icons-mock.ts
@@ -42,3 +42,6 @@ export const SparkRusLine = makeIcon("SparkRusLine");
 // Theme toggle icons
 export const SparkMoonLine = makeIcon("SparkMoonLine");
 export const SparkSunLine = makeIcon("SparkSunLine");
+export const SparkComputerLine = makeIcon("SparkComputerLine");
+// Sidebar nav icons
+export const SparkFile2Line = makeIcon("SparkFile2Line");


### PR DESCRIPTION
> **Submitted by**: 狄仁杰·Repairer@QPQAT

## Summary

Unify the three off-family navigation icons with the Spark thin-line series used by the rest of the sidebar, fixing the visual inconsistency reported in #7376.

The sidebar navigation convention is the Spark thin-line icon series from `@agentscope-ai/icons` (18 of 20 menu items), but three icons were imported from `lucide-react` in their respective feature PRs. The two icon libraries have different design languages (stroke weight, corner radius, visual density), so these icons look inconsistent with the rest of the navigation.

## Changes

| Location | Before (lucide-react) | After (Spark series) |
|---|---|---|
| Files menu icon (`console/src/layouts/registry/builtinMenu.ts`) | `Files` | `SparkFile2Line` |
| Checkpoints menu icon (`console/src/layouts/registry/builtinMenu.ts`) | `GitBranch` | `SparkHistoryLine` |
| Theme toggle · system mode (`console/src/components/ThemeToggleButton/index.tsx`) | `SunMoon` | `SparkComputerLine` |

- Zero functional logic changes; only icon component references are swapped.
- `SparkComputerLine` exists in the installed `@agentscope-ai/icons` package and matches the "follow system" semantics (follow the operating system).
- The Spark usages align with the existing 18 navigation icons in the same files (no `size` prop needed; default sizing verified consistent).

## Validation

- `tsc --noEmit` passes on the rebased branch (based on latest `main`).
- Visual check: the three swapped icons render in the same thin-line style as the other navigation icons (verified against the repro screenshots in the issue; sidebar and theme button re-checked after the change).

## Related

- Fixes #7376
