### PR TITLE
fix(channels): lazy-load unused builtin channel modules

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -105,11 +105,20 @@ class ChannelManager:
         """
         available = get_available_channels()
         registry = get_channel_registry()
-        channels: list[BaseChannel] = [
-            ch_cls.from_env(process, on_reply_sent=on_last_dispatch)
-            for key, ch_cls in registry.items()
-            if key in available
-        ]
+        channels: list[BaseChannel] = []
+        for key, ch_cls in registry.items():
+            if key not in available:
+                continue
+            try:
+                channels.append(
+                    ch_cls.from_env(process, on_reply_sent=on_last_dispatch),
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to initialize channel '%s', skipping: %s",
+                    key,
+                    e,
+                )
         return cls(channels)
 
     @classmethod
@@ -177,24 +186,25 @@ class ChannelManager:
                 "workspace_dir": workspace_dir,
             }
 
-            # Only pass kwargs that the channel's from_config accepts
-            import inspect
-
-            sig = inspect.signature(ch_cls.from_config)
-            filtered_kwargs: dict[str, Any]
-            if any(
-                p.kind == inspect.Parameter.VAR_KEYWORD
-                for p in sig.parameters.values()
-            ):
-                filtered_kwargs = from_config_kwargs
-            else:
-                filtered_kwargs = {
-                    k: v
-                    for k, v in from_config_kwargs.items()
-                    if k in sig.parameters
-                }
-
             try:
+                # Inspecting from_config also resolves a lazy channel
+                # class. Keep that inside the try so a missing optional
+                # SDK becomes the existing "skipping" warning instead of
+                # aborting workspace startup.
+                import inspect
+
+                sig = inspect.signature(ch_cls.from_config)
+                if any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in sig.parameters.values()
+                ):
+                    filtered_kwargs = from_config_kwargs
+                else:
+                    filtered_kwargs = {
+                        k: v
+                        for k, v in from_config_kwargs.items()
+                        if k in sig.parameters
+                    }
                 channels.append(ch_cls.from_config(**filtered_kwargs))
             except Exception as e:
                 logger.warning(

--- a/src/qwenpaw/app/channels/registry.py
+++ b/src/qwenpaw/app/channels/registry.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from .base import BaseChannel
 
@@ -43,39 +43,98 @@ _BUILTIN_CHANNEL_CACHE: dict[str, type[BaseChannel]] | None = None
 _BUILTIN_CHANNEL_CACHE_LOCK = threading.Lock()
 
 
-def _load_builtin_channels() -> dict[str, type[BaseChannel]]:
-    """Load built-in channels safely.
+def _import_channel_class(
+    key: str,
+    module_name: str,
+    class_name: str,
+) -> type[BaseChannel]:
+    """Import one built-in channel class and validate the contract."""
+    mod = importlib.import_module(module_name, package=__package__)
+    cls = getattr(mod, class_name)
+    if not (
+        isinstance(cls, type)
+        and issubclass(cls, BaseChannel)
+        and cls is not BaseChannel
+    ):
+        raise TypeError(
+            f"{key}: {module_name}.{class_name} is not a "
+            f"BaseChannel subtype",
+        )
+    return cls
 
-    A single optional dependency failure should not break CLI startup.
+
+class _LazyChannelClass:
+    """Stand-in for a built-in channel class until it is first used.
+
+    Attribute access, instantiation, and ``from_config`` / ``from_env``
+    resolve the real class once and then delegate. Registry listing and
+    key iteration do not import the channel module.
+    """
+
+    __slots__ = ("_key", "_module_name", "_class_name", "_cls", "_lock")
+
+    def __init__(
+        self,
+        key: str,
+        module_name: str,
+        class_name: str,
+    ) -> None:
+        self._key = key
+        self._module_name = module_name
+        self._class_name = class_name
+        self._cls: type[BaseChannel] | None = None
+        self._lock = threading.Lock()
+
+    def _resolve(self) -> type[BaseChannel]:
+        if self._cls is not None:
+            return self._cls
+        with self._lock:
+            if self._cls is None:
+                self._cls = _import_channel_class(
+                    self._key,
+                    self._module_name,
+                    self._class_name,
+                )
+            return self._cls
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._resolve()(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        if self._cls is not None:
+            return f"<LazyChannel {self._key} -> {self._cls!r}>"
+        return f"<LazyChannel {self._key} (unresolved)>"
+
+
+def _load_builtin_channels() -> dict[str, type[BaseChannel]]:
+    """Build the built-in channel map.
+
+    Required channels (currently ``console``) are imported immediately so
+    startup fails fast if they are broken. Optional channels are wrapped
+    in a lazy proxy and imported on first attribute access, so unused
+    channel SDKs (for example ``lark_oapi``) are not paid for at startup.
     """
     out: dict[str, type[BaseChannel]] = {}
     for key, (module_name, class_name) in _BUILTIN_SPECS.items():
-        try:
-            mod = importlib.import_module(module_name, package=__package__)
-            cls = getattr(mod, class_name)
-            if not (
-                isinstance(cls, type)
-                and issubclass(cls, BaseChannel)
-                and cls is not BaseChannel
-            ):
-                raise TypeError(
-                    f"{module_name}.{class_name} is not a BaseChannel subtype",
+        if key in _REQUIRED_CHANNEL_KEYS:
+            try:
+                out[key] = _import_channel_class(
+                    key,
+                    module_name,
+                    class_name,
                 )
-        except Exception:
-            if key in _REQUIRED_CHANNEL_KEYS:
+            except Exception:
                 logger.error(
                     'failed to load required built-in channel "%s"',
                     key,
                     exc_info=True,
                 )
                 raise
-            logger.debug(
-                "built-in channel unavailable: %s",
-                key,
-                exc_info=True,
-            )
             continue
-        out[key] = cls
+        out[key] = _LazyChannelClass(key, module_name, class_name)
     return out
 
 

--- a/tests/unit/app/channels/test_registry.py
+++ b/tests/unit/app/channels/test_registry.py
@@ -1,0 +1,315 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for lazy built-in channel registry loading."""
+
+from __future__ import annotations
+
+# pylint: disable=protected-access
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw.app.channels import manager as manager_mod
+from qwenpaw.app.channels import registry as registry_mod
+from qwenpaw.app.channels.base import BaseChannel
+from qwenpaw.app.channels.manager import ChannelManager
+from qwenpaw.app.channels.registry import (
+    _BUILTIN_SPECS,
+    _REQUIRED_CHANNEL_KEYS,
+    _LazyChannelClass,
+    _import_channel_class,
+    _load_builtin_channels,
+    clear_builtin_channel_cache,
+    get_channel_registry,
+)
+from qwenpaw.config.config import ChannelConfig, ConsoleConfig, FeishuConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SRC_DIR = _REPO_ROOT / "src"
+
+
+class _DummyChannel(BaseChannel):
+    """Minimal BaseChannel subclass used to validate lazy import."""
+
+    channel = "dummy"
+
+
+class _ImportlibStub:
+    """Replace registry.importlib without touching the stdlib module."""
+
+    def __init__(self, import_module):
+        self.import_module = import_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_builtin_cache():
+    clear_builtin_channel_cache()
+    yield
+    clear_builtin_channel_cache()
+
+
+def test_load_builtin_channels_imports_only_required(monkeypatch):
+    imported: list[str] = []
+
+    def _fake_import(key, module_name, class_name):
+        imported.append(module_name)
+        if module_name != ".console":
+            raise AssertionError(f"unexpected eager import: {module_name}")
+        return _DummyChannel
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _fake_import)
+
+    loaded = _load_builtin_channels()
+
+    assert imported == [".console"]
+    assert set(loaded) == set(_BUILTIN_SPECS)
+    assert loaded["console"] is _DummyChannel
+    for key in _BUILTIN_SPECS:
+        if key in _REQUIRED_CHANNEL_KEYS:
+            continue
+        assert isinstance(loaded[key], _LazyChannelClass)
+        assert loaded[key]._cls is None
+
+
+def test_lazy_channel_resolves_on_first_attribute_access(monkeypatch):
+    calls: list[str] = []
+
+    def _fake_import(key, module_name, class_name):
+        calls.append(module_name)
+        return _DummyChannel
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _fake_import)
+
+    proxy = _LazyChannelClass("feishu", ".feishu", "FeishuChannel")
+    assert proxy._cls is None
+    assert calls == []
+
+    assert proxy.channel == "dummy"
+    assert calls == [".feishu"]
+    assert proxy._cls is _DummyChannel
+    assert proxy.channel == "dummy"
+    assert calls == [".feishu"]
+
+
+def test_lazy_from_config_delegates_to_real_class(monkeypatch):
+    class _FactoryChannel(_DummyChannel):
+        @classmethod
+        def from_config(cls, process, config, **_kwargs):
+            return SimpleNamespace(
+                channel=cls.channel,
+                process=process,
+                config=config,
+            )
+
+    monkeypatch.setattr(
+        registry_mod,
+        "_import_channel_class",
+        lambda key, module_name, class_name: _FactoryChannel,
+    )
+
+    proxy = _LazyChannelClass("feishu", ".feishu", "FeishuChannel")
+    process = object()
+    created = proxy.from_config(process=process, config={"enabled": True})
+    assert created.channel == "dummy"
+    assert created.process is process
+    assert created.config == {"enabled": True}
+
+
+def test_required_channel_import_failure_is_raised(monkeypatch):
+    def _boom(key, module_name, class_name):
+        raise ImportError("console module missing")
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _boom)
+
+    with pytest.raises(ImportError, match="console module missing"):
+        _load_builtin_channels()
+
+
+def test_import_channel_class_rejects_non_channel(monkeypatch):
+    def _fake_import(name, package=None):
+        module = ModuleType("qwenpaw.app.channels.feishu")
+        module.FeishuChannel = object
+        return module
+
+    monkeypatch.setattr(
+        registry_mod, "importlib", _ImportlibStub(_fake_import)
+    )
+
+    with pytest.raises(TypeError, match="not a BaseChannel subtype"):
+        _import_channel_class("feishu", ".feishu", "FeishuChannel")
+
+
+def test_from_config_console_only_does_not_resolve_other_channels(
+    monkeypatch,
+):
+    from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+    lazy_feishu = _LazyChannelClass("feishu", ".feishu", "FeishuChannel")
+
+    monkeypatch.setattr(
+        manager_mod,
+        "get_channel_registry",
+        lambda: {"console": ConsoleChannel, "feishu": lazy_feishu},
+    )
+    monkeypatch.setattr(
+        manager_mod,
+        "get_available_channels",
+        lambda: ("console", "feishu"),
+    )
+
+    config = SimpleNamespace(
+        channels=ChannelConfig(
+            console=ConsoleConfig(enabled=True),
+            feishu=FeishuConfig(enabled=False, app_id="x", app_secret="y"),
+        ),
+        show_tool_details=True,
+    )
+    manager = ChannelManager.from_config(
+        process=MagicMock(),
+        config=config,
+    )
+
+    assert [ch.channel for ch in manager.channels] == ["console"]
+    assert lazy_feishu._cls is None
+
+
+def test_from_config_skips_channel_when_lazy_import_fails(monkeypatch):
+    from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+    def _boom(key, module_name, class_name):
+        raise ImportError("lark_oapi missing")
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _boom)
+    lazy_feishu = _LazyChannelClass("feishu", ".feishu", "FeishuChannel")
+
+    monkeypatch.setattr(
+        manager_mod,
+        "get_channel_registry",
+        lambda: {"console": ConsoleChannel, "feishu": lazy_feishu},
+    )
+    monkeypatch.setattr(
+        manager_mod,
+        "get_available_channels",
+        lambda: ("console", "feishu"),
+    )
+
+    config = SimpleNamespace(
+        channels=ChannelConfig(
+            console=ConsoleConfig(enabled=True),
+            feishu=FeishuConfig(enabled=True, app_id="x", app_secret="y"),
+        ),
+        show_tool_details=True,
+    )
+    manager = ChannelManager.from_config(
+        process=MagicMock(),
+        config=config,
+    )
+
+    assert [ch.channel for ch in manager.channels] == ["console"]
+
+
+def test_from_env_skips_channel_when_lazy_import_fails(monkeypatch):
+    from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+    def _boom(key, module_name, class_name):
+        raise ImportError("lark_oapi missing")
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _boom)
+    lazy_feishu = _LazyChannelClass("feishu", ".feishu", "FeishuChannel")
+
+    monkeypatch.setattr(
+        manager_mod,
+        "get_channel_registry",
+        lambda: {"console": ConsoleChannel, "feishu": lazy_feishu},
+    )
+    monkeypatch.setattr(
+        manager_mod,
+        "get_available_channels",
+        lambda: ("console", "feishu"),
+    )
+
+    manager = ChannelManager.from_env(process=MagicMock())
+    assert [ch.channel for ch in manager.channels] == ["console"]
+
+
+def test_get_channel_registry_keys_include_unresolved_optional_channels(
+    monkeypatch,
+):
+    imported: list[str] = []
+
+    def _fake_import(key, module_name, class_name):
+        imported.append(module_name)
+        if module_name != ".console":
+            raise AssertionError(f"unexpected eager import: {module_name}")
+        return _DummyChannel
+
+    monkeypatch.setattr(registry_mod, "_import_channel_class", _fake_import)
+    monkeypatch.setattr(registry_mod, "_get_plugin_channels", lambda: {})
+
+    registry = get_channel_registry()
+    assert set(registry) == set(_BUILTIN_SPECS)
+    assert imported == [".console"]
+
+
+def test_registry_load_does_not_import_heavy_channel_sdks():
+    """Fresh process: only console is imported when building the registry."""
+    script = r"""
+import sys
+from qwenpaw.app.channels.registry import (
+    _REQUIRED_CHANNEL_KEYS,
+    _BUILTIN_SPECS,
+    clear_builtin_channel_cache,
+    get_channel_registry,
+)
+
+clear_builtin_channel_cache()
+registry = get_channel_registry()
+assert set(_BUILTIN_SPECS).issubset(set(registry))
+assert "console" in registry
+
+heavy = ("lark_oapi", "telegram", "slack_bolt", "aibot")
+imported_heavy = [name for name in heavy if name in sys.modules]
+assert imported_heavy == [], imported_heavy
+
+optional_pkgs = (
+    "qwenpaw.app.channels.feishu",
+    "qwenpaw.app.channels.feishu.channel",
+    "qwenpaw.app.channels.telegram",
+    "qwenpaw.app.channels.telegram.channel",
+    "qwenpaw.app.channels.slack",
+    "qwenpaw.app.channels.slack.channel",
+    "qwenpaw.app.channels.wecom",
+    "qwenpaw.app.channels.wecom.channel",
+)
+imported_optional = [name for name in optional_pkgs if name in sys.modules]
+assert imported_optional == [], imported_optional
+
+assert "qwenpaw.app.channels.console" in sys.modules
+console_cls = registry["console"]
+assert getattr(console_cls, "channel", None) == "console"
+for key in _BUILTIN_SPECS:
+    if key in _REQUIRED_CHANNEL_KEYS:
+        continue
+    proxy = registry[key]
+    assert getattr(proxy, "_cls", "missing") is None
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(_SRC_DIR), env.get("PYTHONPATH", "")],
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_REPO_ROOT),
+    )
+    assert completed.returncode == 0, (
+        completed.stdout + "\n" + completed.stderr
+    )


### PR DESCRIPTION
## What Problem This Solves

Building the channel registry used to import every builtin channel module up front, so a console-only workspace still paid for heavy SDKs such as `lark_oapi` (often tens of seconds of startup). Root cause: `_load_builtin_channels()` eagerly imported all ~18 builtins before `QWENPAW_ENABLED_CHANNELS` filtering.

## Description

Eager-load only the required `console` channel; resolve other builtins lazily on first use (`from_config` / `from_env` / class access). Keep ChannelManager's existing skip-on-failure behavior when an enabled channel cannot be imported. Leave `_BUILTIN_SPECS` as a static literal so contract checks can still enumerate all builtins. Add unit/regression tests (including a subprocess check that heavy SDKs stay out of `sys.modules` when only building the registry).

**Related Issue:** Fixes #7367

**Security Considerations:** N/A — import/lazy-load only; no new auth surface.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Tests

## Checklist

- [x] I ran tests locally (`pytest`) and they pass
- [x] Ready for review

## Testing

```bash
python3 -m pytest tests/unit/app/channels/test_registry.py tests/unit/config/test_channel_shape_consistency.py tests/unit/app/channels/test_schema.py tests/integration/test_channels_manager_module.py -q
```

Contract listing still returns all builtin channel specs.

## Evidence

Before: building the channel registry imported all builtin modules (including heavy SDKs like `lark_oapi`) even for a console-only workspace, adding tens of seconds of startup.
After: only `console` is eager-loaded; other builtins resolve lazily. Unit/subprocess tests assert heavy SDKs stay out of `sys.modules` when only building the registry; contract listing still enumerates all builtins.
