### PR TITLE
fix(providers): forward OpenAI extra_headers during connection testing

### DIFF
--- a/console/src/api/modules/provider.test.ts
+++ b/console/src/api/modules/provider.test.ts
@@ -84,6 +84,21 @@ describe("providerApi", () => {
     );
   });
 
+  it("testProviderConnection forwards generation headers", async () => {
+    const body = {
+      generate_kwargs: {
+        extra_headers: { "X-Legacy-Token": "legacy-token" },
+      },
+    };
+
+    await providerApi.testProviderConnection("open/ai", body);
+
+    expect(request).toHaveBeenCalledWith("/models/open%2Fai/test", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  });
+
   it("addModel sends POST to the correct path", async () => {
     await providerApi.addModel("openai", { id: "gpt-5", name: "GPT-5" });
     expect(request).toHaveBeenCalledWith(

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -500,6 +500,7 @@ export function ProviderConfigModal({
           api_key: values.api_key,
           base_url: values.base_url,
           chat_model: values.chat_model,
+          generate_kwargs: hasGenerateConfigInput ? generateConfig : {},
           custom_headers: testHeaders,
           auth_mode: isAnthropicProvider ? authMode : undefined,
         });
@@ -553,7 +554,9 @@ export function ProviderConfigModal({
         "api_key",
         "base_url",
         "chat_model",
+        "generate_kwargs_text",
       ]);
+      const generateConfig = parseGenerateConfig(values.generate_kwargs_text);
       const testHeaders = customHeaders
         .filter((h) => h.key.trim())
         .reduce<Record<string, string>>((acc, h) => {
@@ -564,6 +567,7 @@ export function ProviderConfigModal({
         api_key: values.api_key,
         base_url: values.base_url,
         chat_model: values.chat_model,
+        generate_kwargs: generateConfig ?? {},
         custom_headers: testHeaders,
         auth_mode: isAnthropicProvider ? authMode : undefined,
       });

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -431,6 +431,10 @@ class TestProviderRequest(BaseModel):
         default=None,
         description="Optional chat model class to test protocol behavior",
     )
+    generate_kwargs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Generation parameters to use for this test request",
+    )
     custom_headers: Optional[Dict[str, str]] = Field(
         default=None,
         description="Custom headers to use for this test request",
@@ -509,6 +513,8 @@ async def test_provider(
             overrides["base_url"] = body.base_url
         if body and body.chat_model:
             overrides["chat_model"] = body.chat_model
+        if body and body.generate_kwargs is not None:
+            overrides["generate_kwargs"] = body.generate_kwargs
         if body and body.custom_headers is not None:
             overrides["custom_headers"] = body.custom_headers
         if body and body.auth_mode in ("api_key", "auth_token"):

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -154,7 +154,11 @@ class OpenAIProvider(Provider):
     )
 
     def _build_default_headers(self) -> dict:
-        return dict(self.custom_headers) if self.custom_headers else {}
+        headers = dict(self.custom_headers) if self.custom_headers else {}
+        extra_headers = self.generate_kwargs.get("extra_headers")
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
 
     def _client(self, timeout: float = 5) -> AsyncOpenAI:
         kwargs: dict = {

--- a/tests/unit/app/routers/test_provider_discovery.py
+++ b/tests/unit/app/routers/test_provider_discovery.py
@@ -311,3 +311,35 @@ async def test_connection_preserves_protocol_override(
     provider.model_copy.assert_called_once_with(
         update={"chat_model": chat_model},
     )
+
+
+async def test_connection_preserves_header_overrides() -> None:
+    """Connection tests must use unsaved header configuration."""
+    provider = MagicMock()
+    provider.model_copy.return_value = provider
+    provider.check_connection = AsyncMock(return_value=(True, ""))
+    manager = MagicMock()
+    manager.get_provider.return_value = provider
+    generate_kwargs = {
+        "extra_headers": {
+            "X-Legacy-Token": "legacy-token",
+        },
+    }
+    custom_headers = {"X-Custom-Token": "custom-token"}
+
+    result = await provider_connection_endpoint(
+        manager=manager,
+        provider_id="custom-provider",
+        body=TestProviderRequest(
+            generate_kwargs=generate_kwargs,
+            custom_headers=custom_headers,
+        ),
+    )
+
+    assert result.success is True
+    provider.model_copy.assert_called_once_with(
+        update={
+            "generate_kwargs": generate_kwargs,
+            "custom_headers": custom_headers,
+        },
+    )

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -29,6 +29,39 @@ def _make_provider(is_custom: bool = False) -> OpenAIProvider:
     )
 
 
+def test_client_merges_generate_extra_headers(monkeypatch) -> None:
+    provider = _make_provider()
+    custom_headers = {
+        "X-Custom": "custom",
+        "X-Shared": "custom",
+    }
+    extra_headers = {
+        "X-Extra": "extra",
+        "X-Shared": "extra",
+    }
+    provider.custom_headers = custom_headers
+    provider.generate_kwargs = {"extra_headers": extra_headers}
+    captured: dict = {}
+    fake_client = SimpleNamespace()
+
+    def create_client(**kwargs):
+        captured.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(openai_provider_module, "AsyncOpenAI", create_client)
+
+    result = provider._client(timeout=2.5)
+
+    assert result is fake_client
+    assert captured["default_headers"] == {
+        "X-Custom": "custom",
+        "X-Extra": "extra",
+        "X-Shared": "extra",
+    }
+    assert provider.custom_headers == custom_headers
+    assert provider.generate_kwargs == {"extra_headers": extra_headers}
+
+
 async def test_check_connection_success(monkeypatch) -> None:
     provider = _make_provider()
     calls: list[float | None] = []


### PR DESCRIPTION
## Summary

This PR continues the approach from #4492 and fixes the propagation of
`generate_kwargs.extra_headers` for OpenAI-compatible providers.

Custom OpenAI-compatible endpoints often require vendor-specific headers for
authentication, tenant routing, request scenes, or streaming negotiation.
Previously, these headers could be configured in the provider UI but were not
consistently applied to provider clients and connection tests.

Related to #4484
Supersedes #4492

## Changes

- Add `generate_kwargs` to `TestProviderRequest`.
- Forward `generate_kwargs` from the provider connection-test API.
- Forward unsaved generation configuration from the provider configuration UI.
- Merge `custom_headers` and `generate_kwargs.extra_headers` when building
  OpenAI client headers.
- Preserve the existing precedence behavior:
  `generate_kwargs.extra_headers` overrides duplicate keys from
  `custom_headers`.
- Add unit tests for header merging and connection-test overrides.
- Add frontend API coverage for forwarding generation headers.

## Verification

Automated tests:

- Provider unit tests: `657 passed, 1 skipped`
- OpenAI/provider routing tests: `59 passed`
- Frontend provider API tests: `11 passed`
- TypeScript checks passed
- Black, Flake8, Mypy, Pylint, and Prettier checks passed

Manual end-to-end verification with a local OpenAI-compatible Mock service:

- Configured a custom provider named `e2etest`.
- Configured `generate_kwargs.extra_headers`.
- Connection test completed successfully.
- Model discovery returned `e2e-model`.
- A real chat request returned `Mock response`.
- The console stream completed successfully with `has_response=True`.
- Session state was saved and updated successfully.
