### PR TITLE
feat: add agent model routing settings

### DIFF
--- a/console/src/api/types/agents.ts
+++ b/console/src/api/types/agents.ts
@@ -144,6 +144,12 @@ export interface CreateAgentRequest {
   language?: string;
   skill_names?: string[];
   active_model?: ModelSlotConfig | null;
+  fallback_models?: ModelSlotConfig[];
+  fallback_policy?: {
+    enabled: boolean;
+    target_scope: "configured" | "free_only";
+  };
+  subagent_model?: ModelSlotConfig | null;
   mail?: AgentMailConfig | null;
   backend?: AgentBackend;
   backend_settings?: {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1977,6 +1977,7 @@
     "loadingAgentSettings": "Loading agent model settings",
     "agentSettingsSaveFailed": "Failed to save agent model settings",
     "agentSettingsSaved": "Agent model settings saved",
+    "saveAgentSettings": "Save routing settings",
     "thinkingLevel": "Thinking level",
     "thinkingUnsupported": "The active model does not advertise configurable thinking.",
     "thinking": {
@@ -1993,7 +1994,6 @@
     "configuredModels": "Configured models",
     "freeModelsOnly": "Free models only",
     "chooseFallback": "Choose a fallback model",
-    "addFallback": "Add fallback model",
     "moveFallbackUp": "Move {{model}} up",
     "moveFallbackDown": "Move {{model}} down",
     "removeFallback": "Remove {{model}}",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1901,6 +1901,7 @@
     "loadingAgentSettings": "正在加载 Agent 模型设置",
     "agentSettingsSaveFailed": "保存 Agent 模型设置失败",
     "agentSettingsSaved": "Agent 模型设置已保存",
+    "saveAgentSettings": "保存路由设置",
     "thinkingLevel": "思考深度",
     "thinkingUnsupported": "当前模型未声明可配置的思考能力。",
     "thinking": {
@@ -1917,7 +1918,6 @@
     "configuredModels": "已配置模型",
     "freeModelsOnly": "仅免费模型",
     "chooseFallback": "选择备用模型",
-    "addFallback": "添加备用模型",
     "moveFallbackUp": "上移 {{model}}",
     "moveFallbackDown": "下移 {{model}}",
     "removeFallback": "移除 {{model}}",

--- a/console/src/pages/Chat/ModelSelector/AgentModelSettings.tsx
+++ b/console/src/pages/Chat/ModelSelector/AgentModelSettings.tsx
@@ -3,12 +3,11 @@ import {
   ChevronDown,
   ChevronUp,
   LoaderCircle,
-  Plus,
   Save,
   Settings2,
   Trash2,
 } from "lucide-react";
-import { Select } from "antd";
+import { Segmented, Select } from "antd";
 import { useTranslation } from "react-i18next";
 
 import { agentsApi } from "@/api/modules/agents";
@@ -28,10 +27,22 @@ interface SettingsProvider {
 }
 
 interface AgentModelSettingsProps {
-  agentId: string;
+  agentId?: string;
   providers: SettingsProvider[];
   activeProviderId?: string;
   activeModelId?: string;
+  showThinking?: boolean;
+  initialConfig?: Pick<
+    AgentProfileConfig,
+    "fallback_models" | "fallback_policy" | "subagent_model"
+  >;
+  draftResetToken?: number;
+  onDraftChange?: (
+    settings: Pick<
+      AgentProfileConfig,
+      "fallback_models" | "fallback_policy" | "subagent_model"
+    >,
+  ) => void;
 }
 
 interface ModelOption {
@@ -57,10 +68,14 @@ export function AgentModelSettings({
   providers,
   activeProviderId,
   activeModelId,
+  showThinking = true,
+  initialConfig,
+  draftResetToken,
+  onDraftChange,
 }: AgentModelSettingsProps) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(!agentId);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -70,7 +85,6 @@ export function AgentModelSettings({
     "configured" | "free_only"
   >("configured");
   const [fallbackKeys, setFallbackKeys] = useState<string[]>([]);
-  const [pendingFallback, setPendingFallback] = useState(EMPTY_KEY);
   const [subagentKey, setSubagentKey] = useState(EMPTY_KEY);
   const [thinkingLevel, setThinkingLevel] = useState<
     "inherit" | "off" | "low" | "medium" | "high"
@@ -85,6 +99,7 @@ export function AgentModelSettings({
   const subagentSelectId = `${bodyId}-subagent-model`;
   const fallbackScopeSelectId = `${bodyId}-fallback-scope`;
   const fallbackSelectId = `${bodyId}-fallback-model`;
+  const draftTokenRef = useRef<number | undefined>();
 
   const options = useMemo<ModelOption[]>(
     () =>
@@ -161,18 +176,7 @@ export function AgentModelSettings({
     [activeKey, fallbackKeys, modelSelectOptions, t],
   );
 
-  useEffect(() => {
-    loadRevision.current += 1;
-    saveRevision.current += 1;
-    configAgentId.current = null;
-    setConfig(null);
-    setLoadError(null);
-    setLoading(false);
-    setSaving(false);
-    setOpen(false);
-  }, [agentId]);
-
-  const applyConfig = (next: AgentProfileConfig, targetAgentId: string) => {
+  function applyConfig(next: AgentProfileConfig, targetAgentId: string): void {
     configAgentId.current = targetAgentId;
     setConfig(next);
     setFallbackEnabled(next.fallback_policy?.enabled ?? true);
@@ -188,9 +192,37 @@ export function AgentModelSettings({
         : EMPTY_KEY,
     );
     setThinkingLevel(next.thinking_level ?? "inherit");
-  };
+  }
+
+  useEffect(() => {
+    if (agentId) return;
+    if (draftTokenRef.current === draftResetToken && config) return;
+    draftTokenRef.current = draftResetToken;
+    applyConfig(
+      {
+        id: "draft",
+        name: "",
+        ...initialConfig,
+      } as AgentProfileConfig,
+      "draft",
+    );
+    setOpen(true);
+  }, [agentId, config, draftResetToken, initialConfig]);
+
+  useEffect(() => {
+    if (!agentId) return;
+    loadRevision.current += 1;
+    saveRevision.current += 1;
+    configAgentId.current = null;
+    setConfig(null);
+    setLoadError(null);
+    setLoading(false);
+    setSaving(false);
+    setOpen(false);
+  }, [agentId]);
 
   const loadConfig = async (force = false) => {
+    if (!agentId) return;
     if ((!force && config) || loading) return;
     const targetAgentId = agentId;
     const revision = ++loadRevision.current;
@@ -228,21 +260,52 @@ export function AgentModelSettings({
   const moveFallback = (index: number, offset: -1 | 1) => {
     const target = index + offset;
     if (target < 0 || target >= fallbackKeys.length) return;
-    setFallbackKeys((current) => {
-      const next = [...current];
-      [next[index], next[target]] = [next[target], next[index]];
-      return next;
-    });
+    const nextFallbackKeys = [...fallbackKeys];
+    [nextFallbackKeys[index], nextFallbackKeys[target]] = [
+      nextFallbackKeys[target],
+      nextFallbackKeys[index],
+    ];
+    setFallbackKeys(nextFallbackKeys);
+    notifyDraft({ fallbackKeys: nextFallbackKeys });
   };
 
-  const addFallback = () => {
-    if (!pendingFallback || fallbackKeys.includes(pendingFallback)) return;
-    setFallbackKeys((current) => [...current, pendingFallback]);
-    setPendingFallback(EMPTY_KEY);
+  const addFallback = (fallbackKey: string) => {
+    if (!fallbackKey || fallbackKeys.includes(fallbackKey)) return;
+    const nextFallbackKeys = [...fallbackKeys, fallbackKey];
+    setFallbackKeys(nextFallbackKeys);
+    notifyDraft({ fallbackKeys: nextFallbackKeys });
   };
+
+  function notifyDraft({
+    fallbackEnabled: nextFallbackEnabled = fallbackEnabled,
+    fallbackKeys: nextFallbackKeys = fallbackKeys,
+    fallbackScope: nextFallbackScope = fallbackScope,
+    subagentKey: nextSubagentKey = subagentKey,
+  }: {
+    fallbackEnabled?: boolean;
+    fallbackKeys?: string[];
+    fallbackScope?: typeof fallbackScope;
+    subagentKey?: string;
+  } = {}): void {
+    if (agentId || !onDraftChange || !config) return;
+    const fallbackModels = nextFallbackKeys.flatMap((key) => {
+      const slot = slotByKey.get(key);
+      return slot ? [slot] : [];
+    });
+    onDraftChange({
+      fallback_models: fallbackModels,
+      fallback_policy: {
+        enabled: nextFallbackEnabled,
+        target_scope: nextFallbackScope,
+      },
+      subagent_model: slotByKey.get(nextSubagentKey) ?? null,
+    });
+  }
 
   const save = async () => {
-    if (!config || saving || configAgentId.current !== agentId) return;
+    if (!agentId || !config || saving || configAgentId.current !== agentId) {
+      return;
+    }
     const targetAgentId = agentId;
     const revision = ++saveRevision.current;
     setSaving(true);
@@ -259,7 +322,9 @@ export function AgentModelSettings({
           target_scope: fallbackScope,
         },
         subagent_model: subagentSlot ?? null,
-        ...(thinkingSupported ? { thinking_level: thinkingLevel } : {}),
+        ...(showThinking && thinkingSupported
+          ? { thinking_level: thinkingLevel }
+          : {}),
       };
       const updated = await agentsApi.updateModelSettings(
         targetAgentId,
@@ -323,174 +388,243 @@ export function AgentModelSettings({
             </div>
           ) : (
             <>
-              <label className={styles.settingsRow} htmlFor={thinkingSelectId}>
-                <span>{t("modelSelector.thinkingLevel")}</span>
-                <Select
-                  id={thinkingSelectId}
-                  aria-label={t("modelSelector.thinkingLevel")}
-                  className={styles.agentSelect}
-                  classNames={{
-                    popup: { root: styles.agentSelectDropdown },
-                  }}
-                  value={thinkingLevel}
-                  disabled={!thinkingSupported}
-                  options={(
-                    ["inherit", "off", "low", "medium", "high"] as const
-                  ).map((level) => ({
-                    label: t(`modelSelector.thinking.${level}`),
-                    value: level,
-                  }))}
-                  onChange={(value) =>
-                    setThinkingLevel(value as typeof thinkingLevel)
-                  }
-                />
-              </label>
-              {!thinkingSupported && (
-                <p className={styles.settingsHint}>
-                  {t("modelSelector.thinkingUnsupported")}
-                </p>
-              )}
-              <label className={styles.settingsRow} htmlFor={subagentSelectId}>
-                <span>{t("modelSelector.subagentModel")}</span>
-                <Select
-                  id={subagentSelectId}
-                  aria-label={t("modelSelector.subagentModel")}
-                  className={styles.agentSelect}
-                  classNames={{
-                    popup: { root: styles.agentSelectDropdown },
-                  }}
-                  value={subagentKey}
-                  options={subagentOptions}
-                  showSearch
-                  optionFilterProp="label"
-                  listHeight={280}
-                  popupMatchSelectWidth={320}
-                  onChange={setSubagentKey}
-                />
-              </label>
-              <label className={styles.settingsCheckRow}>
-                <input
-                  type="checkbox"
-                  checked={fallbackEnabled}
-                  onChange={(event) => setFallbackEnabled(event.target.checked)}
-                />
-                <span>{t("modelSelector.enableFallback")}</span>
-              </label>
-              {fallbackEnabled && (
+              {showThinking && (
                 <>
                   <label
                     className={styles.settingsRow}
-                    htmlFor={fallbackScopeSelectId}
+                    htmlFor={thinkingSelectId}
                   >
-                    <span>{t("modelSelector.fallbackScope")}</span>
+                    <span>{t("modelSelector.thinkingLevel")}</span>
                     <Select
-                      id={fallbackScopeSelectId}
-                      aria-label={t("modelSelector.fallbackScope")}
+                      id={thinkingSelectId}
+                      aria-label={t("modelSelector.thinkingLevel")}
                       className={styles.agentSelect}
                       classNames={{
                         popup: { root: styles.agentSelectDropdown },
                       }}
-                      value={fallbackScope}
-                      options={[
-                        {
-                          label: t("modelSelector.configuredModels"),
-                          value: "configured",
-                        },
-                        {
-                          label: t("modelSelector.freeModelsOnly"),
-                          value: "free_only",
-                        },
-                      ]}
+                      value={thinkingLevel}
+                      disabled={!thinkingSupported}
+                      options={(
+                        ["inherit", "off", "low", "medium", "high"] as const
+                      ).map((level) => ({
+                        label: t(`modelSelector.thinking.${level}`),
+                        value: level,
+                      }))}
                       onChange={(value) =>
-                        setFallbackScope(value as typeof fallbackScope)
+                        setThinkingLevel(value as typeof thinkingLevel)
                       }
                     />
                   </label>
-                  <div className={styles.fallbackComposer}>
-                    <label className={styles.srOnly} htmlFor={fallbackSelectId}>
-                      {t("modelSelector.chooseFallback")}
-                    </label>
-                    <Select
-                      id={fallbackSelectId}
-                      aria-label={t("modelSelector.chooseFallback")}
-                      className={styles.agentSelect}
-                      classNames={{
-                        popup: { root: styles.agentSelectDropdown },
-                      }}
-                      value={pendingFallback}
-                      options={fallbackOptions}
-                      showSearch
-                      optionFilterProp="label"
-                      listHeight={280}
-                      popupMatchSelectWidth={320}
-                      onChange={setPendingFallback}
-                    />
-                    <button
-                      type="button"
-                      aria-label={t("modelSelector.addFallback")}
-                      disabled={!pendingFallback}
-                      onClick={addFallback}
-                    >
-                      <Plus size={14} />
-                    </button>
-                  </div>
-                  <div className={styles.fallbackList}>
-                    {fallbackKeys.map((key, index) => (
-                      <div key={key}>
-                        <span title={optionByKey.get(key)?.label ?? key}>
-                          {optionByKey.get(key)?.label ?? key}
-                        </span>
-                        <button
-                          type="button"
-                          aria-label={t("modelSelector.moveFallbackUp", {
-                            model: optionByKey.get(key)?.label ?? key,
-                          })}
-                          disabled={index === 0}
-                          onClick={() => moveFallback(index, -1)}
-                        >
-                          <ChevronUp size={13} />
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={t("modelSelector.moveFallbackDown", {
-                            model: optionByKey.get(key)?.label ?? key,
-                          })}
-                          disabled={index === fallbackKeys.length - 1}
-                          onClick={() => moveFallback(index, 1)}
-                        >
-                          <ChevronDown size={13} />
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={t("modelSelector.removeFallback", {
-                            model: optionByKey.get(key)?.label ?? key,
-                          })}
-                          onClick={() =>
-                            setFallbackKeys((current) =>
-                              current.filter((item) => item !== key),
-                            )
-                          }
-                        >
-                          <Trash2 size={13} />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
+                  {!thinkingSupported && (
+                    <p className={styles.settingsHint}>
+                      {t("modelSelector.thinkingUnsupported")}
+                    </p>
+                  )}
                 </>
               )}
-              <button
-                type="button"
-                className={styles.saveAgentSettings}
-                disabled={saving}
-                onClick={save}
-              >
-                {saving ? (
-                  <LoaderCircle size={14} className={styles.spinning} />
-                ) : (
-                  <Save size={14} />
+              <div className={styles.settingsSection}>
+                <div className={styles.settingsSectionHeader}>
+                  <span className={styles.settingsSectionTitle}>
+                    {t("modelSelector.subagentModel")}
+                  </span>
+                </div>
+                <label
+                  className={styles.settingsControl}
+                  htmlFor={subagentSelectId}
+                >
+                  <Select
+                    id={subagentSelectId}
+                    aria-label={t("modelSelector.subagentModel")}
+                    className={styles.agentSelect}
+                    classNames={{
+                      popup: { root: styles.agentSelectDropdown },
+                    }}
+                    value={subagentKey}
+                    options={subagentOptions}
+                    showSearch
+                    optionFilterProp="label"
+                    listHeight={280}
+                    popupMatchSelectWidth={320}
+                    onChange={(value) => {
+                      setSubagentKey(value);
+                      notifyDraft({ subagentKey: value });
+                    }}
+                  />
+                </label>
+              </div>
+              <div className={styles.settingsSection}>
+                <label className={styles.settingsCheckRow}>
+                  <input
+                    type="checkbox"
+                    checked={fallbackEnabled}
+                    onChange={(event) => {
+                      const nextFallbackEnabled = event.target.checked;
+                      setFallbackEnabled(nextFallbackEnabled);
+                      notifyDraft({ fallbackEnabled: nextFallbackEnabled });
+                    }}
+                  />
+                  <span>{t("modelSelector.enableFallback")}</span>
+                </label>
+                {fallbackEnabled && (
+                  <div className={styles.fallbackSettings}>
+                    <div className={styles.settingsField}>
+                      <span className={styles.settingsFieldLabel}>
+                        {t("modelSelector.fallbackScope")}
+                      </span>
+                      {showThinking ? (
+                        <Select
+                          id={fallbackScopeSelectId}
+                          aria-label={t("modelSelector.fallbackScope")}
+                          className={styles.agentSelect}
+                          classNames={{
+                            popup: { root: styles.agentSelectDropdown },
+                          }}
+                          value={fallbackScope}
+                          options={[
+                            {
+                              label: t("modelSelector.configuredModels"),
+                              value: "configured",
+                            },
+                            {
+                              label: t("modelSelector.freeModelsOnly"),
+                              value: "free_only",
+                            },
+                          ]}
+                          onChange={(value) => {
+                            const nextFallbackScope =
+                              value as typeof fallbackScope;
+                            setFallbackScope(nextFallbackScope);
+                            notifyDraft({ fallbackScope: nextFallbackScope });
+                          }}
+                        />
+                      ) : (
+                        <Segmented
+                          aria-label={t("modelSelector.fallbackScope")}
+                          className={styles.fallbackScope}
+                          block
+                          value={fallbackScope}
+                          options={[
+                            {
+                              label: t("modelSelector.configuredModels"),
+                              value: "configured",
+                            },
+                            {
+                              label: t("modelSelector.freeModelsOnly"),
+                              value: "free_only",
+                            },
+                          ]}
+                          onChange={(value) => {
+                            const nextFallbackScope =
+                              value as typeof fallbackScope;
+                            setFallbackScope(nextFallbackScope);
+                            notifyDraft({ fallbackScope: nextFallbackScope });
+                          }}
+                        />
+                      )}
+                    </div>
+                    <div className={styles.settingsField}>
+                      <span className={styles.settingsFieldLabel}>
+                        {t("modelSelector.chooseFallback")}
+                      </span>
+                      <div className={styles.fallbackComposer}>
+                        <label
+                          className={styles.srOnly}
+                          htmlFor={fallbackSelectId}
+                        >
+                          {t("modelSelector.chooseFallback")}
+                        </label>
+                        <Select
+                          id={fallbackSelectId}
+                          aria-label={t("modelSelector.chooseFallback")}
+                          className={styles.agentSelect}
+                          classNames={{
+                            popup: { root: styles.agentSelectDropdown },
+                          }}
+                          value={EMPTY_KEY}
+                          options={fallbackOptions}
+                          showSearch
+                          optionFilterProp="label"
+                          listHeight={280}
+                          popupMatchSelectWidth={320}
+                          onChange={addFallback}
+                        />
+                      </div>
+                    </div>
+                    <div className={styles.fallbackList}>
+                      {fallbackKeys.map((key, index) => (
+                        <div key={key}>
+                          <span title={optionByKey.get(key)?.label ?? key}>
+                            {optionByKey.get(key)?.label ?? key}
+                          </span>
+                          <button
+                            type="button"
+                            aria-label={t("modelSelector.moveFallbackUp", {
+                              model: optionByKey.get(key)?.label ?? key,
+                            })}
+                            disabled={index === 0}
+                            onClick={() => moveFallback(index, -1)}
+                          >
+                            <ChevronUp size={13} />
+                          </button>
+                          <button
+                            type="button"
+                            aria-label={t("modelSelector.moveFallbackDown", {
+                              model: optionByKey.get(key)?.label ?? key,
+                            })}
+                            disabled={index === fallbackKeys.length - 1}
+                            onClick={() => moveFallback(index, 1)}
+                          >
+                            <ChevronDown size={13} />
+                          </button>
+                          <button
+                            type="button"
+                            aria-label={t("modelSelector.removeFallback", {
+                              model: optionByKey.get(key)?.label ?? key,
+                            })}
+                            onClick={() =>
+                              (() => {
+                                const nextFallbackKeys = fallbackKeys.filter(
+                                  (item) => item !== key,
+                                );
+                                setFallbackKeys(nextFallbackKeys);
+                                notifyDraft({
+                                  fallbackKeys: nextFallbackKeys,
+                                });
+                              })()
+                            }
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 )}
-                {t("common.save")}
-              </button>
+              </div>
+              {agentId && (
+                <button
+                  type="button"
+                  className={styles.saveAgentSettings}
+                  aria-label={t(
+                    showThinking
+                      ? "common.save"
+                      : "modelSelector.saveAgentSettings",
+                  )}
+                  disabled={saving}
+                  onClick={save}
+                >
+                  {saving ? (
+                    <LoaderCircle size={14} className={styles.spinning} />
+                  ) : (
+                    <Save size={14} />
+                  )}
+                  {t(
+                    showThinking
+                      ? "common.save"
+                      : "modelSelector.saveAgentSettings",
+                  )}
+                </button>
+              )}
             </>
           )}
         </div>

--- a/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
+++ b/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
@@ -1290,9 +1290,6 @@ describe("ModelSelector", () => {
     );
     const fallbackOptions = screen.getAllByText("OpenAI / GPT-3.5 Turbo");
     await user.click(fallbackOptions[fallbackOptions.length - 1]);
-    await user.click(
-      screen.getByRole("button", { name: "modelSelector.addFallback" }),
-    );
     await user.click(screen.getByRole("button", { name: /common.save/ }));
 
     await waitFor(() =>
@@ -1582,6 +1579,94 @@ describe("ModelSelector", () => {
     expect(agentsApi.updateModelSettings).toHaveBeenCalledWith(
       "default",
       expect.not.objectContaining({ thinking_level: expect.anything() }),
+    );
+  });
+
+  it("hides thinking in the agent management routing editor", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AgentModelSettings
+        agentId="default"
+        providers={[
+          {
+            id: mockProvider.id,
+            name: mockProvider.name,
+            models: mockProvider.models,
+          },
+        ]}
+        activeProviderId="openai"
+        activeModelId="gpt-4"
+        showThinking={false}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /modelSelector.agentModelSettings/,
+      }),
+    );
+
+    expect(
+      screen.queryByRole("combobox", {
+        name: "modelSelector.thinkingLevel",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("modelSelector.thinkingUnsupported"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /modelSelector.saveAgentSettings/ }),
+    );
+    await waitFor(() =>
+      expect(agentsApi.updateModelSettings).toHaveBeenCalledOnce(),
+    );
+    expect(agentsApi.updateModelSettings).toHaveBeenCalledWith(
+      "default",
+      expect.not.objectContaining({ thinking_level: expect.anything() }),
+    );
+  });
+
+  it("reports routing changes from a new-agent draft", async () => {
+    const onDraftChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AgentModelSettings
+        providers={[
+          {
+            id: mockProvider.id,
+            name: mockProvider.name,
+            models: mockProvider.models,
+          },
+        ]}
+        activeProviderId="openai"
+        activeModelId="gpt-4"
+        showThinking={false}
+        initialConfig={{
+          fallback_models: [],
+          fallback_policy: { enabled: true, target_scope: "configured" },
+          subagent_model: null,
+        }}
+        draftResetToken={1}
+        onDraftChange={onDraftChange}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("combobox", {
+        name: "modelSelector.subagentModel",
+      }),
+    );
+    const subagentOptions = screen.getAllByText("OpenAI / GPT-3.5 Turbo");
+    await user.click(subagentOptions[subagentOptions.length - 1]);
+
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        subagent_model: {
+          provider_id: "openai",
+          model: "gpt-3.5-turbo",
+        },
+      }),
     );
   });
 

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -240,6 +240,12 @@
   border-radius: 9px;
 }
 
+.agentModelSettings {
+  margin: 0;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
 .candidateSectionToggle,
 .agentSettingsToggle {
   display: flex;
@@ -401,6 +407,51 @@
   padding: 4px 10px 10px;
 }
 
+.settingsSection {
+  padding: 10px 0;
+  border-top: 1px solid var(--ms-border);
+}
+
+.settingsSection:first-child {
+  border-top: 0;
+}
+
+.settingsSectionHeader {
+  display: flex;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+
+.settingsSectionTitle,
+.settingsFieldLabel {
+  color: var(--ms-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.settingsControl {
+  display: block;
+}
+
+.fallbackSettings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.settingsField {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.settingsFieldLabel {
+  color: var(--ms-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
 .settingsRow {
   display: grid;
   grid-template-columns: 102px minmax(0, 1fr);
@@ -542,29 +593,66 @@
 }
 
 .fallbackComposer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 36px;
-  gap: 8px;
+  display: block;
+}
 
-  button {
-    min-width: 0;
-    padding: 0;
-    border: 1px solid var(--ms-border);
-    border-radius: 8px;
-    color: var(--ms-text);
-    background: var(--ms-surface);
+.fallbackScope {
+  width: 100%;
+  min-height: 36px;
+  padding: 3px;
+  border: 1px solid var(--ms-border);
+  border-radius: 8px;
+  color: var(--ms-text-muted);
+  background: var(--ms-surface);
+
+  :global(.ant-segmented-group),
+  :global(.qwenpaw-segmented-group) {
+    gap: 3px;
   }
 
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
+  :global(.ant-segmented-item),
+  :global(.qwenpaw-segmented-item) {
+    min-height: 28px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--ms-text-muted);
+    font-size: 12px;
+    line-height: 28px;
+  }
 
-    &:disabled {
-      cursor: not-allowed;
-      opacity: 0.46;
-    }
+  :global(.ant-segmented-item-label),
+  :global(.qwenpaw-segmented-item-label) {
+    min-height: 28px;
+    line-height: 28px;
+  }
+
+  :global(.ant-segmented-item-selected),
+  :global(.qwenpaw-segmented-item-selected) {
+    border-color: color-mix(
+      in srgb,
+      var(--ms-accent) 42%,
+      transparent
+    ) !important;
+    color: var(--ms-accent-strong) !important;
+    font-weight: 600;
+    background: color-mix(
+      in srgb,
+      var(--ms-accent) 16%,
+      var(--ms-surface)
+    ) !important;
+    box-shadow: none !important;
+  }
+
+  :global(.ant-segmented-thumb),
+  :global(.qwenpaw-segmented-thumb) {
+    border: 1px solid color-mix(in srgb, var(--ms-accent) 42%, transparent) !important;
+    border-radius: 6px;
+    background: color-mix(
+      in srgb,
+      var(--ms-accent) 16%,
+      var(--ms-surface)
+    ) !important;
+    box-shadow: none !important;
   }
 }
 
@@ -605,8 +693,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  align-self: flex-end;
   gap: 6px;
-  padding: 7px 10px;
+  min-width: 132px;
+  padding: 7px 14px;
   border: 0;
   border-radius: 7px;
   color: #fff;
@@ -732,6 +822,7 @@
 .panel,
 .trigger,
 .oauthModalContent,
+.agentModelSettings,
 .agentSelectDropdown {
   --ms-primary: var(--qwenpaw-color-primary, var(--colorPrimary, #ff7f16));
   --ms-accent: var(--qwenpaw-color-primary, var(--colorPrimary, #ff7f16));
@@ -1004,7 +1095,7 @@
 .candidateModelSection,
 .agentModelSettings {
   border-color: var(--ms-border);
-  background: var(--ms-surface-muted);
+  background: var(--ms-surface);
   box-shadow: none;
 }
 
@@ -1045,6 +1136,19 @@
 .candidateSectionToggle,
 .agentSettingsToggle {
   min-height: 40px;
+}
+
+.agentSettingsToggle {
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: 0;
+  color: var(--ms-text);
+  font-size: 13px;
+  font-weight: 600;
+
+  &[aria-expanded="true"] {
+    border-bottom: 1px solid var(--ms-border);
+  }
 }
 
 .candidateSectionToggle:focus-visible,
@@ -1264,6 +1368,7 @@
   .panel,
   .trigger,
   .oauthModalContent,
+  .agentModelSettings,
   .agentSelectDropdown {
     --ms-primary: var(--qwenpaw-color-primary, var(--colorPrimary, #ff9d4d));
     --ms-accent: var(--qwenpaw-color-primary, var(--colorPrimary, #ff9d4d));
@@ -1295,9 +1400,12 @@
   }
 
   .candidateItem,
-  .candidateModelSection,
-  .agentModelSettings {
+  .candidateModelSection {
     background: var(--ms-surface-muted);
+  }
+
+  .agentModelSettings {
+    background: var(--ms-surface);
   }
 
   .modelItem:hover,
@@ -1313,6 +1421,26 @@
   .hiddenModels,
   .fallbackList span {
     color: var(--ms-text-muted);
+  }
+
+  .fallbackScope {
+    background: var(--ms-surface);
+
+    :global(.ant-segmented-item-selected),
+    :global(.qwenpaw-segmented-item-selected) {
+      border-color: color-mix(
+        in srgb,
+        var(--ms-accent) 52%,
+        transparent
+      ) !important;
+      color: var(--ms-accent-strong) !important;
+      background: color-mix(
+        in srgb,
+        var(--ms-accent) 24%,
+        var(--ms-surface)
+      ) !important;
+      box-shadow: none !important;
+    }
   }
 
   .candidateSectionToggle:hover:not(:disabled),
@@ -1343,12 +1471,6 @@
     :global(.ant-select-selection-search-input) {
       color: var(--ms-text) !important;
     }
-  }
-
-  .fallbackComposer button {
-    color: var(--ms-text);
-    background: var(--ms-surface);
-    border-color: var(--ms-border);
   }
 
   .fallbackList > div {

--- a/console/src/pages/Settings/Agents/components/AgentModal.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentModal.tsx
@@ -14,13 +14,15 @@ import {
 } from "antd";
 import { CheckOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
-import type { AgentSummary } from "@/api/types/agents";
+import type { AgentProfileConfig, AgentSummary } from "@/api/types/agents";
+import type { ModelInfo } from "@/api/types/provider";
 import type { ProviderInfo } from "@/api/types/provider";
 import { getAgentDisplayName } from "@/utils/agentDisplayName";
 import type { PoolSkillSpec } from "@/api/types/skill";
 import { skillApi } from "@/api/modules/skill";
 import { providerApi } from "@/api/modules/provider";
 import { providerIcon } from "../../Models/components/providerIcon";
+import { AgentModelSettings } from "../../../Chat/ModelSelector/AgentModelSettings";
 import styles from "../index.module.less";
 import { AgentBackendFields } from "./AgentBackendFields";
 import {
@@ -74,8 +76,13 @@ const LEGACY_MAIL_PUSH_MODE_LABEL_KEYS: Record<string, string> = {
 interface EligibleProvider {
   id: string;
   name: string;
-  models: Array<{ id: string; name: string }>;
+  models: ModelInfo[];
 }
+
+type ModelSettingsDraft = Pick<
+  AgentProfileConfig,
+  "fallback_models" | "fallback_policy" | "subagent_model"
+>;
 
 interface AgentModalProps {
   open: boolean;
@@ -84,6 +91,9 @@ interface AgentModalProps {
   selectedSkills: string[];
   onSelectedSkillsChange: (skills: string[]) => void;
   onInstalledSkillsLoaded: (skills: string[]) => void;
+  modelSettings?: ModelSettingsDraft;
+  modelSettingsResetToken?: number;
+  onModelSettingsChange?: (settings: ModelSettingsDraft) => void;
   onSave: () => Promise<void>;
   onCancel: () => void;
 }
@@ -95,6 +105,9 @@ export function AgentModal({
   selectedSkills,
   onSelectedSkillsChange,
   onInstalledSkillsLoaded,
+  modelSettings,
+  modelSettingsResetToken,
+  onModelSettingsChange,
   onSave,
   onCancel,
 }: AgentModalProps) {
@@ -373,6 +386,20 @@ export function AgentModal({
             />
           </Space.Compact>
         </Form.Item>
+        {selectedBackend === "qwenpaw" && (
+          <Form.Item className={styles.agentRoutingFormItem}>
+            <AgentModelSettings
+              agentId={editingAgent?.id}
+              providers={eligibleProviders}
+              activeProviderId={selectedProviderId}
+              activeModelId={selectedModelId}
+              showThinking={false}
+              initialConfig={modelSettings}
+              draftResetToken={modelSettingsResetToken}
+              onDraftChange={onModelSettingsChange}
+            />
+          </Form.Item>
+        )}
         <Form.Item
           name="workspace_dir"
           label={t("agent.workspace")}

--- a/console/src/pages/Settings/Agents/index.module.less
+++ b/console/src/pages/Settings/Agents/index.module.less
@@ -155,6 +155,16 @@
   background: #fff4e9;
 }
 
+.agentRoutingFormItem {
+  padding-top: 4px;
+  margin-bottom: 20px;
+
+  :global(.ant-form-item-control-input),
+  :global(.qwenpaw-form-item-control-input) {
+    min-height: 0;
+  }
+}
+
 .dragHandleButton {
   width: 28px;
   height: 28px;

--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -5,7 +5,11 @@ import { PlusOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { agentsApi } from "../../../api/modules/agents";
 import { invalidateSkillCache, skillApi } from "../../../api/modules/skill";
-import type { AgentSummary, CopyAgentRequest } from "../../../api/types/agents";
+import type {
+  AgentProfileConfig,
+  AgentSummary,
+  CopyAgentRequest,
+} from "../../../api/types/agents";
 import { useAgentStore } from "../../../stores/agentStore";
 import { useAgents } from "./useAgents";
 import { AgentTable, AgentModal, CopyAgentModal } from "./components";
@@ -13,6 +17,17 @@ import { MAIL_DOMAIN_WHITELIST } from "./components/mailDomains";
 import { PageHeader } from "@/components/PageHeader";
 import { reorderAgents } from "./reorder";
 import styles from "./index.module.less";
+
+type ModelSettingsDraft = Pick<
+  AgentProfileConfig,
+  "fallback_models" | "fallback_policy" | "subagent_model"
+>;
+
+const EMPTY_MODEL_SETTINGS: ModelSettingsDraft = {
+  fallback_models: [],
+  fallback_policy: { enabled: true, target_scope: "configured" },
+  subagent_model: null,
+};
 
 export default function AgentsPage() {
   const { t, i18n } = useTranslation();
@@ -34,11 +49,16 @@ export default function AgentsPage() {
   const [reordering, setReordering] = useState(false);
   const [form] = Form.useForm();
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [modelSettings, setModelSettings] =
+    useState<ModelSettingsDraft>(EMPTY_MODEL_SETTINGS);
+  const [modelSettingsResetToken, setModelSettingsResetToken] = useState(0);
   const installedSkillsRef = useRef<string[]>([]);
   const { message } = useAppMessage();
 
   const handleCreate = () => {
     setEditingAgent(null);
+    setModelSettings(EMPTY_MODEL_SETTINGS);
+    setModelSettingsResetToken((token) => token + 1);
     form.resetFields();
     form.setFieldsValue({
       workspace_dir: "",
@@ -294,6 +314,7 @@ export default function AgentsPage() {
       } else {
         const result = await agentsApi.createAgent({
           ...payload,
+          ...(values.backend === "qwenpaw" ? modelSettings : {}),
           language: i18n.language,
           skill_names: values.backend === "qwenpaw" ? selectedSkills : [],
         });
@@ -374,6 +395,9 @@ export default function AgentsPage() {
         selectedSkills={selectedSkills}
         onSelectedSkillsChange={setSelectedSkills}
         onInstalledSkillsLoaded={handleInstalledSkillsLoaded}
+        modelSettings={editingAgent ? undefined : modelSettings}
+        modelSettingsResetToken={modelSettingsResetToken}
+        onModelSettingsChange={(settings) => setModelSettings(settings)}
         onSave={handleSubmit}
         onCancel={() => setModalVisible(false)}
       />

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -250,6 +250,11 @@ class CreateAgentRequest(BaseModel):
     language: str | None = None
     skill_names: list[str] | None = None
     active_model: ModelSlotConfig | None = None
+    fallback_models: list[ModelSlotConfig] = Field(default_factory=list)
+    fallback_policy: FallbackPolicyConfig = Field(
+        default_factory=FallbackPolicyConfig,
+    )
+    subagent_model: ModelSlotConfig | None = None
     mail: AgentMailConfig | None = None
     backend: str = "qwenpaw"
     backend_settings: dict[str, Any] = Field(default_factory=dict)
@@ -840,6 +845,9 @@ async def create_agent(
         heartbeat=HeartbeatConfig(),
         tools=ToolsConfig(),
         active_model=active_model,
+        fallback_models=request.fallback_models,
+        fallback_policy=request.fallback_policy,
+        subagent_model=request.subagent_model,
         mail=request.mail,
     )
 

--- a/tests/integration/test_multi_agent_lifecycle.py
+++ b/tests/integration/test_multi_agent_lifecycle.py
@@ -80,6 +80,46 @@ def test_create_agent_with_full_options(app_server) -> None:
 
 @pytest.mark.integration
 @pytest.mark.p1
+def test_create_agent_persists_model_routing(app_server) -> None:
+    """Verify model routing fields are persisted during agent creation."""
+    agent_id = "integ_ma_routing_01"
+    fallback_models = [
+        {"provider_id": "openai", "model": "fallback-model"},
+    ]
+    fallback_policy = {"enabled": True, "target_scope": "free_only"}
+    subagent_model = {"provider_id": "openai", "model": "subagent-model"}
+
+    try:
+        resp = app_server.api_request(
+            "POST",
+            "/api/agents",
+            json={
+                "id": agent_id,
+                "name": "Routing Agent",
+                "fallback_models": fallback_models,
+                "fallback_policy": fallback_policy,
+                "subagent_model": subagent_model,
+            },
+            timeout=_AGENT_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 201, app_server.logs_tail()
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}",
+            timeout=_AGENT_HTTP_TIMEOUT,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        profile = get_resp.json()
+        assert profile.get("fallback_models") == fallback_models
+        assert profile.get("fallback_policy") == fallback_policy
+        assert profile.get("subagent_model") == subagent_model
+    finally:
+        delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
 def test_create_agent_auto_id_when_omitted(app_server) -> None:
     """Test purpose:
     - Verify POST /api/agents without an id returns 201 with an


### PR DESCRIPTION
Added sub-agent model configuration to the agent management section.

Added a toggle and scope selection for fallback models:

Configured models

Free models only

Added a selection option for backup models; they are added immediately upon selection, without needing to click a plus sign.

Supported reordering and removal of backup models.

Hid the "thinking" configuration in the agent management interface while retaining the existing "thinking" functionality on the chat page.

Fixed the selected state display for the fallback scope (using the theme color).

Saved sub-agent models, backup models, and fallback strategies when creating an agent.

Updated backend creation API fields and persisted model routing configurations.

Fixes #7493

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
