### PR TITLE
fix(chat): sync resolved sessions during streaming

### DIFF
--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -17,6 +17,7 @@ import {
 } from "../turnUsage";
 import { useTurnUsageStore } from "../turnUsageStore";
 import { QWENPAW_CLIENT_MESSAGE_ID_KEY } from "../../../utils/clientMessageId";
+import { syncSessionsGlobal } from "../../../stores/sessionListStore";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1566,6 +1567,9 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const { list, realId } = resolveRealId(this.sessionList, tempId);
     this.sessionList = list;
     if (realId) {
+      // Publish the resolved mapping immediately so the SDK can match a URL
+      // carrying the backend UUID while the response is still generating.
+      syncSessionsGlobal(this.sessionList as ExtendedSession[]);
       // Migrate the pending user message from the local timestamp key to
       // the backend UUID key so patchLastUserMessage can find it after
       // page refresh (where the URL — and therefore the lookup key — is

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -16,6 +16,7 @@ import type { ChatSpec, ChatHistory } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
 import { useAgentStore } from "../../../stores/agentStore";
+import { useSessionListStore } from "../../../stores/sessionListStore";
 import { useTurnUsageStore } from "../turnUsageStore";
 import type { TurnUsageSnapshot } from "../turnUsage";
 
@@ -34,7 +35,12 @@ async function flush(): Promise<void> {
   await new Promise((res) => setTimeout(res, 0));
 }
 
-function makeChatSpec(id: string, sessionId: string, name = "chat"): ChatSpec {
+function makeChatSpec(
+  id: string,
+  sessionId: string,
+  name = "chat",
+  status: "idle" | "running" = "idle",
+): ChatSpec {
   return {
     id,
     name,
@@ -44,7 +50,7 @@ function makeChatSpec(id: string, sessionId: string, name = "chat"): ChatSpec {
     created_at: "2026-07-27T10:00:00.000000+00:00",
     updated_at: "2026-07-27T10:00:00.000000+00:00",
     meta: {},
-    status: "idle",
+    status,
     pinned: false,
     archived: false,
     archived_at: null,
@@ -61,11 +67,13 @@ const B_CHAT = "22222222-bbbb-4bbb-8bbb-222222222222";
 beforeEach(() => {
   sessionApi.resetForTests();
   useAgentStore.setState({ lastChatIdByAgent: {} });
+  useSessionListStore.setState({ _setLibrarySessions: null });
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   sessionApi.resetForTests();
+  useSessionListStore.setState({ _setLibrarySessions: null });
 });
 
 describe("agent session ownership epochs", () => {
@@ -212,6 +220,45 @@ describe("agent session ownership epochs", () => {
     sessionApi.triggerResolve(tempId);
     await flush();
     expect(onSessionIdResolved).toHaveBeenCalledWith(tempId, B_CHAT);
+  });
+
+  it("keeps both generating sessions selectable after resolving their ids", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+    const setLibrarySessions = vi.fn();
+    useSessionListStore.setState({ _setLibrarySessions: setLibrarySessions });
+
+    sessionApi.setActiveAgent("agent-a");
+    const firstSpec: { id?: string } = {};
+    await sessionApi.createSession(firstSpec);
+    const firstTempId = firstSpec.id!;
+
+    listSpy.mockResolvedValueOnce([
+      makeChatSpec(A_CHAT, firstTempId, "chat-1", "running"),
+    ]);
+    sessionApi.triggerResolve(firstTempId);
+    await flush();
+
+    const secondSpec: { id?: string } = {};
+    await sessionApi.createSession(secondSpec);
+    const secondTempId = secondSpec.id!;
+
+    listSpy.mockResolvedValueOnce([
+      makeChatSpec(B_CHAT, secondTempId, "chat-2", "running"),
+      makeChatSpec(A_CHAT, firstTempId, "chat-1", "running"),
+    ]);
+    sessionApi.triggerResolve(secondTempId);
+    await flush();
+
+    const latestSessions =
+      setLibrarySessions.mock.calls[
+        setLibrarySessions.mock.calls.length - 1
+      ][0];
+    expect(latestSessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: firstTempId, realId: A_CHAT }),
+        expect.objectContaining({ id: secondTempId, realId: B_CHAT }),
+      ]),
+    );
   });
 
   it("a stale getSession cannot rewrite window identity, turn usage, or fire selection", async () => {


### PR DESCRIPTION
## Summary

Synchronize the temporary session ID and backend UUID mapping to the SDK immediately after session resolution.

Allow users to switch between multiple conversations while their responses are still generating.

Add a regression test covering two concurrently generating sessions.

Fixes #7512

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
