### PR TITLE
fix(memory): return proper status for unavailable routes

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -1375,6 +1375,13 @@ async def undo_agent_memory_reindex(
     request: Request = None,
 ) -> EmbeddingModelConfig:
     """Restore the provider configuration matching the still-valid vectors."""
+    config = await run_sync_io(load_config)
+    if agentId not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agentId}' not found",
+        )
+
     agent_config = await run_sync_io(load_agent_config, agentId)
     if agent_config.running.memory_manager_backend != "remelight":
         raise HTTPException(
@@ -1485,7 +1492,19 @@ async def get_agent_memory_status(
             detail="Memory manager is not available",
         )
 
-    response = await memory_manager.reme_status()
+    try:
+        response = await memory_manager.reme_status()
+    except RuntimeError as exc:
+        message = str(exc)
+        if not (
+            message.startswith("Dependency ")
+            and " accessed before start()" in message
+        ):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail="ReMe is not started or status reporting is unavailable",
+        ) from exc
     if response is None:
         raise HTTPException(
             status_code=503,

--- a/tests/unit/app/routers/test_agents_router.py
+++ b/tests/unit/app/routers/test_agents_router.py
@@ -717,6 +717,7 @@ def test_rebuild_all_rejects_disabled_embedding(
 
 def test_undo_pending_embedding_reindex_restores_indexed_config(
     client,
+    fake_config,
     manager_mock,
 ):
     profile = AgentProfileConfig(id="bot", name="Bot")
@@ -734,6 +735,10 @@ def test_undo_pending_embedding_reindex_restores_indexed_config(
 
     with (
         patch(
+            "qwenpaw.app.routers.agents.load_config",
+            return_value=fake_config,
+        ),
+        patch(
             "qwenpaw.app.routers.agents.load_agent_config",
             return_value=profile,
         ),
@@ -744,6 +749,30 @@ def test_undo_pending_embedding_reindex_restores_indexed_config(
     assert response.status_code == 200
     assert response.json()["model_name"] == "indexed-model"
     memory_manager.undo_embedding_reindex.assert_awaited_once_with()
+
+
+def test_undo_pending_embedding_reindex_rejects_unknown_agent(
+    client,
+    fake_config,
+    manager_mock,
+):
+    with (
+        patch(
+            "qwenpaw.app.routers.agents.load_config",
+            return_value=fake_config,
+        ),
+        patch(
+            "qwenpaw.app.routers.agents.load_agent_config",
+        ) as load_agent_config_mock,
+    ):
+        response = client.post(
+            "/api/agents/integ-unknown-xyz/memory/reindex/undo",
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == ("Agent 'integ-unknown-xyz' not found")
+    load_agent_config_mock.assert_not_called()
+    manager_mock.get_agent.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -931,6 +960,68 @@ def test_get_memory_status_does_not_start_an_unloaded_agent(
     assert response.json()["detail"] == "Agent is not running"
     manager_mock.get_loaded_agent.assert_called_once_with("bot")
     manager_mock.get_agent.assert_not_awaited()
+
+
+def test_get_memory_status_returns_503_while_reme_dependency_is_starting(
+    client,
+    fake_config,
+    manager_mock,
+):
+    agent_config = AgentProfileConfig(id="bot", name="Bot")
+    memory_manager = MagicMock()
+    memory_manager.reme_status = AsyncMock(
+        side_effect=RuntimeError(
+            "Dependency keyword_index:default accessed before start()",
+        ),
+    )
+    manager_mock.get_loaded_agent.return_value = MagicMock(
+        memory_manager=memory_manager,
+    )
+
+    with (
+        patch(
+            "qwenpaw.app.routers.agents.load_config",
+            return_value=fake_config,
+        ),
+        patch(
+            "qwenpaw.app.routers.agents.load_agent_config",
+            return_value=agent_config,
+        ),
+    ):
+        response = client.get("/api/agents/bot/memory/status")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "ReMe is not started or status reporting is unavailable"
+    )
+
+
+def test_get_memory_status_does_not_mask_unexpected_runtime_error(
+    client,
+    fake_config,
+    manager_mock,
+):
+    agent_config = AgentProfileConfig(id="bot", name="Bot")
+    memory_manager = MagicMock()
+    memory_manager.reme_status = AsyncMock(
+        side_effect=RuntimeError("unexpected failure"),
+    )
+    manager_mock.get_loaded_agent.return_value = MagicMock(
+        memory_manager=memory_manager,
+    )
+
+    with (
+        patch(
+            "qwenpaw.app.routers.agents.load_config",
+            return_value=fake_config,
+        ),
+        patch(
+            "qwenpaw.app.routers.agents.load_agent_config",
+            return_value=agent_config,
+        ),
+        pytest.raises(RuntimeError, match="unexpected failure"),
+    ):
+        client.get("/api/agents/bot/memory/status")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Return actionable HTTP status codes for two unavailable states in the Memory & ReMe agent routes:

- Return `404` from `POST /api/agents/{agentId}/memory/reindex/undo` when the agent does not exist, instead of allowing `ConfigurationException` to become a plain `500`.
- Return `503` from `GET /api/agents/{agentId}/memory/status` when a ReMe dependency is still starting, instead of exposing a startup-race `RuntimeError` as a plain `500`.
- Preserve unexpected `RuntimeError` failures so genuine server defects are not masked as temporary unavailability.

This PR完善并补充处理 AOne work item [#86306608](https://project.aone.alibaba-inc.com/coco/projects/2155950/workitems/86306608) 中记录的问题。

**Related Issue:** AOne #86306608

**Security Considerations:** No security-sensitive behavior or configuration is changed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this API error-handling fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable.

## Testing

- Added a regression test verifying unknown agents receive `404` before config/workspace loading.
- Added a regression test verifying the ReMe dependency startup race receives `503`.
- Added a regression test verifying unrelated runtime errors remain visible.
- Ran all unit tests for the agents router.

## Evidence

```bash
uv run pre-commit run --files src/qwenpaw/app/routers/agents.py tests/unit/app/routers/test_agents_router.py
# all hooks passed

uv run pytest -q tests/unit/app/routers/test_agents_router.py
# 58 passed, 1 warning in 1.55s

git diff --check
# passed
```

## Additional Notes

The `503` mapping is intentionally narrow: it only recognizes ReMe's `Dependency ... accessed before start()` lifecycle error. Other `RuntimeError` instances continue through the normal server error path.
