### PR TITLE
fix(mcp): enforce per-tool whitelist on the agent runtime path

### DIFF
--- a/src/qwenpaw/app/mcp/config_service.py
+++ b/src/qwenpaw/app/mcp/config_service.py
@@ -31,6 +31,7 @@ from ...drivers.adapters.mcp_console import (
     mcp_credential_ref,
     mcp_oauth_credential_ref,
 )
+from ...drivers.capabilities import mcp_tool_is_enabled, mcp_tool_whitelist
 from ...drivers.constants import (
     CAPABILITY_KIND_TOOL,
     CREDENTIAL_ALIAS_OAUTH,
@@ -147,14 +148,13 @@ class MCPConfigService:
                 detail=f"Failed to query tools from MCP server: {exc}",
             ) from exc
 
-        whitelist = card.config.get("tools")
-        whitelist_set = set(whitelist) if whitelist is not None else None
+        # Disk card is source of truth; in-memory capability.enabled may lag.
+        whitelist = mcp_tool_whitelist(card.config.get("tools"))
         return [
             MCPToolInfo(
                 name=capability.name,
                 description=capability.description,
-                enabled=whitelist_set is None
-                or capability.name in whitelist_set,
+                enabled=mcp_tool_is_enabled(whitelist, capability.name),
                 input_schema=capability.input_schema,
             )
             for capability in capabilities
@@ -174,7 +174,22 @@ class MCPConfigService:
         card = await self.load_card(client_key)
         card.config = dict(card.config)
         card.config["tools"] = tools
-        await self._driver_config.save_card(card)
+        await self._driver_config.save_card(card, reload_driver=False)
+        manager = getattr(self._workspace, "driver_manager", None)
+        if manager is not None:
+            try:
+                await manager.refresh_driver(client_key)
+            except Exception as exc:
+                logger.warning(
+                    "MCP client '%s' whitelist saved but driver not "
+                    "refreshed: %s",
+                    client_key,
+                    exc,
+                    exc_info=True,
+                )
+                await self._driver_config.reload_driver_best_effort(
+                    client_key,
+                )
         try:
             return await self.list_tools(client_key)
         except HTTPException:

--- a/src/qwenpaw/app/mcp/config_service.py
+++ b/src/qwenpaw/app/mcp/config_service.py
@@ -179,12 +179,9 @@ class MCPConfigService:
         if manager is not None:
             try:
                 await manager.refresh_driver(client_key)
-            except Exception as exc:
+            except Exception:
                 logger.warning(
-                    "MCP client '%s' whitelist saved but driver not "
-                    "refreshed: %s",
-                    client_key,
-                    exc,
+                    "MCP tool whitelist saved but driver was not refreshed",
                     exc_info=True,
                 )
                 await self._driver_config.reload_driver_best_effort(

--- a/src/qwenpaw/app/mcp/config_service.py
+++ b/src/qwenpaw/app/mcp/config_service.py
@@ -179,14 +179,14 @@ class MCPConfigService:
         if manager is not None:
             try:
                 await manager.refresh_driver(client_key)
-            except Exception:
-                logger.warning(
-                    "MCP tool whitelist saved but driver was not refreshed",
-                    exc_info=True,
-                )
-                await self._driver_config.reload_driver_best_effort(
-                    client_key,
-                )
+            except Exception as exc:
+                raise HTTPException(
+                    502,
+                    detail=(
+                        f"MCP tool whitelist saved but failed to apply to "
+                        f"the active runtime: {exc}"
+                    ),
+                ) from exc
         try:
             return await self.list_tools(client_key)
         except HTTPException:

--- a/src/qwenpaw/drivers/adapters/agentscope_tool.py
+++ b/src/qwenpaw/drivers/adapters/agentscope_tool.py
@@ -205,6 +205,7 @@ async def build_driver_agent_tools(
             )
             for capability in driver_capabilities
             if getattr(capability.exposure, "as_tool", False)
+            and getattr(capability, "enabled", True)
         ]
     except Exception:
         logger.debug(

--- a/src/qwenpaw/drivers/capabilities.py
+++ b/src/qwenpaw/drivers/capabilities.py
@@ -22,6 +22,8 @@ __all__ = [
     "DriverInvocationResult",
     "DriverRuntimeInfo",
     "format_capability_id",
+    "mcp_tool_is_enabled",
+    "mcp_tool_whitelist",
     "parse_capability_id",
 ]
 
@@ -50,6 +52,8 @@ class DriverCapability:
     output_schema: dict[str, Any] = field(default_factory=dict)
     exposure: CapabilityExposure = field(default_factory=CapabilityExposure)
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Per-tool whitelist from card.config.tools, not the Driver enable switch.
+    enabled: bool = True
 
 
 @dataclass(frozen=True)
@@ -101,6 +105,20 @@ def format_capability_id(
         f"{_encode_part(name)}"
         f"#{_encode_part(action)}"
     )
+
+
+def mcp_tool_whitelist(whitelist: Any) -> frozenset[str] | None:
+    """Normalize ``card.config.tools``: non-list is open, ``[]`` is closed."""
+    if not isinstance(whitelist, list):
+        return None
+    return frozenset(str(item) for item in whitelist)
+
+
+def mcp_tool_is_enabled(
+    whitelist: frozenset[str] | None,
+    name: str,
+) -> bool:
+    return whitelist is None or name in whitelist
 
 
 def parse_capability_id(capability_id: str) -> tuple[str, str, str, str, str]:

--- a/src/qwenpaw/drivers/handlers/mcp.py
+++ b/src/qwenpaw/drivers/handlers/mcp.py
@@ -15,6 +15,8 @@ from ..capabilities import (
     DriverInvocation,
     DriverInvocationResult,
     format_capability_id,
+    mcp_tool_is_enabled,
+    mcp_tool_whitelist,
     parse_capability_id,
 )
 from ..constants import (
@@ -115,6 +117,26 @@ class MCPDriverHandler(DriverHandler):
             await self._client.close()
             self._client = None
 
+    def sync_runtime_metadata(self, card: DriverCard) -> None:
+        """Refresh card metadata and drop stale capability cache on config."""
+        if card.config != self._card.config:
+            self._capability_cache = None
+        super().sync_runtime_metadata(card)
+
+    def _card_tool_whitelist(
+        self,
+        *,
+        warn: bool = False,
+    ) -> frozenset[str] | None:
+        raw = self._card.config.get("tools")
+        if warn and raw is not None and not isinstance(raw, list):
+            logger.warning(
+                "MCP driver '%s' config.tools is %s; treating as open",
+                self.name,
+                type(raw).__name__,
+            )
+        return mcp_tool_whitelist(raw)
+
     async def _execute(
         self,
         credential: ResolvedCredential,
@@ -150,18 +172,20 @@ class MCPDriverHandler(DriverHandler):
                 return list(cached)
 
         tools = await self.list_tools()
+        whitelist = self._card_tool_whitelist(warn=True)
         capabilities = [
             _mcp_tool_to_capability(
                 self.name,
                 tool,
                 display_name=str(self._card.config.get("display_name") or ""),
+                whitelist=whitelist,
             )
             for tool in tools
         ]
         self._capability_cache = (now, capabilities)
         return list(capabilities)
 
-    async def invoke_capability(
+    async def invoke_capability(  # pylint: disable=too-many-return-statements
         self,
         invocation: DriverInvocation,
     ) -> DriverInvocationResult:
@@ -194,6 +218,20 @@ class MCPDriverHandler(DriverHandler):
                 message=(
                     f"Unsupported MCP capability: {invocation.capability_id}"
                 ),
+            )
+        whitelist = self._card_tool_whitelist()
+        if not mcp_tool_is_enabled(whitelist, tool_name):
+            return DriverInvocationResult(
+                ok=False,
+                error_type="tool_disabled",
+                message=(
+                    f"MCP tool '{tool_name}' is disabled for driver "
+                    f"'{self.name}'"
+                ),
+                metadata={
+                    "driver_name": self.name,
+                    "tool_name": tool_name,
+                },
             )
         subjects = _subjects_from_context(invocation.request_context)
         subject = subjects[0]
@@ -336,6 +374,7 @@ def _mcp_tool_to_capability(
     tool: Any,
     *,
     display_name: str = "",
+    whitelist: frozenset[str] | None = None,
 ) -> DriverCapability:
     raw_tool = getattr(tool, "_tool", tool)
     name = str(getattr(raw_tool, "name", getattr(tool, "name", tool)))
@@ -396,6 +435,7 @@ def _mcp_tool_to_capability(
             "driver_key": driver_name,
             "display_name": display_name or driver_name,
         },
+        enabled=mcp_tool_is_enabled(whitelist, name),
     )
 
 

--- a/src/qwenpaw/harnesses/capabilities/resolver.py
+++ b/src/qwenpaw/harnesses/capabilities/resolver.py
@@ -17,6 +17,7 @@ from ...agents.skill_system import (
 )
 from ...agents.skill_system.store import read_skill_from_dir
 from ...app.driver_config_service import DriverConfigService
+from ...drivers.capabilities import mcp_tool_whitelist
 from ...drivers.constants import (
     CAPABILITY_KIND_TOOL,
     CREDENTIAL_ALIAS_DEFAULT,
@@ -149,8 +150,9 @@ class HarnessCapabilityResolver:
         )
         headers.update(implicit_auth_headers(credentials, headers))
         tools = card.config.get("tools")
+        whitelist = mcp_tool_whitelist(tools)
         tool_names = (
-            [str(item) for item in tools] if isinstance(tools, list) else None
+            None if whitelist is None else [str(item) for item in tools]
         )
         return HarnessMCPServerDefinition(
             name=card.name,

--- a/tests/unit/drivers/handlers/test_mcp_tool_whitelist.py
+++ b/tests/unit/drivers/handlers/test_mcp_tool_whitelist.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""MCP per-tool whitelist: discovery tags, assembly filters, invoke rejects."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qwenpaw.app.mcp.config_service import MCPConfigService
+from qwenpaw.drivers.adapters.agentscope_tool import build_driver_agent_tools
+from qwenpaw.drivers.capabilities import (
+    CapabilityExposure,
+    DriverCapability,
+    DriverInvocation,
+    DriverInvocationResult,
+    format_capability_id,
+    mcp_tool_is_enabled,
+    mcp_tool_whitelist,
+)
+from qwenpaw.drivers.contracts import DriverCard
+from qwenpaw.drivers.credentials.providers import NoneProvider
+from qwenpaw.drivers.handlers.mcp import (
+    MCPDriverHandler,
+    _mcp_tool_to_capability,
+)
+
+
+def _tool(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description="", inputSchema={})
+
+
+def _handler(tools_config: Any) -> MCPDriverHandler:
+    card = DriverCard(
+        name="fs",
+        protocol="mcp",
+        endpoint={"transport": "stdio", "command": "true"},
+        config={"tools": tools_config},
+    )
+    return MCPDriverHandler(card, NoneProvider())
+
+
+@pytest.mark.parametrize(
+    ("whitelist", "name", "expected"),
+    [
+        (None, "write", True),
+        ([], "write", False),
+        (["read"], "read", True),
+        (["read"], "write", False),
+        ("read", "write", True),
+    ],
+)
+def test_mcp_tool_is_enabled(
+    whitelist: Any,
+    name: str,
+    expected: bool,
+) -> None:
+    assert mcp_tool_is_enabled(mcp_tool_whitelist(whitelist), name) is expected
+
+
+@pytest.mark.parametrize(
+    ("whitelist", "expected"),
+    [
+        (None, True),
+        (["read"], True),
+        (["write"], False),
+        ([], False),
+    ],
+)
+def test_mcp_capability_enabled_from_whitelist(
+    whitelist: list[str] | None,
+    expected: bool,
+) -> None:
+    capability = _mcp_tool_to_capability(
+        "fs",
+        _tool("read"),
+        whitelist=mcp_tool_whitelist(whitelist),
+    )
+    assert capability.name == "read"
+    assert capability.enabled is expected
+    assert capability.exposure.as_tool is True
+
+
+def test_mcp_prefixed_tool_name_uses_raw_whitelist_key() -> None:
+    capability = _mcp_tool_to_capability(
+        "fs",
+        _tool("mcp__fs__read"),
+        whitelist=mcp_tool_whitelist(["read"]),
+    )
+    assert capability.name == "read"
+    assert capability.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_build_driver_agent_tools_omits_disabled() -> None:
+    enabled = DriverCapability(
+        capability_id="on",
+        driver_name="fs",
+        protocol="mcp",
+        kind="tool",
+        action="invoke",
+        name="read",
+        exposure=CapabilityExposure(as_tool=True, tool_name="fs__read"),
+        enabled=True,
+    )
+    disabled = DriverCapability(
+        capability_id="off",
+        driver_name="fs",
+        protocol="mcp",
+        kind="tool",
+        action="invoke",
+        name="write",
+        exposure=CapabilityExposure(as_tool=True, tool_name="fs__write"),
+        enabled=False,
+    )
+
+    class _Manager:
+        async def list_capabilities(
+            self,
+            **_kwargs: Any,
+        ) -> list[DriverCapability]:
+            return [enabled, disabled]
+
+        async def invoke_capability(self, *_args: Any, **_kwargs: Any) -> Any:
+            return DriverInvocationResult(ok=True)
+
+    tools, _hints = await build_driver_agent_tools(_Manager(), {})
+    assert [tool.name for tool in tools] == ["fs__read"]
+
+
+@pytest.mark.asyncio
+async def test_build_driver_agent_tools_missing_enabled_stays_open() -> None:
+    cap = SimpleNamespace(
+        exposure=CapabilityExposure(as_tool=True, tool_name="fs__read"),
+        name="read",
+        description="",
+        input_schema={},
+    )
+
+    class _Manager:
+        async def list_capabilities(self, **_kwargs: Any) -> list[Any]:
+            return [cap]
+
+        async def invoke_capability(self, *_args: Any, **_kwargs: Any) -> Any:
+            return DriverInvocationResult(ok=True)
+
+    tools, _hints = await build_driver_agent_tools(_Manager(), {})
+    assert [tool.name for tool in tools] == ["fs__read"]
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_reads_card_config_tools() -> None:
+    handler = _handler(["read"])
+
+    async def _list_tools() -> list[SimpleNamespace]:
+        return [_tool("read"), _tool("write")]
+
+    handler.list_tools = _list_tools  # type: ignore[method-assign]
+    capabilities = await handler.list_capabilities()
+    assert {item.name: item.enabled for item in capabilities} == {
+        "read": True,
+        "write": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_runtime_metadata_clears_capability_cache() -> None:
+    handler = _handler(["read"])
+
+    async def _list_tools() -> list[SimpleNamespace]:
+        return [_tool("read"), _tool("write")]
+
+    handler.list_tools = _list_tools  # type: ignore[method-assign]
+    await handler.list_capabilities()
+    assert handler._capability_cache is not None
+
+    handler.sync_runtime_metadata(
+        DriverCard(
+            name="fs",
+            protocol="mcp",
+            endpoint={"transport": "stdio", "command": "true"},
+            config={"tools": ["read", "write"]},
+        ),
+    )
+    assert handler._capability_cache is None
+    capabilities = await handler.list_capabilities()
+    assert {item.name: item.enabled for item in capabilities} == {
+        "read": True,
+        "write": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_disabled_tools_omitted_from_toolkit() -> None:
+    handler = _handler(["read"])
+
+    async def _list_tools() -> list[SimpleNamespace]:
+        return [_tool("read"), _tool("write")]
+
+    handler.list_tools = _list_tools  # type: ignore[method-assign]
+    capabilities = await handler.list_capabilities()
+
+    class _Manager:
+        async def list_capabilities(
+            self,
+            **_kwargs: Any,
+        ) -> list[DriverCapability]:
+            return capabilities
+
+        async def invoke_capability(self, *_args: Any, **_kwargs: Any) -> Any:
+            return DriverInvocationResult(ok=True)
+
+    tools, _hints = await build_driver_agent_tools(_Manager(), {})
+    assert [tool.name for tool in tools] == ["fs__read"]
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_non_list_whitelist_is_open() -> None:
+    handler = _handler("read")
+
+    async def _list_tools() -> list[SimpleNamespace]:
+        return [_tool("read"), _tool("write")]
+
+    handler.list_tools = _list_tools  # type: ignore[method-assign]
+    capabilities = await handler.list_capabilities()
+    assert all(item.enabled for item in capabilities)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tools_config", "tool_name", "disabled"),
+    [
+        (["read"], "write", True),
+        (["read"], "read", False),
+        ([], "read", True),
+    ],
+)
+async def test_invoke_capability_whitelist_contract(
+    tools_config: list[str],
+    tool_name: str,
+    disabled: bool,
+) -> None:
+    handler = _handler(tools_config)
+    result = await handler.invoke_capability(
+        DriverInvocation(
+            capability_id=format_capability_id(
+                "mcp",
+                "fs",
+                "tool",
+                "invoke",
+                tool_name,
+            ),
+            payload={},
+        ),
+    )
+    if disabled:
+        assert result.ok is False
+        assert result.error_type == "tool_disabled"
+        assert result.metadata == {
+            "driver_name": "fs",
+            "tool_name": tool_name,
+        }
+        return
+    assert result.error_type != "tool_disabled"
+
+
+def _whitelist_service(*, refresh_fails: bool) -> tuple[Any, ...]:
+    card = DriverCard(
+        name="fs",
+        protocol="mcp",
+        endpoint={"transport": "stdio", "command": "true"},
+        config={"tools": ["write"]},
+    )
+    saves: list[bool] = []
+    refreshed: list[str] = []
+    reloads: list[str] = []
+
+    class _Store:
+        async def load_card(self, *_args: Any, **_kwargs: Any) -> DriverCard:
+            return card
+
+        async def save_card(
+            self,
+            saved: DriverCard,
+            *,
+            reload_driver: bool = True,
+        ) -> None:
+            card.config = dict(saved.config)
+            saves.append(reload_driver)
+
+        async def list_driver_capabilities(
+            self,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> list[Any]:
+            return []
+
+        async def reload_driver_best_effort(self, name: str) -> None:
+            reloads.append(name)
+
+    class _Manager:
+        async def refresh_driver(self, name: str) -> None:
+            refreshed.append(name)
+            if refresh_fails:
+                raise RuntimeError("refresh failed")
+
+        async def reload_driver(self, name: str) -> None:
+            raise AssertionError("reload_driver should not run")
+
+    service = MCPConfigService(SimpleNamespace(driver_manager=_Manager()))
+    service._driver_config = _Store()
+    return service, card, saves, refreshed, reloads
+
+
+@pytest.mark.asyncio
+async def test_update_tool_whitelist_refreshes_without_reload() -> None:
+    service, card, saves, refreshed, reloads = _whitelist_service(
+        refresh_fails=False,
+    )
+    result = await service.update_tool_whitelist("fs", ["read"])
+    assert saves == [False]
+    assert refreshed == ["fs"]
+    assert not reloads
+    assert card.config["tools"] == ["read"]
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_update_tool_whitelist_falls_back_when_refresh_fails() -> None:
+    service, card, saves, refreshed, reloads = _whitelist_service(
+        refresh_fails=True,
+    )
+    result = await service.update_tool_whitelist("fs", ["read"])
+    assert saves == [False]
+    assert refreshed == ["fs"]
+    assert reloads == ["fs"]
+    assert card.config["tools"] == ["read"]
+    assert result == []

--- a/tests/unit/drivers/handlers/test_mcp_tool_whitelist.py
+++ b/tests/unit/drivers/handlers/test_mcp_tool_whitelist.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from fastapi import HTTPException
 
 from qwenpaw.app.mcp.config_service import MCPConfigService
 from qwenpaw.drivers.adapters.agentscope_tool import build_driver_agent_tools
@@ -328,13 +329,14 @@ async def test_update_tool_whitelist_refreshes_without_reload() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_tool_whitelist_falls_back_when_refresh_fails() -> None:
+async def test_update_tool_whitelist_rejects_when_refresh_fails() -> None:
     service, card, saves, refreshed, reloads = _whitelist_service(
         refresh_fails=True,
     )
-    result = await service.update_tool_whitelist("fs", ["read"])
+    with pytest.raises(HTTPException) as caught:
+        await service.update_tool_whitelist("fs", ["read"])
+    assert caught.value.status_code == 502
     assert saves == [False]
     assert refreshed == ["fs"]
-    assert reloads == ["fs"]
+    assert not reloads
     assert card.config["tools"] == ["read"]
-    assert result == []

--- a/tests/unit/drivers/test_capabilities.py
+++ b/tests/unit/drivers/test_capabilities.py
@@ -103,6 +103,7 @@ class TestCapabilityDataclasses:
         assert not cap.output_schema
         assert cap.exposure == CapabilityExposure()
         assert not cap.metadata
+        assert cap.enabled is True
         with pytest.raises(AttributeError):  # frozen dataclass
             cap.name = "x"
 


### PR DESCRIPTION
## Description

- `card.config.tools` was only used for Console display and the external harness path after the 2.0 Driver rewrite, so disabled MCP tools still appeared in the agent toolkit and remained callable.
- Tag each MCP capability with `enabled` from the whitelist (`None` = all on, `[]` = all off), omit disabled tools in `build_driver_agent_tools`, and reject invoke with `tool_disabled` before policy/execution.
- Whitelist saves now `refresh_driver` (no reconnect); if that fails, fall back to the existing background reload.

**Related Issue:** Fixes #7470 or Relates to #7470

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
