### PR TITLE
fix(console): separate free models from pro tab

### DIFF
--- a/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
+++ b/console/src/pages/Chat/ModelSelector/ModelSelector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/common_setup";
 import ModelSelector from "./index";
@@ -1100,13 +1100,16 @@ describe("ModelSelector", () => {
     expect(screen.queryByText("OpenCode Paid Model")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "PRO" }));
+    const proPanel = screen.getByRole("tabpanel");
     expect(
-      (await screen.findAllByText("OpenCode Free One")).length,
-    ).toBeGreaterThan(0);
+      within(proPanel).queryByText("OpenCode Free One"),
+    ).not.toBeInTheDocument();
     expect(
-      (await screen.findAllByText("OpenCode Free Two")).length,
-    ).toBeGreaterThan(0);
-    expect(await screen.findByText("OpenCode Paid Model")).toBeInTheDocument();
+      within(proPanel).queryByText("OpenCode Free Two"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(proPanel).getByText("OpenCode Paid Model"),
+    ).toBeInTheDocument();
   });
 
   it("does not show paid discovery candidates in the free tab search", async () => {

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -191,7 +191,7 @@ export default function ModelSelector({
     [providers],
   );
 
-  // Free providers appear in both tabs; other providers use model-level tags.
+  // Models are split by is_free; mixed-tier providers can appear in both tabs.
   const { freeProviders, proProviders } = useMemo(() => {
     return splitProvidersByTier(eligibleProviders);
   }, [eligibleProviders]);

--- a/console/src/pages/Chat/ModelSelector/modelSelectorModels.test.ts
+++ b/console/src/pages/Chat/ModelSelector/modelSelectorModels.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildEligibleProviders, modelKey } from "./modelSelectorModels";
+import {
+  buildEligibleProviders,
+  modelKey,
+  splitProvidersByTier,
+} from "./modelSelectorModels";
 import type { ProviderInfo } from "../../../api/types";
 
 function makeModel(
@@ -169,6 +173,31 @@ describe("modelSelectorModels (#5784 压缩阈值跨 provider 校验)", () => {
       const eligible = buildEligibleProviders(providers);
       expect(eligible).toHaveLength(1);
       expect(eligible[0].id).toBe("free");
+    });
+  });
+
+  describe("splitProvidersByTier", () => {
+    it("keeps free models out of the PRO group", () => {
+      const provider = makeProvider({
+        id: "free-tier",
+        name: "Free Tier Provider",
+        is_free_tier: true,
+        models: [
+          { ...makeModel("free-model", 32768), is_free: true },
+          { ...makeModel("paid-model", 65536), is_free: false },
+        ],
+      });
+
+      const { freeProviders, proProviders } = splitProvidersByTier(
+        buildEligibleProviders([provider]),
+      );
+
+      expect(freeProviders[0].models.map((model) => model.id)).toEqual([
+        "free-model",
+      ]);
+      expect(proProviders[0].models.map((model) => model.id)).toEqual([
+        "paid-model",
+      ]);
     });
   });
 });

--- a/console/src/pages/Chat/ModelSelector/modelSelectorModels.ts
+++ b/console/src/pages/Chat/ModelSelector/modelSelectorModels.ts
@@ -26,9 +26,7 @@ export function splitProvidersByTier(providers: EligibleProvider[]): {
   const proProviders: EligibleProvider[] = [];
   for (const provider of providers) {
     const freeModels = provider.models.filter((model) => model.is_free);
-    const proModels = provider.is_free_tier
-      ? provider.models
-      : provider.models.filter((model) => !model.is_free);
+    const proModels = provider.models.filter((model) => !model.is_free);
     if (freeModels.length > 0 || provider.is_free_tier) {
       freeProviders.push({ ...provider, models: freeModels });
     }


### PR DESCRIPTION
## Description

- Keep free models out of the PRO tab, including models from providers marked as `is_free_tier`.
- Keep the FREE tab limited to models with `is_free === true`.
- Add regression coverage for a provider containing both free and paid models.
- Update the model selector integration test to verify the separation.

<img width="554" height="893" alt="free" src="https://github.com/user-attachments/assets/95686275-c40b-4c50-a85e-ecabf54a95e9" />
<img width="555" height="923" alt="pro" src="https://github.com/user-attachments/assets/22be2537-8d55-4e17-8b29-77c713e6b96f" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
