### PR TITLE
[Bug]: OpenCode API now requires `x-opencode-session` header

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -913,6 +913,15 @@ class OpenCodeProvider(_FreeSuffixProviderMixin, OpenAIProvider):
         },
     )
 
+    def _build_default_headers(self) -> dict:
+        """Add the session header required by OpenCode."""
+        from ..app.agent_context import get_current_session_id
+
+        headers = {
+            "x-opencode-session": get_current_session_id() or "qwenpaw",
+        }
+        return {**headers, **self.custom_headers}
+
     async def fetch_models(
         self,
         timeout: float = 5,

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -9,6 +9,7 @@ from agentscope.model import OpenAIChatModel
 import pytest
 
 import qwenpaw.providers.openai_provider as openai_provider_module
+from qwenpaw.app.agent_context import scoped_session_id
 from qwenpaw.providers.openai_provider import (
     GitHubModelsProvider,
     KiloProvider,
@@ -185,6 +186,47 @@ async def test_opencode_excludes_unavailable_free_models(monkeypatch) -> None:
     ]
     assert all(model.is_free for model in models)
     close.assert_awaited_once()
+
+
+def test_opencode_sends_current_session_header() -> None:
+    provider = OpenCodeProvider(
+        id="opencode",
+        name="OpenCode",
+        base_url="https://opencode.ai/zen/go/v1",
+        require_api_key=False,
+    )
+
+    with scoped_session_id("session-123"):
+        headers = provider._build_default_headers()
+
+    assert headers["x-opencode-session"] == "session-123"
+
+
+def test_opencode_sends_fallback_session_header() -> None:
+    provider = OpenCodeProvider(
+        id="opencode",
+        name="OpenCode",
+        base_url="https://opencode.ai/zen/go/v1",
+        require_api_key=False,
+    )
+
+    assert provider._build_default_headers()["x-opencode-session"] == (
+        "qwenpaw"
+    )
+
+
+def test_opencode_session_header_can_be_overridden() -> None:
+    provider = OpenCodeProvider(
+        id="opencode",
+        name="OpenCode",
+        base_url="https://opencode.ai/zen/go/v1",
+        require_api_key=False,
+        custom_headers={"x-opencode-session": "custom-session"},
+    )
+
+    assert provider._build_default_headers()["x-opencode-session"] == (
+        "custom-session"
+    )
 
 
 async def test_custom_list_model_error_propagates(monkeypatch) -> None:


### PR DESCRIPTION
Implemented the OpenCode session-header fix.

- Added `x-opencode-session` to OpenCode SDK and chat requests.
- Uses the active QwenPaw session ID, with `qwenpaw` as a fallback outside chat context.
- Preserves explicit overrides through `custom_headers`.
- Added regression coverage for active, fallback, and custom session values.

Checks:

- `50 passed` across the targeted provider tests.
- All file-level pre-commit checks passed, including mypy, Black, Flake8, and pylint.
- `git diff --check` passed.

No live OpenCode request was made; verification used the provider’s unit-test coverage.

Closes #7531