### PR TITLE
启用langfuse监控，工具输出空白

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -973,17 +973,19 @@ class LangfuseToolSpanMiddleware(MiddlewareBase):
             input=tool_input,
             metadata={"tool_call_id": getattr(tool_call, "id", None)},
         ) as observation:
-            final_response = None
-            async for event in next_handler():
-                if isinstance(event, ToolResponse):
-                    final_response = event
-                yield event
-            if observation is not None and final_response is not None:
-                observation.update(
-                    output={
-                        "content": [
-                            getattr(b, "text", str(b))
-                            for b in (final_response.content or [])
-                        ],
-                    },
+            try:
+                final_response = None
+                async for event in next_handler():
+                    if isinstance(event, ToolResponse):
+                        final_response = event
+                    yield event
+            finally:
+                if observation is not None and final_response is not None:
+                    observation.update(
+                        output={
+                            "content": [
+                                getattr(b, "text", str(b))
+                                for b in (final_response.content or [])
+                            ],
+                        },
                 )


### PR DESCRIPTION
## Description

修复启用 Langfuse 监控后，工具调用成功但对应 Tool Observation 的 `output` 字段为空的问题。

QwenPaw 的工具调用中间件通过异步生成器传递事件。原实现会先遍历并向上游传递所有事件，然后在异步事件流完整结束后，将最终捕获到的 `ToolResponse` 写入 Langfuse Observation。

当上游消费者在收到最终 `ToolResponse` 后停止消费或关闭异步生成器时，事件循环之后的 Observation 更新逻辑可能不会执行。因此，工具本身能够正常执行，Agent 也能够收到工具返回结果，但 Langfuse 中对应工具调用的 `output` 仍为空。

本次修改将 Langfuse Observation 的输出更新逻辑放入 `finally` 块。这样，即使异步生成器在返回最终工具响应后被关闭，只要已经捕获到 `ToolResponse`，其中的内容仍会被写入对应的 Langfuse Observation。

该修改不改变工具的调用方式、响应结构或 Agent 的处理逻辑，只修复 Langfuse 工具输出的记录时机。

**Related Issue:** Fixes #7529 

**Security Considerations:** 本次修改不涉及认证、权限、环境变量处理或密钥暴露。修改仅影响已经产生的工具响应如何写入 Langfuse。工具输出本身可能包含业务数据，其可见范围仍由现有 Langfuse 配置和访问控制决定。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

本次修改不涉及 Channel 或 Console，以下检查不适用。

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

建议通过以下方式验证修改：

1. 安装并配置 Langfuse，确保 QwenPaw 能够创建 trace。
2. 配置有效的 `LANGFUSE_SECRET_KEY`、`LANGFUSE_PUBLIC_KEY` 和 `LANGFUSE_BASE_URL`。
3. 启动 QwenPaw，并发起一个会调用工具的任务。
4. 确认工具能够正常执行，并且 Agent 能够收到对应的 `ToolResponse`。
5. 在 Agent 收到最终工具响应后结束对异步工具事件流的消费，以覆盖异步生成器被关闭的场景。
6. 打开 Langfuse 中对应的 trace 和 Tool Observation。
7. 确认 Tool Observation 的 `output.content` 包含最终 `ToolResponse` 的实际内容。
8. 同时确认工具事件仍按原顺序传递，Agent 的最终回复未发生变化。