### PR TITLE
feat(chats): add scroll-back message pagination

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "qwenpaw-console",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@agentscope-ai/chat": "1.1.73-beta.1787638407498",
         "@agentscope-ai/design": "1.0.29",
@@ -19,6 +20,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@lexical/react": "0.48.0",
         "@monaco-editor/react": "^4.7.0",
+        "@tanstack/react-virtual": "^3.14.10",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@types/react-window": "^1.8.8",
@@ -74,6 +76,7 @@
         "globals": "^16.0.0",
         "jsdom": "^29.0.2",
         "less": "^4.5.1",
+        "patch-package": "^8.0.1",
         "prettier": "3.0.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
@@ -4414,6 +4417,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
@@ -5844,6 +5874,13 @@
       "integrity": "sha512-bNRWBhWYl0edVgyX6AYbhoCM2tk2lXJjGCyO2VDc2xn6Dw8dLd7WGj2DDXkVOkmOIQTNjEAcxrEpIzz5pWVwFg==",
       "license": "MIT"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/3d-force-graph": {
       "version": "1.80.0",
       "resolved": "https://registry.npmjs.org/3d-force-graph/-/3d-force-graph-1.80.0.tgz",
@@ -6264,6 +6301,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
@@ -6465,6 +6515,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/classnames": {
@@ -8200,6 +8266,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
@@ -8230,6 +8309,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat-cache": {
@@ -8324,6 +8413,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -8520,8 +8624,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/graphlib": {
       "version": "2.1.8",
@@ -9190,6 +9293,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -9306,6 +9425,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -9501,6 +9630,19 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -9682,10 +9824,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9709,6 +9878,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jszip": {
@@ -9774,6 +9966,16 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "node_modules/layout-base": {
       "version": "1.0.2",
@@ -11004,6 +11206,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -11039,6 +11268,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ml-array-max": {
@@ -11314,6 +11553,23 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -11483,6 +11739,49 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-data-parser": {
@@ -13283,6 +13582,16 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/slate": {
       "version": "0.91.4",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
@@ -13809,6 +14118,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
@@ -14143,6 +14475,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -14689,6 +15031,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yjs": {
       "version": "13.6.32",

--- a/console/package.json
+++ b/console/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "postinstall": "patch-package",
     "dev": "vite --host",
     "build": "tsc -b && vite build && npm run verify:monaco-css && npm run precompress && npm run verify:initial-bundle",
     "build:prod": "tsc -b && vite build --mode production && npm run verify:monaco-css && npm run precompress && npm run verify:initial-bundle",
@@ -34,6 +35,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lexical/react": "0.48.0",
     "@monaco-editor/react": "^4.7.0",
+    "@tanstack/react-virtual": "^3.14.10",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@types/react-window": "^1.8.8",
@@ -89,6 +91,7 @@
     "globals": "^16.0.0",
     "jsdom": "^29.0.2",
     "less": "^4.5.1",
+    "patch-package": "^8.0.1",
     "prettier": "3.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",

--- a/console/patches/@agentscope-ai+chat+1.1.73-beta.1787638407498.patch
+++ b/console/patches/@agentscope-ai+chat+1.1.73-beta.1787638407498.patch
@@ -1,0 +1,447 @@
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/WindowedBubbleList.js b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/WindowedBubbleList.js
+new file mode 100644
+index 0000000..952ef91
+--- /dev/null
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/WindowedBubbleList.js
+@@ -0,0 +1,190 @@
++function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
++function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
++function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
++function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
++function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
++function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
++function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
++function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
++import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
++import { useVirtualizer } from '@tanstack/react-virtual';
++import Bubble from "../../../../Bubble/Bubble";
++import { jsx as _jsx } from "react/jsx-runtime";
++import { jsxs as _jsxs } from "react/jsx-runtime";
++import { Fragment as _Fragment } from "react/jsx-runtime";
++import { createElement as _createElement } from "react";
++
++var _excluded = ["key"];
++
++// Must match `gap: 24px` on `.{prefixCls}-bubble-list` in Bubble/style/list.js.
++// The virtualizer needs it because measured row heights come from
++// getBoundingClientRect(), which excludes the flex gap.
++var LIST_GAP_PX = 24;
++
++// Rough height of an unmeasured row. Only affects the scrollbar's feel for
++// not-yet-rendered regions; every row that scrolls into view is measured for
++// real and the estimate stops mattering for it.
++var ESTIMATED_ROW_HEIGHT = 140;
++
++/**
++ * 消息列表的虚拟化渲染（补丁新增）。
++ *
++ * 作为 `Bubble.List` 的 children 传入，走它内部
++ * `children ? children : paginationItems.map(...)` 这个既有分支，从而在不改
++ * 动 Bubble.List 自身滚动逻辑的前提下，把"每次渲染全部消息"换成"只渲染视口
++ * 附近的消息"。
++ *
++ * Virtualized rendering for the message list (patch addition). Passed as
++ * `Bubble.List`'s children so it takes over the existing
++ * `children ? children : paginationItems.map(...)` branch — the whole list
++ * no longer mounts at once, which is what made each "load older" prepend
++ * block the main thread for seconds.
++ *
++ * Design notes, because the container this renders into is unusual:
++ *
++ * - The scroll container is `Bubble.List`'s own `.{prefixCls}-bubble-list`
++ *   div (native `overflow: auto`), NOT one this component owns. We hand it
++ *   to the virtualizer via `getScrollElement` so `scrollToBottom`,
++ *   `checkIsAtBottom` and the load-more sentinel — all of which read that
++ *   element's raw `scrollTop` — keep working untouched.
++ * - That container is `flex-direction: column-reverse` for `order="desc"`:
++ *   items[0] (newest) paints at the BOTTOM, and Chrome reports a NEGATIVE
++ *   `scrollTop` that runs 0 → -(scrollHeight - clientHeight) as you scroll
++ *   back toward older messages. (BubbleList's own `checkShowScrollToBottom`
++ *   relies on the same thing: `scrollTop <= -10`.) The virtualizer assumes a
++ *   0→positive axis, so `observeElementOffset`/`scrollToFn` below translate
++ *   between the two — without that translation it clamps every negative
++ *   offset to 0, believes it is permanently parked at items[0], and leaves
++ *   the viewport blank once you scroll away from the newest message.
++ * - Rows are therefore rendered as ordinary flex children (NOT absolutely
++ *   positioned the way the virtualizer's docs show), with one spacer div on
++ *   each side standing in for the un-rendered ranges. Absolute positioning
++ *   would take the rows out of the column-reverse flow and break the layout.
++ */
++function WindowedBubbleList(props) {
++  var items = props.items || [];
++  var count = items.length;
++
++  // The probe is the first real DOM node this component renders, and
++  // BubbleListContent renders us straight into the scroll container with no
++  // wrapper in between — so its parentElement IS that container. Cheaper and
++  // less brittle than a global querySelector for the prefixed class name.
++  var probeRef = useRef(null);
++  var _useState = useState(null),
++    scrollEl = _useState[0],
++    setScrollEl = _useState[1];
++
++  useEffect(function () {
++    var parent = probeRef.current ? probeRef.current.parentElement : null;
++    if (parent && parent !== scrollEl) setScrollEl(parent);
++  }, [scrollEl]);
++
++  var getItemKey = useCallback(function (index) {
++    var item = items[index];
++    return (item && (item.id || item.key)) || index;
++  }, [items]);
++
++  // column-reverse ⇒ Chrome's scrollTop is 0 at the newest message and goes
++  // negative toward older ones. Feed the virtualizer the absolute value so
++  // its 0→positive offset math lines up with array order, and invert again
++  // on the way out when it repositions the scroll (it does that itself when
++  // a row above the viewport is measured at a different height than
++  // estimated, to keep the visible content from jumping).
++  var observeElementOffset = useCallback(function (instance, cb) {
++    var el = instance.scrollElement;
++    if (!el) return undefined;
++    var report = function report(isScrolling) {
++      return function () {
++        cb(Math.abs(el.scrollTop), isScrolling);
++      };
++    };
++    var onScroll = report(true);
++    var onScrollEnd = report(false);
++    el.addEventListener('scroll', onScroll, {
++      passive: true
++    });
++    el.addEventListener('scrollend', onScrollEnd, {
++      passive: true
++    });
++    // Seed the initial offset; without it the first frame renders against a
++    // stale 0 before any scroll event fires.
++    cb(Math.abs(el.scrollTop), false);
++    return function () {
++      el.removeEventListener('scroll', onScroll);
++      el.removeEventListener('scrollend', onScrollEnd);
++    };
++  }, []);
++
++  var scrollToFn = useCallback(function (offset, options, instance) {
++    var el = instance.scrollElement;
++    if (!el || !el.scrollTo) return;
++    var adjustments = options && options.adjustments || 0;
++    el.scrollTo({
++      top: -(offset + adjustments),
++      behavior: options && options.behavior
++    });
++  }, []);
++
++  var virtualizer = useVirtualizer({
++    count: count,
++    getScrollElement: function getScrollElement() {
++      return scrollEl;
++    },
++    estimateSize: function estimateSize() {
++      return ESTIMATED_ROW_HEIGHT;
++    },
++    getItemKey: getItemKey,
++    gap: LIST_GAP_PX,
++    overscan: 6,
++    observeElementOffset: observeElementOffset,
++    scrollToFn: scrollToFn
++  });
++
++  var virtualItems = virtualizer.getVirtualItems();
++  var totalSize = virtualizer.getTotalSize();
++
++  // Space held open for the rows we did not render. `before` covers the
++  // newer side (array indices below the window, painted below the viewport
++  // under column-reverse); `after` covers the older side above it.
++  var padBefore = virtualItems.length > 0 ? virtualItems[0].start : 0;
++  var padAfter = virtualItems.length > 0
++    ? Math.max(0, totalSize - virtualItems[virtualItems.length - 1].end)
++    : Math.max(0, totalSize);
++
++  var rows = useMemo(function () {
++    return virtualItems.map(function (virtualRow) {
++      var item = items[virtualRow.index];
++      if (!item) return null;
++      var key = item.key,
++        bubble = _objectWithoutProperties(item, _excluded);
++      // Preserved verbatim from the original inline map in BubbleList.js so
++      // Bubble keeps receiving exactly what it did before.
++      var isLast = virtualRow.index === count - 1;
++      return /*#__PURE__*/_jsx("div", {
++        ref: virtualizer.measureElement,
++        "data-index": virtualRow.index,
++        children: /*#__PURE__*/_createElement(Bubble, _objectSpread(_objectSpread({}, bubble), {}, {
++          isLast: isLast
++        }))
++      }, virtualRow.key);
++    });
++  }, [virtualItems, items, count, virtualizer]);
++
++  return /*#__PURE__*/_jsxs(_Fragment, {
++    children: [/*#__PURE__*/_jsx("div", {
++      ref: probeRef,
++      style: {
++        height: padBefore,
++        flex: '0 0 auto'
++      },
++      "aria-hidden": true
++    }), rows, /*#__PURE__*/_jsx("div", {
++      style: {
++        height: padAfter,
++        flex: '0 0 auto'
++      },
++      "aria-hidden": true
++    })]
++  });
++}
++export default WindowedBubbleList;
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/index.js b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/index.js
+index 5f36fe1..801acb3 100644
+--- a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/index.js
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Chat/MessageList/index.js
+@@ -15,7 +15,8 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+ import { Bubble, useProviderContext } from "../../../..";
+ import { ChatAnywhereMessagesContext } from "../../Context/ChatAnywhereMessagesContext";
+ import { useContextSelector } from "use-context-selector";
+-import { ChatAnywhereSessionsContext } from "../../Context/ChatAnywhereSessionsContext";
++import { ChatAnywhereSessionsContext, useChatAnywhereLoadMoreHistory } from "../../Context/ChatAnywhereSessionsContext";
++import WindowedBubbleList from "./WindowedBubbleList";
+ import { useChatAnywhereOptions } from "../../Context/ChatAnywhereOptionsContext";
+ import cls from 'classnames';
+ import Welcome from "../Welcome";
+@@ -186,21 +187,44 @@ export default function MessageList(props) {
+   var prevMessagesLengthRef = React.useRef(safeMessages.length);
+   var _useSimulatedMessageP = useSimulatedMessagePagination(safeMessages, currentSessionId),
+     visibleMessages = _useSimulatedMessageP.visibleMessages,
+-    noMore = _useSimulatedMessageP.noMore,
+-    loadMore = _useSimulatedMessageP.loadMore,
++    simulatedNoMore = _useSimulatedMessageP.noMore,
++    simulatedLoadMore = _useSimulatedMessageP.loadMore,
+     ensureMessageVisible = _useSimulatedMessageP.ensureMessageVisible;
++  // Real backend-driven pagination (patch addition) takes priority when the
++  // host app supplies options.session.onLoadMore: the full already-loaded
++  // array is shown as-is (no client-side reveal windowing — the network
++  // page size already bounds what's in memory), and "load more" fetches an
++  // actual older page instead of just revealing more of what's in memory.
++  var _useChatAnywhereLoadM = useChatAnywhereLoadMoreHistory(),
++    realLoadMore = _useChatAnywhereLoadM.loadMore,
++    realNoMore = _useChatAnywhereLoadM.noMore,
++    hasRealLoadMore = _useChatAnywhereLoadM.hasRealLoadMore;
++  var displayMessages = hasRealLoadMore ? safeMessages : visibleMessages;
++  var noMore = hasRealLoadMore ? realNoMore : simulatedNoMore;
++  var loadMore = hasRealLoadMore ? realLoadMore : simulatedLoadMore;
+   var renderedItemsKey = useMemo(function () {
+-    return visibleMessages.map(function (message) {
++    return displayMessages.map(function (message) {
+       return message.id;
+     }).join('|');
+-  }, [visibleMessages]);
++  }, [displayMessages]);
++  // Auto-scroll to bottom only when a genuinely new message arrives at the
++  // end — not merely when the array grows for any reason. A loadMore
++  // prepend also grows safeMessages.length, but the newest message (index
++  // 0 of the reversed/desc array) is unchanged; without this distinction
++  // the length-only check below used to yank the view back to the bottom
++  // right after the user scrolled up to load older history (patch fix).
++  var prevNewestIdRef = React.useRef(safeMessages[0] && safeMessages[0].id);
+   React.useEffect(function () {
+-    if (safeMessages.length > prevMessagesLengthRef.current) {
++    var newestId = safeMessages[0] && safeMessages[0].id;
++    var grew = safeMessages.length > prevMessagesLengthRef.current;
++    var newestChanged = newestId !== prevNewestIdRef.current;
++    if (grew && newestChanged) {
+       var _listRef$current;
+       (_listRef$current = listRef.current) === null || _listRef$current === void 0 || _listRef$current.scrollToBottom();
+     }
+     prevMessagesLengthRef.current = safeMessages.length;
+-  }, [safeMessages.length]);
++    prevNewestIdRef.current = newestId;
++  }, [safeMessages]);
+   if (safeMessages.length === 0) return /*#__PURE__*/_jsx("div", {
+     className: cls(prefixCls, "".concat(prefixCls, "-welcome")),
+     children: /*#__PURE__*/_jsx(Welcome, {
+@@ -218,7 +242,15 @@ export default function MessageList(props) {
+         wrapper: "".concat(prefixCls, "-bubble-wrapper"),
+         list: scrollContainerClassName
+       },
+-      items: visibleMessages
++      items: displayMessages,
++      // Virtualize only the real-backend-pagination path: there the list
++      // grows without bound as older pages load, and mounting every bubble
++      // on each prepend is what stalls the main thread. The simulated path
++      // already hands us a small pre-windowed slice, so it renders inline
++      // exactly as before (children undefined ⇒ Bubble.List's own map).
++      children: hasRealLoadMore ? /*#__PURE__*/_jsx(WindowedBubbleList, {
++        items: displayMessages
++      }) : undefined
+     }, currentSessionId), /*#__PURE__*/_jsx(UserMessageAnchors, {
+       badgeMaxCount: userMessageAnchorsOptions === null || userMessageAnchorsOptions === void 0 ? void 0 : userMessageAnchorsOptions.badgeMaxCount,
+       enabled: (userMessageAnchorsOptions === null || userMessageAnchorsOptions === void 0 ? void 0 : userMessageAnchorsOptions.enabled) !== false,
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.d.ts b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.d.ts
+index 0d083ab..5d0e2a3 100644
+--- a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.d.ts
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.d.ts
+@@ -9,6 +9,15 @@ export declare function ChatAnywhereSessionsContextProvider(props: {
+  * 会话切换时加载消息和判断重连的 hook，必须保证只挂载一次
+  */
+ export declare const useChatAnywhereSessionLoader: () => void;
++/**
++ * 真实后端分页加载更早历史消息的 hook（补丁新增）。options.session.onLoadMore
++ * 由宿主应用提供；未提供时 hasRealLoadMore 为 false。
++ */
++export declare const useChatAnywhereLoadMoreHistory: () => {
++    loadMore: () => Promise<void>;
++    noMore: boolean;
++    hasRealLoadMore: boolean;
++};
+ /**
+  * 获取会话列表的 reactive 状态，供外部自定义会话面板使用
+  */
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.js b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.js
+index 4544e8d..cf63cf1 100644
+--- a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.js
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.js
+@@ -126,6 +126,91 @@ export var useChatAnywhereSessionLoader = function useChatAnywhereSessionLoader(
+   })), [currentSessionId]);
+ };
+ 
++// Bounded history window: once the loaded message count exceeds this after
++// a loadMore prepend, the newest (tail) end is trimmed so repeated backward
++// scrolling can't grow memory/DOM without bound. The user has scrolled away
++// from those messages into older history; only the cursor (tracked by the
++// app's own onLoadMore closure, not here) is kept.
++var LOAD_MORE_MAX_MESSAGES = 300;
++
++/**
++ * 真实后端分页加载更早历史消息的 hook（补丁新增）。
++ * options.session.onLoadMore 由宿主应用提供；未提供时 hasRealLoadMore 为
++ * false，MessageList 回退到原有的模拟分页（揭示已加载数组）。
++ *
++ * Real backend-driven "load older history" (patch addition). The host app
++ * supplies options.session.onLoadMore; when absent, hasRealLoadMore is
++ * false and MessageList falls back to the original simulated pagination
++ * (revealing more of an already-loaded array).
++ */
++export var useChatAnywhereLoadMoreHistory = function useChatAnywhereLoadMoreHistory() {
++  var currentSessionId = useContextSelector(ChatAnywhereSessionsContext, function (v) {
++    return v.currentSessionId;
++  });
++  var onLoadMore = useChatAnywhereOptions(function (v) {
++    var _v$session;
++    return (_v$session = v.session) === null || _v$session === void 0 ? void 0 : _v$session.onLoadMore;
++  });
++  var setMessages = useContextSelector(ChatAnywhereMessagesContext, function (v) {
++    return v.setMessages;
++  });
++  var _useGetState6 = useGetState(false),
++    _useGetState7 = _slicedToArray(_useGetState6, 2),
++    noMore = _useGetState7[0],
++    setNoMore = _useGetState7[1];
++  var loadingRef = React.useRef(false);
++  // A ref, not the closed-over `currentSessionId` value: the race guard
++  // below must observe a session switch that happens *while* the request
++  // is in flight, and a value captured in the async closure at call time
++  // would just equal `sessionIdAtCall` forever (both frozen at the same
++  // render), making the guard a no-op.
++  var currentSessionIdRef = React.useRef(currentSessionId);
++  React.useEffect(function () {
++    currentSessionIdRef.current = currentSessionId;
++    // A new session starts with its own "reached the end" state and no
++    // in-flight request carried over from the previous one.
++    setNoMore(false);
++    loadingRef.current = false;
++  }, [currentSessionId, setNoMore]);
++  var loadMore = React.useCallback(async function () {
++    if (!onLoadMore || loadingRef.current) return;
++    var sessionIdAtCall = currentSessionIdRef.current;
++    loadingRef.current = true;
++    try {
++      var result = await onLoadMore(sessionIdAtCall);
++      // Race guard: the active session changed while this request was in
++      // flight — discard the response rather than prepending stale history
++      // (or a stale noMore) onto whatever session is now showing.
++      if (currentSessionIdRef.current !== sessionIdAtCall) return;
++      if (result && result.messages && result.messages.length) {
++        setMessages(function (prev) {
++          var older = result.messages.map(function (item) {
++            return _objectSpread(_objectSpread({}, item), {}, {
++              history: true
++            });
++          });
++          // Both operands are already real arrays (older from .map(),
++          // prev from React state) — plain .concat() needs no spread
++          // helper, unlike [...older, ...prev].
++          var merged = older.concat(prev);
++          if (merged.length > LOAD_MORE_MAX_MESSAGES) {
++            merged = merged.slice(0, LOAD_MORE_MAX_MESSAGES);
++          }
++          return merged;
++        });
++      }
++      setNoMore(!result || result.noMore !== false);
++    } finally {
++      loadingRef.current = false;
++    }
++  }, [onLoadMore, setMessages, setNoMore]);
++  return {
++    loadMore: loadMore,
++    noMore: noMore,
++    hasRealLoadMore: typeof onLoadMore === 'function'
++  };
++};
++
+ /**
+  * 获取会话列表的 reactive 状态，供外部自定义会话面板使用
+  */
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.d.ts b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.d.ts
+index 3068df5..dc3ac5f 100644
+--- a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.d.ts
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.d.ts
+@@ -3,6 +3,7 @@ import { UploadProps } from 'antd';
+ import type { SenderComponents } from '../../../Sender';
+ import { IAgentScopeRuntimeMessage, IAgentScopeRuntimeRequest, IAgentScopeRuntimeResponse, IContent } from '../AgentScopeRuntime/types';
+ import { IAgentScopeRuntimeWebUISession } from './ISessions';
++import { IAgentScopeRuntimeWebUIMessage } from './IMessages';
+ /**
+  * @description API 配置选项
+  * @descriptionEn API configuration options
+@@ -567,6 +568,20 @@ export interface IAgentScopeRuntimeWebUISessionOptions {
+      * @descriptionEn Session API interface
+      */
+     api?: IAgentScopeRuntimeWebUISessionAPI;
++    /**
++     * @description 加载更早历史消息的回调（补丁新增）。提供时，MessageList 使用
++     * 真实网络分页并在触底/点击时前插返回的消息；不提供时退回原有的模拟分页
++     * （揭示已加载数组）。
++     * @descriptionEn Callback to load older history messages (patch addition).
++     * When provided, MessageList uses real network-backed pagination and
++     * prepends the returned messages; when omitted, falls back to the
++     * original simulated pagination (revealing more of an already-loaded
++     * array).
++     */
++    onLoadMore?: (sessionId: string) => Promise<{
++        messages: IAgentScopeRuntimeWebUIMessage[];
++        noMore: boolean;
++    }>;
+ }
+ /**
+  * @description 自定义卡片组件配置
+diff --git a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IMessages.d.ts b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IMessages.d.ts
+index e787b8d..4b911a3 100644
+--- a/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IMessages.d.ts
++++ b/node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/types/IMessages.d.ts
+@@ -42,6 +42,15 @@ export interface IAgentScopeRuntimeWebUIMessage<T = string | any> {
+      * @descriptionEn Processing status of the message, affects display effects
+      */
+     msgStatus?: 'finished' | 'interrupted' | 'generating' | 'error';
++    /**
++     * @description 是否为已加载的历史消息（会话首屏加载或 onLoadMore 追加），
++     * 用于模拟分页/真实分页两种模式区分"当前新消息"与"历史消息"
++     * @descriptionEn Whether this is an already-loaded history message (from
++     * the initial session load or an onLoadMore page), used to distinguish
++     * "current new messages" from "history" in both the simulated and real
++     * pagination modes
++     */
++    history?: boolean;
+ }
+ export interface IAgentScopeRuntimeWebUIMessagesContext {
+     messages: IAgentScopeRuntimeWebUIMessage[];

--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -4,6 +4,7 @@ import { buildAuthHeaders } from "../authHeaders";
 import type {
   ChatSpec,
   ChatHistory,
+  ChatMessagesPage,
   ChatDeleteResponse,
   ChatUpdateRequest,
   ChatGroup,
@@ -98,6 +99,36 @@ export const chatApi = {
       {
         signal: options?.signal,
       },
+    );
+  },
+
+  /** Paginated scroll-back read path: GET /chats/{id}/messages. No
+   * `beforeSeq` = turn-aligned first-screen window (anchored for later
+   * paging); with `beforeSeq` = the next older page straight from
+   * history.db. See docs/session-scroll-loading-design.md. */
+  getMessages: (
+    chatId: string,
+    params?: {
+      limit?: number;
+      beforeSeq?: number;
+      include_app_owned?: boolean;
+    },
+    options?: { signal?: AbortSignal },
+  ) => {
+    const searchParams = new URLSearchParams();
+    if (params?.limit !== undefined)
+      searchParams.append("limit", String(params.limit));
+    if (params?.beforeSeq !== undefined)
+      searchParams.append("before_seq", String(params.beforeSeq));
+    if (params?.include_app_owned !== undefined)
+      searchParams.append(
+        "include_app_owned",
+        String(params.include_app_owned),
+      );
+    const query = searchParams.toString();
+    return request<ChatMessagesPage>(
+      `/chats/${encodeURIComponent(chatId)}/messages${query ? `?${query}` : ""}`,
+      { signal: options?.signal },
     );
   },
 

--- a/console/src/api/types/chat.ts
+++ b/console/src/api/types/chat.ts
@@ -42,6 +42,32 @@ export interface ChatHistory {
   status?: ChatStatus; // Conversation status: idle or running
 }
 
+// Value semantics for GET /chats/{id}/messages — see
+// docs/session-scroll-loading-design.md §2.1.
+// - "available": more history exists before next_cursor; keep paging.
+// - "complete": reached the true start of the conversation.
+// - "expired": the true start was purged by an old retention policy.
+// - "unavailable": this session has no history store to scroll into
+//   (non-scroll mode) — messages is a capped safety window, not a page.
+// - "degraded": history.db exists but couldn't be read for this request —
+//   never treat this the same as "complete".
+export type ChatHistoryStatus =
+  | "available"
+  | "complete"
+  | "expired"
+  | "unavailable"
+  | "degraded";
+
+export interface ChatMessagesPage {
+  messages: Message[];
+  next_cursor: number | null; // pass as before_seq to fetch the next (older) page
+  has_more: boolean;
+  history_status: ChatHistoryStatus;
+  status: ChatStatus;
+  truncated: boolean; // a single turn exceeded the expansion budget; next_cursor continues it
+  fallback_limited: boolean; // messages is a capped safety window, not a normal page
+}
+
 export interface ChatUpdateRequest {
   name?: string;
   pinned?: boolean;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -3313,6 +3313,12 @@ export default function ChatPage() {
         multiple: true,
         hideBuiltInSessionList: true,
         api: sessionApi,
+        // Real backend-driven scroll-back pagination — requires the
+        // @jsfund/agent-chat patch in console/patches/ (see
+        // docs/session-scroll-loading-design.md §3). sessionId here is
+        // whatever the SDK considers "current" (display id or backend
+        // UUID); loadOlderMessages resolves it internally.
+        onLoadMore: (sessionId: string) => sessionApi.loadOlderMessages(sessionId),
       },
       api: {
         ...defaultConfig.api,

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -6,6 +6,8 @@ import type {
 import api, {
   type ChatSpec,
   type ChatHistory,
+  type ChatMessagesPage,
+  type ChatHistoryStatus,
   type ChatStatus,
   type Message,
 } from "../../../api";
@@ -134,6 +136,14 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   groupId?: string | null;
   parentSessionId?: string | null;
   rootSessionId?: string | null;
+  /** Cursor for the next (older) page from GET /chats/{id}/messages; null
+   * once the true start of history has been reached, undefined before the
+   * first screen has loaded at all. See loadOlderMessages. */
+  nextCursor?: number | null;
+  /** Tail-of-scroll state from the most recent messages page (first screen
+   * or loadOlderMessages) — drives the "load more" affordance and its
+   * end-of-history / degraded / expired messaging. */
+  historyStatus?: ChatHistoryStatus;
 }
 
 // ---------------------------------------------------------------------------
@@ -409,7 +419,7 @@ const isLocalTimestamp = (id: string): boolean => /^\d+-[a-z0-9]+$/.test(id);
  *  When status is missing (undefined) treat the chat as idle to avoid
  *  false-positive reconnects that cause infinite loading (issue #4903).
  */
-const isGenerating = (chatHistory: ChatHistory): boolean => {
+const isGenerating = (chatHistory: ChatHistory | ChatMessagesPage): boolean => {
   return chatHistory.status === "running";
 };
 
@@ -665,6 +675,65 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.convertedSessionCache.delete(backendId);
   }
 
+  // ---------------------------------------------------------------------------
+  // Scroll-back pagination (GET /chats/{id}/messages) — see
+  // docs/session-scroll-loading-design.md §3.
+  // ---------------------------------------------------------------------------
+
+  /** backendId -> next_cursor from the most recent messages page. Tracked
+   * independently of convertedSessionCache (which can evict, or never gets
+   * populated at all while a session is generating) so loadOlderMessages
+   * always knows where to resume regardless of cache state. */
+  private nextCursorBySession = new Map<string, number | null>();
+
+  /**
+   * Fetch the next older page of history for `sessionId` (as passed by the
+   * SDK's onLoadMore — a display id or a real backend UUID; resolved here)
+   * and prepend it. Returns `{messages: [], noMore: true}` when no first
+   * screen has loaded yet or the cursor is already null (reached the true
+   * start) — `noMore: false` on any fetch error so the load-more affordance
+   * stays visible and a rescroll retries, instead of silently dead-ending.
+   */
+  async loadOlderMessages(
+    sessionId: string,
+  ): Promise<{ messages: IAgentScopeRuntimeWebUIMessage[]; noMore: boolean }> {
+    const backendId = this.getRealIdForSession(sessionId) ?? sessionId;
+    const cursor = this.nextCursorBySession.get(backendId);
+    if (cursor === undefined || cursor === null) {
+      return { messages: [], noMore: true };
+    }
+
+    let page: ChatMessagesPage;
+    try {
+      page = await api.getMessages(backendId, {
+        beforeSeq: cursor,
+        limit: 50,
+        include_app_owned: false,
+      });
+    } catch {
+      // Transient failure: don't advance the cursor and don't claim
+      // noMore, so the next scroll/click just retries from the same spot.
+      return { messages: [], noMore: false };
+    }
+
+    this.nextCursorBySession.set(backendId, page.next_cursor);
+    const converted = convertMessages(page.messages || []);
+
+    const cacheEntry = this.convertedSessionCache.get(backendId);
+    if (cacheEntry) {
+      cacheEntry.session.messages = [...converted, ...cacheEntry.session.messages];
+      cacheEntry.session.nextCursor = page.next_cursor;
+      cacheEntry.session.historyStatus = page.history_status;
+    }
+    const listEntry = this.findSession(sessionId) ?? this.findSession(backendId);
+    if (listEntry) {
+      listEntry.nextCursor = page.next_cursor;
+      listEntry.historyStatus = page.history_status;
+    }
+
+    return { messages: converted, noMore: !page.has_more };
+  }
+
   /**
    * Pre-load a session's data. Returns the session with its realId resolved.
    * Used by handleSessionClick to load data BEFORE setting currentSessionId,
@@ -762,6 +831,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.sessionRequests.clear();
     this.sessionResultCache.clear();
     this.convertedSessionCache.clear();
+    this.nextCursorBySession.clear();
     // Reset the session list and its comparison state as well: the next
     // agent's chats can share a session_id (channel:user_id) with the old
     // list, and merging against leftover entries would transfer the previous
@@ -817,6 +887,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.sessionRequests.clear();
     this.sessionResultCache.clear();
     this.convertedSessionCache.clear();
+    this.nextCursorBySession.clear();
     this.sessionList = [];
     this._prevReturnedList = null;
     this.lastSelectedIds.clear();
@@ -1421,10 +1492,11 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       }
     }
 
-    const chatHistory = await api.getChat(backendId, {
-      signal,
-      include_app_owned: false,
-    });
+    const chatHistory = await api.getMessages(
+      backendId,
+      { limit: 50, include_app_owned: false },
+      { signal },
+    );
     if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
     const generating = isGenerating(chatHistory);
     const messages = convertMessages(chatHistory.messages || []);
@@ -1433,6 +1505,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       generating,
       backendId,
     );
+    this.nextCursorBySession.set(backendId, chatHistory.next_cursor);
 
     const session: ExtendedSession = {
       id: displayId,
@@ -1444,6 +1517,8 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       meta: listEntry?.meta || {},
       realId: listEntry?.realId,
       generating,
+      nextCursor: chatHistory.next_cursor,
+      historyStatus: chatHistory.history_status,
     };
 
     // Cache non-generating sessions — only within the epoch that fetched
@@ -1689,9 +1764,15 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     if (deleteId) await api.deleteChat(deleteId);
 
-    // Invalidate LRU cache for the deleted session
-    if (deleteId) this.invalidateConvertedCache(deleteId);
-    if (existing?.realId) this.invalidateConvertedCache(existing.realId);
+    // Invalidate LRU cache and pagination cursor for the deleted session
+    if (deleteId) {
+      this.invalidateConvertedCache(deleteId);
+      this.nextCursorBySession.delete(deleteId);
+    }
+    if (existing?.realId) {
+      this.invalidateConvertedCache(existing.realId);
+      this.nextCursorBySession.delete(existing.realId);
+    }
 
     // Use the canonical id from the list entry (existing?.id = localId even when
     // the caller passed a UUID), so the filter always removes the right entry.

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -12,13 +12,14 @@
  * rejected, while same-epoch results keep working.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ChatSpec, ChatHistory } from "../../../api";
+import type { ChatSpec, ChatMessagesPage } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
 import { useAgentStore } from "../../../stores/agentStore";
 import { useSessionListStore } from "../../../stores/sessionListStore";
 import { useTurnUsageStore } from "../turnUsageStore";
 import type { TurnUsageSnapshot } from "../turnUsage";
+import { toMessagesPage } from "./convertMessagesHelper";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -57,8 +58,8 @@ function makeChatSpec(
   } as unknown as ChatSpec;
 }
 
-function makeHistory(): ChatHistory {
-  return { messages: [], status: "idle" } as unknown as ChatHistory;
+function makeHistory(): ChatMessagesPage {
+  return toMessagesPage({ messages: [], status: "idle" });
 }
 
 const A_CHAT = "11111111-aaaa-4aaa-8aaa-111111111111";
@@ -81,7 +82,7 @@ describe("agent session ownership epochs", () => {
     const listSpy = vi
       .spyOn(api, "listChats")
       .mockResolvedValue([makeChatSpec(A_CHAT, "console:a")]);
-    const getSpy = vi.spyOn(api, "getChat").mockResolvedValue(makeHistory());
+    const getSpy = vi.spyOn(api, "getMessages").mockResolvedValue(makeHistory());
     sessionApi.setActiveAgent("agent-a");
 
     await sessionApi.getSessionList();
@@ -91,10 +92,11 @@ describe("agent session ownership epochs", () => {
       archived: false,
       include_app_owned: false,
     });
-    expect(getSpy).toHaveBeenCalledWith(A_CHAT, {
-      signal: undefined,
-      include_app_owned: false,
-    });
+    expect(getSpy).toHaveBeenCalledWith(
+      A_CHAT,
+      { limit: 50, include_app_owned: false },
+      { signal: undefined },
+    );
   });
 
   it("Test A: an old agent's list request cannot replace the new agent's list", async () => {
@@ -191,7 +193,7 @@ describe("agent session ownership epochs", () => {
 
   it("Test D: same-owner list, selection, and temp-id resolution still work", async () => {
     const listSpy = vi.spyOn(api, "listChats");
-    vi.spyOn(api, "getChat").mockResolvedValue(makeHistory());
+    vi.spyOn(api, "getMessages").mockResolvedValue(makeHistory());
     const onSessionSelected = vi.fn();
     const onSessionIdResolved = vi.fn();
     sessionApi.onSessionSelected = onSessionSelected;
@@ -265,8 +267,8 @@ describe("agent session ownership epochs", () => {
     vi.spyOn(api, "listChats").mockResolvedValue([
       makeChatSpec(A_CHAT, "console:a"),
     ]);
-    const dChat = deferred<ChatHistory>();
-    vi.spyOn(api, "getChat").mockReturnValueOnce(dChat.promise);
+    const dChat = deferred<ChatMessagesPage>();
+    vi.spyOn(api, "getMessages").mockReturnValueOnce(dChat.promise);
     const onSessionSelected = vi.fn();
     sessionApi.onSessionSelected = onSessionSelected;
 
@@ -299,9 +301,9 @@ describe("agent session ownership epochs", () => {
     vi.spyOn(api, "listChats").mockResolvedValue([
       makeChatSpec(A_CHAT, "console:a"),
     ]);
-    const dA = deferred<ChatHistory>();
+    const dA = deferred<ChatMessagesPage>();
     const getChatSpy = vi
-      .spyOn(api, "getChat")
+      .spyOn(api, "getMessages")
       .mockReturnValueOnce(dA.promise)
       .mockResolvedValue(makeHistory());
 
@@ -330,8 +332,8 @@ describe("agent session ownership epochs", () => {
     vi.spyOn(api, "listChats").mockResolvedValue([
       makeChatSpec(A_CHAT, "console:a"),
     ]);
-    const dChat = deferred<ChatHistory>();
-    vi.spyOn(api, "getChat").mockReturnValueOnce(dChat.promise);
+    const dChat = deferred<ChatMessagesPage>();
+    vi.spyOn(api, "getMessages").mockReturnValueOnce(dChat.promise);
 
     // Agent A starts a preload whose fetch is still pending at switch time.
     sessionApi.setActiveAgent("agent-a");

--- a/console/src/pages/Chat/tests/convertMessagesHelper.ts
+++ b/console/src/pages/Chat/tests/convertMessagesHelper.ts
@@ -137,3 +137,34 @@ export function convertMessages(messages: Message[]): UIMessage[] {
 export function isGenerating(chatHistory: { status?: string }): boolean {
   return chatHistory.status === "running";
 }
+
+/**
+ * fetchAndBuildSession reads its first screen from `api.getMessages`
+ * (ChatMessagesPage), not `api.getChat` (ChatHistory). Tests written before
+ * that switch mock `getChat` with a plain `{messages, status}` object —
+ * this wraps one into the page shape `getMessages` actually returns, with
+ * defaults ("no more history, not paginating") that are inert for tests
+ * that don't care about pagination themselves.
+ */
+export function toMessagesPage<M>(history: {
+  messages: M[];
+  status?: "idle" | "running";
+}): {
+  messages: M[];
+  next_cursor: number | null;
+  has_more: boolean;
+  history_status: "unavailable";
+  status: "idle" | "running";
+  truncated: boolean;
+  fallback_limited: boolean;
+} {
+  return {
+    messages: history.messages,
+    next_cursor: null,
+    has_more: false,
+    history_status: "unavailable",
+    status: history.status ?? "idle",
+    truncated: false,
+    fallback_limited: false,
+  };
+}

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -43,6 +43,7 @@ import {
   attachClientMessageId,
   QWENPAW_CLIENT_MESSAGE_ID_KEY,
 } from "../../../utils/clientMessageId";
+import { toMessagesPage } from "./convertMessagesHelper";
 
 const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
 
@@ -109,7 +110,9 @@ function seedSessionList(id: string): void {
 
 async function mockGetChat(history: ChatHistory) {
   const apiImport = await import("../../../api");
-  return vi.spyOn(apiImport.api, "getChat").mockResolvedValue(history);
+  return vi
+    .spyOn(apiImport.api, "getMessages")
+    .mockResolvedValue(toMessagesPage(history));
 }
 
 /** Collect texts of user-role cards from a converted session. */

--- a/console/src/pages/Chat/tests/sessionCacheStaleness.test.ts
+++ b/console/src/pages/Chat/tests/sessionCacheStaleness.test.ts
@@ -20,9 +20,10 @@
  * when `updated_at` advances (and NOT when it stays the same).
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import type { ChatSpec, ChatHistory, Message } from "../../../api";
+import type { ChatSpec, ChatMessagesPage, Message } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
+import { toMessagesPage } from "./convertMessagesHelper";
 
 const T0 = "2026-07-16T15:30:00.000000+00:00";
 const T1 = "2026-07-16T15:36:00.000000+00:00";
@@ -46,7 +47,7 @@ function makeChatSpec(id: string, updatedAt: string): ChatSpec {
 
 function makeHistory(
   turns: Array<{ role: string; text: string }>,
-): ChatHistory {
+): ChatMessagesPage {
   const messages: Message[] = turns.map(
     ({ role, text }) =>
       ({
@@ -54,7 +55,7 @@ function makeHistory(
         content: [{ type: "text", text }],
       }) as unknown as Message,
   );
-  return { messages, status: "idle" } as unknown as ChatHistory;
+  return toMessagesPage({ messages, status: "idle" });
 }
 
 afterEach(() => {
@@ -68,7 +69,7 @@ describe("SessionApi converted-cache staleness on updated_at change (#6131)", ()
       .spyOn(api, "listChats")
       .mockResolvedValue([makeChatSpec(id, T0)]);
     const getChatSpy = vi
-      .spyOn(api, "getChat")
+      .spyOn(api, "getMessages")
       .mockResolvedValue(makeHistory([{ role: "assistant", text: "first" }]));
 
     // Initial poll + open: fetches history v1 and caches it.
@@ -101,7 +102,7 @@ describe("SessionApi converted-cache staleness on updated_at change (#6131)", ()
     const id = "22222222-2222-4222-8222-222222222222";
     vi.spyOn(api, "listChats").mockResolvedValue([makeChatSpec(id, T0)]);
     const getChatSpy = vi
-      .spyOn(api, "getChat")
+      .spyOn(api, "getMessages")
       .mockResolvedValue(makeHistory([{ role: "assistant", text: "only" }]));
 
     await sessionApi.getSessionList();

--- a/console/src/pages/Chat/tests/staleChannelIdentity.test.ts
+++ b/console/src/pages/Chat/tests/staleChannelIdentity.test.ts
@@ -16,9 +16,10 @@
  *  - `resetWindowIdentity()` clears the globals (called on agent switch).
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import type { ChatSpec, ChatHistory, Message } from "../../../api";
+import type { ChatSpec, ChatMessagesPage, Message } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
+import { toMessagesPage } from "./convertMessagesHelper";
 
 interface IdentityWindow extends Window {
   currentSessionId?: string;
@@ -47,21 +48,21 @@ function makeChatSpec(id: string, channel: string, userId: string): ChatSpec {
   } as unknown as ChatSpec;
 }
 
-function makeHistory(): ChatHistory {
+function makeHistory(): ChatMessagesPage {
   const messages: Message[] = [
     {
       role: "assistant",
       content: [{ type: "text", text: "hello" }],
     } as unknown as Message,
   ];
-  return { messages, status: "idle" } as unknown as ChatHistory;
+  return toMessagesPage({ messages, status: "idle" });
 }
 
 /** Loads the given chats into sessionApi and opens the first one so the
  *  window identity globals are populated from it. */
 async function openChat(spec: ChatSpec): Promise<void> {
   vi.spyOn(api, "listChats").mockResolvedValue([spec]);
-  vi.spyOn(api, "getChat").mockResolvedValue(makeHistory());
+  vi.spyOn(api, "getMessages").mockResolvedValue(makeHistory());
   await sessionApi.getSessionList();
   await sessionApi.getSession(spec.id);
 }

--- a/console/src/pages/Chat/tests/testLargeSession.test.ts
+++ b/console/src/pages/Chat/tests/testLargeSession.test.ts
@@ -63,6 +63,7 @@ vi.mock("../../../api/modules/chat", async (importOriginal) => {
 // Import AFTER mocks are registered.
 import { __test__ } from "../sessionApi";
 import sessionApiDefaultExport from "../sessionApi";
+import { toMessagesPage } from "./convertMessagesHelper";
 
 const {
   convertMessages,
@@ -660,12 +661,11 @@ describe("SessionApi.getSession — large payload integration (#5479)", () => {
     );
     // We reach into the default `api` aggregate used by sessionApi.
     const apiImport = await import("../../../api");
-    vi.spyOn(apiImport.api, "getChat").mockResolvedValue({
-      messages,
-      status: "idle",
-    } as ChatHistory);
+    vi.spyOn(apiImport.api, "getMessages").mockResolvedValue(
+      toMessagesPage({ messages, status: "idle" } as ChatHistory),
+    );
 
-    // getChat is invoked via the `api` import inside sessionApi/index.ts.
+    // getMessages is invoked via the `api` import inside sessionApi/index.ts.
     // Pre-seed the session list so getSession finds an entry (and resolves
     // the backend id directly through the UUID branch).
     (sessionApiDefaultExport as any).sessionList = [
@@ -687,12 +687,12 @@ describe("SessionApi.getSession — large payload integration (#5479)", () => {
     expect(typeof ext.messages[0].cards[0].code).toBe("string");
   });
 
-  it("returns an empty session (no white-screen) when getChat throws 'Chat not found'", async () => {
+  it("returns an empty session (no white-screen) when getMessages throws 'Chat not found'", async () => {
     // Regression: historically a 404 on a stale large session would propagate
     // the error and blank the page. The fix returns an empty session so the
     // user sees the chat shell instead of a crash.
     const apiImport = await import("../../../api");
-    vi.spyOn(apiImport.api, "getChat").mockRejectedValue(
+    vi.spyOn(apiImport.api, "getMessages").mockRejectedValue(
       new Error("Chat not found"),
     );
 
@@ -707,8 +707,10 @@ describe("SessionApi.getSession — large payload integration (#5479)", () => {
 
     const apiImport = await import("../../../api");
     const getChat = vi
-      .spyOn(apiImport.api, "getChat")
-      .mockResolvedValue({ messages, status: "running" } as ChatHistory);
+      .spyOn(apiImport.api, "getMessages")
+      .mockResolvedValue(
+        toMessagesPage({ messages, status: "running" } as ChatHistory),
+      );
 
     (sessionApiDefaultExport as any).sessionList = [
       {
@@ -732,8 +734,10 @@ describe("SessionApi.getSession — large payload integration (#5479)", () => {
 
     const apiImport = await import("../../../api");
     const getChat = vi
-      .spyOn(apiImport.api, "getChat")
-      .mockResolvedValue({ messages, status: "idle" } as ChatHistory);
+      .spyOn(apiImport.api, "getMessages")
+      .mockResolvedValue(
+        toMessagesPage({ messages, status: "idle" } as ChatHistory),
+      );
 
     (sessionApiDefaultExport as any).sessionList = [
       {

--- a/docs/session-scroll-loading-design.md
+++ b/docs/session-scroll-loading-design.md
@@ -1,0 +1,470 @@
+# 聊天历史滚动加载：设计文档（可读版 v3.2）
+
+> **一句话版本**：聊天历史被"上下文压缩"藏起来之后，用户仍然可以在**原会话里向上滚动**把它们翻回来看——就像从仓库里把旧货取回柜台。整个过程不需要用户进任何"归档"页面。
+
+- 版本：v3.2（对照当前代码逐项核实修订：扩页预算常量、大内容防护实现状态、有界窗口只按条数不按字节；v3.1 → v3.2 的具体改动见附录 B）
+- 日期：2026-09-03
+- 前置评估：`docs/session-scroll-loading-assessment.md`
+- **Phase 1 已实施并做了真实环境验证，见 §9**；历史版本见附录 B
+
+---
+
+## 怎么读这篇文档
+
+| 你的身份 | 建议路径 |
+|---|---|
+| 只想快速了解方案 | 读 §1 → §2 → §3，约 5 分钟 |
+| 要动手实现（或者接着往下做剩下的活） | §4 后端 + §5 前端 + §6 边界 + §7 验收，边写边查附录 A 速查表；**§9 列了已验证的部分和还没做完的部分，别重复造轮子** |
+| 想复核某个技术断言 | 直接看附录 A 的代码事实表（含文件路径与行号） |
+| 好奇设计为什么反复改 | 附录 B 有一段压缩版历程 |
+
+**阅读约定**：正文尽量用大白话讲"为什么"；凡是写着 `code` 或"速查"的地方，都是给实现者看的细节，普通读者可以直接跳过。
+
+---
+
+## 1. 问题：聊天记录为什么"消失了"
+
+### 1.1 用户看到的现象
+
+- 聊了很久（几百条消息），突然触发了一次**上下文压缩**；
+- 压缩后刷新页面、或切去别的会话再回来；
+- 结果：**早期聊天不见了**，只剩压缩后的最近一段。
+
+### 1.2 为什么会这样（三个概念，用比喻讲）
+
+系统里有两处存聊天数据的地方，外加一个"搬移动作"：
+
+| 概念 | 正式名 | 比喻 | 它存什么 |
+|---|---|---|---|
+| 会话 JSON | `AgentState.context` | **柜台桌面** | 当前正在用的消息。前端只读它 |
+| 历史数据库 | `history.db`（`conversation_history` 表） | **仓库** | 每一句话的流水账，**全部**记录都在，带唯一货架号 `seq` |
+| 上下文压缩 | scroll compaction / `/compact` | **收桌子** | 把早期消息从桌面撤下、只留一段摘要——但**仓库里的记录一条没删** |
+
+问题就出在这：**前端只认桌面**。压缩只是把旧消息从桌面移走了，仓库里明明还有，前端却从不去取。
+
+> 关键事实：Scroll 是默认的上下文管理模式，`history.db` 是全量记录（写入即落库，压缩不删行）。所以"仓库"天然完整——缺的只是一条从仓库取货的路。
+
+### 1.3 本期要做什么、不做什么
+
+**做**：
+- 默认 Scroll 模式下，无论自动压缩还是手动 `/compact`，用户刷新/切换会话后，都能在原会话向上滚动，看到保留期内的**完整用户消息与助手回复**；
+- 用户不需要知道消息来自桌面还是仓库——前端无缝衔接；
+- 超过保留期的**工具执行详情**可以显示"已过期"，但聊天正文不能跟着消失。
+
+**不做（诚实声明）**：
+- 旧版本写的 `dialog/*.jsonl` 归档不带会话 ID，无法可靠合并回原会话（Phase 3 只做工作区级查看/导出）；
+- 会话本身已被删除/未出现在列表里的，不属本期范围；
+- 已经被旧版本删除的历史数据无法自动找回。
+
+### 1.4 验收测试（一句话记住目标）
+
+> 造 200 条消息 → 触发 `/compact` → 刷新页面 → 切换会话再回来 → **向上滚动后仍能看到压缩前的第 1 条消息**。
+
+再加一条 OOM 验收：历史加载再多，浏览器内存和 DOM 节点**必须有上限**，"能翻到底但把 Chrome 翻崩"不算通过。
+
+---
+
+## 2. 总体思路：桌面不够就从仓库取
+
+```
+┌─ 首屏：先看桌面 ──────────────────────────────┐
+│  GET /api/chats/{id}/messages?limit=50        │
+│  从会话 JSON 取最近一页 → 转成聊天卡片 → 返回    │
+│  顺手记下"这一页最早一条"的仓库货架号 seq        │
+└──────────────────────────────────────────────┘
+                  │ 用户向上滚动
+                  ▼
+┌─ 翻页：去仓库往前取 ───────────────────────────┐
+│  GET /api/chats/{id}/messages?before_seq=123  │
+│  查 history.db 中 seq < 123 的更早记录         │
+│  → 还原成聊天卡片 → 插到消息列表顶部             │
+└──────────────────────────────────────────────┘
+```
+
+三条铁律，全程不破：
+
+1. **一个统一端点**。不区分"聊天分页接口"和"归档接口"，前端只认一套返回结构；
+2. **游标只用 `seq`**。`seq` 是仓库货架号，只增不减，压缩不动它，清理过期工具结果也只形成空隙不断号——所以**游标永不因压缩失效**（曾经想用消息 id 当游标，被证明每次请求都会重新生成随机 id，必坏，已废弃）；
+3. **不改数据库表结构、不改任何写入路径**。所有改动只发生在"读"的一侧。
+
+### 三个最容易踩的坑（先记住，后面细讲）
+
+| 坑 | 一句话 | 对策 |
+|---|---|---|
+| 分页把"一次问答"切成两半 | 助手一条回复可能带思考+工具调用+工具结果，切开就碎了 | 所有分页都**按"用户问题"对齐**，宁可多返回几条，不切半个回合 |
+| 翻页翻出内存问题 | SDK 会把加载过的消息全渲染，翻得越深浏览器越卡 | 前端**有界窗口 + 虚拟列表**（§5.2），后端限制单页体积（§4.4） |
+| 出问题时把现有消息也搞丢 | 异常降级若只返回最近 50 条，比现状还糟 | 降级返回"受保护的安全窗口"，明确提示并提供重试/下载（§4.5） |
+
+---
+
+## 3. 关键概念小词典
+
+先读懂这些词，后面全是它们。
+
+| 词 | 大白话 | 为什么重要 |
+|---|---|---|
+| **seq** | 仓库里每条记录的**货架号**，自增、永不复用 | 拿它当前后翻页的"书签"，压缩不影响它 |
+| **回合** | 一次完整的问答 = 用户提问 → 助手思考/调工具/最终回复 | 分页的**最小不可切单位** |
+| **卡片合并** | 前端把"用户问题"和"助手一整套回复"各自渲染成一张大卡片 | 分页切错位置会把卡片从中间劈开 |
+| **dedup_key** | 仓库行上盖的"来源戳"：存的就是原始消息的 Msg.id | 用来把桌面消息和仓库记录对上号（锚定） |
+| **锚定** | 首屏返回时，拿"窗口最早一条用户消息"去仓库查它的货架号 | 拿到货架号，下一页才知道从哪儿继续取 |
+| **占位符/合成消息** | 压缩时系统塞进桌面的"伪消息"，从不进仓库 | 不能拿它们当锚点，否则必失败 |
+| **ResponseCard** | 前端聊天里一张完整的助手回复卡片 | 它跨了多条仓库记录，是分页最难伺候的对象 |
+
+---
+
+## 4. 后端改动
+
+### 4.1 新接口长什么样
+
+新增一个端点（旧接口 `GET /api/chats/{id}` 原样保留，老客户端不受影响）：
+
+```
+GET /api/chats/{chat_id}/messages?limit=50            ← 首屏（最近一页）
+GET /api/chats/{chat_id}/messages?before_seq=123&limit=50   ← 向上翻页（更早一页）
+```
+
+返回结构（统一，前端只认这个）：
+
+```jsonc
+{
+  "messages": [ /* 聊天卡片，按时间从旧到新排好 */ ],
+  "next_cursor": 123,        // 下一页从哪个货架号往前取；null = 没有下一页
+  "has_more": true,          // 还有没有更早的
+  "history_status": "available", // 历史处于什么状态（§4.5）
+  "status": "idle",          // 会话是否正在生成（原样透传，见附录 A-2）
+  "truncated": false,        // 是否因超长回合被截断（§4.4）
+  "fallback_limited": false  // 是否因异常只给了安全窗口（§4.5）
+}
+```
+
+> ⚠️ `limit` 是"目标大小"，不是"严格条数"。它数的是**原始消息/记录条数**，不是最终卡片数——因为要保证回合完整，返回的卡片数可能多也可能少。**禁止**先把整个会话转成卡片再切片（既切坏回合，又白费转换开销）。
+
+### 4.2 首屏：从桌面拿最近一页（4 步）
+
+1. **读桌面**：从会话 JSON 取出当前消息列表（复用现有读取逻辑）；
+2. **按回合取窗**：从尾部往回数 `limit` 条左右，然后**继续向前走到最近一条真实的用户提问**，窗口从那里开始——绝不从半句回复/半张工具卡开始。`limit` 不够 50 没关系，回合完整优先；
+3. **转卡片 + 锚定**：把窗口转成聊天卡片；拿窗口最早那条用户提问的 Msg.id 去仓库查货架号 → 得到 `next_cursor`；
+4. **回答三个问题**：`has_more`（仓库里还有没有更早的）、`history_status`（历史状态）、`status`（会话在不在生成）。
+
+**为什么这么麻烦？** 因为如果简单截"最后 50 条"，很可能从助手回复中间或一张工具卡中间开始——用户看不到自己的问题，只看到半截回答；而且若拿系统占位符当锚点，它从不进仓库，锚定必失败。
+
+### 4.3 翻页：去仓库往前取（8 步）
+
+1. **取一页**：`WHERE session_id=? AND seq<? ORDER BY seq DESC LIMIT limit+1`（多取 1 条用来判断"还有没有更早"）；
+2. **补齐回合**：如果这一页最老的一头切在了某个回合中间，就继续往前查，直到把那回合开头的用户提问也收进来——**绝不切开一次完整问答**；
+3. **还原成卡片**：仓库行 → 聊天卡片（核心转换层，见 §4.6）；
+4. **排好序再返回**：仓库查出来是从新到旧，返回前翻成**从旧到新**（跟 prepend 语义一致）；
+5. **记录书签**：`next_cursor` = 本页最老那条的货架号；下一页从它往前查，天然不重叠、无缺口；
+6. **重算 has_more**：因为补齐回合可能吃掉了预取的那条，得再查一次仓库确认；
+7. **孤儿工具结果不丢**：某条工具结果在本页找不到它对应的工具调用（调用在更早的一页）→ 降级成独立卡片展示，信息保留；
+8. **给超长回合上保险**：连续补齐最多补 `DEFAULT_MAX_EXPANSION_ROWS`（固定 600 行，不是 `3 × limit`——早期设计想按 `limit` 动态算，实现时简化成一个不随请求变化的定值；`limit` 上限本身是 200，`max(limit, 600)` 在当前参数范围内恒等于 600）。真遇到病态超长回合，就停手返回、标记 `truncated=true`，前端在两段之间显示"该历史回合过长，已截断显示"——这是全设计**唯一**允许回合被切开的情况，后续页从断点继续，内容不丢、也不会无限查询。
+
+> **技术细节**：仓库是 SQLite，同步查询不能阻塞异步服务——分页/补齐查询用 `asyncio.to_thread` 丢到工作线程执行；只读连接（`mode=ro` + WAL）在同一线程里建、查、关，不跨线程传递。
+
+### 4.4 最难的点：为什么"回合不能切开"
+
+前端会把一次问答渲染成一张大卡片，而它在仓库里其实占**好几行**：
+
+```
+一次完整问答在仓库里长这样：
+seq 100  用户提问            ← 回合开始
+seq 101  助手思考
+seq 102  助手调用工具A
+seq 103  工具A 返回结果
+seq 104  助手最终回复        ← 回合结束
+```
+
+如果分页切在 seq 102 和 103 之间，前端就会拿到"半张卡片"：有工具调用没结果、有思考没回答。所以前后端定下两条规矩：
+
+- **后端**：任何一页都必须从"用户提问"那一条开始（§4.3 步骤 2）；
+- **前端**：翻页请求只带着 `next_cursor`（货架号）去要"更早的一页"，不参与判断边界——边界问题后端全包了。
+
+这条是全设计唯一的实现难点，测试里专门给它排了最高优先级（§7）。
+
+### 4.5 历史到底处于什么状态（`history_status`）
+
+一页翻到底时，要分清五种截然不同的情况，不能让"数据库坏了"和"真翻到头了"显示成同一个结果：
+
+| 值 | 人话 | 前端显示 |
+|---|---|---|
+| `available` | 正常，还有更早的 | 继续翻页 |
+| `complete` | 真翻到最早一条了 | "已到最早消息" |
+| `expired` | 早期**正文**被旧版本策略/人工清理删过（新版本不会再发生） | "部分早期聊天已被旧版保留策略清理" |
+| `unavailable` | 这个会话本来就没有历史库（非 Scroll 模式） | 不显示翻页入口（不是故障） |
+| `degraded` | 本该有历史库，但库坏了/查不动/锚定失败 | **绝不装成"翻到头"**：给重试入口 + 记日志 |
+
+判断"是否被旧版清理"用的是压缩索引里的归档货架号范围（具体规则见附录 A-3），没有可靠证据时**默认按正常到底处理，不瞎猜**。
+
+**注意区分**：工具详情过期 ≠ 页面到头。如果只是某个工具的执行结果超过保留期被清了，那只是那一张工具卡显示"工具详情已过期"，聊天正文和翻页照常。
+
+### 4.6 核心转换层：仓库行 → 聊天卡片（`history_rows_to_messages`）
+
+这是全项目**唯一需要新写的主要函数**，单独立项。它负责：
+
+- 仓库里的"用户提问行"还原成用户消息、"助手回合行"还原成助手消息；
+- 把工具结果行**合并回**对应的工具调用卡片（按 `tool_call_id` 对上号）；
+- 过滤系统占位符/合成消息；
+- 页边界对齐（见 §4.4）；
+- 孤儿工具结果独立成卡；工具结果缺失时按是否过期显示"已过期"或"暂不可用"（两者都不删正文）；
+- 输出按时间从旧到新排列；
+- **给每条还原的消息一个稳定且唯一的 ID**：`metadata.original_id` 记原始消息 ID，`Message.id` 用 `"{原始ID}:{序号}"`（如 `abc123:0 文本 / abc123:1 思考 / abc123:2 工具调用 / abc123:3 工具结果`）。理由：一条助手回复会拆成多条卡片消息，ID 全一样会让前端列表 key 打架。
+
+### 4.7 前端还需要防重吗
+
+**不需要。** 曾经的方案让前端按 `original_id` 去重——但同一条原始消息拆出的思考/工具调用/工具结果共享同一个 `original_id`，一去重就把它们误删了。正确的保证是**数学上的**：首屏拿 `seq >= 书签` 的部分，翻页拿 `seq < 书签` 的部分，两边天然没有交集。加一条"相邻两页连续且不重叠"的断言单测兜底即可。
+
+### 4.8 安全防护：上限（防浏览器 OOM，Phase 1 必做）
+
+| 防线 | 数值 | 人话 | 状态 |
+|---|---|---|---|
+| 超长回合扩页预算 | `DEFAULT_MAX_EXPANSION_ROWS` = 600（§4.3 步骤 8） | 补齐回合最多补这么多行，超了就 `truncated=true` 停手 | **已实现** |
+| 单页响应体积 / 单条超大内容预览 | 设计里的 `MAX_PAGE_CONTENT_BYTES`（4 MiB）+ 超大块 64 KiB 预览、`large_content=true` | 一页/一条内容太大时只给预览，完整原文走只读下载 | **未实现**（后端没有任何体积上限或 `large_content` 标记，见 §9.4；不是"后端做了前端没接"，是两边都没做） |
+| 翻页总额（前端） | `LOAD_MORE_MAX_MESSAGES` = 300 条（消息**数量**上限，SDK patch 里实现，见 §5.2） | 消息数超过 300 时从较新一端裁掉 | **已实现，但只按条数封顶，没有独立的字节数（如"约 8 MiB"）上限**——之前几处提到的"约 8 MiB"是设计阶段的预估值，代码里没有对应的字节统计逻辑 |
+
+只改"读"，不动表结构和写入格式。
+
+### 4.9 保留策略：30 天只清"工具结果"，正文永久保留
+
+**这是 v2.6 的一个重大纠偏**——此前设计"30 天后清理全部历史"，等于聊天正文也只有 30 天，与用户预期不符。现在：
+
+- `history_retention_days`（默认 30）语义改为：**工具结果保留天数**；
+- 自动清理**只删除 30 天前的工具结果行**；用户消息、助手回复（含思考与工具调用）**永久保留**；
+- **两处调用点都要改，漏一处就白修**：`ScrollContextManager.purge_old()`（运行中定期清理）和 `sync.py` 的 `_purge_old_history()`（**启动时**的兜底清理，容易漏掉）都要传 `kinds=("tool_result",)`，只改前者的话，每次重启/新建 agent 时仍会把全部历史清空；
+- 设 `0` = 工具结果也永久保留（什么都不清）；
+- 配置说明和 release note 同步改措辞，别让用户误以为聊天正文只有 30 天；
+- 已被旧版本删掉的正文**无法自动恢复**——升级只是阻止以后继续删。
+
+> 为什么敢让正文永久保留？翻页时正文行就是聊天本身，体积小；真正占地方的是工具结果（可能含大段日志/截图数据），那才是需要定期清理的。
+
+### 4.10 数据库索引需要加吗
+
+**暂不需要。** `seq` 是 SQLite 自增主键（本身就是 rowid），现有单列索引 `ch_session(session_id)` 已能让查询高效执行。是否补复合索引由 5k/20k 行压测决定，不作为本期必做项。
+
+---
+
+## 5. 前端改动
+
+### 5.1 怎么接上翻页（**与最初设想不同，实为改 SDK 源码**）
+
+最初以为 SDK 本来就内置了"加载更早消息"的回调钩子，只是 console 没传——**这个判断是错的**，实施时才核实清楚：console 实际用的是 `@jsfund/agent-chat`（`package.json` 依赖名，本仓库内部维护的 fork，不是公开的 `@agentscope-ai/chat`）里的 `AgentScopeRuntimeWebUI` 组件树；它内部真正挂载消息列表的 `MessageList`/`ChatAnywhereSessionsContext` 只有"模拟分页"——把已经加载进内存的数组多显示一截，从未真正按需请求后端。`onLoadMore` 这个网络驱动的回调**根本不存在**，得自己加。
+
+因为 `@jsfund/agent-chat` 是内部 fork，改源码是被允许的，做法是：
+
+1. **`patch-package`**：直接改 `node_modules/@jsfund/agent-chat` 源码，生成 diff 存在 `console/patches/@jsfund+agent-chat+<version>.patch`，`package.json` 加 `postinstall: patch-package` 自动应用。改动需要走内网 npm 合并回 SDK 本体，本仓库这份 patch 只是过渡；
+2. 在 `ChatAnywhereSessionsContext.js` 新增 `useChatAnywhereLoadMoreHistory` hook：真正调用 `options.session.onLoadMore(sessionId)`，返回的更早消息 `prepend` 进消息数组，并在 hook 内部做**竞态守卫**（用 ref 而非闭包变量比对当前会话 id，否则请求期间切换会话时守卫形同虚设）；
+3. `MessageList/index.js` 里，`hasRealLoadMore` 为真时优先用这个真实 hook，否则回退到原有的模拟分页——不影响 SDK 其他不传 `onLoadMore` 的调用方；
+4. console 侧：首屏改走新端点，返回的 `next_cursor` 存好；**用返回的 `status` 驱动"正在生成"和 pending 消息补回**；`sessionApi.loadOlderMessages` 解析 `sessionId`（可能是显示 id 也可能是后端 UUID）、调新端点、转卡片、合并回 `convertedSessionCache`（SDK 的 prepend 不会自动同步这个缓存）。
+
+### 5.2 内存三道防线（防 OOM，Phase 1 必做，**虚拟化技术选型有变**）
+
+前面说过 SDK 会把所有加载过的消息全量渲染。所以前端必须主动设限：
+
+1. **有界窗口**：`useChatAnywhereLoadMoreHistory` 里维护，聊天里最多保留 300 条消息（`LOAD_MORE_MAX_MESSAGES`），超限时从数组"较新"一端裁掉——这条和最初设想一致，已实现。
+2. **虚拟渲染**：**没有用 `react-window`**。原计划复用项目已装的 `react-window`，但它自己接管一个独立视口做虚拟滚动，而 `Bubble.List` 的滚动容器是 `flex-direction: column-reverse` 的原生 `overflow:auto` div，`scrollToBottom`/"是否到底"等逻辑直接读写这个 div 的原生 `scrollTop`——两者的滚动模型不兼容，硬塞会跟 SDK 自己的滚动追踪打架。改用 **`@tanstack/react-virtual`**（新依赖，需要走内网 npm）：它的 `getScrollElement` 允许指向任意已存在的滚动元素，不抢滚动权，正好适配这个约束。新写了 `WindowedBubbleList.js`，作为 `children` 传给 `Bubble.List`（利用它内部本来就有的 `children ? children : items.map(...)` 分支），只在 `hasRealLoadMore` 为真时启用，模拟分页路径保持原样不变。
+   - **一个不写代码看不出来的坑**：`column-reverse` 容器在 Chrome 里 `scrollTop` 是**负数**（从 0 一路负到最老消息，`Bubble.List` 自己的 `checkShowScrollToBottom` 判断用的就是 `scrollTop <= -10`）。`@tanstack/react-virtual` 默认假设 0→正的坐标系，直接接会把所有负偏移钳成 0——表现为无论往上滚多深，虚拟化都以为自己停在最新消息那，只渲染最前面几条，深处一片空白。修法是自定义 `observeElementOffset`/`scrollToFn` 做正负号转换。
+   - 效果（真实浏览器验证，见 §9）：单次 prepend 的主线程长任务从约 2.9 秒降到 300ms 以内，且不随已加载消息总数增长。
+3. **大内容预览**：设计目标是标了 `large_content=true` 的只显示预览 + "下载完整内容"，不在聊天页里渲染完整 Markdown/代码高亮。**（整个机制——后端标记和前端 UI——都还没做，见 §9.4 未完成项）**
+
+> 结论：后端一页一页读 + 前端限制消息数/字节数/DOM 数——三道闸一起，深翻时浏览器内存进入平台期，而不是靠减小页大小拖延崩溃。
+
+### 5.3 两个必须处理的竞态
+
+| 场景 | 问题 | 对策 |
+|---|---|---|
+| 翻页途中切换会话 | 旧请求返回后把旧会话消息插进新会话 | 回调里快照"当前会话 + 书签"，返回时对不上就**整包丢弃**，并且返回 `{messages: [], noMore: false}`——`noMore` 必须 false，否则会误把新会话标成"没有更多历史" |
+| 切走再切回 | 缓存只存了首屏，翻过页丢了 | 翻页结果**先合并进该会话的缓存**（SDK 的 prepend 不会自动同步缓存），LRU 缓存整个有界窗口 |
+
+### 5.4 各种状态提示长什么样
+
+| 后端状态 | 前端文案/行为 |
+|---|---|
+| `available` | 正常翻页 |
+| `complete` | "已到最早消息" |
+| `expired` | "部分早期聊天已被旧版保留策略清理" |
+| `degraded` | 重试入口（不显示"已到最早"） |
+| `unavailable` | 不显示翻页入口 |
+| `truncated` | "该历史回合过长，已截断显示" |
+| `fallback_limited` | "为避免浏览器内存不足，仅显示最近消息"+ 重试/下载（**不能**显示"已到最早"） |
+| 工具卡 `tool_result_expired` | 只显示工具名、调用时间、"工具详情已过期"，不提供重试；不影响继续看更早聊天 |
+
+PC 与移动端共用同一套窗口策略。
+
+---
+
+## 6. 各种情况下会发生什么（速查表）
+
+| 场景 | 结果 |
+|---|---|
+| 压缩后翻页 | 仓库行不受压缩影响，正常翻到底 |
+| 翻页途中切会话 | 旧响应被守卫丢弃，新会话不受污染 |
+| 非 Scroll 会话 | 返回最近安全窗口；超限则 `fallback_limited=true, history_status=unavailable` + 原始会话下载 |
+| Scroll 下锚定失败/库坏了 | 返回最近安全窗口；`fallback_limited=true, history_status=degraded` + 重试/下载，**不装成正常到头** |
+| 会话仍在生成 | 响应 `status="running"`，前端照常补回 pending 消息 |
+| 超 30 天的工具结果 | 正文照常显示，该工具卡显示"工具详情已过期"；页面状态不变 |
+| 旧版本已删正文 | `history_status=expired`，提示旧版清理 |
+| 真翻到最早 | `history_status=complete`，"已到最早消息" |
+| 超长回合超预算 | `truncated=true` + 截断标记，后续页从断点继续 |
+| 旧客户端调旧接口 | 旧端点不动，行为不变 |
+
+---
+
+## 7. 怎么验收
+
+**主验收（集成级，最高优先级）**：200 条消息 → `/compact` → 重进会话 → 连续上翻到第 1 条可见。
+
+**OOM 验收**：造 ≥ 10,000 条历史（混入长文本和超大工具结果）连续翻页——任一时刻内存消息 ≤ 300 条（当前只有条数上限，无独立字节数上限，见 §4.8）、DOM 只渲染视口项；翻过第 20 页后 Chrome heap 不再随页数线性增长；"返回最新"、动态高度、prepend 后滚动锚点都正常。
+
+**单测重点**（建议按序补）：
+1. 转换层（先行）：kind 还原、工具合并、边界对齐、孤儿工具结果、占位符过滤、输出升序、ID 唯一；
+2. 分页：游标、扩页、空表、清理后、5k/20k 行压测（p95 < 50ms）；
+3. 锚定：命中/未命中；失败 → 安全窗口 + `fallback_limited`，原始会话仍可下载；
+4. 首屏对齐：不从半截回复开始；占位符不做锚点；
+5. `history_status` 五值 + `expired` 四条判定规则；
+6. 分类型保留：30 天自动清理只删工具结果，正文数量不变；`=0` 全不清；
+7. 工具过期展示：过期 → 占位；未过期 → "暂不可用"+warning；两者都不动游标和正文顺序；
+8. 页边界断言：相邻两页连续且不重叠；
+9. 扩页预算：超长回合触发 `truncated`，连续翻不无限循环；
+10. status 透传、缓存合并（切走切回）、竞态守卫（含 `noMore:false`）。
+
+**受影响既有测试**：`tests/unit/app/chats/test_session.py`、`tests/integration/test_chats_global.py`、`test_chats_agent_scoped.py`。
+
+**新增测试文件**：`tests/unit/app/chats/test_history_pagination.py`（转换层单测）、`tests/unit/app/chats/test_messages_endpoint.py`（端点级，走真实 `TestClient` + 真实 `HistoryStore`，workspace/session/task_tracker 走 mock；含验收测试"200 条消息压缩后连续翻页到第 1 条"）。
+
+---
+
+## 8. 分期计划
+
+| 阶段 | 内容 | 工作量 |
+|---|---|---|
+| **Phase 1（本期）** | 统一 messages 端点 + 转换层 + 分类型保留 + 大内容保护 + 前端有界窗口/虚拟列表 + 竞态守卫 + 完整验收（含 OOM） | **7–9 人日**（新增部分是 SDK 列表适配与 OOM 压测） |
+| Phase 2 | 历史浏览体验优化、导出/诊断抽屉、保留期设置 UI | 2–3 人日 |
+| Phase 3 | 旧 dialog 工作区级查看/搜索、可确认归属的迁移、新 dialog 写入补 session_id | 2 人日 |
+
+> Phase 1 不碰数据库表结构和写入路径。OOM 防护**必须在 Phase 1 做掉**——否则只是把"看不到"换成"看得到但翻崩浏览器"，问题原地打转。
+
+---
+
+## 9. 实施记录（2026-09-02～03，代码/真实环境核实）
+
+Phase 1 已经写完并做了三层验证，跟纯看代码/单测不一样，记一下都验了什么、怎么验的，以及还差什么。
+
+### 9.1 后端：单测 + 真实服务器双重验证
+
+193 个后端单测全过（`test_history_store.py`、`test_scroll_manager.py`、`test_sync.py`、`test_utils.py`、`test_messages_endpoint.py`）。但只做到这一步不够——`test_messages_endpoint.py` 的 `workspace` 是 `MagicMock`，`workspace.config.light_context_config` 这种**路径写错了 mock 也不会报错**（`MagicMock` 对任意属性访问来者不拒）。于是又额外起了一个真实的本地 `qwenpaw app` 服务器（真实 config 加载、真实 `AgentProfileConfig`、真实 SQLite 文件），跑通两件事：
+
+1. **200 条种子数据（无需真实模型）**：直接写 `history.db` + 精简会话 JSON 模拟"压缩后"状态，40 次真实 HTTP 分页请求连续翻到第 1 条，零重复零缺口，`history_status` 正确落到 `complete`。这一步就撞见了事实表 #20 的 bug（`light_context_config` 路径），是 mock 测试完全没暴露、真实服务器一启动就 500 的问题。
+2. **真实模型触发的真实压缩**（复用本机已配置的火山引擎 coding plan key，未写入任何新密钥、未改用户真实数据目录）：临时把模型的 `max_input_length` 调到 40000，20 轮真实对话后 `ScrollContextManager` 真的触发了一次压缩（`prompt_tokens` 从 29653 掉到 19671），再翻页验证——17 条留在实时会话 JSON，翻一页拿回 70 条，零重复，正确落到 `complete`，这次读的是真实 `EvictionIndex`（事实表 #13 的 `agent_raw["scroll"]["index"]`），不是种子脚本从没写过的字段。
+
+### 9.2 前端：SDK 补丁两轮踩坑，都是真实浏览器验证出来的
+
+§5.1/5.2 已经记录了两个"实施后才发现设计假设是错的"的地方（SDK 无真实 `onLoadMore`、`react-window` 与 `column-reverse` 冲突）。除此之外，虚拟化补丁本身在真实浏览器里连续踩了两个只有跑起来才看得出来的坑：
+
+1. **`_toConsumableArray is not defined`**：手写补丁代码里用了一个这个文件从来没定义过的 babel 辅助函数（其他函数如 `_objectSpread`/`_slicedToArray` 是原文件自带的，`_toConsumableArray` 不是），Vite 预打包时不报错，只有真的触发 `loadMore` 那条代码路径才在浏览器里抛出。改成 `.concat()`（两个操作数本来就是真数组，不需要展开语法）就不需要这个辅助函数了。
+2. **深滚动整屏空白**：接入 `@tanstack/react-virtual` 第一版直接用默认的 `observeElementOffset`，负数 `scrollTop` 被钳成 0，虚拟化一直以为自己停在最新消息——这就是事实表 #19 的坑，改自定义 `observeElementOffset`/`scrollToFn` 做符号转换后解决。
+3. **Vite 依赖预打包缓存**：改完 SDK 源码后不清 `node_modules/.vite` 缓存，浏览器加载的还是旧 bundle——中间调试时被这个坑晃点过一次，往`node_modules`里手改文件后必须清缓存重启才能验证到最新代码。
+
+修复后真实测得：单次 prepend 的主线程长任务从 2870ms 降到 300ms 以内（`PerformanceObserver('longtask')` 实测），DOM 节点数不再随已加载消息总数线性增长。
+
+### 9.3 新增依赖与产物
+
+- `console/patches/@jsfund+agent-chat+1.1.73-beta.1786415183789.patch` + `package.json` 新增 `patch-package` devDependency + `postinstall` 脚本；
+- `console/package.json` 新增 `@tanstack/react-virtual` 依赖；
+- 以上两项都需要在能访问内网 npm 源的环境里跑一次 `npm install` 来同步 `package-lock.json`（本次实施环境访问不到内网源，只能单独拉包验证，没法生成锁文件）。
+
+### 9.4 还没做完的（诚实列一下，别让人以为 Phase 1 100% 完工）
+
+- **前端测试基建仍是空的**：vitest 没装，`sessionApi.loadOlderMessages`/竞态守卫等逻辑目前只有真实浏览器手工验证，没有自动化前端单测兜底；
+- **`history_status` 驱动的尾部文案没接**（§5.4 那张表还只是设计，没写进组件）：`available`/`complete`/`expired`/`degraded`/`unavailable`/`truncated`/`fallback_limited` 对应的提示文案和"返回最新消息"按钮都还没做；
+- **富内容（图片/思维链/工具调用/文件）虚拟化只做过一轮轻量验证**：336 条混合类型种子数据滚动测试里最长主线程任务到过 457ms（比纯文本的 116~300ms 高，符合预期——工具卡/思维链渲染更重），还没有专门针对这类重内容做过大规模 OOM 压测；
+- **`large_content=true` 超大内容预览/下载完全没做**（§4.8）：核对代码时发现之前"后端已支持，前端 UI 还没接"的说法是错的——`MAX_PAGE_CONTENT_BYTES`、单条内容 64 KiB 预览、`large_content` 标记，在 `chats/api.py`/`chats/utils.py`/`scroll/history.py` 里都没有任何实现，是后端和前端都还没做的一整块；
+- **有界窗口只按消息条数封顶（300 条），没有独立的字节数上限**：`useChatAnywhereLoadMoreHistory` 里的 `LOAD_MORE_MAX_MESSAGES` 只数消息个数，代码里没有统计过已加载内容的字节数——之前文档里出现的"约 8 MiB"是设计阶段的预估，不是已实现的另一道独立防线；
+
+---
+
+## 附录 A：实现者速查
+
+### A-1 代码事实表（全部经代码核实，设计的地基）
+
+| # | 事实 | 出处 | 设计推论 |
+|---|---|---|---|
+| 1 | `GET /api/chats/{id}` 读会话 JSON 全量返回 | `chats/api.py:333-413` | 首屏数据源；压缩后只剩最近消息 |
+| 2 | 后端转换每次生成随机 Message.id（uuid4），原始 Msg.id 仅存 `metadata.original_id` | `chats/utils.py:557-565`、`schemas.py:202` | ~~before_id 游标~~ 废案；游标必须用 db 的 `seq` |
+| 3 | **实施后核实为误判**：console 实际用的 `@jsfund/agent-chat`（内部 fork）里，`AgentScopeRuntimeWebUI` 组件树的 `onLoadMore` 从未真正接到网络请求，只有"模拟分页"（多显示一截已加载数组）；此前引用的 `hooks/types.d.ts:308`/`Chat/index.js` 是另一个同包内、未被 console 使用的通用 `ChatAnywhere` 组件树的代码 | `node_modules/@jsfund/agent-chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereSessionsContext.js`、`.../Chat/MessageList/index.js` | 真实 `onLoadMore` 要靠 `patch-package` 改 SDK 源码新增，见 §5.1 |
+| 4 | 因为 #3 是误判，"互斥"这条不适用于实际用到的组件树；`useSimulatedMessagePagination` 与新增的真实分页 hook 通过 `hasRealLoadMore` 显式二选一，互不干扰 | `.../Chat/MessageList/index.js` | 不需要处理"互斥"问题，但两套逻辑要显式切换避免同时生效 |
+| 5 | 新增的 `useChatAnywhereLoadMoreHistory` hook 若用闭包变量比对当前会话 id 做竞态守卫，请求期间会话切换后闭包值不变，守卫形同虚设——已知的一个实现坑，用 ref 存最新会话 id 才能生效 | `.../Context/ChatAnywhereSessionsContext.js` | 竞态守卫必须用 ref，不能用闭包捕获的普通变量 |
+| 6 | scroll 默认启用；history.db 带 session_id + 自增 seq 主键 + ch_session 索引，全量 write-through（压缩不删行） | `config/config.py:1118`、`scroll/history.py:150-176` | 压缩前历史与当前历史同库同表，单数据源即可恢复 |
+| 7 | db 行 `dedup_key` = Msg.id（model turn）/ tool_call_id（工具调用） | `scroll/manager.py:1610-1660` | `metadata.original_id` 可锚定 db seq |
+| 8 | db 行按 kind 区分：context_msg / model_turn / tool_result 等，一次助手回复 = 多行 | `scroll/history.py:154`、`scroll/manager.py` | 需要专门 `history_rows_to_messages` 转换层（核心难点） |
+| 9 | `purge(before, kinds=...)` 支持按 kind 行级删除，表/文件从不删除 | `scroll/history.py:613-631,661-707` | 自动清理只删 tool_result 即可，无需改表结构 |
+| 10 | 现有转换已过滤占位符与合成 user 消息 | `chats/utils.py:547-550` | 转换层复用这些过滤 |
+| 11 | 旧 dialog jsonl per-workspace、按日期分文件、不带 session_id | `agent_context.py:46-130` | 旧 dialog 无法归属会话，只能工作区级查看（Phase 3） |
+| 12 | 前端 `isGenerating()` = `status === "running"`，getChat 返回后立即用于 pending 补丁 | `pages/Chat/sessionApi/index.ts:363-365,1372-1391` | 新端点必须带 status |
+| 13 | 压缩证据在 EvictionIndex `_index._tiers`，Block 带归档 (seq_lo, seq_hi) | `eviction_index.py:150,185`、`manager.py:140` | expired 判定依据 |
+| 14 | 一条 Msg 转换拆多条 Message，共享同一 original_id | `chats/utils.py:557-613` | 不能按 original_id 去重扁平消息 |
+| 15 | 会话运行状态唯一来源是 `workspace.task_tracker.get_status(chat_id)`，get_chat 直接透传 | `chats/api.py:388` | 新端点复用同一调用，不从 agent state 推断 |
+| 16 | `Bubble.List` 的 `BubbleListContent` 对 `items` 无条件 `.map()` 全量挂载，且支持 `children ? children : items.map(...)` 这个逃生舱——可以从外部注入自定义渲染而不用碰 `Bubble.List` 自身的滚动/"加载更多"逻辑 | `Bubble/BubbleList.js:49`（`BubbleListContent` 函数） | Phase 1 必须有界窗口 + 虚拟渲染；虚拟化实现走 `children` 注入，不改 `Bubble.List` 本体 |
+| 17 | **实施后改判**：`react-window` 自己接管一个独立视口做虚拟滚动，与 `Bubble.List` 的原生 `overflow:auto` + `flex-direction:column-reverse` 滚动容器模型冲突；改用 `@tanstack/react-virtual`（`getScrollElement` 可指向任意已有滚动元素，不抢滚动权），新增依赖需要走内网 npm | `Bubble/style/list.js`（`column-reverse` 样式来源） | 不复用 `react-window`；改用 `@tanstack/react-virtual` + 手写 `WindowedBubbleList.js` |
+| 18 | model_turn.blocks 保留工具调用及 tool_call_id，工具输出单独存 tool_result 行 | `scroll/serialize.py:250-345` | 删过期工具结果后仍能保留正文与调用位置 |
+| 19 | `column-reverse` 容器下 Chrome 的 `scrollTop` 是负数（从 0 一路负到最老消息），`checkShowScrollToBottom` 判断用 `scrollTop <= -10` | `Bubble/BubbleList.js`（`checkIsAtBottom`/`checkShowScrollToBottom`） | 接第三方虚拟化库时必须做坐标系正负号转换，否则深滚会渲染空白 |
+| 20 | 后端 `AgentProfileConfig` 的 `light_context_config` 挂在 `.running` 下（`config.running.light_context_config`），不是直接挂在 `config` 上——只有真实 `AgentProfileConfig` 才会暴露这个层级，`MagicMock` 单测对错误路径没有防御力 | `config/config.py`（`AgentsRunningConfig.light_context_config`）；`app/chats/api.py` 的 `_light_context_config` 辅助函数 | 单测必须配合真实服务器验证，纯 mock 测试会漏掉这类路径错误 |
+| 21 | 分类型保留策略有两处调用点都要传 `kinds=("tool_result",)`，不只 `ScrollContextManager.purge_old`：启动时的兜底清理 `sync.py` 的 `_purge_old_history` 也要改，否则新建 agent 或重启后仍会清空全部历史 | `agents/context/scroll/manager.py`（`purge_old`）、`agents/context/scroll/sync.py`（`_purge_old_history`） | §4.9 的保留策略修复要覆盖两处调用点 |
+
+### A-2 响应模型与关键来源
+
+```python
+class ChatMessagesPage(BaseModel):  # chats/models.py 新增
+    messages: list[Message]
+    next_cursor: int | None          # 下一页 from-seq；null = 无更多
+    has_more: bool
+    history_status: Literal["available","complete","expired","unavailable","degraded"]
+    status: Literal["idle","running"] = "idle"   # 来源：workspace.task_tracker.get_status(chat_id)
+    truncated: bool = False
+    fallback_limited: bool = False
+```
+
+- `expired` 判定（仅旧版/人工清理）：①索引空 → complete；②db 最小剩余 seq ≤ 索引最小 seq_lo → complete；③db 最小 seq > 索引最小 seq_lo → expired；④索引不可读 → complete（不猜）。
+- `tool_result_expired`（单卡片）：model_turn 有工具调用但同回合找不到 tool_result，且调用早于 `history_retention_days` 截止 → 过期占位；未过期 → "暂不可用"+warning。
+- 常量（已实现）：`DEFAULT_MAX_EXPANSION_ROWS = 600`（固定值，不随 `limit` 变化）；有界窗口 `LOAD_MORE_MAX_MESSAGES = 300` 条（仅条数，无字节上限）；`limit` 用 `Query(ge=1, le=200)`。
+- 常量（设计中，未实现，见 §9.4）：`MAX_PAGE_CONTENT_BYTES = 4 MiB`；超大块预览 64 KiB。
+- 保留策略：`purge(before=cutoff, kinds=("tool_result",))`；`history_retention_days=0` 不清；人工路径可显式传 kinds，但须 `estimate_purge()` 预览 + 二次确认。
+
+### A-3 术语 → 实现对照
+
+| 文档用语 | 代码/数据对应 |
+|---|---|
+| 桌面 | `AgentState.context`（会话 JSON） |
+| 仓库 | `conversation_history` 表（history.db） |
+| 货架号 seq | 自增主键，rowid 别名（history.py:151） |
+| 占位符/合成消息 | `_is_scroll_memory_placeholder` / `_is_synthetic_user_message`（utils.py:61/92，从不落盘 db：manager.py:1585） |
+| 真实用户行判定 | 复用 `memoryspace.py:1108 _real_user_conditions` 同款条件 |
+| 旧 dialog | `dialog/*.jsonl`（agent_context.py:46-130） |
+
+---
+
+## 附录 B：为什么改了这么多版（评审历程压缩版）
+
+v3 之前，文档先后经 **Claude 一轮 + ChatGPT 四轮** 外部评审，22 条意见全部闭合。主线的几次大转向：
+
+1. **v1 → v2（推翻重写）**：原方案只做"当前上下文分页"，评审指出用户主诉是"压缩后历史消失"，分页解决不了——目标纠偏，`history.db` 接回滚动流提为 Phase 1；
+2. **游标换血**：曾用消息 id 当游标（before_id），评审核实每次请求都重新生成随机 id，必坏 → 改用仓库 `seq`；
+3. **两处行为纠错**：SDK 两层分页其实互斥（不能两层同开）；前端不能按 `original_id` 去重（一条消息拆多条会误删）；
+4. **降级策略两次翻转**：v2.1"降级返回全量"（防丢消息）→ v2.5 因 OOM 约束改为"返回受保护的安全窗口 + `fallback_limited` 明示 + 重试/下载"；
+5. **保留策略纠偏（v2.6）**：从"30 天后全清"改为"只清工具结果，正文永久保留"；
+6. **OOM 从"以后再说"升级为 Phase 1 阻断项（v2.5）**：SDK 无界渲染被核实后，三道内存防线进入本期。
+
+> 工程教训写在附录里：这份文档的反复，大多不是方案写错，而是**评审揪出了代码事实与假设的偏差**（随机 id、占位符不落盘、SDK 互斥、无界渲染……）。每一条都先核实代码、再改文档——这也是为什么事实表（附录 A-1）必须跟着文档一起维护。
+
+7. **v3 → v3.1（实施完成，真实环境核实）**：写代码、跑真实服务器、跑真实浏览器，暴露出评审阶段没查到的偏差——不是又一轮"看代码假设哪里错"，是"代码写完、真的跑起来才知道设计里哪几句站不住"：
+   - **SDK 里根本没有真实 `onLoadMore`**：v2.6/v3 都以为 SDK 已经内置了这个钩子，只是 console 没接上；实施时核实发现 console 实际用的组件树里这个钩子从来没连过网络，得靠 `patch-package` 改 SDK 源码新增（§5.1）；
+   - **`react-window` 装不进去**：v3 §5.2 写的是复用已装的 `react-window`，实施时发现它跟 `Bubble.List` 的 `column-reverse` 原生滚动容器模型冲突，换成了 `@tanstack/react-virtual`（新依赖，§9.3）；
+   - **`column-reverse` 下 `scrollTop` 为负**这个坑评审阶段完全没人提过，真机滚动测试才炸出来（事实表 #19）；
+   - **`light_context_config` 配置路径写错**（事实表 #20）：全部单测用 `MagicMock` 走过，起一个真实服务器才 500 报错；
+   - **分类型保留策略有两处调用点**（事实表 #21），文档此前只提到 `ScrollContextManager.purge_old`，漏了启动时的 `sync.py` 兜底清理。
+   
+   详见 §9。这条印证了 v2 那条教训的延伸版：**代码核实能挡住"假设与已有代码不符"，但挡不住"假设与运行时行为不符"——后者只能靠真的跑起来验证**。
+
+8. **v3.1 → v3.2（逐项核对代码后的修订）**：v3.1 写完之后，把文档里每条数值/状态断言重新对照当前代码核实了一遍，改了三处站不住的地方：
+   - **扩页预算不是 `3 × limit`**：§4.3/§4.9/附录 A-2 之前写的公式是设计阶段的想法，实际代码里 `DEFAULT_MAX_EXPANSION_ROWS` 是固定的 600，不随 `limit` 变化（`scroll/history.py:29`）；
+   - **"大内容预览后端已支持，前端没接"是错的**：核实 `chats/api.py`/`chats/utils.py`/`scroll/history.py` 全文没有 `MAX_PAGE_CONTENT_BYTES`、`large_content` 或任何字节级截断逻辑——这一整块（不只是前端 UI）都还没做，§4.8/§9.4 已改口径；
+   - **"约 8 MiB" 不是已实现的独立防线**：有界窗口（`LOAD_MORE_MAX_MESSAGES=300`）只统计消息条数，代码里没有字节数估算——之前几处提到的"约 8 MiB"只是设计阶段的预估值，混进了"已实现"的表述里，容易让人以为字节上限也做了。

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -9,16 +9,24 @@ import sqlite3
 import sys
 import threading
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from ..types import LogEntry
+from .memoryspace import MemorySpace
 
 logger = logging.getLogger(__name__)
 
 _BUSY_TIMEOUT_MS = 5000
 _UNSET = object()
+
+# Read-endpoint expansion budget: how far a single page is allowed to walk
+# backward past its own ``limit`` to reach a complete user turn boundary
+# before giving up and returning a truncated page. Mirrors the "唯一允许回
+# 合跨页切分的场景" rule in the pagination design doc.
+DEFAULT_MAX_EXPANSION_ROWS = 600
 
 # The recall tool's own turns — the model's ``ms.*`` Python source and its
 # printed stdout/stderr — are written through to history like any turn, but
@@ -758,3 +766,257 @@ def _to_json(value) -> str | None:
     if isinstance(value, str):
         return value
     return json.dumps(value, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Stateless read-only page queries for the HTTP pagination endpoint.
+#
+# These are deliberately free functions, not ``HistoryStore`` methods: the
+# endpoint opens its own short-lived ``mode=ro`` connection per request
+# (never the live agent's read-write ``HistoryStore._conn``) so a slow or
+# stuck page query can never contend with write-through persistence. The
+# connection must be created, queried and closed inside one
+# ``asyncio.to_thread`` call — see ``read_history_page``.
+# ---------------------------------------------------------------------------
+
+
+class HistoryUnavailable(Exception):
+    """The history db can't be read (missing file, corruption, query error).
+
+    Callers map this to ``history_status="degraded"`` — never to "no more
+    history" — so a broken store doesn't masquerade as a clean end of scroll.
+    """
+
+
+@dataclass
+class HistoryPageResult:
+    """One page of raw db rows plus the bookkeeping to request the next."""
+
+    rows: list[sqlite3.Row]  # ascending seq order (oldest -> newest)
+    next_cursor: int | None  # smallest seq in ``rows``; None if rows is empty
+    has_more: bool
+    truncated: bool
+
+
+def open_readonly_connection(db_path: str | Path) -> sqlite3.Connection:
+    """Open a standalone ``mode=ro`` connection to an existing history db.
+
+    Raises :class:`HistoryUnavailable` if the file is missing or SQLite can't
+    open/read it (corruption, mid-write torn WAL, etc.) — the caller decides
+    what "unavailable" means for its response (degraded vs unavailable).
+    """
+    path = Path(db_path)
+    if not path.exists():
+        raise HistoryUnavailable(f"history db not found: {path}")
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+        # Cheap read to fail fast on a corrupt/torn file rather than on the
+        # caller's first real query.
+        conn.execute("SELECT 1 FROM conversation_history LIMIT 1")
+    except sqlite3.Error as exc:
+        raise HistoryUnavailable(f"history db unreadable: {exc}") from exc
+    return conn
+
+
+def find_seq_by_dedup_key(
+    conn: sqlite3.Connection,
+    session_id: str,
+    dedup_key: str,
+) -> int | None:
+    """Resolve a live Msg's ``id`` (= db ``dedup_key``) to its durable ``seq``.
+
+    This is the first-screen "anchor" query (design doc §2.1 step 4): the
+    earliest real user Msg still visible in the live session JSON window
+    tells the endpoint where to resume once the user scrolls up into
+    ``history.db``.
+    """
+    row = conn.execute(
+        "SELECT seq FROM conversation_history "
+        "WHERE session_id = ? AND dedup_key = ?",
+        (session_id, dedup_key),
+    ).fetchone()
+    return int(row["seq"]) if row else None
+
+
+def min_seq_for_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> int | None:
+    """Smallest surviving ``seq`` for a session, or ``None`` if it has no rows.
+
+    Used to tell "reached the true start" (``complete``) apart from "the true
+    start was purged by an old retention policy" (``expired``) — see the
+    design doc's expired-detection algorithm.
+    """
+    row = conn.execute(
+        "SELECT MIN(seq) AS seq FROM conversation_history "
+        "WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    return int(row["seq"]) if row and row["seq"] is not None else None
+
+
+def fetch_tool_results_by_call_ids(
+    conn: sqlite3.Connection,
+    session_id: str,
+    call_ids: Sequence[str],
+) -> dict[str, sqlite3.Row]:
+    """Look up ``tool_result`` rows anywhere in the session by call id.
+
+    Used to tell "this call's result is just on a different page" apart from
+    "no result row exists anywhere in history" — the latter is what actually
+    drives the expired/pending tool-result placeholder in
+    ``history_rows_to_messages``. Not scoped to a seq range on purpose.
+    """
+    ids = [c for c in dict.fromkeys(call_ids) if c]
+    if not ids:
+        return {}
+    found: dict[str, sqlite3.Row] = {}
+    for start in range(0, len(ids), 400):
+        chunk = ids[start : start + 400]
+        placeholders = ", ".join("?" for _ in chunk)
+        rows = conn.execute(
+            "SELECT * FROM conversation_history "
+            f"WHERE session_id = ? AND kind = 'tool_result' "
+            f"AND tool_call_id IN ({placeholders})",
+            (session_id, *chunk),
+        ).fetchall()
+        for row in rows:
+            found[row["tool_call_id"]] = row
+    return found
+
+
+def has_rows_before(
+    conn: sqlite3.Connection,
+    session_id: str,
+    seq: int,
+) -> bool:
+    """Whether any row for ``session_id`` still exists with ``seq < seq``."""
+    row = conn.execute(
+        "SELECT 1 FROM conversation_history "
+        "WHERE session_id = ? AND seq < ? LIMIT 1",
+        (session_id, seq),
+    ).fetchone()
+    return row is not None
+
+
+def _turn_start_seq_at_or_before(
+    conn: sqlite3.Connection,
+    session_id: str,
+    seq: int,
+) -> int | None:
+    """Max seq of a real user turn boundary with ``seq <= seq`` in-session.
+
+    Reuses ``MemorySpace._real_user_conditions`` — the same role/synthetic-tag
+    test the recall REPL uses to find turn boundaries — so the HTTP read path
+    and the model's own recall queries agree on what counts as a turn start.
+    """
+    conditions, params = MemorySpace._real_user_conditions()
+    sql = (
+        "SELECT MAX(seq) AS seq FROM conversation_history "
+        "WHERE session_id = ? AND "
+        + " AND ".join(conditions)
+        + " AND seq <= ?"
+    )
+    row = conn.execute(sql, (session_id, *params, seq)).fetchone()
+    return int(row["seq"]) if row and row["seq"] is not None else None
+
+
+def read_history_page(
+    db_path: str | Path,
+    session_id: str,
+    *,
+    before_seq: int,
+    limit: int,
+    max_expansion_rows: int = DEFAULT_MAX_EXPANSION_ROWS,
+) -> HistoryPageResult:
+    """Load one turn-aligned page strictly older than ``before_seq``.
+
+    Opens its own read-only connection, runs the whole query (including any
+    boundary expansion), and closes it before returning — the caller wraps
+    this single call in ``asyncio.to_thread``. Raises ``HistoryUnavailable``
+    on any db-level failure; never returns a partial/corrupt result silently.
+    """
+    conn = open_readonly_connection(db_path)
+    try:
+        return _read_history_page(
+            conn,
+            session_id,
+            before_seq=before_seq,
+            limit=max(1, limit),
+            max_expansion_rows=max(limit, max_expansion_rows),
+        )
+    except sqlite3.Error as exc:
+        raise HistoryUnavailable(f"history page query failed: {exc}") from exc
+    finally:
+        conn.close()
+
+
+def _read_history_page(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    before_seq: int,
+    limit: int,
+    max_expansion_rows: int,
+) -> HistoryPageResult:
+    seed = conn.execute(
+        "SELECT seq FROM conversation_history "
+        "WHERE session_id = ? AND seq < ? ORDER BY seq DESC LIMIT ?",
+        (session_id, before_seq, limit),
+    ).fetchall()
+    if not seed:
+        return HistoryPageResult(
+            rows=[],
+            next_cursor=None,
+            has_more=False,
+            truncated=False,
+        )
+
+    oldest_seed_seq = int(seed[-1]["seq"])
+    boundary_seq = _turn_start_seq_at_or_before(
+        conn,
+        session_id,
+        oldest_seed_seq,
+    )
+    if boundary_seq is None:
+        # No real user row at or before the oldest candidate in this session
+        # at all (legacy/imported data with no turn markers). Fall back to
+        # the oldest row we actually found rather than expanding forever.
+        boundary_seq = oldest_seed_seq
+
+    span = before_seq - boundary_seq
+    truncated = False
+    if span > max_expansion_rows:
+        # Pathological single turn far exceeding the budget: stop expanding,
+        # return the most recent ``max_expansion_rows`` rows below the
+        # cursor and let the caller mark the page truncated. The next page
+        # picks up exactly where this one stopped (no gap, no duplication).
+        boundary_seq = before_seq - max_expansion_rows
+        truncated = True
+
+    rows_desc = conn.execute(
+        "SELECT * FROM conversation_history "
+        "WHERE session_id = ? AND seq >= ? AND seq < ? "
+        "ORDER BY seq DESC",
+        (session_id, boundary_seq, before_seq),
+    ).fetchall()
+    if not rows_desc:
+        return HistoryPageResult(
+            rows=[],
+            next_cursor=None,
+            has_more=False,
+            truncated=False,
+        )
+
+    ascending = list(reversed(rows_desc))
+    next_cursor = int(ascending[0]["seq"])
+    has_more = has_rows_before(conn, session_id, next_cursor)
+    return HistoryPageResult(
+        rows=ascending,
+        next_cursor=next_cursor,
+        has_more=has_more,
+        truncated=truncated,
+    )

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -2004,14 +2004,21 @@ class ScrollContextManager:
         )
 
     def purge_old(self, retention_days: int, *, dry_run: bool = False) -> int:
-        """Drop durable history older than ``retention_days`` (0 = keep
+        """Drop durable tool output older than ``retention_days`` (0 = keep
         forever). Returns the number of rows removed (or, with ``dry_run``,
-        that would be removed — nothing is deleted)."""
+        that would be removed — nothing is deleted).
+
+        Only ``kind="tool_result"`` rows are eligible: user messages and
+        assistant replies (``context_msg``/``model_turn``) are conversation
+        history, not disposable tool output, and must survive this purge so
+        a user can always scroll back to them.
+        """
         if retention_days <= 0:
             return 0
         return self._history.purge(
             before=self._cutoff(retention_days),
             dry_run=dry_run,
+            kinds=("tool_result",),
         )
 
     @staticmethod

--- a/src/qwenpaw/agents/context/scroll/sync.py
+++ b/src/qwenpaw/agents/context/scroll/sync.py
@@ -754,7 +754,9 @@ def _purge_old_history(
         datetime.now(timezone.utc) - timedelta(days=retention_days)
     ).isoformat()
     try:
-        removed = history.purge(before=cutoff)
+        # Only tool output is disposable; user/assistant turns stay durable
+        # so scroll-back always reaches the true start of the conversation.
+        removed = history.purge(before=cutoff, kinds=("tool_result",))
     except Exception as exc:  # noqa: BLE001 - retention must never break boot
         logger.warning(
             "session-sync[%s]: retention purge failed: %s",

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -22,16 +22,40 @@ from .models import (
     ChatGroupCreate,
     ChatGroupOrderUpdate,
     ChatGroupUpdate,
+    ChatMessagesPage,
     ChatSpec,
     ChatUpdate,
     ChatHistory,
 )
-from .utils import agentscope_msg_to_message, parse_legacy_memory_state
+from .utils import (
+    agentscope_msg_to_message,
+    first_screen_window,
+    history_rows_to_messages,
+    missing_tool_call_ids,
+    parse_legacy_memory_state,
+)
+from ...agents.context.scroll.history import (
+    HistoryUnavailable,
+    fetch_tool_results_by_call_ids,
+    find_seq_by_dedup_key,
+    has_rows_before,
+    min_seq_for_session,
+    open_readonly_connection,
+    read_history_page,
+)
 from ...services.project_directory import (
     resolve_effective_project_dir,
     session_project_dir,
 )
 from ...checkpoints.runtime import RUNTIME as CHECKPOINT_RUNTIME
+
+# First-screen / fallback safety window — see docs/session-scroll-loading-
+# design.md §2.1 "安全降级 (OOM 约束优先)". Applies whenever the endpoint
+# can't hand the browser a normal db-backed page: non-scroll sessions,
+# and scroll sessions where the db is unreachable or the anchor can't be
+# resolved. Independent of the caller's requested ``limit``.
+_SAFE_WINDOW_MAX_MESSAGES = 300
+_SAFE_WINDOW_MAX_BYTES = 8 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
 
@@ -696,33 +720,31 @@ async def clear_chat_project_dirs(
 # ----- Existing CRUD endpoints -----
 
 
-@router.get("/{chat_id}", response_model=ChatHistory)
-async def get_chat(
+async def _resolve_chat_state(
     chat_id: str,
-    include_app_owned: bool = Query(
-        True,
-        description=(
-            "Allow reading PawApp-owned chat history. The main Chat surface "
-            "opts out so app dialogues stay inside their owning app."
-        ),
-    ),
-    mgr: ChatManager = Depends(get_chat_manager),
-    session: SafeJSONSession = Depends(get_session),
-    workspace=Depends(get_workspace),
-):
-    """Get detailed information about a specific chat by UUID.
+    mgr: ChatManager,
+    session: SafeJSONSession,
+    workspace,
+    include_app_owned: bool = True,
+) -> tuple[ChatSpec, dict, list[Msg], str]:
+    """Shared chat_spec/session-state/status resolution for read endpoints.
 
-    Args:
-        request: FastAPI request (for agent context)
-        chat_id: Chat UUID
-        mgr: Chat manager dependency
-        session: SafeJSONSession dependency
+    Returns ``(chat_spec, agent_raw, memories, status)``:
+    - ``agent_raw`` is the raw ``state["agent"]`` dict — carries both
+      ``state`` (the ``AgentState`` dump) and, for scroll sessions,
+      ``scroll`` (``ScrollContextManager.to_dict()``, including the eviction
+      index used for the expired/complete determination — see
+      ``react_agent.py`` ``state_dict()``).
+    - ``memories`` is the parsed live ``AgentState.context`` (empty if
+      unparseable, legacy, or the session has no state yet).
 
-    Returns:
-        ChatHistory with messages and status (idle/running)
+    ``include_app_owned=False`` makes a PawApp-owned chat read as 404, the
+    same way ``GET /{chat_id}`` treats it — the gate belongs here so every
+    read endpoint built on this helper inherits it rather than each one
+    re-implementing the check.
 
-    Raises:
-        HTTPException: If chat not found (404)
+    Raises ``HTTPException(404)`` if the chat doesn't exist — both callers
+    want that exact behavior, so it lives here rather than being duplicated.
     """
     chat_spec = await mgr.get_chat(chat_id)
     if not chat_spec:
@@ -765,7 +787,7 @@ async def get_chat(
             )
     status = await workspace.task_tracker.get_status(chat_id)
     if not state:
-        return ChatHistory(messages=[], status=status)
+        return chat_spec, {}, [], status
 
     agent_raw = state.get("agent", {})
     memories: list[Msg] = []
@@ -787,8 +809,396 @@ async def get_chat(
         if memory_raw:
             memories, _summary = parse_legacy_memory_state(memory_raw)
 
+    return chat_spec, agent_raw, memories, status
+
+
+@router.get("/{chat_id}", response_model=ChatHistory)
+async def get_chat(
+    chat_id: str,
+    include_app_owned: bool = Query(
+        True,
+        description=(
+            "Allow reading PawApp-owned chat history. The main Chat surface "
+            "opts out so app dialogues stay inside their owning app."
+        ),
+    ),
+    mgr: ChatManager = Depends(get_chat_manager),
+    session: SafeJSONSession = Depends(get_session),
+    workspace=Depends(get_workspace),
+):
+    """Get detailed information about a specific chat by UUID.
+
+    Args:
+        request: FastAPI request (for agent context)
+        chat_id: Chat UUID
+        mgr: Chat manager dependency
+        session: SafeJSONSession dependency
+
+    Returns:
+        ChatHistory with messages and status (idle/running)
+
+    Raises:
+        HTTPException: If chat not found (404)
+    """
+    _chat_spec, _agent_raw, memories, status = await _resolve_chat_state(
+        chat_id,
+        mgr,
+        session,
+        workspace,
+        include_app_owned=include_app_owned,
+    )
     messages = agentscope_msg_to_message(memories)
     return ChatHistory(messages=messages, status=status)
+
+
+def _light_context_config(workspace):
+    """Resolve ``LightContextConfig`` off the agent's profile config.
+
+    Lives under ``config.running.light_context_config`` on the real
+    ``AgentProfileConfig`` (matches ``agents/context/scroll/sync.py``'s
+    ``agent_config.running.light_context_config``) — NOT directly on
+    ``config``, unlike ``backend``/``backend_settings``. ``getattr``-chained
+    so a test double or an unexpected config shape degrades to "native"
+    (non-scroll) rather than raising.
+    """
+    running = getattr(workspace.config, "running", None)
+    return getattr(running, "light_context_config", None)
+
+
+def _is_scroll_strategy(workspace) -> bool:
+    lcc = _light_context_config(workspace)
+    return getattr(lcc, "strategy", "native") == "scroll"
+
+
+def _history_db_path(workspace) -> Path:
+    lcc = _light_context_config(workspace)
+    return Path(workspace.workspace_dir) / lcc.scroll_config.db_filename
+
+
+def _retention_days(workspace) -> int:
+    lcc = _light_context_config(workspace)
+    scroll_config = getattr(lcc, "scroll_config", None)
+    return getattr(scroll_config, "history_retention_days", 30)
+
+
+def _safety_window(memories: list[Msg]) -> list:
+    """Bounded fallback used whenever there's no db page to serve instead:
+    non-scroll sessions, or a scroll session whose db/anchor can't be
+    reached. Turn-aligned via :func:`first_screen_window`, then hard-capped
+    at ``_SAFE_WINDOW_MAX_MESSAGES`` / ``_SAFE_WINDOW_MAX_BYTES`` so a huge
+    session JSON can never be handed whole to the browser even on this path
+    (design doc §2.1 "安全降级 (OOM 约束优先)").
+
+    Every caller marks its response ``fallback_limited=True`` regardless of
+    whether these caps actually trimmed anything — the flag means "this is a
+    capped safety window, not a normal page with a real cursor", which is
+    true the moment this path is taken at all.
+    """
+    window, _anchor = first_screen_window(memories, _SAFE_WINDOW_MAX_MESSAGES)
+    messages = agentscope_msg_to_message(window)
+    if len(messages) > _SAFE_WINDOW_MAX_MESSAGES:
+        messages = messages[-_SAFE_WINDOW_MAX_MESSAGES:]
+
+    total_bytes = 0
+    kept: list = []
+    for message in reversed(messages):
+        size = len(message.model_dump_json())
+        if kept and total_bytes + size > _SAFE_WINDOW_MAX_BYTES:
+            break
+        kept.append(message)
+        total_bytes += size
+    kept.reverse()
+    return kept
+
+
+def _expired_or_complete(
+    agent_raw: dict,
+    min_remaining_seq: Optional[int],
+) -> str:
+    """'complete' vs 'expired' once no more history can be loaded.
+
+    Reads the eviction index straight out of the already-fetched session
+    state (``agent_raw["scroll"]["index"]`` — see
+    ``ScrollContextManager.to_dict()`` / ``EvictionIndex.to_dict()``); no
+    live manager or extra db round-trip needed. No reliable evidence of loss
+    defaults to ``complete`` — never guess ``expired`` (design doc §2.1).
+    """
+    scroll_state = (
+        agent_raw.get("scroll") if isinstance(agent_raw, dict) else None
+    )
+    index_data = (
+        scroll_state.get("index") if isinstance(scroll_state, dict) else None
+    )
+    tiers = (
+        index_data.get("tiers", index_data.get("levels"))
+        if isinstance(
+            index_data,
+            dict,
+        )
+        else None
+    )
+    if not tiers:
+        return "complete"
+    try:
+        seq_los = [
+            block["seq_lo"]
+            for tier in tiers
+            for block in tier
+            if isinstance(block, dict) and "seq_lo" in block
+        ]
+    except (TypeError, KeyError):
+        return "complete"
+    if not seq_los:
+        return "complete"
+    index_min_seq_lo = min(seq_los)
+    if min_remaining_seq is None or min_remaining_seq <= index_min_seq_lo:
+        return "complete"
+    return "expired"
+
+
+@router.get("/{chat_id}/messages", response_model=ChatMessagesPage)
+async def get_chat_messages(
+    chat_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    before_seq: Optional[int] = Query(None),
+    include_app_owned: bool = Query(
+        True,
+        description=(
+            "Allow reading PawApp-owned chat history. The main Chat surface "
+            "opts out so app dialogues stay inside their owning app."
+        ),
+    ),
+    mgr: ChatManager = Depends(get_chat_manager),
+    session: SafeJSONSession = Depends(get_session),
+    workspace=Depends(get_workspace),
+):
+    """Paginated scroll-back read path — see
+    ``docs/session-scroll-loading-design.md``.
+
+    No ``before_seq``: turn-aligned first-screen window off the live session
+    JSON, anchored into ``history.db`` for "load older". With ``before_seq``:
+    a turn-aligned page straight from ``history.db``, strictly older than
+    the cursor. The existing ``GET /{chat_id}`` is untouched for older
+    clients/integrations.
+
+    ``include_app_owned`` mirrors ``GET /{chat_id}`` exactly: without it this
+    endpoint would be a way to read a PawApp-owned transcript that the
+    non-paginated read path refuses to serve.
+    """
+    chat_spec, agent_raw, memories, status = await _resolve_chat_state(
+        chat_id,
+        mgr,
+        session,
+        workspace,
+        include_app_owned=include_app_owned,
+    )
+    is_scroll = _is_scroll_strategy(workspace)
+    retention_days = _retention_days(workspace)
+    session_id = chat_spec.session_id
+    db_path = _history_db_path(workspace)
+
+    if before_seq is None:
+        window, anchor = first_screen_window(memories, limit)
+        messages = agentscope_msg_to_message(window)
+
+        if not is_scroll:
+            return ChatMessagesPage(
+                messages=_safety_window(memories),
+                next_cursor=None,
+                has_more=False,
+                history_status="unavailable",
+                status=status,
+                fallback_limited=True,
+            )
+
+        if anchor is None:
+            # Nothing to anchor to — e.g. a brand new chat with no real
+            # user turn yet. There's nothing older to page into.
+            return ChatMessagesPage(
+                messages=messages,
+                next_cursor=None,
+                has_more=False,
+                history_status="complete",
+                status=status,
+            )
+
+        def _anchor_lookup():
+            conn = open_readonly_connection(db_path)
+            try:
+                seq = find_seq_by_dedup_key(conn, session_id, anchor.id)
+                if seq is None:
+                    return None
+                has_more = has_rows_before(conn, session_id, seq)
+                min_seq = (
+                    None if has_more else min_seq_for_session(conn, session_id)
+                )
+                return seq, has_more, min_seq
+            finally:
+                conn.close()
+
+        try:
+            anchor_result = await asyncio.to_thread(_anchor_lookup)
+        except HistoryUnavailable:
+            anchor_result = None
+        except Exception:
+            logger.warning(
+                "get_chat_messages: first-screen anchor lookup failed for "
+                "chat %s",
+                chat_id,
+                exc_info=True,
+            )
+            anchor_result = None
+
+        if anchor_result is None:
+            # db missing/corrupt, query failed, or the anchor Msg hasn't
+            # been write-through persisted yet — never silently report this
+            # as "reached the end".
+            return ChatMessagesPage(
+                messages=_safety_window(memories),
+                next_cursor=None,
+                has_more=False,
+                history_status="degraded",
+                status=status,
+                fallback_limited=True,
+            )
+
+        seq, has_more, min_seq = anchor_result
+        history_status = (
+            "available"
+            if has_more
+            else _expired_or_complete(agent_raw, min_seq)
+        )
+        return ChatMessagesPage(
+            messages=messages,
+            next_cursor=seq if has_more else None,
+            has_more=has_more,
+            history_status=history_status,
+            status=status,
+        )
+
+    # --- pagination branch (before_seq given) ---
+
+    if not is_scroll:
+        return ChatMessagesPage(
+            messages=[],
+            next_cursor=None,
+            has_more=False,
+            history_status="unavailable",
+            status=status,
+        )
+
+    try:
+        page = await asyncio.to_thread(
+            read_history_page,
+            db_path,
+            session_id,
+            before_seq=before_seq,
+            limit=limit,
+        )
+    except HistoryUnavailable:
+        return ChatMessagesPage(
+            messages=[],
+            next_cursor=None,
+            has_more=False,
+            history_status="degraded",
+            status=status,
+            fallback_limited=True,
+        )
+    except Exception:
+        logger.warning(
+            "get_chat_messages: page query failed for chat %s",
+            chat_id,
+            exc_info=True,
+        )
+        return ChatMessagesPage(
+            messages=[],
+            next_cursor=None,
+            has_more=False,
+            history_status="degraded",
+            status=status,
+            fallback_limited=True,
+        )
+
+    if not page.rows:
+        min_seq = None
+        try:
+            min_seq = await asyncio.to_thread(
+                lambda: _with_readonly_conn(
+                    db_path,
+                    lambda conn: min_seq_for_session(conn, session_id),
+                ),
+            )
+        except HistoryUnavailable:
+            pass
+        return ChatMessagesPage(
+            messages=[],
+            next_cursor=None,
+            has_more=False,
+            history_status=_expired_or_complete(agent_raw, min_seq),
+            status=status,
+            truncated=page.truncated,
+        )
+
+    call_ids = missing_tool_call_ids(page.rows)
+    external_tool_results: dict = {}
+    if call_ids:
+        try:
+            external_tool_results = await asyncio.to_thread(
+                lambda: _with_readonly_conn(
+                    db_path,
+                    lambda conn: fetch_tool_results_by_call_ids(
+                        conn,
+                        session_id,
+                        call_ids,
+                    ),
+                ),
+            )
+        except HistoryUnavailable:
+            external_tool_results = {}
+
+    messages = history_rows_to_messages(
+        page.rows,
+        retention_days=retention_days,
+        external_tool_results=external_tool_results,
+    )
+
+    if page.has_more:
+        history_status = "available"
+    else:
+        min_seq = None
+        try:
+            min_seq = await asyncio.to_thread(
+                lambda: _with_readonly_conn(
+                    db_path,
+                    lambda conn: min_seq_for_session(conn, session_id),
+                ),
+            )
+        except HistoryUnavailable:
+            pass
+        history_status = _expired_or_complete(agent_raw, min_seq)
+
+    return ChatMessagesPage(
+        messages=messages,
+        next_cursor=page.next_cursor if page.has_more else None,
+        has_more=page.has_more,
+        history_status=history_status,
+        status=status,
+        truncated=page.truncated,
+    )
+
+
+def _with_readonly_conn(db_path: Path, fn):
+    """Run ``fn(conn)`` against a short-lived read-only connection.
+
+    Small helper for the supplemental (non-page) read-only queries below —
+    keeps "open, run, close inside one thread call" in one place rather than
+    repeating the try/finally at each call site.
+    """
+    conn = open_readonly_connection(db_path)
+    try:
+        return fn(conn)
+    finally:
+        conn.close()
 
 
 @router.put("/{chat_id}", response_model=ChatSpec)

--- a/src/qwenpaw/app/chats/models.py
+++ b/src/qwenpaw/app/chats/models.py
@@ -226,6 +226,58 @@ class ChatHistory(BaseModel):
     )
 
 
+class ChatMessagesPage(BaseModel):
+    """One page from ``GET /chats/{id}/messages`` — the scroll-back read path.
+
+    See ``docs/session-scroll-loading-design.md`` §2.1 for the full field
+    semantics. ``history_status`` distinguishes "more to load" (``available``),
+    "reached the true start" (``complete``), "the true start was purged by an
+    old retention policy" (``expired``), "this session has no history store to
+    scroll into" (``unavailable``), and "the history store exists but this
+    request couldn't read it" (``degraded`` — never silently reported as
+    ``complete``).
+    """
+
+    messages: list[Message] = Field(default_factory=list)
+    next_cursor: Optional[int] = Field(
+        default=None,
+        description="Pass as before_seq to fetch the next (older) page.",
+    )
+    has_more: bool = Field(
+        default=False,
+        description="Whether an older page exists past next_cursor.",
+    )
+    history_status: Literal[
+        "available",
+        "complete",
+        "expired",
+        "unavailable",
+        "degraded",
+    ] = Field(default="unavailable")
+    status: Literal["idle", "running"] = Field(
+        default="idle",
+        description=(
+            "Conversation run status, same source as " "ChatHistory.status."
+        ),
+    )
+    truncated: bool = Field(
+        default=False,
+        description=(
+            "True when a single turn exceeded the expansion budget and this "
+            "page had to cut it mid-turn; the next page continues from "
+            "next_cursor with no gap or duplication."
+        ),
+    )
+    fallback_limited: bool = Field(
+        default=False,
+        description=(
+            "True when messages is a capped safety window rather than a "
+            "normal page (non-scroll mode, or a degraded/unreachable "
+            "history store) — the full session may still be larger."
+        ),
+    )
+
+
 class BatchFailure(BaseModel):
     """A single failure entry in a batch operation."""
 

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -3,8 +3,8 @@ import json
 import logging
 import platform
 import re
-from datetime import datetime, timezone
-from typing import List, Optional, Union
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Mapping, Optional, Sequence, Union
 from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -109,6 +109,46 @@ def _is_synthetic_user_message(msg: Msg) -> bool:
         and metadata.get(QWENPAW_MESSAGE_TAG_KEY)
         in SYNTHETIC_USER_MESSAGE_TAGS
     )
+
+
+def _is_real_user_turn_start(msg: Msg) -> bool:
+    """Whether *msg* is a genuine user turn boundary — not a scroll
+    placeholder, not a runtime-injected stub. The same test the db read path
+    applies via ``MemorySpace._real_user_conditions`` (role='user' minus the
+    same synthetic tags), kept in sync manually since one side is live
+    ``Msg`` objects and the other is SQL."""
+    return (
+        msg.role == "user"
+        and not _is_scroll_memory_placeholder(msg)
+        and not _is_synthetic_user_message(msg)
+    )
+
+
+def first_screen_window(
+    messages: List[Msg],
+    limit: int,
+) -> tuple[List[Msg], Optional[Msg]]:
+    """Turn-aligned first-screen window: the tail of ``messages``, extended
+    backward to the nearest real user turn boundary (design doc §2.1 "回合对
+    齐取窗"). ``limit`` is a target size, not an exact count — keeping a turn
+    whole takes priority over hitting the count exactly.
+
+    Returns ``(window, anchor)``. ``anchor`` is the earliest real user Msg in
+    the window — the endpoint resolves its id to a db ``seq`` to know where
+    "load older" should resume. ``anchor`` is ``None`` when the window has no
+    real user message at all (e.g. a brand new chat with nothing to page
+    into yet), in which case there is nothing to anchor and pagination stops
+    here.
+    """
+    n = len(messages)
+    if n == 0:
+        return [], None
+    idx = max(0, n - max(1, limit))
+    while idx > 0 and not _is_real_user_turn_start(messages[idx]):
+        idx -= 1
+    window = messages[idx:]
+    anchor = next((m for m in window if _is_real_user_turn_start(m)), None)
+    return window, anchor
 
 
 def parse_legacy_memory_state(
@@ -512,6 +552,310 @@ def clean_display_text(text: str, role: str) -> str:
 
 
 # pylint: disable=too-many-branches,too-many-statements, too-many-nested-blocks
+def _blocks_to_messages(
+    blocks: List[Any],
+    *,
+    role: str,
+    metadata: dict,
+    id_prefix: Optional[str] = None,
+) -> List[Message]:
+    """Dispatch one Msg's content blocks into one or more display Messages.
+
+    Shared by :func:`agentscope_msg_to_message` (live ``Msg.content``) and
+    :func:`history_rows_to_messages` (a db row's deserialized ``blocks``
+    column) — both need identical text/thinking/tool_call/tool_result/media
+    rendering, so this is the single place that owns it.
+
+    When ``id_prefix`` is given, each Message this call starts gets a
+    deterministic id ``f"{id_prefix}:{part_index}"`` (part_index counts every
+    new Message started, in order) instead of the default random uuid4 — see
+    the design doc's "还原消息 id 唯一性" rule. Passing ``None`` (the live-Msg
+    path) preserves the exact previous behavior: default random ids.
+    """
+    results: List[Message] = []
+    current_message: Optional[Message] = None
+    current_type: Optional[MessageType] = None
+    part_index = 0
+
+    def start_message(msg_type: MessageType) -> Message:
+        nonlocal current_message, current_type, part_index
+        if current_message:
+            results.append(current_message.completed())
+        kwargs: dict = {"type": msg_type, "role": role}
+        if id_prefix is not None:
+            kwargs["id"] = f"{id_prefix}:{part_index}"
+        part_index += 1
+        current_message = Message(**kwargs)
+        current_message.metadata = metadata
+        current_type = msg_type
+        return current_message
+
+    for block in blocks:
+        # Normalize pydantic block models to dict so the rest of
+        # this conversion (which uses .get) handles both shapes.
+        if hasattr(block, "model_dump"):
+            block = block.model_dump()
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "text")
+
+        # DataBlock (2.0): map type="data" to concrete media type
+        if btype == "data":
+            source = block.get("source") or {}
+            mt = (
+                source.get("media_type", "")
+                if isinstance(source, dict)
+                else ""
+            )
+            if mt.startswith("image/"):
+                btype = "image"
+            elif mt.startswith("audio/"):
+                btype = "audio"
+            elif mt.startswith("video/"):
+                btype = "video"
+            else:
+                btype = "file"
+
+        if btype == "text":
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            text_content = TextContent(
+                delta=False,
+                index=None,
+                text=clean_display_text(
+                    block.get("text", ""),
+                    role,
+                ),
+            )
+            current_message.add_content(new_content=text_content)
+
+        elif btype == "hint":
+            # Hint blocks are runtime/model-facing state (for example,
+            # current-time reminders). They belong in the agent context,
+            # but never in a user-visible transcript restored by either
+            # the console chat UI or a PawApp. Skipping it here covers the
+            # live path and the db replay path at once, so scroll-back can
+            # never surface a hint that live rendering hides.
+            continue
+
+        elif btype == "thinking":
+            if current_type != MessageType.REASONING:
+                start_message(MessageType.REASONING)
+
+            text_content = TextContent(
+                delta=False,
+                index=None,
+                text=block.get("thinking", ""),
+            )
+            current_message.add_content(new_content=text_content)
+
+        elif btype in ("tool_use", "tool_call"):
+            start_message(MessageType.PLUGIN_CALL)
+
+            if isinstance(block.get("input"), (dict, list)):
+                arguments = json.dumps(
+                    block.get("input"),
+                    ensure_ascii=False,
+                )
+            else:
+                arguments = block.get("input")
+
+            call_data = FunctionCall(
+                call_id=block.get("id"),
+                name=block.get("name"),
+                arguments=arguments,
+            ).model_dump()
+
+            data_content = DataContent(
+                delta=False,
+                index=None,
+                data=call_data,
+            )
+            current_message.add_content(new_content=data_content)
+
+        elif btype == "tool_result":
+            start_message(MessageType.PLUGIN_CALL_OUTPUT)
+
+            if isinstance(block.get("output"), (dict, list)):
+                output = json.dumps(
+                    block.get("output"),
+                    ensure_ascii=False,
+                )
+            else:
+                output = block.get("output")
+
+            output_data = FunctionCallOutput(
+                call_id=block.get("id"),
+                name=block.get("name"),
+                output=output,
+            ).model_dump(exclude_none=True)
+
+            tool_state = block.get("state")
+            if hasattr(tool_state, "value"):
+                tool_state = tool_state.value
+            if tool_state is not None:
+                output_data["state"] = tool_state
+
+            data_content = DataContent(
+                delta=False,
+                index=None,
+                data=output_data,
+            )
+            current_message.add_content(new_content=data_content)
+
+        elif btype == "image":
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            kwargs = {}
+            if (
+                isinstance(block.get("source"), dict)
+                and block.get("source", {}).get("type") == "url"
+            ):
+                url = block.get("source", {}).get("url")
+                url = _resolve_content_url(url)
+                kwargs["image_url"] = url
+
+            elif (
+                isinstance(block.get("source"), dict)
+                and block.get("source").get("type") == "base64"
+            ):
+                media_type = block.get("source", {}).get(
+                    "media_type",
+                    "image/jpeg",
+                )
+                base64_data = block.get("source", {}).get("data", "")
+                url = f"data:{media_type};base64,{base64_data}"
+                kwargs["image_url"] = url
+
+            image_content = ImageContent(
+                delta=False,
+                index=None,
+                **kwargs,
+            )
+            current_message.add_content(new_content=image_content)
+
+        elif btype == "audio":
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            kwargs = {}
+            if (
+                isinstance(block.get("source"), dict)
+                and block.get("source", {}).get("type") == "url"
+            ):
+                url = block.get("source", {}).get("url")
+                url = _resolve_content_url(url)
+                kwargs["data"] = url
+                try:
+                    kwargs["format"] = urlparse(url).path.split(".")[-1]
+                except (AttributeError, IndexError, ValueError):
+                    kwargs["format"] = None
+
+            elif (
+                isinstance(block.get("source"), dict)
+                and block.get("source").get("type") == "base64"
+            ):
+                media_type = block.get("source", {}).get("media_type")
+                base64_data = block.get("source", {}).get("data", "")
+                url = f"data:{media_type};base64,{base64_data}"
+                kwargs["data"] = url
+                kwargs["format"] = media_type
+
+            audio_content = AudioContent(
+                delta=False,
+                index=None,
+                **kwargs,
+            )
+            current_message.add_content(new_content=audio_content)
+
+        elif btype == "video":
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            kwargs = {}
+            if (
+                isinstance(block.get("source"), dict)
+                and block.get("source", {}).get("type") == "url"
+            ):
+                url = block.get("source", {}).get("url")
+                url = _resolve_content_url(url)
+                kwargs["video_url"] = url
+
+            elif (
+                isinstance(block.get("source"), dict)
+                and block.get("source").get("type") == "base64"
+            ):
+                media_type = block.get("source", {}).get(
+                    "media_type",
+                    "video/mp4",
+                )
+                base64_data = block.get("source", {}).get("data", "")
+                url = f"data:{media_type};base64,{base64_data}"
+                kwargs["video_url"] = url
+
+            video_content = VideoContent(
+                delta=False,
+                index=None,
+                **kwargs,
+            )
+            current_message.add_content(new_content=video_content)
+
+        elif btype == "file":
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            kwargs = {
+                "filename": block.get("filename") or block.get("name"),
+            }
+            if (
+                isinstance(block.get("source"), dict)
+                and block.get("source", {}).get("type") == "url"
+            ):
+                url = block.get("source", {}).get("url")
+                url = _resolve_content_url(url)
+                kwargs["file_url"] = url
+
+            elif (
+                isinstance(block.get("source"), dict)
+                and block.get("source").get("type") == "base64"
+            ):
+                media_type = block.get("source", {}).get(
+                    "media_type",
+                    "application/octet-stream",
+                )
+                base64_data = block.get("source", {}).get("data", "")
+                url = f"data:{media_type};base64,{base64_data}"
+                kwargs["file_url"] = url
+            elif isinstance(block.get("source"), str):
+                url = _resolve_content_url(block.get("source", ""))
+                kwargs["file_url"] = url
+
+            file_content = FileContent(
+                delta=False,
+                index=None,
+                **kwargs,
+            )
+            current_message.add_content(new_content=file_content)
+
+        else:
+            if current_type != MessageType.MESSAGE:
+                start_message(MessageType.MESSAGE)
+
+            text_content = TextContent(
+                delta=False,
+                index=None,
+                text=str(block),
+            )
+            current_message.add_content(new_content=text_content)
+
+    if current_message:
+        results.append(current_message.completed())
+
+    return results
+
+
 def agentscope_msg_to_message(
     messages: Union[Msg, List[Msg]],
 ) -> List[Message]:
@@ -586,333 +930,326 @@ def agentscope_msg_to_message(
             results.append(message)
             continue
 
-        current_message = None
-        current_type = None
+        results.extend(
+            _blocks_to_messages(
+                msg.content,
+                role=role,
+                metadata=metadata,
+                id_prefix=None,
+            ),
+        )
 
-        for block in msg.content:
-            # Normalize pydantic block models to dict so the rest of
-            # this conversion (which uses .get) handles both shapes.
-            if hasattr(block, "model_dump"):
-                block = block.model_dump()
-            if not isinstance(block, dict):
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction from ``conversation_history`` db rows (the pagination read
+# path — see ``docs/session-scroll-loading-design.md`` §2.2). This mirrors
+# ``agentscope_msg_to_message`` above but starts from persisted rows instead
+# of live ``Msg`` objects.
+# ---------------------------------------------------------------------------
+
+
+def _row_is_synthetic_user_message(row: Any) -> bool:
+    """Row-level analog of :func:`_is_synthetic_user_message`.
+
+    Scroll's model-only placeholders never reach ``conversation_history``
+    (``ScrollContextManager._persist_new`` skips them before persisting), so
+    only the synthetic-user-stub check applies to db rows.
+    """
+    if row["role"] != "user":
+        return False
+    if row["name"] in _VISUAL_PLACEHOLDER_NAMES:
+        return True
+    raw_metadata = row["metadata"]
+    if not raw_metadata:
+        return False
+    try:
+        metadata = json.loads(raw_metadata)
+    except (TypeError, ValueError):
+        return False
+    return (
+        isinstance(metadata, dict)
+        and metadata.get(QWENPAW_MESSAGE_TAG_KEY)
+        in SYNTHETIC_USER_MESSAGE_TAGS
+    )
+
+
+def _parsed_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        dt_obj = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if dt_obj.tzinfo is None:
+        dt_obj = dt_obj.replace(tzinfo=timezone.utc)
+    return dt_obj
+
+
+def _row_display_metadata(row: Any, user_tz: ZoneInfo) -> dict:
+    ts_value = row["created_at"]
+    if ts_value:
+        ts_value = _normalize_msg_timestamp(ts_value, user_tz)
+    raw_metadata = row["metadata"]
+    parsed_metadata = None
+    if raw_metadata:
+        try:
+            parsed_metadata = json.loads(raw_metadata)
+        except (TypeError, ValueError):
+            parsed_metadata = None
+    return {
+        "original_id": row["dedup_key"],
+        "original_name": row["name"],
+        "metadata": parsed_metadata,
+        "timestamp": ts_value,
+        # ``conversation_history`` has no ``finished_at`` column, so a
+        # scrolled-back message can never carry a real completion stamp.
+        # Emit the key anyway (as None) to keep the metadata shape identical
+        # to the live path — consumers already fall back to ``timestamp``
+        # when it's None, which is exactly the desired behavior here.
+        "finished_at": None,
+    }
+
+
+def _row_blocks(row: Any) -> List[Any]:
+    raw_blocks = row["blocks"]
+    if not raw_blocks:
+        return []
+    try:
+        parsed = json.loads(raw_blocks)
+    except (TypeError, ValueError):
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _tool_placeholder_message(
+    *,
+    call_id: Optional[str],
+    call_name: Optional[str],
+    role: str,
+    metadata: dict,
+    id_prefix: Optional[str],
+    part_index: int,
+    expired: bool,
+) -> Message:
+    """A stand-in card for a tool call whose result row can't be found.
+
+    ``expired`` distinguishes a result the retention policy purged
+    (``metadata.tool_result_expired``) from one that simply hasn't landed
+    yet within its retention window (``metadata.tool_result_pending`` — the
+    caller logs a warning for this case since it should be transient).
+    """
+    output_data = FunctionCallOutput(
+        call_id=call_id,
+        name=call_name,
+        output="工具详情已过期" if expired else "工具结果暂不可用",
+    ).model_dump(exclude_none=True)
+    message_metadata = dict(metadata)
+    flag = "tool_result_expired" if expired else "tool_result_pending"
+    message_metadata[flag] = True
+    kwargs: dict = {"type": MessageType.PLUGIN_CALL_OUTPUT, "role": role}
+    if id_prefix is not None:
+        kwargs["id"] = f"{id_prefix}:{part_index}"
+    message = Message(**kwargs)
+    message.metadata = message_metadata
+    message.add_content(
+        new_content=DataContent(delta=False, index=None, data=output_data),
+    )
+    return message.completed()
+
+
+def missing_tool_call_ids(rows: Sequence[Any]) -> List[str]:
+    """Tool_call ids referenced within ``rows`` with no matching tool_result
+    row also in ``rows`` — candidates for a supplemental cross-page db lookup
+    (``history.fetch_tool_results_by_call_ids``) before calling
+    :func:`history_rows_to_messages`, so a call split across a page boundary
+    isn't confused with one whose result was genuinely never persisted.
+    """
+    in_page_results: set = set()
+    for row in rows:
+        if row["kind"] == "tool_result":
+            call_id = row["tool_call_id"] or row["dedup_key"]
+            if call_id:
+                in_page_results.add(call_id)
+
+    call_ids: List[str] = []
+    for row in rows:
+        if row["kind"] not in ("context_msg", "model_turn"):
+            continue
+        for block in _row_blocks(row):
+            if (
+                isinstance(block, dict)
+                and block.get("type") in ("tool_use", "tool_call")
+                and block.get("id")
+            ):
+                call_ids.append(block.get("id"))
+    return [c for c in dict.fromkeys(call_ids) if c not in in_page_results]
+
+
+def history_rows_to_messages(
+    rows: Sequence[Any],
+    *,
+    retention_days: int = 30,
+    external_tool_results: Optional[Mapping[str, Any]] = None,
+) -> List[Message]:
+    """Reconstruct display Messages from ``conversation_history`` db rows.
+
+    Mirrors :func:`agentscope_msg_to_message` but reads persisted rows
+    instead of live ``Msg`` objects: ``context_msg``/``model_turn`` rows are
+    rendered via the same :func:`_blocks_to_messages` dispatcher used by the
+    live path (so text, thinking and tool-call parts round-trip identically),
+    and a matching ``tool_result`` row is spliced in right after its
+    ``tool_call`` block by ``tool_call_id`` (= db ``dedup_key``).
+
+    ``rows`` must already be seq-ascending (oldest first) and is treated as
+    one page: a ``tool_result`` row whose call isn't anywhere in ``rows``
+    renders as a standalone orphan card instead of being silently dropped.
+    ``external_tool_results`` (keyed by ``tool_call_id``) lets the caller
+    supply results that live outside this page's seq range, so "no result
+    row in this page" and "no result row anywhere in history" aren't
+    confused — the latter is what actually drives the expired/pending
+    placeholder.
+
+    Each reconstructed Message gets a deterministic id
+    ``f"{original_id}:{part_index}"`` (the design doc's "还原消息 id 唯一性"
+    rule), so the same db row always reconstructs to the same ids across
+    pages and reloads.
+    """
+    external_tool_results = external_tool_results or {}
+    user_tz_name = load_config().user_timezone or "UTC"
+    try:
+        user_tz = ZoneInfo(user_tz_name)
+    except (ZoneInfoNotFoundError, KeyError):
+        user_tz = timezone.utc
+
+    cutoff: Optional[datetime] = None
+    if retention_days and retention_days > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+    in_page_results: dict = {}
+    in_page_calls: set = set()
+    for row in rows:
+        kind = row["kind"]
+        if kind == "tool_result":
+            call_id = row["tool_call_id"] or row["dedup_key"]
+            if call_id:
+                in_page_results[call_id] = row
+        elif kind in ("context_msg", "model_turn"):
+            for block in _row_blocks(row):
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") in ("tool_use", "tool_call")
+                    and block.get("id")
+                ):
+                    in_page_calls.add(block.get("id"))
+
+    def render_tool_result_row(row: Any) -> List[Message]:
+        blocks = _row_blocks(row) or [
+            {
+                "type": "tool_result",
+                "id": row["tool_call_id"],
+                "name": row["name"],
+                "output": row["content"],
+                "state": row["tool_state"],
+            },
+        ]
+        return _blocks_to_messages(
+            blocks,
+            role=row["role"] or "assistant",
+            metadata=_row_display_metadata(row, user_tz),
+            id_prefix=row["dedup_key"] or row["tool_call_id"],
+        )
+
+    results: List[Message] = []
+    for row in rows:
+        kind = row["kind"]
+
+        if kind == "tool_result":
+            call_id = row["tool_call_id"] or row["dedup_key"]
+            if call_id and call_id in in_page_calls:
+                # Rendered inline by its tool_call's turn row below (or
+                # above it — the pre-scan already accounted for it) — don't
+                # double-render the same result.
                 continue
-            btype = block.get("type", "text")
+            results.extend(render_tool_result_row(row))
+            continue
 
-            # DataBlock (2.0): map type="data" to concrete media type
-            if btype == "data":
-                source = block.get("source") or {}
-                mt = (
-                    source.get("media_type", "")
-                    if isinstance(source, dict)
-                    else ""
+        if kind not in ("context_msg", "model_turn"):
+            # Recall-tool turns and any other non-transcript kind are not
+            # displayed, mirroring the live path (they never reach the
+            # SSE/history transcript either).
+            continue
+        if _row_is_synthetic_user_message(row):
+            continue
+
+        original_id = row["dedup_key"]
+        role = row["role"] or ("assistant" if kind == "model_turn" else "user")
+        metadata = _row_display_metadata(row, user_tz)
+        blocks = _row_blocks(row)
+
+        if blocks:
+            turn_messages = _blocks_to_messages(
+                blocks,
+                role=role,
+                metadata=metadata,
+                id_prefix=original_id,
+            )
+            results.extend(turn_messages)
+            part_index = len(turn_messages)
+            for block in blocks:
+                if not (
+                    isinstance(block, dict)
+                    and block.get("type") in ("tool_use", "tool_call")
+                ):
+                    continue
+                call_id = block.get("id")
+                result_row = in_page_results.get(call_id) or (
+                    external_tool_results.get(call_id) if call_id else None
                 )
-                if mt.startswith("image/"):
-                    btype = "image"
-                elif mt.startswith("audio/"):
-                    btype = "audio"
-                elif mt.startswith("video/"):
-                    btype = "video"
-                else:
-                    btype = "file"
-
-            if btype == "text":
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
+                if result_row is not None:
+                    results.extend(render_tool_result_row(result_row))
+                    continue
+                created_dt = _parsed_datetime(row["created_at"])
+                expired = bool(
+                    cutoff is not None
+                    and created_dt is not None
+                    and created_dt < cutoff,
+                )
+                if not expired:
+                    logger.warning(
+                        "history_rows_to_messages: tool_result missing for "
+                        "call_id=%s (turn %s) and not past the retention "
+                        "window; rendering as unavailable",
+                        call_id,
+                        original_id,
                     )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                text_content = TextContent(
-                    delta=False,
-                    index=None,
-                    text=clean_display_text(
-                        block.get("text", ""),
-                        role,
+                results.append(
+                    _tool_placeholder_message(
+                        call_id=call_id,
+                        call_name=block.get("name"),
+                        role=role,
+                        metadata=metadata,
+                        id_prefix=original_id,
+                        part_index=part_index,
+                        expired=expired,
                     ),
                 )
-                current_message.add_content(new_content=text_content)
-
-            elif btype == "hint":
-                # Hint blocks are runtime/model-facing state (for example,
-                # current-time reminders). They belong in the agent context,
-                # but never in a user-visible transcript restored by either
-                # the console chat UI or a PawApp.
-                continue
-
-            elif btype == "thinking":
-                if current_type != MessageType.REASONING:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.REASONING,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.REASONING
-
-                text_content = TextContent(
+                part_index += 1
+        elif row["content"]:
+            message = Message(
+                type=MessageType.MESSAGE,
+                role=role,
+                **({"id": f"{original_id}:0"} if original_id else {}),
+            )
+            message.metadata = metadata
+            message.add_content(
+                new_content=TextContent(
                     delta=False,
                     index=None,
-                    text=block.get("thinking", ""),
-                )
-                current_message.add_content(new_content=text_content)
-
-            elif btype in ("tool_use", "tool_call"):
-                if current_message:
-                    results.append(current_message.completed())
-
-                current_message = Message(
-                    type=MessageType.PLUGIN_CALL,
-                    role=role,
-                )
-                current_message.metadata = metadata
-                current_type = MessageType.PLUGIN_CALL
-
-                if isinstance(block.get("input"), (dict, list)):
-                    arguments = json.dumps(
-                        block.get("input"),
-                        ensure_ascii=False,
-                    )
-                else:
-                    arguments = block.get("input")
-
-                call_data = FunctionCall(
-                    call_id=block.get("id"),
-                    name=block.get("name"),
-                    arguments=arguments,
-                ).model_dump()
-
-                data_content = DataContent(
-                    delta=False,
-                    index=None,
-                    data=call_data,
-                )
-                current_message.add_content(new_content=data_content)
-
-            elif btype == "tool_result":
-                if current_message:
-                    results.append(current_message.completed())
-
-                current_message = Message(
-                    type=MessageType.PLUGIN_CALL_OUTPUT,
-                    role=role,
-                )
-                current_message.metadata = metadata
-                current_type = MessageType.PLUGIN_CALL_OUTPUT
-
-                if isinstance(block.get("output"), (dict, list)):
-                    output = json.dumps(
-                        block.get("output"),
-                        ensure_ascii=False,
-                    )
-                else:
-                    output = block.get("output")
-
-                output_data = FunctionCallOutput(
-                    call_id=block.get("id"),
-                    name=block.get("name"),
-                    output=output,
-                ).model_dump(exclude_none=True)
-
-                tool_state = block.get("state")
-                if hasattr(tool_state, "value"):
-                    tool_state = tool_state.value
-                if tool_state is not None:
-                    output_data["state"] = tool_state
-
-                data_content = DataContent(
-                    delta=False,
-                    index=None,
-                    data=output_data,
-                )
-                current_message.add_content(new_content=data_content)
-
-            elif btype == "image":
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                kwargs = {}
-                if (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source", {}).get("type") == "url"
-                ):
-                    url = block.get("source", {}).get("url")
-                    url = _resolve_content_url(url)
-                    kwargs["image_url"] = url
-
-                elif (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source").get("type") == "base64"
-                ):
-                    media_type = block.get("source", {}).get(
-                        "media_type",
-                        "image/jpeg",
-                    )
-                    base64_data = block.get("source", {}).get("data", "")
-                    url = f"data:{media_type};base64,{base64_data}"
-                    kwargs["image_url"] = url
-
-                image_content = ImageContent(
-                    delta=False,
-                    index=None,
-                    **kwargs,
-                )
-                current_message.add_content(new_content=image_content)
-
-            elif btype == "audio":
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                kwargs = {}
-                if (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source", {}).get("type") == "url"
-                ):
-                    url = block.get("source", {}).get("url")
-                    url = _resolve_content_url(url)
-                    kwargs["data"] = url
-                    try:
-                        kwargs["format"] = urlparse(url).path.split(".")[-1]
-                    except (AttributeError, IndexError, ValueError):
-                        kwargs["format"] = None
-
-                elif (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source").get("type") == "base64"
-                ):
-                    media_type = block.get("source", {}).get("media_type")
-                    base64_data = block.get("source", {}).get("data", "")
-                    url = f"data:{media_type};base64,{base64_data}"
-                    kwargs["data"] = url
-                    kwargs["format"] = media_type
-
-                audio_content = AudioContent(
-                    delta=False,
-                    index=None,
-                    **kwargs,
-                )
-                current_message.add_content(new_content=audio_content)
-
-            elif btype == "video":
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                kwargs = {}
-                if (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source", {}).get("type") == "url"
-                ):
-                    url = block.get("source", {}).get("url")
-                    url = _resolve_content_url(url)
-                    kwargs["video_url"] = url
-
-                elif (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source").get("type") == "base64"
-                ):
-                    media_type = block.get("source", {}).get(
-                        "media_type",
-                        "video/mp4",
-                    )
-                    base64_data = block.get("source", {}).get("data", "")
-                    url = f"data:{media_type};base64,{base64_data}"
-                    kwargs["video_url"] = url
-
-                video_content = VideoContent(
-                    delta=False,
-                    index=None,
-                    **kwargs,
-                )
-                current_message.add_content(new_content=video_content)
-
-            elif btype == "file":
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                kwargs = {
-                    "filename": block.get("filename") or block.get("name"),
-                }
-                if (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source", {}).get("type") == "url"
-                ):
-                    url = block.get("source", {}).get("url")
-                    url = _resolve_content_url(url)
-                    kwargs["file_url"] = url
-
-                elif (
-                    isinstance(block.get("source"), dict)
-                    and block.get("source").get("type") == "base64"
-                ):
-                    media_type = block.get("source", {}).get(
-                        "media_type",
-                        "application/octet-stream",
-                    )
-                    base64_data = block.get("source", {}).get("data", "")
-                    url = f"data:{media_type};base64,{base64_data}"
-                    kwargs["file_url"] = url
-                elif isinstance(block.get("source"), str):
-                    url = _resolve_content_url(block.get("source", ""))
-                    kwargs["file_url"] = url
-
-                file_content = FileContent(
-                    delta=False,
-                    index=None,
-                    **kwargs,
-                )
-                current_message.add_content(new_content=file_content)
-
-            else:
-                if current_type != MessageType.MESSAGE:
-                    if current_message:
-                        results.append(current_message.completed())
-                    current_message = Message(
-                        type=MessageType.MESSAGE,
-                        role=role,
-                    )
-                    current_message.metadata = metadata
-                    current_type = MessageType.MESSAGE
-
-                text_content = TextContent(
-                    delta=False,
-                    index=None,
-                    text=str(block),
-                )
-                current_message.add_content(new_content=text_content)
-
-        if current_message:
-            results.append(current_message.completed())
+                    text=clean_display_text(row["content"], role),
+                ),
+            )
+            results.append(message.completed())
 
     return results

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1211,10 +1211,14 @@ class ScrollContextConfig(BaseModel):
         default=30,
         ge=0,
         description=(
-            "Days of durable history to keep; rows older than this are "
-            "purged automatically on startup and on agent teardown. Default "
-            "30 keeps roughly the last month. Set 0 to keep history forever "
-            "(unbounded growth — only the capacity warning fires)."
+            "Days of durable *tool result* output to keep; tool_result rows "
+            "older than this are purged automatically on startup and on "
+            "agent teardown. Does NOT apply to conversation history — user "
+            "messages and assistant replies are kept indefinitely regardless "
+            "of this setting, so scroll-back always reaches the start of the "
+            "conversation. Default 30 keeps roughly the last month of tool "
+            "output. Set 0 to keep tool output forever too (unbounded "
+            "growth — only the capacity warning fires)."
         ),
     )
 

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -14,7 +14,13 @@ from pathlib import Path
 
 import pytest
 
-from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.history import (
+    HistoryStore,
+    HistoryUnavailable,
+    has_rows_before,
+    open_readonly_connection,
+    read_history_page,
+)
 from qwenpaw.agents.context.types import LogEntry
 
 
@@ -499,3 +505,190 @@ def test_corrupt_db_is_quarantined_and_recreated(tmp_path: Path):
         assert store.count("s") == 1
     finally:
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# Read-only pagination (``read_history_page`` / ``has_rows_before`` /
+# ``open_readonly_connection``) — the HTTP messages endpoint's read path.
+# ---------------------------------------------------------------------------
+
+
+def _append_turn(
+    store: HistoryStore,
+    session_id: str,
+    idx: int,
+) -> tuple[int, int]:
+    """Append one user+assistant turn; returns (user_seq, assistant_seq)."""
+    user_seq = store.append(
+        session_id=session_id,
+        dedup_key=f"u{idx}",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content=f"question {idx}",
+        ),
+    )
+    assistant_seq = store.append(
+        session_id=session_id,
+        dedup_key=f"a{idx}",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content=f"answer {idx}",
+        ),
+    )
+    return user_seq, assistant_seq
+
+
+def test_read_history_page_aligned_window_matches_full_turn(
+    store: HistoryStore,
+):
+    """When the naive fetch already lands on a real user row, no expansion
+    is needed and the page is exactly the requested turn."""
+    for i in range(1, 6):
+        _append_turn(store, "s1", i)
+
+    page = read_history_page(store.path, "s1", before_seq=11, limit=2)
+    assert [r["seq"] for r in page.rows] == [9, 10]
+    assert page.next_cursor == 9
+    assert page.has_more is True
+    assert page.truncated is False
+
+
+def test_read_history_page_expands_to_full_turn_when_cut_mid_turn(
+    store: HistoryStore,
+):
+    """``limit=1`` naively lands mid-turn (on the assistant row); the page
+    must expand backward to include that turn's user row too, never
+    returning a half-turn."""
+    for i in range(1, 6):
+        _append_turn(store, "s1", i)
+
+    page = read_history_page(store.path, "s1", before_seq=11, limit=1)
+    assert [r["seq"] for r in page.rows] == [9, 10]
+    assert page.next_cursor == 9
+    assert page.has_more is True
+    assert page.truncated is False
+
+
+def test_read_history_page_reaches_start_reports_no_more(
+    store: HistoryStore,
+):
+    for i in range(1, 4):
+        _append_turn(store, "s1", i)
+
+    page = read_history_page(store.path, "s1", before_seq=3, limit=10)
+    assert [r["seq"] for r in page.rows] == [1, 2]
+    assert page.next_cursor == 1
+    assert page.has_more is False
+    assert page.truncated is False
+
+
+def test_read_history_page_empty_before_cursor_returns_empty(
+    store: HistoryStore,
+):
+    _append_turn(store, "s1", 1)
+    page = read_history_page(store.path, "s1", before_seq=1, limit=10)
+    assert page.rows == []
+    assert page.next_cursor is None
+    assert page.has_more is False
+    assert page.truncated is False
+
+
+def test_read_history_page_truncates_pathological_single_turn(
+    store: HistoryStore,
+):
+    """One user row followed by hundreds of assistant rows with no further
+    user boundary (a runaway single turn) must not expand past the budget —
+    it truncates, and the *next* page picks up exactly where this one
+    stopped."""
+    store.append(
+        session_id="s1",
+        dedup_key="u1",
+        entry=LogEntry(kind="context_msg", role="user", content="start"),
+    )
+    for i in range(700):
+        store.append(
+            session_id="s1",
+            dedup_key=f"a{i}",
+            entry=LogEntry(
+                kind="model_turn",
+                role="assistant",
+                content=f"chunk {i}",
+            ),
+        )
+
+    page = read_history_page(
+        store.path,
+        "s1",
+        before_seq=702,
+        limit=5,
+        max_expansion_rows=50,
+    )
+    assert page.truncated is True
+    assert len(page.rows) == 50
+    assert page.next_cursor == min(r["seq"] for r in page.rows)
+    assert page.has_more is True
+
+    # The next page continues below the truncation point with no gap and no
+    # duplication.
+    next_page = read_history_page(
+        store.path,
+        "s1",
+        before_seq=page.next_cursor,
+        limit=5,
+        max_expansion_rows=50,
+    )
+    assert max(r["seq"] for r in next_page.rows) < page.next_cursor
+
+
+def test_read_history_page_after_purge_skips_removed_rows(
+    store: HistoryStore,
+):
+    for i in range(1, 4):
+        _append_turn(store, "s1", i)
+    # Purge everything (simulating a retention purge with no kind filter,
+    # as a worst case) so the page query has to cope with gaps in seq.
+    store.purge(before="9999-01-01T00:00:00+00:00")
+    assert store.count("s1") == 0
+
+    page = read_history_page(store.path, "s1", before_seq=999, limit=10)
+    assert page.rows == []
+    assert page.has_more is False
+
+
+def test_open_readonly_connection_missing_file_raises(tmp_path: Path):
+    with pytest.raises(HistoryUnavailable):
+        open_readonly_connection(tmp_path / "nope.db")
+
+
+def test_open_readonly_connection_reads_concurrently_with_writer(
+    store: HistoryStore,
+):
+    """The read-only connection must be independent of the live writer's
+    connection — a concurrent read must see committed rows without
+    contending for the writer's lock."""
+    store.append(session_id="s1", dedup_key="m1", entry=_entry("hello"))
+    conn = open_readonly_connection(store.path)
+    try:
+        row = conn.execute(
+            "SELECT content FROM conversation_history WHERE session_id = ?",
+            ("s1",),
+        ).fetchone()
+        assert row["content"] == "hello"
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("DELETE FROM conversation_history")
+    finally:
+        conn.close()
+
+
+def test_has_rows_before(store: HistoryStore):
+    for i in range(1, 4):
+        _append_turn(store, "s1", i)
+    conn = open_readonly_connection(store.path)
+    try:
+        assert has_rows_before(conn, "s1", 3) is True
+        assert has_rows_before(conn, "s1", 1) is False
+        assert has_rows_before(conn, "other-session", 999) is False
+    finally:
+        conn.close()

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -2220,8 +2220,9 @@ def test_purge_old_zero_keeps_everything(store: HistoryStore):
         session_id="s1",
         dedup_key="m1",
         entry=LogEntry(
-            kind="model_turn",
+            kind="tool_result",
             content="x",
+            tool_call_id="tc1",
             created_at="2000-01-01T00:00:00+00:00",
         ),
     )
@@ -2235,13 +2236,53 @@ def test_purge_old_drops_rows_past_window(store: HistoryStore):
         session_id="s1",
         dedup_key="m1",
         entry=LogEntry(
-            kind="model_turn",
+            kind="tool_result",
             content="ancient",
+            tool_call_id="tc1",
             created_at="2000-01-01T00:00:00+00:00",
         ),
     )
     assert mgr.purge_old(1) == 1
     assert store.count("s1") == 0
+
+
+def test_purge_old_keeps_conversation_turns_past_window(store: HistoryStore):
+    """Only ``tool_result`` rows are disposable — user/assistant turns must
+    survive ``purge_old`` regardless of age, so scroll-back never loses
+    conversation history to the tool-result retention window."""
+    mgr = make_manager(store)
+    store.append(
+        session_id="s1",
+        dedup_key="u1",
+        entry=LogEntry(
+            kind="context_msg",
+            role="user",
+            content="ancient question",
+            created_at="2000-01-01T00:00:00+00:00",
+        ),
+    )
+    store.append(
+        session_id="s1",
+        dedup_key="a1",
+        entry=LogEntry(
+            kind="model_turn",
+            role="assistant",
+            content="ancient answer",
+            created_at="2000-01-01T00:00:00+00:00",
+        ),
+    )
+    store.append(
+        session_id="s1",
+        dedup_key="tc1",
+        entry=LogEntry(
+            kind="tool_result",
+            content="ancient tool output",
+            tool_call_id="tc1",
+            created_at="2000-01-01T00:00:00+00:00",
+        ),
+    )
+    assert mgr.purge_old(1) == 1
+    assert store.count("s1") == 2
 
 
 def test_serialize_persists_runtime_tag():

--- a/tests/unit/agents/context/test_sync.py
+++ b/tests/unit/agents/context/test_sync.py
@@ -1059,3 +1059,49 @@ def test_blocked_registry_does_not_quarantine_corrupt_history(
 
     assert db_path.read_bytes() == original
     assert not list(workspace.glob("history.db.corrupt-*"))
+
+
+def test_purge_old_history_only_drops_tool_result(tmp_path: Path):
+    """The startup retention purge (``_purge_old_history``) must scope to
+    ``kind="tool_result"`` like ``ScrollContextManager.purge_old`` does —
+    otherwise a fresh boot would silently delete conversation history past
+    the tool-result retention window."""
+    store = HistoryStore(tmp_path / "history.db")
+    try:
+        ancient = "2000-01-01T00:00:00+00:00"
+        store.append(
+            session_id="s1",
+            dedup_key="u1",
+            entry=LogEntry(
+                kind="context_msg",
+                role="user",
+                content="ancient question",
+                created_at=ancient,
+            ),
+        )
+        store.append(
+            session_id="s1",
+            dedup_key="a1",
+            entry=LogEntry(
+                kind="model_turn",
+                role="assistant",
+                content="ancient answer",
+                created_at=ancient,
+            ),
+        )
+        store.append(
+            session_id="s1",
+            dedup_key="tc1",
+            entry=LogEntry(
+                kind="tool_result",
+                content="ancient tool output",
+                tool_call_id="tc1",
+                created_at=ancient,
+            ),
+        )
+
+        sync_mod._purge_old_history(store, retention_days=1, agent_id="ag1")
+
+        assert store.count("s1") == 2
+    finally:
+        store.close()

--- a/tests/unit/app/chats/test_messages_endpoint.py
+++ b/tests/unit/app/chats/test_messages_endpoint.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``GET /chats/{chat_id}/messages`` (the scroll-back read path).
+
+Exercises the endpoint through a real FastAPI ``TestClient`` + a real
+``HistoryStore`` on a temp dir, with everything else (chat manager, session
+store, task tracker) mocked — the same "mock the workspace, mount just the
+router" pattern as ``tests/unit/app/routers/test_messages_router.py``. This
+lets the acceptance scenario (200 messages, most evicted from the live
+session JSON, scroll back to message 1) run fast and deterministically
+without a live LLM/subprocess.
+"""
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agentscope.message import Msg
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.serialize import msg_to_entries
+from qwenpaw.app.chats.api import (
+    get_chat_manager,
+    get_session,
+    get_workspace,
+    router as chats_router,
+)
+from qwenpaw.app.chats.models import ChatSpec
+
+
+def _persist_msg(store: HistoryStore, session_id: str, msg: Msg) -> None:
+    for entry in msg_to_entries(msg):
+        dedup_key = (
+            entry.tool_call_id if entry.kind == "tool_result" else msg.id
+        )
+        store.append(session_id=session_id, dedup_key=dedup_key, entry=entry)
+
+
+def _turn(i: int) -> tuple[Msg, Msg]:
+    user = Msg(
+        name="user",
+        role="user",
+        content=[{"type": "text", "text": f"question {i}"}],
+    )
+    assistant = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": f"answer {i}"}],
+    )
+    return user, assistant
+
+
+def _agent_state_dict(msgs: list[Msg], session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "summary": "",
+        "context": [m.model_dump(mode="json") for m in msgs],
+    }
+
+
+@pytest.fixture
+def workspace_mock(tmp_path: Path) -> Any:
+    workspace = MagicMock(name="Workspace")
+    workspace.workspace_dir = tmp_path
+    workspace.config.backend = "qwenpaw"
+    # Real AgentProfileConfig nests this under `.running`, not directly on
+    # `.config` (unlike `backend`/`backend_settings`) — matches
+    # `agents/context/scroll/sync.py`'s `agent_config.running.
+    # light_context_config`. Mocking the wrong path here previously let a
+    # `.running` typo in api.py ship undetected; only a live server caught it.
+    workspace.config.running.light_context_config.strategy = "scroll"
+    workspace.config.running.light_context_config.scroll_config.db_filename = (
+        "history.db"
+    )
+    scroll_cfg = workspace.config.running.light_context_config.scroll_config
+    scroll_cfg.history_retention_days = 30
+    workspace.task_tracker.get_status = AsyncMock(return_value="idle")
+    return workspace
+
+
+@pytest.fixture
+def app(workspace_mock) -> FastAPI:
+    """Mount just the chats router, with its three workspace-resolving
+    dependencies overridden straight to ``workspace_mock`` — bypasses the
+    real ``get_agent_for_request``/config-profile lookup entirely, so no
+    on-disk agent profile is needed for these tests."""
+    application = FastAPI()
+    application.include_router(chats_router, prefix="/api")
+    application.dependency_overrides[get_workspace] = lambda: workspace_mock
+    application.dependency_overrides[
+        get_chat_manager
+    ] = lambda: workspace_mock.chat_manager
+    application.dependency_overrides[
+        get_session
+    ] = lambda: workspace_mock.session
+    return application
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _wire_chat(
+    workspace_mock,
+    *,
+    chat_id: str,
+    session_id: str,
+    live_msgs: list[Msg],
+    scroll_extra: dict | None = None,
+) -> None:
+    chat_spec = ChatSpec(
+        id=chat_id,
+        session_id=session_id,
+        user_id="u1",
+        channel="console",
+    )
+    workspace_mock.chat_manager.get_chat = AsyncMock(return_value=chat_spec)
+    agent_raw: dict = {"state": _agent_state_dict(live_msgs, session_id)}
+    if scroll_extra is not None:
+        agent_raw["scroll"] = scroll_extra
+    workspace_mock.session.get_session_state_dict = AsyncMock(
+        return_value={"agent": agent_raw},
+    )
+
+
+@pytest.mark.p0
+def test_scroll_back_reaches_first_message_after_eviction(
+    client,
+    workspace_mock,
+    tmp_path: Path,
+):
+    """The acceptance scenario: 200 turns persisted to history.db, only the
+    last few survive in the live session JSON (simulating compaction) —
+    scrolling back page by page must reach turn 0 with no gaps, no
+    duplicates, and end in history_status="complete"."""
+    session_id = "console:u1"
+    store = HistoryStore(tmp_path / "history.db")
+    try:
+        all_msgs: list[Msg] = []
+        for i in range(200):
+            user, assistant = _turn(i)
+            _persist_msg(store, session_id, user)
+            _persist_msg(store, session_id, assistant)
+            all_msgs.extend([user, assistant])
+    finally:
+        store.close()
+
+    # Only the last 3 turns are still in the live session JSON — everything
+    # older was evicted by compaction (but is still durable in history.db).
+    live_msgs = all_msgs[-6:]
+    _wire_chat(
+        workspace_mock,
+        chat_id="c1",
+        session_id=session_id,
+        live_msgs=live_msgs,
+    )
+
+    first = client.get(
+        "/api/chats/c1/messages",
+        params={"limit": 10},
+        headers={"X-Agent-Id": "a1"},
+    )
+    assert first.status_code == 200, first.text
+    body = first.json()
+    assert body["history_status"] == "available"
+    assert body["has_more"] is True
+    assert body["status"] == "idle"
+
+    collected_texts: list[str] = []
+    seen_ids: set[str] = set()
+    for message in body["messages"]:
+        seen_ids.add(message["id"])
+        for content in message["content"]:
+            if content.get("text"):
+                collected_texts.append(content["text"])
+
+    cursor = body["next_cursor"]
+    history_status = body["history_status"]
+    pages = 0
+    while history_status == "available":
+        pages += 1
+        assert pages < 100, "pagination did not terminate"
+        page = client.get(
+            "/api/chats/c1/messages",
+            params={"limit": 10, "before_seq": cursor},
+            headers={"X-Agent-Id": "a1"},
+        )
+        assert page.status_code == 200, page.text
+        page_body = page.json()
+        for message in page_body["messages"]:
+            assert message["id"] not in seen_ids, "duplicate message id"
+            seen_ids.add(message["id"])
+            for content in message["content"]:
+                if content.get("text"):
+                    collected_texts.append(content["text"])
+        history_status = page_body["history_status"]
+        cursor = page_body["next_cursor"]
+
+    assert history_status == "complete"
+    # The very first thing ever sent must be reachable, and pages come back
+    # oldest-last (we paginate backward) but each page internally ascending.
+    assert "question 0" in collected_texts
+    assert collected_texts.index("question 0") < collected_texts.index(
+        "answer 0",
+    )
+    assert "answer 199" in collected_texts[:6]
+    assert len(collected_texts) == 400
+
+
+def test_non_scroll_mode_reports_unavailable(client, workspace_mock):
+    workspace_mock.config.running.light_context_config.strategy = "native"
+    user, assistant = _turn(0)
+    _wire_chat(
+        workspace_mock,
+        chat_id="c1",
+        session_id="console:u1",
+        live_msgs=[user, assistant],
+    )
+
+    resp = client.get(
+        "/api/chats/c1/messages",
+        headers={"X-Agent-Id": "a1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["history_status"] == "unavailable"
+    assert body["has_more"] is False
+    assert body["next_cursor"] is None
+    # Fallback safety window still renders the live messages — the user
+    # doesn't lose what's already in the session JSON.
+    assert len(body["messages"]) == 2
+
+
+def test_missing_history_db_reports_degraded_not_complete(
+    client,
+    workspace_mock,
+):
+    """Scroll mode expects a history db; if it's simply not there (never
+    created, or wiped), that must never masquerade as "reached the end"."""
+    user, assistant = _turn(0)
+    _wire_chat(
+        workspace_mock,
+        chat_id="c1",
+        session_id="console:u1",
+        live_msgs=[user, assistant],
+    )
+    # workspace_mock.workspace_dir points at an empty tmp_path — no
+    # history.db file exists there.
+
+    resp = client.get(
+        "/api/chats/c1/messages",
+        headers={"X-Agent-Id": "a1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["history_status"] == "degraded"
+    assert body["fallback_limited"] is True
+    assert body["has_more"] is False
+
+
+def test_running_status_is_passed_through(client, workspace_mock):
+    workspace_mock.task_tracker.get_status = AsyncMock(return_value="running")
+    user, assistant = _turn(0)
+    _wire_chat(
+        workspace_mock,
+        chat_id="c1",
+        session_id="console:u1",
+        live_msgs=[user, assistant],
+    )
+
+    resp = client.get(
+        "/api/chats/c1/messages",
+        headers={"X-Agent-Id": "a1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+
+
+def test_expired_when_index_claims_more_than_db_has(
+    client,
+    workspace_mock,
+    tmp_path: Path,
+):
+    """An eviction index claiming archived content older than anything left
+    in history.db means an old retention policy purged real conversation
+    turns — the page-level status must say so, not "complete"."""
+    session_id = "console:u1"
+    user0, assistant0 = _turn(0)
+    user1, assistant1 = _turn(1)
+    store = HistoryStore(tmp_path / "history.db")
+    try:
+        _persist_msg(store, session_id, user0)  # seq 1
+        _persist_msg(store, session_id, assistant0)  # seq 2
+        _persist_msg(store, session_id, user1)  # seq 3
+        _persist_msg(store, session_id, assistant1)  # seq 4
+        # Simulate an old retention policy that already purged turn 0's
+        # rows — the eviction index still remembers archiving them.
+        with store._lock, store._conn:  # pylint: disable=protected-access
+            store._conn.execute(
+                "DELETE FROM conversation_history WHERE seq IN (1, 2)",
+            )
+    finally:
+        store.close()
+
+    _wire_chat(
+        workspace_mock,
+        chat_id="c1",
+        session_id=session_id,
+        live_msgs=[user1, assistant1],
+        scroll_extra={
+            "index": {
+                "session_id": session_id,
+                "agent_id": None,
+                "tiers": [
+                    [
+                        {
+                            "seq_lo": 1,
+                            "seq_hi": 2,
+                            "lines": [[1, 2, "old turn", "old turn"]],
+                        },
+                    ],
+                ],
+            },
+        },
+    )
+
+    resp = client.get(
+        "/api/chats/c1/messages",
+        headers={"X-Agent-Id": "a1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["history_status"] == "expired"
+    assert body["has_more"] is False

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -1,13 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import tempfile
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-from agentscope.message import Msg
+from agentscope.message import Msg, TextBlock, ToolCallBlock, ToolResultBlock
 
+from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.serialize import msg_to_entries
+from qwenpaw.agents.context.types import LogEntry
+from qwenpaw.schemas import MessageType
 from qwenpaw.app.chats.utils import (
     _abspath_from_url,
     _is_local_file_url,
@@ -15,10 +21,12 @@ from qwenpaw.app.chats.utils import (
     _resolve_content_url,
     agentscope_msg_to_message,
     clean_display_text,
+    history_rows_to_messages,
     strip_injected_skill_block,
 )
 from qwenpaw.app.chats.title_generator import _clean_title
 from qwenpaw.constant import (
+    LOOP_CONTINUATION_MESSAGE_TAG,
     QWENPAW_MESSAGE_TAG_KEY,
     SCROLL_MEMORY_MESSAGE_TAG,
     SYNTHETIC_USER_MESSAGE_TAGS,
@@ -506,3 +514,361 @@ def test_clean_title_truncates_long_title():
     long_title = "x" * 200
     result = _clean_title(long_title)
     assert len(result) <= 80
+
+
+# ---------------------------------------------------------------------------
+# history_rows_to_messages — reconstruction from conversation_history rows
+# ---------------------------------------------------------------------------
+
+
+def _persist_msg(store, session_id: str, msg: Msg) -> None:
+    """Persist one Msg the way ``ScrollContextManager._persist_new`` does:
+    ``dedup_key`` is the Msg id for non-result entries, the tool_call_id for
+    each tool_result entry."""
+    for entry in msg_to_entries(msg):
+        dedup_key = (
+            entry.tool_call_id if entry.kind == "tool_result" else msg.id
+        )
+        store.append(session_id=session_id, dedup_key=dedup_key, entry=entry)
+
+
+def _rows_for_session(store, session_id: str) -> list:
+    return list(
+        store._conn.execute(  # pylint: disable=protected-access
+            "SELECT * FROM conversation_history "
+            "WHERE session_id = ? ORDER BY seq",
+            (session_id,),
+        ),
+    )
+
+
+def _rendered_text(messages) -> str:
+    parts = []
+    for message in messages:
+        for content in message.content:
+            text = getattr(content, "text", None)
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def test_history_rows_to_messages_matches_live_path_for_text_turn():
+    """A plain user question + assistant answer round-trips through
+    HistoryStore to the same displayed text as the live-Msg conversion."""
+
+    user_msg = Msg(
+        name="user",
+        role="user",
+        content=[{"type": "text", "text": "what is 2+2?"}],
+    )
+    assistant_msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "2+2 is 4"}],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            _persist_msg(store, "s1", user_msg)
+            _persist_msg(store, "s1", assistant_msg)
+            rows = _rows_for_session(store, "s1")
+
+            live = agentscope_msg_to_message([user_msg, assistant_msg])
+            from_db = history_rows_to_messages(rows)
+
+            assert len(from_db) == len(live) == 2
+            assert [m.role for m in from_db] == [m.role for m in live]
+            assert _rendered_text(from_db) == _rendered_text(live)
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_matches_live_path_for_tool_turn():
+    """A turn with text + tool_call + tool_result round-trips with the tool
+    call/output content intact, matching the live-Msg conversion."""
+
+    assistant_msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            TextBlock(type="text", text="let me check"),
+            ToolCallBlock(type="tool_call", id="c1", name="grep", input="{}"),
+            ToolResultBlock(
+                type="tool_result",
+                id="c1",
+                name="grep",
+                output=[TextBlock(type="text", text="found it")],
+            ),
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            _persist_msg(store, "s1", assistant_msg)
+            rows = _rows_for_session(store, "s1")
+
+            live = agentscope_msg_to_message([assistant_msg])
+            from_db = history_rows_to_messages(rows)
+
+            assert [m.type for m in from_db] == [m.type for m in live]
+            live_call = next(
+                m for m in live if m.type == MessageType.PLUGIN_CALL
+            )
+            db_call = next(
+                m for m in from_db if m.type == MessageType.PLUGIN_CALL
+            )
+            assert live_call.content[0].data["name"] == "grep"
+            assert db_call.content[0].data["name"] == "grep"
+            assert db_call.content[0].data["call_id"] == "c1"
+
+            live_output = next(
+                m for m in live if m.type == MessageType.PLUGIN_CALL_OUTPUT
+            )
+            db_output = next(
+                m for m in from_db if m.type == MessageType.PLUGIN_CALL_OUTPUT
+            )
+            assert live_output.content[0].data["output"] == (
+                db_output.content[0].data["output"]
+            )
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_ids_are_unique_and_prefixed():
+    """Every reconstructed Message id is ``{original_id}:{part_index}`` and
+    no two parts of the same turn collide."""
+
+    assistant_msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            TextBlock(type="text", text="working"),
+            ToolCallBlock(type="tool_call", id="c1", name="grep", input="{}"),
+            ToolResultBlock(
+                type="tool_result",
+                id="c1",
+                name="grep",
+                output=[TextBlock(type="text", text="ok")],
+            ),
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            _persist_msg(store, "s1", assistant_msg)
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows)
+
+            ids = [m.id for m in messages]
+            assert len(ids) == len(set(ids))
+            # The turn's own parts (text, tool_call) are prefixed by the
+            # Msg id; the tool_result — a separate db row with its own
+            # dedup_key (= tool_call_id) — is prefixed by that instead.
+            assert ids[0].startswith(f"{assistant_msg.id}:")
+            assert ids[1].startswith(f"{assistant_msg.id}:")
+            assert ids[2].startswith("c1:")
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_orphan_tool_result_renders_standalone():
+    """A tool_result row whose tool_call isn't in the page renders as its
+    own card instead of being dropped (design doc §2.2 "孤儿 tool_result")."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            # A bare tool_result row with no accompanying tool_call row at
+            # all (simulating one split off onto a different page).
+            store.append(
+                session_id="s1",
+                dedup_key="c1",
+                entry=LogEntry(
+                    kind="tool_result",
+                    role="assistant",
+                    name="grep",
+                    tool_call_id="c1",
+                    content="found it",
+                    blocks=[
+                        ToolResultBlock(
+                            type="tool_result",
+                            id="c1",
+                            name="grep",
+                            output=[
+                                TextBlock(type="text", text="found it"),
+                            ],
+                        ).model_dump(),
+                    ],
+                ),
+            )
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows)
+
+            assert len(messages) == 1
+            assert messages[0].type == MessageType.PLUGIN_CALL_OUTPUT
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_missing_result_is_expired_past_retention():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            store.append(
+                session_id="s1",
+                dedup_key="m1",
+                entry=LogEntry(
+                    kind="model_turn",
+                    role="assistant",
+                    content="let me check",
+                    created_at="2000-01-01T00:00:00+00:00",
+                    blocks=[
+                        TextBlock(
+                            type="text",
+                            text="let me check",
+                        ).model_dump(),
+                        ToolCallBlock(
+                            type="tool_call",
+                            id="c1",
+                            name="grep",
+                            input="{}",
+                        ).model_dump(),
+                    ],
+                ),
+            )
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows, retention_days=30)
+
+            output = next(
+                m for m in messages if m.type == MessageType.PLUGIN_CALL_OUTPUT
+            )
+            assert output.metadata.get("tool_result_expired") is True
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_missing_result_is_pending_within_retention():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            store.append(
+                session_id="s1",
+                dedup_key="m1",
+                entry=LogEntry(
+                    kind="model_turn",
+                    role="assistant",
+                    content="let me check",
+                    blocks=[
+                        TextBlock(
+                            type="text",
+                            text="let me check",
+                        ).model_dump(),
+                        ToolCallBlock(
+                            type="tool_call",
+                            id="c1",
+                            name="grep",
+                            input="{}",
+                        ).model_dump(),
+                    ],
+                ),
+            )
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows, retention_days=30)
+
+            output = next(
+                m for m in messages if m.type == MessageType.PLUGIN_CALL_OUTPUT
+            )
+            assert output.metadata.get("tool_result_pending") is True
+            assert not output.metadata.get("tool_result_expired")
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_filters_synthetic_user_row():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            store.append(
+                session_id="s1",
+                dedup_key="u1",
+                entry=LogEntry(
+                    kind="context_msg",
+                    role="user",
+                    content="Continue working on the task.",
+                    metadata={
+                        QWENPAW_MESSAGE_TAG_KEY: LOOP_CONTINUATION_MESSAGE_TAG,
+                    },
+                ),
+            )
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows)
+            assert messages == []
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_output_is_seq_ascending():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            for i in range(5):
+                store.append(
+                    session_id="s1",
+                    dedup_key=f"u{i}",
+                    entry=LogEntry(
+                        kind="context_msg",
+                        role="user",
+                        content=f"question {i}",
+                    ),
+                )
+            rows = _rows_for_session(store, "s1")
+            messages = history_rows_to_messages(rows)
+            rendered = [m.content[0].text for m in messages]
+            assert rendered == [f"question {i}" for i in range(5)]
+        finally:
+            store.close()
+
+
+def test_history_rows_to_messages_omits_runtime_hints():
+    """Scroll-back replay must hide hint blocks exactly like the live path.
+
+    Hint blocks are runtime/model-facing state that
+    ``test_msg_to_message_omits_runtime_hints_from_history`` already keeps
+    out of the live transcript. Both paths share ``_blocks_to_messages``, so
+    this pins the guarantee for the db side too — without it a refactor
+    could restore hints only when a user scrolls back, which is exactly the
+    inconsistency users would notice.
+    """
+
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            {
+                "type": "hint",
+                "hint": (
+                    "<system-reminder>private runtime state"
+                    "</system-reminder>"
+                ),
+                "source": '{"label": "System"}',
+            },
+            {"type": "text", "text": "visible answer"},
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = HistoryStore(Path(tmp) / "history.db")
+        try:
+            _persist_msg(store, "s1", msg)
+            rows = _rows_for_session(store, "s1")
+
+            live = agentscope_msg_to_message([msg])
+            from_db = history_rows_to_messages(rows)
+
+            assert _rendered_text(from_db) == _rendered_text(live)
+            assert "system-reminder" not in _rendered_text(from_db)
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary
Under the default scroll context strategy, context compaction moves older messages out of the live session JSON (they stay in `history.db`). Today, refreshing or switching back to a compacted chat shows a transcript that silently begins mid-conversation — the compacted messages are unreachable from the UI even though they still exist. This adds a paginated read path so the console can page back to the true first message.

**Backend** (`0050ee92`):
- `GET /chats/{chat_id}/messages` — turn-aligned pagination with a `seq` cursor. Without `before_seq`, serves a first-screen window off the live session and anchors it into `history.db`; with it, reads straight from the db. The existing `GET /chats/{chat_id}` is untouched.
- `history_status` (`available`/`complete`/`expired`/`unavailable`/`degraded`) so "reached the beginning" is never confused with "the db is unreachable" or "retention already purged these rows".
- Fixes a retention bug found while building this: both `HistoryStore.purge()` call sites omitted `kinds=`, so retention deleted user/assistant text along with expired tool results — it's meant to bound tool-result payloads only.
- Message reconstruction is shared, not duplicated, between the live path and the db-replay path (`_blocks_to_messages`), so a hint block that's hidden from a live transcript is also hidden from scroll-back — verified by mutation-testing that the shared filter actually gets exercised on the db-replay side, not just carried over as dead code.

**Frontend** (`6a9dd302`):
- `fetchAndBuildSession` now opens on the new paginated `api.getMessages`; `SessionApi.loadOlderMessages(sessionId)` fetches and merges older pages, with a race guard for session switches mid-request.
- `Chat/index.tsx` wires `pageOptions.session.onLoadMore` to it. This option is new in `@agentscope-ai/chat`; see the paired SDK PR agentscope-ai/agentscope-spark-design#103.
- **The SDK dependency is patched via `patch-package`** (`console/patches/@agentscope-ai+chat+*.patch`) rather than waiting on that PR — this makes the feature work today, independent of if/when the SDK PR lands. Once it's released upstream, the patch can be dropped in favor of a normal version bump.
- Six existing tests mocked `api.getChat` directly and needed updating to mock `api.getMessages` with an equivalent response, rather than being loosened.

## Test plan
- [x] Backend: `pytest tests/unit/app/chats/ tests/unit/agents/context/` — 613 passed (includes 25 new tests)
- [x] Backend: per-directory diff against a pristine `origin/main` baseline confirms zero regressions — identical failure counts in every directory, only `passed` counts increase by the new tests
- [x] Backend: `flake8` + `black==23.3.0` (this repo's pinned pre-commit version) clean on all 12 changed files
- [x] Frontend: `tsc -b --noEmit` clean across the whole `console/` app
- [x] Frontend: `vitest run` — 3078 passed, 2 failed (both pre-existing on `origin/main`, unrelated to this change — confirmed by running them against a pristine checkout)
- [x] Frontend: `eslint` — identical problem count before/after on every touched file (pre-existing debt, zero new issues)
- [x] End-to-end: real `npm install` in a fresh checkout of this branch — `postinstall` runs `patch-package` and applies the SDK patch cleanly against the real registry copy of `@agentscope-ai/chat@1.1.73-beta.1787638407498`

🤖 Generated with [Claude Code](https://claude.com/claude-code)