### PR TITLE
fix(agent): fold consumed thinking under context pressure

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -119,6 +119,13 @@ class ScrollContextManager:
         # recovery fold old results in the active turn without guessing from
         # block order. It is checkpointed with the rest of the manager state.
         self._seen_tool_result_ids: set[str] = set()
+        # Thinking blocks included in a model request that completed
+        # successfully. Under sustained pressure their text may be omitted from
+        # later wire requests without mutating the live Msg or its durable
+        # history row. The separate folded set keeps that request-time choice
+        # stable across subsequent reasoning steps and session checkpoints.
+        self._seen_thinking_block_ids: set[str] = set()
+        self._folded_thinking_block_ids: set[str] = set()
         self._seq_by_tcid: dict[
             str,
             int,
@@ -149,6 +156,7 @@ class ScrollContextManager:
             "pre_folded": 0,
             "live_folded": 0,
             "active_folded": 0,
+            "active_thinking_folded": 0,
             "folded": 0,
         }
         # Warn once per overflow episode, not once per reasoning step.
@@ -272,6 +280,21 @@ class ScrollContextManager:
                 ids.add(str(tcid))
         return ids
 
+    def model_input_thinking_block_ids(self, agent: Any) -> set[str]:
+        """Snapshot active thinking blocks about to be sent to the model.
+
+        Previously folded ids are first applied to the request formatter so
+        resumed sessions keep the same bounded wire representation. Only
+        blocks whose reasoning text is still being relayed are returned for
+        acknowledgement after a successful request.
+        """
+        self._apply_folded_thinking_filter(agent)
+        return {
+            block_id
+            for block_id, _ in self._active_thinking_blocks(agent)
+            if block_id not in self._folded_thinking_block_ids
+        }
+
     def acknowledge_model_input_tool_results(
         self,
         tool_result_ids: set[str],
@@ -279,6 +302,15 @@ class ScrollContextManager:
         """Mark a successfully submitted model input's results as seen."""
         self._seen_tool_result_ids.update(
             str(item) for item in tool_result_ids
+        )
+
+    def acknowledge_model_input_thinking_blocks(
+        self,
+        thinking_block_ids: set[str],
+    ) -> None:
+        """Mark successfully submitted active reasoning as safe to fold."""
+        self._seen_thinking_block_ids.update(
+            str(item) for item in thinking_block_ids
         )
 
     def _persist_guarded(self, agent: Any) -> bool:
@@ -391,7 +423,9 @@ class ScrollContextManager:
         7. live-fold   — still under real pressure after finished turns are
                          evicted: replace remaining eligible completed-turn
                          results with recovery pointers.
-        8. active-fold— above the effective hard limit, fold old active-turn
+        8. think-fold — under sustained pressure, omit active-turn reasoning
+                         that a successful model call already read.
+        9. active-fold— if above the hard limit, fold old active-turn
                          results that a successful model call already read.
         """
         cfg = context_config or agent.context_config
@@ -400,8 +434,13 @@ class ScrollContextManager:
             "pre_folded": 0,
             "live_folded": 0,
             "active_folded": 0,
+            "active_thinking_folded": 0,
             "folded": 0,
         }
+        # ``load_state`` restores folded ids before an agent/formatter exists.
+        # Reapply them whenever compression gets a live agent so token counting
+        # sees the same request that the provider will receive.
+        self._apply_folded_thinking_filter(agent)
         hard_limit = int(agent.model.context_size)
         output_reserve = min(
             _MAX_OUTPUT_RESERVE_TOKENS,
@@ -603,12 +642,36 @@ class ScrollContextManager:
                     "scroll: pressure-folded %d live tool result(s)",
                     folded,
                 )
-        # 8) A single long tool-running turn can itself exceed the input hard
-        #    limit after every completed turn has been folded/evicted. At this
-        #    final boundary, reclaim only active-turn results proven to have
-        #    appeared in a successful prior model request. The current user
-        #    request, pending/unread results, and the five newest results stay
-        #    verbatim. Fold the whole safe batch, then recount exactly once.
+        # 8) A single long tool-running turn can remain above the pressure
+        #    target after every completed turn has been folded/evicted.
+        #    Reasoning text is cheaper evidence than tool output and is already
+        #    durable, so omit only active ThinkingBlocks proven to have
+        #    appeared in a successful prior request. This is a request-time
+        #    filter: the live Msg and history.db keep the exact original text.
+        #    Running at the pressure target (not merely the hard limit) leaves
+        #    headroom for the next step and provider token-count variance.
+        if tokens > pressure_threshold:
+            (
+                thinking_folded,
+                tokens,
+            ) = await self._batch_fold_seen_active_thinking(
+                agent,
+                tokens=tokens,
+            )
+            mark("active_turn_thinking_fold")
+            if thinking_folded:
+                self.last_compress["active_thinking_folded"] = thinking_folded
+                self.last_compress["folded"] += thinking_folded
+                logger.info(
+                    "scroll: pressure-folded %d seen active-turn thinking "
+                    "block(s)",
+                    thinking_folded,
+                )
+        # 9) If reasoning omission was insufficient, reclaim active-turn tool
+        #    results proven to have appeared in a successful prior request. The
+        #    current user request, pending/unread results, and the five newest
+        #    results stay verbatim. Fold the whole safe batch, then recount
+        #    once.
         if tokens > effective_hard_limit:
             active_folded, tokens = await self._batch_fold_seen_active_results(
                 agent,
@@ -1551,6 +1614,73 @@ class ScrollContextManager:
             return 0, tokens
         return len(candidates), await self._live_tokens(agent)
 
+    def _active_thinking_blocks(self, agent: Any) -> list[tuple[str, Any]]:
+        """Return id-bearing ThinkingBlocks in the current active turn."""
+        blocks: list[tuple[str, Any]] = []
+        for msg in self._active_turn_tail(agent):
+            for block in getattr(msg, "content", None) or []:
+                if self._block_type(block) != "thinking":
+                    continue
+                block_id = (
+                    block.get("id")
+                    if isinstance(block, dict)
+                    else getattr(block, "id", None)
+                )
+                thinking = (
+                    block.get("thinking")
+                    if isinstance(block, dict)
+                    else getattr(block, "thinking", None)
+                )
+                if block_id and thinking:
+                    blocks.append((str(block_id), block))
+        return blocks
+
+    def _apply_folded_thinking_filter(self, agent: Any) -> bool:
+        """Apply request-only thinking omissions through QwenPawAgent."""
+        setter = getattr(agent, "_set_formatter_thinking_omit_ids", None)
+        if not callable(setter):
+            return False
+        setter(set(self._folded_thinking_block_ids))
+        return True
+
+    async def _batch_fold_seen_active_thinking(
+        self,
+        agent: Any,
+        *,
+        tokens: int,
+    ) -> tuple[int, int]:
+        """Omit acknowledged active reasoning, then recount exactly once."""
+        candidates = {
+            block_id
+            for block_id, _ in self._active_thinking_blocks(agent)
+            if block_id in self._seen_thinking_block_ids
+            and block_id not in self._folded_thinking_block_ids
+        }
+        if not candidates:
+            return 0, tokens
+        self._folded_thinking_block_ids.update(candidates)
+        if not self._apply_folded_thinking_filter(agent):
+            self._folded_thinking_block_ids.difference_update(candidates)
+            return 0, tokens
+        try:
+            compacted_tokens = await self._live_tokens(agent)
+        except BaseException:
+            # The omission is request-only, so a failed exact recount must not
+            # leave the formatter in a state that was never accepted by the
+            # compression pipeline. This also handles task cancellation.
+            self._folded_thinking_block_ids.difference_update(candidates)
+            self._apply_folded_thinking_filter(agent)
+            raise
+        if compacted_tokens >= tokens:
+            # A formatter with reasoning relay disabled (or a provider-native
+            # counter that already ignores ThinkingBlocks) gains nothing from
+            # this filter. Roll it back so reporting and checkpoints do not
+            # claim a fold that saved no request tokens.
+            self._folded_thinking_block_ids.difference_update(candidates)
+            self._apply_folded_thinking_filter(agent)
+            return 0, tokens
+        return len(candidates), compacted_tokens
+
     async def _fold_tool_results_under_pressure(
         self,
         agent: Any,
@@ -1849,6 +1979,7 @@ class ScrollContextManager:
         """
         live_msg_ids: set[str] = set()
         live_tool_ids: set[str] = set()
+        live_thinking_ids: set[str] = set()
         for msg in getattr(agent.state, "context", []) or []:
             mid = getattr(msg, "id", None) or str(id(msg))
             live_msg_ids.add(str(mid))
@@ -1858,6 +1989,15 @@ class ScrollContextManager:
                     if isinstance(block, dict)
                     else getattr(block, "type", None)
                 )
+                if btype == "thinking":
+                    block_id = (
+                        block.get("id")
+                        if isinstance(block, dict)
+                        else getattr(block, "id", None)
+                    )
+                    if block_id:
+                        live_thinking_ids.add(str(block_id))
+                    continue
                 if btype not in ("tool_call", "tool_result"):
                     continue
                 tcid = (
@@ -1871,6 +2011,9 @@ class ScrollContextManager:
         self._persisted_ids.intersection_update(live_msg_ids)
         self._persisted_tcids.intersection_update(live_tool_ids)
         self._seen_tool_result_ids.intersection_update(live_tool_ids)
+        self._seen_thinking_block_ids.intersection_update(live_thinking_ids)
+        self._folded_thinking_block_ids.intersection_update(live_thinking_ids)
+        self._apply_folded_thinking_filter(agent)
         self._synthetic_ids.intersection_update(live_msg_ids)
         self._seq_by_id = {
             key: value
@@ -1951,6 +2094,12 @@ class ScrollContextManager:
             "persisted_ids": sorted(self._persisted_ids),
             "persisted_tcids": sorted(self._persisted_tcids),
             "seen_tool_result_ids": sorted(self._seen_tool_result_ids),
+            "seen_thinking_block_ids": sorted(
+                self._seen_thinking_block_ids,
+            ),
+            "folded_thinking_block_ids": sorted(
+                self._folded_thinking_block_ids,
+            ),
             "seq_by_tcid": dict(self._seq_by_tcid),
             "synthetic_ids": sorted(self._synthetic_ids),
             "seq_by_id": {
@@ -1980,6 +2129,12 @@ class ScrollContextManager:
         self._persisted_tcids = set(data.get("persisted_tcids", ()))
         self._seen_tool_result_ids = set(
             data.get("seen_tool_result_ids", ()),
+        )
+        self._seen_thinking_block_ids = set(
+            data.get("seen_thinking_block_ids", ()),
+        )
+        self._folded_thinking_block_ids = set(
+            data.get("folded_thinking_block_ids", ()),
         )
         self._seq_by_tcid = dict(data.get("seq_by_tcid", {}))
         self._synthetic_ids = set(data.get("synthetic_ids", ()))

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -1640,8 +1640,10 @@ class ScrollContextManager:
         setter = getattr(agent, "_set_formatter_thinking_omit_ids", None)
         if not callable(setter):
             return False
-        setter(set(self._folded_thinking_block_ids))
-        return True
+        applied = setter(set(self._folded_thinking_block_ids))
+        # Preserve compatibility with third-party agents implementing the
+        # original setter before it returned an explicit capability result.
+        return applied is not False
 
     async def _batch_fold_seen_active_thinking(
         self,

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1477,6 +1477,14 @@ def _create_file_block_support_formatter(
         Enhanced formatter class with file block support
     """
 
+    supports_thinking_omission = not (
+        (
+            AnthropicChatFormatter is not None
+            and issubclass(base_formatter_class, AnthropicChatFormatter)
+        )
+        or issubclass(base_formatter_class, OpenAIResponseFormatter)
+    )
+
     class FileBlockSupportFormatter(base_formatter_class):
         """Formatter with file block support for tool results."""
 
@@ -1499,6 +1507,22 @@ def _create_file_block_support_formatter(
                     "video/*",
                 ]
             super().__init__(**kwargs)
+
+        def set_thinking_omit_ids(self, block_ids: set[str]) -> bool:
+            """Set request-time reasoning omissions when wire-compatible.
+
+            Anthropic thinking blocks are signed and must remain intact during
+            tool use. Responses formatters own their reasoning representation
+            as well. Both therefore reject this OpenAI-chat extension instead
+            of silently carrying a stale private attribute.
+            """
+            accepted_ids = (
+                {str(item) for item in block_ids}
+                if supports_thinking_omission
+                else set()
+            )
+            setattr(self, "_qwenpaw_omit_thinking_ids", accepted_ids)
+            return supports_thinking_omission
 
         def _format_anthropic_data_block(self, block):
             """Route video ``DataBlock``s to our local helper; defer
@@ -1704,9 +1728,7 @@ def _create_file_block_support_formatter(
                 False,
             )
             should_inject_reasoning = has_reasoning or require_reasoning
-            formatter_supports_reasoning = (
-                not is_anthropic_formatter and not _is_response_formatter
-            )
+            formatter_supports_reasoning = supports_thinking_omission
             should_relay_reasoning = relay_reasoning or require_reasoning
             if (
                 should_inject_reasoning

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1295,10 +1295,21 @@ def _reasoning_by_assistant_segment(
     aligned: list[str | None] = []
     reasoning_parts: list[str] = []
     segment_survives = False
+    omitted_ids = {
+        str(item)
+        for item in getattr(
+            formatter,
+            "_qwenpaw_omit_thinking_ids",
+            set(),
+        )
+    }
 
     for block in blocks:
         block_type = _get(block, "type")
         if block_type == "thinking":
+            block_id = _get(block, "id")
+            if block_id is not None and str(block_id) in omitted_ids:
+                continue
             thinking = _get(block, "thinking", "")
             if thinking:
                 reasoning_parts.append(thinking)

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1303,6 +1303,12 @@ def _reasoning_by_assistant_segment(
             set(),
         )
     }
+    if getattr(formatter, "_qwenpaw_require_reasoning_content", False):
+        # Some OpenAI-compatible providers require the exact reasoning text
+        # from every previous assistant tool-call turn. Once that capability
+        # is known, a stale request-time fold must never replace the original
+        # content with either omission or a placeholder.
+        omitted_ids.clear()
 
     for block in blocks:
         block_type = _get(block, "type")
@@ -1457,10 +1463,33 @@ def _fixup_media_list(items: list) -> None:
                 _fixup_media_list(output)
 
 
+_EXACT_REASONING_REPLAY_PROVIDER_IDS = frozenset({"deepseek"})
+
+
+def _requires_exact_reasoning_replay(
+    provider_id: str | None,
+    model_id: str | None,
+) -> bool:
+    """Return the provider/model-level reasoning replay capability.
+
+    Formatter inheritance is insufficient here because many providers share
+    the OpenAI chat formatter while enforcing different tool-call protocols.
+    The model-name check also covers routed DeepSeek models served through an
+    aggregator such as OpenRouter.
+    """
+    normalized_provider_id = (provider_id or "").strip().lower()
+    normalized_model_id = (model_id or "").strip().lower()
+    return (
+        normalized_provider_id in _EXACT_REASONING_REPLAY_PROVIDER_IDS
+        or "deepseek" in normalized_model_id
+    )
+
+
 # pylint: disable-next=too-many-statements
 def _create_file_block_support_formatter(
     base_formatter_class: Type[FormatterBase],
     provider_id: str | None = None,
+    model_id: str | None = None,
 ) -> Type[FormatterBase]:
     """Create a formatter class with file block support.
 
@@ -1472,17 +1501,28 @@ def _create_file_block_support_formatter(
         provider_id: Provider owning the formatter. Provider-specific
             tool-call metadata is relayed only when this matches the
             provider that originally emitted it.
+        model_id: Model served by the provider. This is used together with
+            ``provider_id`` for request-protocol capabilities that cannot be
+            inferred from the shared formatter base class.
 
     Returns:
         Enhanced formatter class with file block support
     """
 
-    supports_thinking_omission = not (
+    supports_reasoning_content_relay = not (
         (
             AnthropicChatFormatter is not None
             and issubclass(base_formatter_class, AnthropicChatFormatter)
         )
         or issubclass(base_formatter_class, OpenAIResponseFormatter)
+    )
+    requires_exact_reasoning_replay = _requires_exact_reasoning_replay(
+        provider_id,
+        model_id,
+    )
+    supports_thinking_omission = (
+        supports_reasoning_content_relay
+        and not requires_exact_reasoning_replay
     )
 
     class FileBlockSupportFormatter(base_formatter_class):
@@ -1513,16 +1553,21 @@ def _create_file_block_support_formatter(
 
             Anthropic thinking blocks are signed and must remain intact during
             tool use. Responses formatters own their reasoning representation
-            as well. Both therefore reject this OpenAI-chat extension instead
-            of silently carrying a stale private attribute.
+            as well. DeepSeek requires the exact reasoning content to be
+            replayed throughout a tool-call chain. A formatter that learned
+            the same requirement from a provider error must also reject this
+            extension. Unsupported formatters clear stale omission state.
             """
+            can_omit = supports_thinking_omission and not getattr(
+                self,
+                "_qwenpaw_require_reasoning_content",
+                False,
+            )
             accepted_ids = (
-                {str(item) for item in block_ids}
-                if supports_thinking_omission
-                else set()
+                {str(item) for item in block_ids} if can_omit else set()
             )
             setattr(self, "_qwenpaw_omit_thinking_ids", accepted_ids)
-            return supports_thinking_omission
+            return can_omit
 
         def _format_anthropic_data_block(self, block):
             """Route video ``DataBlock``s to our local helper; defer
@@ -1728,7 +1773,7 @@ def _create_file_block_support_formatter(
                 False,
             )
             should_inject_reasoning = has_reasoning or require_reasoning
-            formatter_supports_reasoning = supports_thinking_omission
+            formatter_supports_reasoning = supports_reasoning_content_relay
             should_relay_reasoning = relay_reasoning or require_reasoning
             if (
                 should_inject_reasoning
@@ -1792,7 +1837,9 @@ def _create_file_block_support_formatter(
                             out_msg.setdefault("reasoning_content", " ")
                 else:
                     for i, out_msg in enumerate(out_assistant):
-                        if relay_reasoning and aligned_reasoning[i]:
+                        if aligned_reasoning[i] and (
+                            relay_reasoning or require_reasoning
+                        ):
                             out_msg["reasoning_content"] = aligned_reasoning[i]
                         elif require_reasoning:
                             out_msg.setdefault("reasoning_content", " ")
@@ -2268,6 +2315,7 @@ def _create_formatter_instance(
     formatter_class = _create_file_block_support_formatter(
         base_formatter_class,
         provider_id=provider_id,
+        model_id=str(getattr(model, "model", "") or ""),
     )
     # Carry over all Pydantic field values (max_bytes,
     # relay_reasoning_content, etc.) from the provider-constructed

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -561,12 +561,22 @@ class QwenPawAgent(CodingModeMixin, Agent):
             return
         setattr(formatter, "_qwenpaw_force_strip_audio", enabled)
 
-    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> None:
-        """Omit selected reasoning text from wire requests without mutation."""
+    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> bool:
+        """Propagate reasoning omissions through model wrappers."""
+        model_setter = getattr(self.model, "set_thinking_omit_ids", None)
+        if callable(model_setter):
+            return bool(model_setter(set(block_ids)))
+
         formatter = self._get_active_formatter()
         if formatter is None:
-            return
+            return False
+        formatter_setter = getattr(formatter, "set_thinking_omit_ids", None)
+        if callable(formatter_setter):
+            return bool(formatter_setter(set(block_ids)))
+        # Compatibility for third-party OpenAI-chat formatters that predate
+        # the explicit interface but consume the QwenPaw extension attribute.
         setattr(formatter, "_qwenpaw_omit_thinking_ids", set(block_ids))
+        return True
 
     def _last_wire_request_had_media(self) -> bool:
         """Return whether the last completed formatting emitted media."""

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -561,6 +561,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
             return
         setattr(formatter, "_qwenpaw_force_strip_audio", enabled)
 
+    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> None:
+        """Omit selected reasoning text from wire requests without mutation."""
+        formatter = self._get_active_formatter()
+        if formatter is None:
+            return
+        setattr(formatter, "_qwenpaw_omit_thinking_ids", set(block_ids))
+
     def _last_wire_request_had_media(self) -> bool:
         """Return whether the last completed formatting emitted media."""
         formatter = self._get_active_formatter()
@@ -795,6 +802,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
         final_msg: Msg | None = None
         context_manager = self._context_manager
         pending_seen_ids: set[str] = set()
+        pending_seen_thinking_ids: set[str] = set()
         if context_manager is not None and hasattr(
             context_manager,
             "model_input_tool_result_ids",
@@ -802,25 +810,39 @@ class QwenPawAgent(CodingModeMixin, Agent):
             pending_seen_ids = context_manager.model_input_tool_result_ids(
                 self,
             )
+        if context_manager is not None and hasattr(
+            context_manager,
+            "model_input_thinking_block_ids",
+        ):
+            pending_seen_thinking_ids = (
+                context_manager.model_input_thinking_block_ids(self)
+            )
 
-        def acknowledge_seen_results(evt: Any) -> None:
+        def acknowledge_seen_inputs(evt: Any) -> None:
             """Acknowledge inputs only after a completed model request."""
             if (
                 isinstance(evt, ModelCallEndEvent)
                 and evt.finished_reason != FinishedReason.INTERRUPTED
                 and context_manager is not None
-                and hasattr(
+            ):
+                if hasattr(
                     context_manager,
                     "acknowledge_model_input_tool_results",
-                )
-            ):
-                context_manager.acknowledge_model_input_tool_results(
-                    pending_seen_ids,
-                )
+                ):
+                    context_manager.acknowledge_model_input_tool_results(
+                        pending_seen_ids,
+                    )
+                if hasattr(
+                    context_manager,
+                    "acknowledge_model_input_thinking_blocks",
+                ):
+                    context_manager.acknowledge_model_input_thinking_blocks(
+                        pending_seen_thinking_ids,
+                    )
 
         try:
             async for evt in super()._reasoning(tool_choice=tool_choice):
-                acknowledge_seen_results(evt)
+                acknowledge_seen_inputs(evt)
                 if isinstance(evt, Msg):
                     final_msg = evt
                 else:
@@ -871,7 +893,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 async for evt in super()._reasoning(
                     tool_choice=tool_choice,
                 ):
-                    acknowledge_seen_results(evt)
+                    acknowledge_seen_inputs(evt)
                     if isinstance(evt, Msg):
                         final_msg = evt
                     else:

--- a/src/qwenpaw/providers/fallback_chat_model.py
+++ b/src/qwenpaw/providers/fallback_chat_model.py
@@ -62,6 +62,7 @@ class FallbackChatModel(ChatModelBase):
             context_size=getattr(primary, "context_size", 32_768),
         )
         self._models = models
+        self._thinking_omit_ids: set[str] = set()
         self._activate_model(primary)
 
     @property
@@ -134,6 +135,34 @@ class FallbackChatModel(ChatModelBase):
     def _activate_model(self, model: ChatModelBase) -> None:
         """Expose routing metadata from the model handling the request."""
         self._active_model = model
+        self._apply_thinking_omit_ids(model)
+
+    @staticmethod
+    def _set_model_thinking_omit_ids(
+        model: ChatModelBase,
+        block_ids: set[str],
+    ) -> bool:
+        """Apply omission state to one candidate's concrete formatter."""
+        formatter = getattr(model, "formatter", None)
+        if formatter is None:
+            return False
+        setter = getattr(formatter, "set_thinking_omit_ids", None)
+        if callable(setter):
+            return bool(setter(set(block_ids)))
+        setattr(formatter, "_qwenpaw_omit_thinking_ids", set(block_ids))
+        return True
+
+    def _apply_thinking_omit_ids(self, model: ChatModelBase) -> bool:
+        """Apply the current request-time omission state to one candidate."""
+        return self._set_model_thinking_omit_ids(
+            model,
+            self._thinking_omit_ids,
+        )
+
+    def set_thinking_omit_ids(self, block_ids: set[str]) -> bool:
+        """Persist omissions and apply them to the currently visible model."""
+        self._thinking_omit_ids = {str(item) for item in block_ids}
+        return self._apply_thinking_omit_ids(self._active_model)
 
     def _begin_request(self) -> Token:
         """Activate the primary model and snapshot the pre-request state.
@@ -146,7 +175,9 @@ class FallbackChatModel(ChatModelBase):
         ``model_key`` -- both must see the primary model, because the
         next request always tries the primary first.
         """
-        return self._active_model_var.set(self._models[0])
+        token = self._active_model_var.set(self._models[0])
+        self._apply_thinking_omit_ids(self._models[0])
+        return token
 
     def _end_request(self, token: Token) -> None:
         """Restore the pre-request active model.

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -289,6 +289,15 @@ def _enable_reasoning_content_fallback(
                 "_qwenpaw_require_reasoning_content",
                 True,
             )
+            # Exact replay and request-time thinking omission are mutually
+            # exclusive. Clear any fold learned before this provider exposed
+            # its stricter tool-call protocol, so the retry is reformatted
+            # from the still-intact AgentScope message content.
+            set_omit_ids = getattr(formatter, "set_thinking_omit_ids", None)
+            if callable(set_omit_ids):
+                set_omit_ids(set())
+            else:
+                setattr(formatter, "_qwenpaw_omit_thinking_ids", set())
             return True
 
         for attr in ("_inner", "_model"):
@@ -841,8 +850,9 @@ class RetryChatModel(ChatModelBase):
                     cache.learn(key, "needs_reasoning_content", True)
                     logger.warning(
                         "Thinking-mode model requires reasoning_content "
-                        "on every assistant message. Injecting empty "
-                        "values and retrying (learned for future calls).",
+                        "on every assistant message. Replaying available "
+                        "reasoning and filling missing values before retrying "
+                        "(learned for future calls).",
                     )
                     self._ensure_provider_available()
                     result = await self._inner(*args, **kwargs)
@@ -996,8 +1006,9 @@ class RetryChatModel(ChatModelBase):
                     )
                     logger.warning(
                         "Thinking-mode stream requires reasoning_content "
-                        "on every assistant message. Injecting empty "
-                        "values and retrying (learned for future calls).",
+                        "on every assistant message. Replaying available "
+                        "reasoning and filling missing values before retrying "
+                        "(learned for future calls).",
                     )
                     continue
 

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -241,8 +241,9 @@ class FakeAgent:
         # Default: compress everything but the last msg.
         return (self.state.context[:-1], self.state.context[-1:])
 
-    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> None:
+    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> bool:
         self.omitted_thinking_ids = set(block_ids)
+        return True
 
 
 class AutoMemoryMsgBuilder(BaseMemoryManager):

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -18,6 +18,7 @@ from agentscope.message import (
     HintBlock,
     Msg,
     TextBlock,
+    ThinkingBlock,
     ToolCallBlock,
     ToolResultBlock,
 )
@@ -229,6 +230,7 @@ class FakeAgent:
         self.model = FakeModel(tokens)
         self.context_config = FakeConfig()
         self._split_return: tuple | None = None
+        self.omitted_thinking_ids: set[str] = set()
 
     async def _prepare_model_input(self) -> dict:
         return {"tools": []}
@@ -238,6 +240,9 @@ class FakeAgent:
             return self._split_return
         # Default: compress everything but the last msg.
         return (self.state.context[:-1], self.state.context[-1:])
+
+    def _set_formatter_thinking_omit_ids(self, block_ids: set[str]) -> None:
+        self.omitted_thinking_ids = set(block_ids)
 
 
 class AutoMemoryMsgBuilder(BaseMemoryManager):
@@ -464,6 +469,34 @@ def test_checkpoint_round_trip_preserves_seen_tool_results(
     mgr2.load_state(mgr1.to_dict())
 
     assert mgr2._seen_tool_result_ids == {"call-seen"}
+
+
+def test_checkpoint_round_trip_preserves_active_thinking_fold_state(
+    store: HistoryStore,
+):
+    """Acknowledgement and request-only omission survive session resume."""
+    thought = ThinkingBlock(thinking="reasoning already consumed")
+    ctx = [
+        user("run it"),
+        Msg(
+            name="a",
+            role="assistant",
+            content=[thought, TextBlock(text="go")],
+        ),
+    ]
+    agent = FakeAgent(ctx)
+    mgr1 = make_manager(store)
+    captured = mgr1.model_input_thinking_block_ids(agent)
+    mgr1.acknowledge_model_input_thinking_blocks(captured)
+    mgr1._folded_thinking_block_ids.update(captured)
+
+    mgr2 = make_manager(store)
+    mgr2.load_state(mgr1.to_dict())
+    resumed = FakeAgent(ctx)
+
+    assert mgr2.model_input_thinking_block_ids(resumed) == set()
+    assert resumed.omitted_thinking_ids == {thought.id}
+    assert mgr2._seen_thinking_block_ids == {thought.id}
 
 
 def test_reappend_blocked_by_db_even_without_checkpoint(store: HistoryStore):
@@ -1444,6 +1477,7 @@ async def test_pretrim_avoids_eviction_at_or_below_trigger(
         "pre_folded": 2,
         "live_folded": 0,
         "active_folded": 0,
+        "active_thinking_folded": 0,
         "folded": 2,
     }
     assert agent.model.calls == 2
@@ -1498,6 +1532,7 @@ async def test_pretrim_insufficient_then_continues_to_eviction(
         "pre_folded": 2,
         "live_folded": 0,
         "active_folded": 0,
+        "active_thinking_folded": 0,
         "folded": 2,
     }
     assert agent.model.calls == 3
@@ -1754,6 +1789,99 @@ async def test_hard_limit_folds_seen_old_active_results(
     assert mgr.last_compress["live_folded"] == 0
     assert mgr.last_compress["folded"] == 2
     assert agent.model.calls == 2
+
+
+async def test_pressure_folds_seen_active_thinking_request_only(
+    store: HistoryStore,
+):
+    """Consumed reasoning leaves the wire but stays live and durable."""
+    thought = ThinkingBlock(thinking="private chain " + "x" * 5000)
+    turn = Msg(
+        name="a",
+        role="assistant",
+        content=[
+            thought,
+            ToolCallBlock(type="tool_call", id="c1", name="grep", input="{}"),
+        ],
+    )
+    ctx = [user("run the long workflow"), turn]
+    mgr = make_manager(store)
+    # Above the pressure target (500), but still below the effective hard
+    # limit (950): fold early enough to leave room for the next reasoning step.
+    agent = FakeAgent(ctx, tokens=[800, 100])
+    agent._split_return = (ctx, [])
+    mgr._persist_new(agent)
+    captured = mgr.model_input_thinking_block_ids(agent)
+    assert captured == {thought.id}
+    mgr.acknowledge_model_input_thinking_blocks(captured)
+
+    await mgr.compress(agent)
+
+    assert agent.omitted_thinking_ids == {thought.id}
+    assert thought.thinking.startswith("private chain ")
+    assert mgr.last_compress["active_thinking_folded"] == 1
+    assert mgr.last_compress["active_folded"] == 0
+    assert mgr.last_compress["folded"] == 1
+    durable = store._conn.execute(
+        "SELECT blocks FROM conversation_history "
+        "WHERE kind='model_turn' AND dedup_key = ?",
+        (turn.id,),
+    ).fetchone()
+    stored_blocks = json.loads(durable["blocks"])
+    assert stored_blocks[0]["thinking"] == thought.thinking
+
+
+async def test_hard_limit_keeps_unread_active_thinking(
+    store: HistoryStore,
+):
+    """A rejected request cannot make its reasoning eligible for omission."""
+    thought = ThinkingBlock(thinking="not consumed " + "x" * 5000)
+    turn = Msg(
+        name="a",
+        role="assistant",
+        content=[thought, TextBlock(text="continue")],
+    )
+    ctx = [user("run it"), turn]
+    mgr = make_manager(store)
+    agent = FakeAgent(ctx, tokens=980)
+    agent._split_return = (ctx, [])
+
+    with pytest.raises(ContextWindowUnfitError):
+        await mgr.compress(agent)
+
+    assert agent.omitted_thinking_ids == set()
+    assert thought.thinking.startswith("not consumed ")
+    assert mgr.last_compress["active_thinking_folded"] == 0
+
+
+async def test_active_thinking_fold_rolls_back_when_recount_fails(
+    store: HistoryStore,
+):
+    """A failed exact recount must not leak request-time omission state."""
+    thought = ThinkingBlock(thinking="consumed reasoning " + "x" * 5000)
+    ctx = [
+        user("run it"),
+        Msg(
+            name="a",
+            role="assistant",
+            content=[thought, TextBlock(text="continue")],
+        ),
+    ]
+    mgr = make_manager(store)
+    agent = FakeAgent(ctx, tokens=800)
+    agent._split_return = (ctx, [])
+    captured = mgr.model_input_thinking_block_ids(agent)
+    mgr.acknowledge_model_input_thinking_blocks(captured)
+    agent.model.count_tokens = AsyncMock(
+        side_effect=[800, RuntimeError("token recount failed")],
+    )
+
+    with pytest.raises(RuntimeError, match="token recount failed"):
+        await mgr.compress(agent)
+
+    assert mgr._folded_thinking_block_ids == set()
+    assert agent.omitted_thinking_ids == set()
+    assert thought.thinking.startswith("consumed reasoning ")
 
 
 async def test_hard_limit_keeps_unread_active_results_and_fails_closed(

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -562,6 +562,72 @@ async def test_openai_formatter_aligns_reasoning_with_split_segments() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_formatter_omits_thinking_without_mutation() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    old_thought = ThinkingBlock(thinking="old reasoning")
+    new_thought = ThinkingBlock(thinking="new reasoning")
+    formatter._qwenpaw_omit_thinking_ids = {old_thought.id}
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            old_thought,
+            ToolCallBlock(id="call_1", name="first", input="{}"),
+            ToolResultBlock(
+                id="call_1",
+                name="first",
+                output=[TextBlock(text="result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            new_thought,
+            TextBlock(text="done"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert "reasoning_content" not in assistant_messages[0]
+    assert assistant_messages[1]["reasoning_content"] == "new reasoning"
+    assert old_thought.thinking == "old reasoning"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_formatter_preserves_native_thinking() -> None:
+    """Request-time elision must not alter signed Anthropic thinking."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingAnthropicFormatter,
+    )
+    formatter = formatter_class()
+    thought = ThinkingBlock(
+        thinking="native reasoning",
+        signature="signature-abc",
+    )
+    formatter._qwenpaw_omit_thinking_ids = {thought.id}
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[thought, TextBlock(text="done")],
+    )
+
+    formatted = await formatter.format([msg])
+
+    thinking = formatted[0]["content"][0]
+    assert thinking == {
+        "type": "thinking",
+        "thinking": "native reasoning",
+        "signature": "signature-abc",
+    }
+
+
+@pytest.mark.asyncio
 async def test_openai_formatter_aligns_reasoning_across_hint() -> None:
     formatter_class = model_factory._create_file_block_support_formatter(
         _CappingOpenAIFormatter,

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -597,6 +597,82 @@ async def test_openai_formatter_omits_thinking_without_mutation() -> None:
     assert old_thought.thinking == "old reasoning"
 
 
+@pytest.mark.parametrize(
+    ("provider_id", "model_id"),
+    [
+        ("deepseek", None),
+        ("openrouter", "deepseek/deepseek-reasoner"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_deepseek_formatter_preserves_exact_reasoning(
+    provider_id: str,
+    model_id: str | None,
+) -> None:
+    """DeepSeek tool-call history must never use thinking omission."""
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id=provider_id,
+        model_id=model_id,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    thought = ThinkingBlock(thinking="must be replayed exactly")
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            thought,
+            ToolCallBlock(id="call_1", name="tool", input="{}"),
+            ToolResultBlock(
+                id="call_1",
+                name="tool",
+                output=[TextBlock(text="result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            TextBlock(text="done"),
+        ],
+    )
+
+    assert formatter.set_thinking_omit_ids({thought.id}) is False
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert assistant_messages[0]["reasoning_content"] == (
+        "must be replayed exactly"
+    )
+    assert formatter._qwenpaw_omit_thinking_ids == set()
+    assert thought.thinking == "must be replayed exactly"
+
+
+@pytest.mark.asyncio
+async def test_required_reasoning_rejects_thinking_omission() -> None:
+    """A learned exact-replay requirement overrides prior fold state."""
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    thought = ThinkingBlock(thinking="must remain available")
+
+    assert formatter.set_thinking_omit_ids({thought.id}) is True
+    formatter._qwenpaw_require_reasoning_content = True
+    assert formatter.set_thinking_omit_ids({thought.id}) is False
+
+    formatted = await formatter.format(
+        [
+            Msg(
+                name="assistant",
+                role="assistant",
+                content=[thought, TextBlock(text="done")],
+            ),
+        ],
+    )
+
+    assert formatted[0]["reasoning_content"] == "must remain available"
+    assert formatter._qwenpaw_omit_thinking_ids == set()
+
+
 @pytest.mark.asyncio
 async def test_anthropic_formatter_preserves_native_thinking() -> None:
     """Request-time elision must not alter signed Anthropic thinking."""
@@ -724,7 +800,7 @@ async def test_required_reasoning_preserves_real_and_fills_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_required_reasoning_respects_disabled_relay_privacy() -> None:
+async def test_required_reasoning_overrides_disabled_relay() -> None:
     formatter_class = model_factory._create_file_block_support_formatter(
         _CappingOpenAIFormatter,
     )
@@ -746,7 +822,7 @@ async def test_required_reasoning_respects_disabled_relay_privacy() -> None:
     assistant_messages = [
         item for item in formatted if item.get("role") == "assistant"
     ]
-    assert assistant_messages[0]["reasoning_content"] == " "
+    assert assistant_messages[0]["reasoning_content"] == "private reasoning"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agents/test_react_agent_scroll_seen.py
+++ b/tests/unit/agents/test_react_agent_scroll_seen.py
@@ -28,6 +28,7 @@ class SeenTracker:
 
     def __init__(self) -> None:
         self.acknowledged: list[set[str]] = []
+        self.thinking_acknowledged: list[set[str]] = []
 
     @staticmethod
     def model_input_tool_result_ids(agent) -> set[str]:
@@ -35,6 +36,13 @@ class SeenTracker:
 
     def acknowledge_model_input_tool_results(self, ids: set[str]) -> None:
         self.acknowledged.append(set(ids))
+
+    @staticmethod
+    def model_input_thinking_block_ids(agent) -> set[str]:
+        return {"thinking-seen"}
+
+    def acknowledge_model_input_thinking_blocks(self, ids: set[str]) -> None:
+        self.thinking_acknowledged.append(set(ids))
 
 
 class CompressionTracker:
@@ -99,6 +107,7 @@ async def test_successful_model_call_acknowledges_input_results(monkeypatch):
     events = [event async for event in agent._reasoning()]
 
     assert tracker.acknowledged == [{"call-seen"}]
+    assert tracker.thinking_acknowledged == [{"thinking-seen"}]
     assert isinstance(events[-1], Msg)
 
 
@@ -119,6 +128,7 @@ async def test_failed_model_call_does_not_acknowledge_results(monkeypatch):
             pass
 
     assert not tracker.acknowledged
+    assert not tracker.thinking_acknowledged
 
 
 async def test_interrupted_model_call_does_not_acknowledge_results(
@@ -141,6 +151,7 @@ async def test_interrupted_model_call_does_not_acknowledge_results(
 
     assert len(events) == 1
     assert not tracker.acknowledged
+    assert not tracker.thinking_acknowledged
 
 
 async def test_compress_context_forwards_one_shot_instructions():

--- a/tests/unit/agents/test_react_agent_scroll_seen.py
+++ b/tests/unit/agents/test_react_agent_scroll_seen.py
@@ -55,6 +55,17 @@ class CompressionTracker:
         self.calls.append((agent, context_config, instructions))
 
 
+class ThinkingOmissionModel:
+    """Record explicit thinking omission calls from the agent."""
+
+    def __init__(self) -> None:
+        self.ids: set[str] | None = None
+
+    def set_thinking_omit_ids(self, block_ids: set[str]) -> bool:
+        self.ids = set(block_ids)
+        return True
+
+
 def make_agent(tracker: SeenTracker) -> QwenPawAgent:
     """Build only the attributes the reasoning wrapper reads."""
     agent = object.__new__(QwenPawAgent)
@@ -83,6 +94,20 @@ def _skip_media_strip(monkeypatch) -> None:
         "qwenpaw.agents.model_factory._supports_multimodal_for_current_model",
         lambda: True,
     )
+
+
+def test_thinking_omissions_delegate_to_model_wrapper() -> None:
+    """Fallback-aware model interfaces take precedence over one formatter."""
+    agent = object.__new__(QwenPawAgent)
+    model = ThinkingOmissionModel()
+    agent.model = model
+    agent.formatter = SimpleNamespace()
+
+    applied = agent._set_formatter_thinking_omit_ids({"thinking-1"})
+
+    assert applied is True
+    assert model.ids == {"thinking-1"}
+    assert not hasattr(agent.formatter, "_qwenpaw_omit_thinking_ids")
 
 
 async def test_successful_model_call_acknowledges_input_results(monkeypatch):

--- a/tests/unit/providers/test_fallback_chat_model.py
+++ b/tests/unit/providers/test_fallback_chat_model.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 """Tests for cross-model fallback boundaries."""
 
+# pylint: disable=protected-access
+
 from __future__ import annotations
 
 import asyncio
 from typing import Any, AsyncGenerator, cast
 
 import pytest
+from agentscope.message import Msg, TextBlock, ThinkingBlock
 from agentscope.model import ChatModelBase
 from agentscope.model._model_response import ChatResponse, StructuredResponse
 from agentscope.model._model_usage import ChatUsage
 
+from qwenpaw.agents import model_factory
+from qwenpaw.providers.capping_formatter import (
+    _CappingAnthropicFormatter,
+    _CappingOpenAIFormatter,
+)
 from qwenpaw.providers.fallback_chat_model import (
     FallbackChatModel,
     install_fallback_notice_sink,
@@ -65,6 +73,24 @@ class _FakeFormatter:
 
     def __init__(self, media_types: list[str]) -> None:
         self.supported_input_media_types = media_types
+
+
+class FormattingFakeModel(FakeModel):
+    """Fake model that records the payload produced by its formatter."""
+
+    def __init__(self, name: str, behavior: Any, formatter: Any) -> None:
+        super().__init__(name, behavior)
+        self.formatter = formatter
+        self.formatted_messages: list[dict[str, Any]] = []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        self.formatted_messages = await self.formatter.format(
+            kwargs["messages"],
+        )
+        if isinstance(self.behavior, Exception):
+            raise self.behavior
+        return self.behavior()
 
 
 class HttpError(Exception):
@@ -826,3 +852,101 @@ def test_fallback_formatter_assignment_reaches_provider_model() -> None:
     assert model.formatter is replacement
     # The idle fallback keeps its own formatter until it serves a request.
     assert fallback.formatter is not replacement
+
+
+def _wrapped_formatting_model(
+    model: FormattingFakeModel,
+    provider_id: str,
+) -> RetryChatModel:
+    """Build the same provider wrapper chain used by model_factory."""
+    return RetryChatModel(
+        TokenRecordingModelWrapper(provider_id, model),
+        retry_config=RetryConfig(enabled=False),
+    )
+
+
+async def test_fallback_propagates_thinking_omissions() -> None:
+    """Every OpenAI-compatible fallback formats with the same omissions."""
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    primary = FormattingFakeModel(
+        "primary",
+        HttpError(503),
+        formatter_class(relay_reasoning_content=True),
+    )
+    fallback = FormattingFakeModel(
+        "fallback",
+        lambda: _response("ok"),
+        formatter_class(relay_reasoning_content=True),
+    )
+    model = FallbackChatModel(
+        [
+            _wrapped_formatting_model(primary, "primary-provider"),
+            _wrapped_formatting_model(fallback, "fallback-provider"),
+        ],
+    )
+    thought = ThinkingBlock(thinking="already consumed")
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[thought, TextBlock(text="continue")],
+        ),
+    ]
+
+    assert model.set_thinking_omit_ids({thought.id}) is True
+    response = await model(messages=messages, tools=[])
+
+    assert response.content[0]["text"] == "ok"
+    assert "reasoning_content" not in primary.formatted_messages[0]
+    assert "reasoning_content" not in fallback.formatted_messages[0]
+
+
+async def test_anthropic_fallback_preserves_native_thinking() -> None:
+    """An Anthropic fallback keeps signed thinking despite outer omissions."""
+    if model_factory.AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+    openai_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    anthropic_class = model_factory._create_file_block_support_formatter(
+        _CappingAnthropicFormatter,
+    )
+    primary = FormattingFakeModel(
+        "primary",
+        HttpError(503),
+        openai_class(relay_reasoning_content=True),
+    )
+    fallback = FormattingFakeModel(
+        "fallback",
+        lambda: _response("ok"),
+        anthropic_class(),
+    )
+    model = FallbackChatModel(
+        [
+            _wrapped_formatting_model(primary, "primary-provider"),
+            _wrapped_formatting_model(fallback, "anthropic"),
+        ],
+    )
+    thought = ThinkingBlock(
+        thinking="signed native reasoning",
+        signature="signature-abc",
+    )
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[thought, TextBlock(text="continue")],
+        ),
+    ]
+
+    assert model.set_thinking_omit_ids({thought.id}) is True
+    await model(messages=messages, tools=[])
+
+    native_thinking = fallback.formatted_messages[0]["content"][0]
+    assert native_thinking == {
+        "type": "thinking",
+        "thinking": "signed native reasoning",
+        "signature": "signature-abc",
+    }

--- a/tests/unit/providers/test_fallback_chat_model.py
+++ b/tests/unit/providers/test_fallback_chat_model.py
@@ -9,7 +9,14 @@ import asyncio
 from typing import Any, AsyncGenerator, cast
 
 import pytest
-from agentscope.message import Msg, TextBlock, ThinkingBlock
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    ToolResultState,
+)
 from agentscope.model import ChatModelBase
 from agentscope.model._model_response import ChatResponse, StructuredResponse
 from agentscope.model._model_usage import ChatUsage
@@ -901,6 +908,75 @@ async def test_fallback_propagates_thinking_omissions() -> None:
     assert response.content[0]["text"] == "ok"
     assert "reasoning_content" not in primary.formatted_messages[0]
     assert "reasoning_content" not in fallback.formatted_messages[0]
+
+
+async def test_deepseek_fallback_preserves_exact_reasoning() -> None:
+    """Omission capability follows the actual serving fallback provider."""
+    primary_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id="openai-compatible",
+    )
+    deepseek_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+        provider_id="deepseek",
+        model_id="deepseek-reasoner",
+    )
+    primary = FormattingFakeModel(
+        "primary",
+        HttpError(503),
+        primary_class(relay_reasoning_content=True),
+    )
+    fallback = FormattingFakeModel(
+        "deepseek-reasoner",
+        lambda: _response("ok"),
+        deepseek_class(relay_reasoning_content=True),
+    )
+    model = FallbackChatModel(
+        [
+            _wrapped_formatting_model(primary, "primary-provider"),
+            _wrapped_formatting_model(fallback, "deepseek"),
+        ],
+    )
+    thought = ThinkingBlock(thinking="must be replayed to DeepSeek")
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                thought,
+                ToolCallBlock(id="call_1", name="tool", input="{}"),
+                ToolResultBlock(
+                    id="call_1",
+                    name="tool",
+                    output=[TextBlock(text="result")],
+                    state=ToolResultState.SUCCESS,
+                ),
+                TextBlock(text="done"),
+            ],
+        ),
+    ]
+
+    assert model.set_thinking_omit_ids({thought.id}) is True
+    await model(
+        messages=messages,
+        tools=[{"type": "function", "function": {"name": "tool"}}],
+    )
+
+    primary_assistants = [
+        item
+        for item in primary.formatted_messages
+        if item.get("role") == "assistant"
+    ]
+    fallback_assistants = [
+        item
+        for item in fallback.formatted_messages
+        if item.get("role") == "assistant"
+    ]
+    assert "reasoning_content" not in primary_assistants[0]
+    assert fallback_assistants[0]["reasoning_content"] == (
+        "must be replayed to DeepSeek"
+    )
+    assert fallback.formatter._qwenpaw_omit_thinking_ids == set()
 
 
 async def test_anthropic_fallback_preserves_native_thinking() -> None:

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -1546,6 +1546,8 @@ async def test_stream_recovers_agentscope_msg_via_formatter_fallback() -> None:
 
     try:
         inner = _ReasoningRetryMsgStreamModel()
+        thought = ThinkingBlock(thinking="real tool reasoning")
+        assert inner.formatter.set_thinking_omit_ids({thought.id}) is True
         model = RetryChatModel(
             inner,  # type: ignore[arg-type]
             retry_config=RetryConfig(enabled=False),
@@ -1562,7 +1564,7 @@ async def test_stream_recovers_agentscope_msg_via_formatter_fallback() -> None:
                 name="assistant",
                 role="assistant",
                 content=[
-                    ThinkingBlock(thinking="real tool reasoning"),
+                    thought,
                     ToolCallBlock(id="call_1", name="tool", input="{}"),
                     ToolResultBlock(
                         id="call_1",
@@ -1593,11 +1595,18 @@ async def test_stream_recovers_agentscope_msg_via_formatter_fallback() -> None:
         ]
         assert [
             message.get("reasoning_content") for message in first_assistants
-        ] == ["real tool reasoning", None]
+        ] == [
+            None,
+            None,
+        ]
         assert [
             message.get("reasoning_content") for message in second_assistants
-        ] == ["real tool reasoning", " "]
+        ] == [
+            "real tool reasoning",
+            " ",
+        ]
         assert inner.formatter._qwenpaw_require_reasoning_content is True
+        assert inner.formatter._qwenpaw_omit_thinking_ids == set()
         assert cache.get(model_key, "needs_reasoning_content") is True
         assert [block.type for block in messages[0].content] == [
             "thinking",


### PR DESCRIPTION
## Summary

- Fold already-consumed active-turn thinking when Scroll remains under context pressure.
- Keep folding request-only without mutating live messages or persistent history.
- Propagate thinking omission state to the concrete model selected by `FallbackChatModel`.
- Preserve complete `reasoning_content` for DeepSeek and endpoints that require exact reasoning replay.

## Problem

A single active turn may contain many reasoning/tool-call steps. Because active-turn thinking was repeatedly included in every subsequent request, the request context could continue growing even after normal Scroll compaction, eventually causing `MODEL_CONTEXT_LENGTH_EXCEEDED`.

Request-time thinking omission addresses this for compatible providers, but applying it to every OpenAI-compatible formatter is unsafe. DeepSeek requires all previous `reasoning_content` to be replayed completely when a request contains tools; omitting or replacing it with a placeholder can result in HTTP 400 responses.

## Changes

### Active-turn thinking folding

- Track ID-bearing thinking blocks included in model requests.
- Mark them foldable only after the corresponding request has been acknowledged successfully.
- Under sustained context pressure, omit acknowledged thinking blocks from subsequent wire requests.
- Recount tokens after folding and roll the fold back when it provides no measurable reduction.
- Persist seen and folded thinking IDs in Scroll checkpoints.
- Remove stale IDs when their corresponding messages leave the live context.

### Fallback propagation

- Store omission IDs in `FallbackChatModel`.
- Apply the omission state whenever a concrete fallback candidate is activated.
- Allow each candidate formatter to accept or reject omission according to its own protocol capability.
- Preserve native Anthropic thinking/signatures when falling back to Anthropic models.

### Reasoning replay compatibility

- Separate “supports `reasoning_content` relay” from “supports thinking omission.”
- Add provider/model-level exact-replay capability detection.
- Disable omission for:
  - the DeepSeek provider;
  - DeepSeek models routed through aggregators such as OpenRouter;
  - formatters that have learned `_qwenpaw_require_reasoning_content`.
- Clear stale omission IDs when retry capability learning determines that reasoning is required.
- Replay the original reasoning whenever it is available; placeholders are used only for assistant segments that never contained reasoning.

DeepSeek protocol reference:
https://api-docs.deepseek.com/guides/thinking_mode/

## Safety

- Original `Msg` and `ThinkingBlock` content remains unchanged.
- Folding affects only compatible wire requests.
- Providers requiring signed or exact reasoning retain their original representation.
- Fallback capability is evaluated against the model actually serving the request.

## Testing

Added regression coverage for:

- active-turn thinking acknowledgement and folding;
- checkpoint save/load and stale-ID cleanup;
- formatter omission without message mutation;
- OpenAI-compatible fallback propagation;
- Anthropic native thinking/signature preservation;
- direct DeepSeek reasoning replay;
- routed DeepSeek model detection;
- OpenAI-compatible primary → DeepSeek fallback;
- retry-time capability learning and omission cleanup.

Validation:

- `241 passed`
- pre-commit AST validation passed
- mypy passed
- Black passed
- Flake8 passed
- Pylint passed