### PR TITLE
fix(channels): recover stuck session queue consumers

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -572,6 +572,25 @@ class BaseChannel(ABC):
             on_finished=self._workspace.chat_manager.mark_chat_finished,
         )
 
+        if not is_new:
+            # A leftover producer (cancelled consumer, MCP hang) stays
+            # registered as running. Steal it when it is stale so the
+            # session queue can recover. Recent concurrent attaches
+            # (e.g. console reconnect) keep the ignore path.
+            is_new = await self._steal_stale_tracker_run(chat.id)
+            if is_new:
+                queue, is_new = (
+                    await self._workspace.task_tracker.attach_or_start(
+                        chat.id,
+                        payload,
+                        self._stream_with_tracker,
+                        owner=self._workspace,
+                        on_finished=(
+                            self._workspace.chat_manager.mark_chat_finished
+                        ),
+                    )
+                )
+
         if is_new:
             try:
                 async for _ in self._workspace.task_tracker.stream_from_queue(
@@ -584,6 +603,16 @@ class BaseChannel(ABC):
                     f"Task cancelled: chat_id={chat.id} "
                     f"session={sanitize_log_value(session_id[:30])}",
                 )
+                try:
+                    await self._workspace.task_tracker.request_stop(
+                        chat.id,
+                        timeout=5.0,
+                    )
+                except Exception:  # pylint: disable=broad-except
+                    logger.debug(
+                        "request_stop after consume cancel failed",
+                        exc_info=True,
+                    )
                 raise
         else:
             logger.warning(
@@ -592,6 +621,48 @@ class BaseChannel(ABC):
                 f"session={sanitize_log_value(session_id[:30])}. "
                 f"This should not happen with UnifiedQueueManager.",
             )
+
+    _STALE_TRACKER_RUN_SECONDS = 1800.0
+
+    async def _steal_stale_tracker_run(self, chat_id: str) -> bool:
+        """Stop a leftover TaskTracker run when it has been running too long.
+
+        Returns ``True`` if a stale run was stopped and the caller should
+        retry ``attach_or_start``. Recent concurrent attaches are left
+        alone (return ``False``).
+        """
+        tracker = getattr(self._workspace, "task_tracker", None)
+        if tracker is None:
+            return False
+        get_age = getattr(tracker, "get_run_age_seconds", None)
+        if get_age is None:
+            return False
+        try:
+            age = await get_age(chat_id)
+        except Exception:  # pylint: disable=broad-except
+            logger.debug(
+                "get_run_age_seconds failed: chat_id=%s",
+                chat_id,
+                exc_info=True,
+            )
+            return False
+        if age is None or age < self._STALE_TRACKER_RUN_SECONDS:
+            return False
+        logger.warning(
+            "Stopping stale tracker run: chat_id=%s age=%.1fs",
+            chat_id,
+            age,
+        )
+        try:
+            await tracker.request_stop(chat_id, timeout=5.0)
+        except Exception:  # pylint: disable=broad-except
+            logger.debug(
+                "request_stop of stale tracker run failed: chat_id=%s",
+                chat_id,
+                exc_info=True,
+            )
+            return False
+        return True
 
     _STREAMABLE_TYPES = {"reasoning", "message"}
     _STREAM_DELTA_MIN_INTERVAL_S: float = 0.0

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -37,6 +37,12 @@ OnLastDispatch = Optional[Callable[[str, str, str], Awaitable[None]]]
 # Default max size per channel queue
 _CHANNEL_QUEUE_MAXSIZE = 1000
 
+# A single handle must not block its session queue forever. 30 minutes
+# covers long agent turns; cleanup also reaps stuck consumers as a
+# backstop. Tests may lower ChannelManager._handle_timeout.
+_HANDLE_TIMEOUT_SECONDS = 1800.0
+_HANDLE_CANCEL_GRACE_SECONDS = 5.0
+
 
 async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
     """Merge if needed and process one payload (native or request)."""
@@ -67,6 +73,27 @@ async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
         await ch.consume_one(batch[0])
 
 
+async def _await_or_abandon(
+    coro: Any,
+    timeout: float,
+    cancel_grace: float,
+) -> None:
+    """Wait for *coro*; on timeout cancel it and continue if it hangs.
+
+    ``asyncio.wait_for`` waits for a cancelled task to finish, so a
+    handle that swallows ``CancelledError`` would block the consumer
+    forever. This helper abandons the task after *cancel_grace*.
+    """
+    task = asyncio.create_task(coro)
+    done, _pending = await asyncio.wait({task}, timeout=timeout)
+    if task in done:
+        task.result()
+        return
+    task.cancel()
+    await asyncio.wait({task}, timeout=cancel_grace)
+    raise asyncio.TimeoutError
+
+
 class ChannelManager:
     """Owns queues and consumer loops; channels define how to consume via
     consume_one(). Enqueue via enqueue(channel_id, payload) (thread-safe).
@@ -90,6 +117,9 @@ class ChannelManager:
 
         # Track channel-start tasks for graceful shutdown
         self._start_tasks: set[asyncio.Task] = set()
+
+        self._handle_timeout = _HANDLE_TIMEOUT_SECONDS
+        self._handle_cancel_grace = _HANDLE_CANCEL_GRACE_SECONDS
 
     @classmethod
     def from_env(
@@ -327,7 +357,11 @@ class ChannelManager:
                 f"query={query[:40] if query else '(empty)'}",
             )
         except asyncio.TimeoutError:
-            pass
+            logger.warning(
+                f"Enqueue timed out: channel={channel_id} "
+                f"session={session_id[:30]} "
+                f"priority={priority_level}",
+            )
         except asyncio.CancelledError:
             logger.debug(
                 f"Enqueue cancelled: channel={channel_id} "
@@ -417,8 +451,34 @@ class ChannelManager:
                     except asyncio.QueueEmpty:
                         break
 
-                # Process batch (with merge logic)
-                await _process_batch(ch, batch)
+                # Process batch (with merge logic). A wedged handle
+                # (e.g. MCP reconnect that never returns) must not
+                # permanently block later messages on this QueueKey.
+                if self._queue_manager is not None:
+                    await self._queue_manager.touch_progress(
+                        channel_id,
+                        session_id,
+                        priority_level,
+                    )
+                try:
+                    await _await_or_abandon(
+                        _process_batch(ch, batch),
+                        timeout=self._handle_timeout,
+                        cancel_grace=self._handle_cancel_grace,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "Handle timed out: "
+                        f"channel={channel_id} "
+                        f"session={session_id[:30]} "
+                        f"priority={priority_level} "
+                        f"timeout={self._handle_timeout:.1f}s",
+                    )
+                    await self._stop_stale_session_tracker(
+                        ch,
+                        session_id,
+                        channel_id,
+                    )
 
                 # Update processed count
                 if self._queue_manager is not None:
@@ -449,6 +509,49 @@ class ChannelManager:
                     f"session={session_id[:30]} "
                     f"priority={priority_level}",
                 )
+
+    async def _stop_stale_session_tracker(
+        self,
+        ch: BaseChannel,
+        session_id: str,
+        channel_id: str,
+    ) -> None:
+        """Best-effort stop of a leftover TaskTracker run for *session_id*.
+
+        A timed-out handle may have left the producer task running. Later
+        ``_consume_with_tracker`` calls would then hit "already running"
+        and drop the message.
+        """
+        workspace = getattr(ch, "_workspace", None) or self._workspace
+        if workspace is None:
+            return
+        tracker = getattr(workspace, "task_tracker", None)
+        chat_manager = getattr(workspace, "chat_manager", None)
+        if tracker is None or chat_manager is None:
+            return
+        try:
+            chat_id = await chat_manager.get_chat_id_by_session(
+                session_id,
+                channel_id,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.debug(
+                "get_chat_id_by_session failed after handle timeout",
+                exc_info=True,
+            )
+            return
+        if not chat_id:
+            return
+        try:
+            await tracker.request_stop(
+                chat_id,
+                timeout=self._handle_cancel_grace,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.debug(
+                "request_stop after handle timeout failed",
+                exc_info=True,
+            )
 
     async def start_all(self) -> None:
         """Start all channels and queue manager."""

--- a/src/qwenpaw/app/channels/unified_queue_manager.py
+++ b/src/qwenpaw/app/channels/unified_queue_manager.py
@@ -46,7 +46,8 @@ class QueueState:
         queue: The asyncio.Queue for this QueueKey
         consumer_task: The asyncio.Task running the consumer
         created_at: Timestamp when queue was created
-        last_activity: Timestamp of last message (enqueue or dequeue)
+        last_activity: Timestamp of last enqueue (or completed handle)
+        last_progress: Timestamp of last handle start/finish
         processed_count: Number of messages processed
     """
 
@@ -54,6 +55,7 @@ class QueueState:
     consumer_task: asyncio.Task[None]
     created_at: float = field(default_factory=time.time)
     last_activity: float = field(default_factory=time.time)
+    last_progress: float = field(default_factory=time.time)
     processed_count: int = 0
 
 
@@ -83,6 +85,8 @@ class UnifiedQueueManager:
         queue_maxsize: int = 1000,
         idle_timeout: float = 600.0,  # 10 minutes
         cleanup_interval: float = 60.0,  # 1 minute
+        stuck_timeout: float = 1800.0,  # 30 minutes
+        cancel_timeout: float = 5.0,
     ):
         """Initialize queue manager.
 
@@ -91,11 +95,16 @@ class UnifiedQueueManager:
             queue_maxsize: Max size per queue (0 = unbounded)
             idle_timeout: Cleanup idle queues after N seconds
             cleanup_interval: Run cleanup every N seconds
+            stuck_timeout: Replace a consumer that has not progressed
+                for N seconds while the queue still has waiting items
+            cancel_timeout: Max seconds to wait for a cancelled consumer
         """
         self._consumer_fn = consumer_fn
         self._queue_maxsize = queue_maxsize
         self._idle_timeout = idle_timeout
         self._cleanup_interval = cleanup_interval
+        self._stuck_timeout = stuck_timeout
+        self._cancel_timeout = cancel_timeout
 
         # QueueKey → QueueState
         self._queues: Dict[QueueKey, QueueState] = {}
@@ -172,27 +181,32 @@ class UnifiedQueueManager:
             QueueState with queue and consumer task
         """
         async with self._lock:
-            # Check if already exists
-            if queue_key in self._queues:
-                return self._queues[queue_key]
+            existing = self._queues.get(queue_key)
+            if existing is not None:
+                if not existing.consumer_task.done():
+                    return existing
+                # Consumer exited but the key was not reaped (race with
+                # finally, or a replaced task that died). Respawn on the
+                # same queue so waiting items are not dropped.
+                channel_id, session_id, priority_level = queue_key
+                existing.consumer_task = self._spawn_consumer(
+                    existing.queue,
+                    queue_key,
+                )
+                existing.last_progress = time.time()
+                logger.warning(
+                    "Replaced dead consumer: "
+                    f"channel={channel_id} "
+                    f"session={session_id[:30]} "
+                    f"priority={priority_level}",
+                )
+                return existing
 
             # Create new queue
             queue = asyncio.Queue(maxsize=self._queue_maxsize)
 
-            # Create consumer task
             channel_id, session_id, priority_level = queue_key
-            consumer_task = asyncio.create_task(
-                self._run_consumer(
-                    queue,
-                    channel_id,
-                    session_id,
-                    priority_level,
-                ),
-                name=(
-                    f"consumer_{channel_id}_"
-                    f"{session_id[:20]}_{priority_level}"
-                ),
-            )
+            consumer_task = self._spawn_consumer(queue, queue_key)
 
             # Create state
             state = QueueState(
@@ -210,6 +224,26 @@ class UnifiedQueueManager:
             )
 
             return state
+
+    def _spawn_consumer(
+        self,
+        queue: asyncio.Queue,
+        queue_key: QueueKey,
+    ) -> asyncio.Task[None]:
+        """Create a consumer task for *queue_key*."""
+        channel_id, session_id, priority_level = queue_key
+        return asyncio.create_task(
+            self._run_consumer(
+                queue,
+                channel_id,
+                session_id,
+                priority_level,
+            ),
+            name=(
+                f"consumer_{channel_id}_"
+                f"{session_id[:20]}_{priority_level}"
+            ),
+        )
 
     async def _run_consumer(
         self,
@@ -261,9 +295,14 @@ class UnifiedQueueManager:
                 f"priority={priority_level}",
             )
         finally:
-            # Remove from queues dict when consumer exits
+            # Only drop the key if we are still the registered consumer.
+            # A replacement consumer for the same key must not be removed
+            # when this (old) task exits.
+            me = asyncio.current_task()
             async with self._lock:
-                self._queues.pop(queue_key, None)
+                current = self._queues.get(queue_key)
+                if current is not None and current.consumer_task is me:
+                    self._queues.pop(queue_key, None)
 
             logger.info(
                 f"Consumer stopped: channel={channel_id} "
@@ -374,10 +413,12 @@ class UnifiedQueueManager:
         logger.info(f"Stopped all queues: total={queue_count}")
 
     async def _cleanup_idle_queues(self) -> None:
-        """Background task to cleanup idle queues.
+        """Background task to cleanup idle and stuck queues.
 
-        Runs every cleanup_interval seconds and removes queues
-        that have been empty and idle for longer than idle_timeout.
+        Runs every cleanup_interval seconds. Removes queues that have
+        been empty and idle for longer than idle_timeout. Also replaces
+        consumers that died while items remain, or that have not made
+        progress for stuck_timeout while later messages are waiting.
         """
         logger.info("Cleanup loop running")
 
@@ -387,17 +428,33 @@ class UnifiedQueueManager:
 
                 now = time.time()
                 to_cleanup: list[QueueKey] = []
+                to_replace: list[QueueKey] = []
 
-                # Find idle queues
                 async with self._lock:
                     for key, state in self._queues.items():
-                        # Check if queue is empty and idle
-                        if state.queue.empty():
+                        if state.consumer_task.done():
+                            if state.queue.empty():
+                                to_cleanup.append(key)
+                            else:
+                                to_replace.append(key)
+                            continue
+                        progress_age = now - state.last_progress
+                        if (
+                            not state.queue.empty()
+                            and progress_age > self._stuck_timeout
+                        ):
+                            # Waiting items + no handle progress: the
+                            # current consumer is wedged and is blocking
+                            # later messages on this QueueKey.
+                            to_replace.append(key)
+                        elif state.queue.empty():
                             idle_time = now - state.last_activity
                             if idle_time > self._idle_timeout:
                                 to_cleanup.append(key)
 
-                # Cancel idle consumers (outside lock)
+                for key in to_replace:
+                    await self._replace_consumer(key, reason="stuck")
+
                 for key in to_cleanup:
                     cleanup_state: QueueState | None = None
                     async with self._lock:
@@ -405,11 +462,9 @@ class UnifiedQueueManager:
                             cleanup_state = self._queues.pop(key)
 
                     if cleanup_state is not None:
-                        cleanup_state.consumer_task.cancel()
-                        try:
-                            await cleanup_state.consumer_task
-                        except asyncio.CancelledError:
-                            pass
+                        await self._cancel_task(
+                            cleanup_state.consumer_task,
+                        )
 
                         channel_id, session_id, priority_level = key
                         logger.info(
@@ -462,6 +517,7 @@ class UnifiedQueueManager:
                         "processed_count": state.processed_count,
                         "age_seconds": now - state.created_at,
                         "idle_seconds": now - state.last_activity,
+                        "progress_idle_seconds": now - state.last_progress,
                     },
                 )
 
@@ -494,4 +550,105 @@ class UnifiedQueueManager:
             state = self._queues.get(queue_key)
             if state is not None:
                 state.processed_count += count
-                state.last_activity = time.time()
+                now = time.time()
+                state.last_activity = now
+                state.last_progress = now
+
+    async def touch_progress(
+        self,
+        channel_id: str,
+        session_id: str,
+        priority_level: int,
+    ) -> None:
+        """Mark that a consumer started processing a handle.
+
+        Separates "messages keep arriving" (last_activity) from "the
+        consumer is actually making progress" so a wedged handle cannot
+        hide behind fresh enqueues.
+        """
+        queue_key = (channel_id, session_id, priority_level)
+
+        async with self._lock:
+            state = self._queues.get(queue_key)
+            if state is not None:
+                state.last_progress = time.time()
+
+    async def _cancel_task(self, task: asyncio.Task[None]) -> None:
+        """Cancel *task* without letting a wedged handle block cleanup."""
+        if task.done():
+            return
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, timeout=self._cancel_timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+
+    async def _replace_consumer(
+        self,
+        queue_key: QueueKey,
+        reason: str,
+    ) -> None:
+        """Cancel a wedged/dead consumer and respawn on leftover items.
+
+        Pending queue items are moved onto a new queue so a handle that
+        ignores cancellation cannot keep later messages trapped.
+        """
+        async with self._lock:
+            state = self._queues.get(queue_key)
+            if state is None:
+                return
+            old_task = state.consumer_task
+            old_queue = state.queue
+            processed = state.processed_count
+
+        await self._cancel_task(old_task)
+
+        leftover: list[Any] = []
+        while True:
+            try:
+                leftover.append(old_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+
+        async with self._lock:
+            current = self._queues.get(queue_key)
+            if current is not None and current.consumer_task is not old_task:
+                for item in leftover:
+                    try:
+                        current.queue.put_nowait(item)
+                    except asyncio.QueueFull:
+                        logger.warning(
+                            "Dropped leftover item during replace: "
+                            f"key={queue_key}",
+                        )
+                        break
+                return
+
+            channel_id, session_id, priority_level = queue_key
+            new_queue = asyncio.Queue(maxsize=self._queue_maxsize)
+            for item in leftover:
+                try:
+                    new_queue.put_nowait(item)
+                except asyncio.QueueFull:
+                    logger.warning(
+                        "Dropped leftover item during replace: "
+                        f"channel={channel_id} "
+                        f"session={session_id[:30]} "
+                        f"priority={priority_level}",
+                    )
+                    break
+
+            new_state = QueueState(
+                queue=new_queue,
+                consumer_task=self._spawn_consumer(new_queue, queue_key),
+                processed_count=processed,
+            )
+            self._queues[queue_key] = new_state
+
+        logger.warning(
+            f"Replaced consumer ({reason}): "
+            f"channel={channel_id} "
+            f"session={session_id[:30]} "
+            f"priority={priority_level} "
+            f"leftover={len(leftover)}",
+        )

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -220,8 +220,31 @@ class TaskTracker:
             except ValueError:
                 pass
 
-    async def request_stop(self, run_key: str) -> bool:
-        """Cancel the run. Returns ``True`` if it was running."""
+    async def get_run_age_seconds(self, run_key: str) -> float | None:
+        """Return seconds since the run started, or ``None`` if idle."""
+        async with self._lock:
+            state = self._runs.get(run_key)
+            if state is None or state.task.done():
+                return None
+            started = state.start_time
+        if started is None:
+            return 0.0
+        now = datetime.now(timezone.utc)
+        return (now - started).total_seconds()
+
+    async def request_stop(
+        self,
+        run_key: str,
+        timeout: float | None = None,
+    ) -> bool:
+        """Cancel the run. Returns ``True`` if it was running.
+
+        Args:
+            run_key: Chat / run identifier
+            timeout: If set, abandon waiting for the producer after
+                this many seconds so a wedged run cannot block the
+                caller (the producer may still be finishing).
+        """
         logger.debug("[STOP] request_stop called for run_key=%s", run_key)
         async with self._lock:
             state = self._runs.get(run_key)
@@ -245,8 +268,11 @@ class TaskTracker:
             task.cancel()
             logger.debug("[STOP] task.cancel() called for run_key=%s", run_key)
         try:
-            await task
-        except asyncio.CancelledError:
+            if timeout is None:
+                await task
+            else:
+                await asyncio.wait_for(task, timeout=timeout)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
             pass
         return True
 

--- a/tests/unit/app/channels/test_consume_queue.py
+++ b/tests/unit/app/channels/test_consume_queue.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""Consumer lifecycle: handle timeout must not wedge the session queue."""
+
+from __future__ import annotations
+
+# pylint: disable=protected-access
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qwenpaw.app.channels.base import BaseChannel
+from qwenpaw.app.channels.manager import ChannelManager
+from qwenpaw.app.channels.unified_queue_manager import UnifiedQueueManager
+
+
+class _HangThenPassChannel:
+    """Native-payload channel that can hang on the first handle."""
+
+    channel = "feishu"
+
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+        self.started = asyncio.Event()
+        self.hang_next = True
+
+    def _is_native_payload(self, payload: object) -> bool:
+        return isinstance(payload, dict)
+
+    async def _consume_one_request(self, payload: object) -> None:
+        self.calls.append(payload)
+        self.started.set()
+        if self.hang_next:
+            await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_unblocks_later_same_queue_messages() -> None:
+    """A wedged high-priority handle must not trap later messages."""
+    ch = _HangThenPassChannel()
+    manager = ChannelManager(channels=[ch])
+    manager._handle_timeout = 0.05
+    manager._handle_cancel_grace = 0.05
+    qmgr = UnifiedQueueManager(
+        consumer_fn=manager._consume_queue,
+        queue_maxsize=10,
+        idle_timeout=60.0,
+        cleanup_interval=60.0,
+        stuck_timeout=60.0,
+        cancel_timeout=0.05,
+    )
+    manager._queue_manager = qmgr
+
+    await qmgr.enqueue("feishu", "feishu:sess", 10, {"text": "card"})
+    await asyncio.wait_for(ch.started.wait(), timeout=1)
+    ch.hang_next = False
+    ch.started.clear()
+    await qmgr.enqueue("feishu", "feishu:sess", 10, {"text": "hello"})
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        if any(
+            isinstance(p, dict) and p.get("text") == "hello" for p in ch.calls
+        ):
+            break
+        await asyncio.sleep(0.02)
+
+    assert any(
+        isinstance(p, dict) and p.get("text") == "hello" for p in ch.calls
+    )
+    await qmgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_high_priority_wedge_does_not_block_normal_priority() -> None:
+    """p10 hang must not prevent a new p20 consumer from being created."""
+    ch = _HangThenPassChannel()
+    manager = ChannelManager(channels=[ch])
+    manager._handle_timeout = 30.0
+    manager._handle_cancel_grace = 0.05
+    qmgr = UnifiedQueueManager(
+        consumer_fn=manager._consume_queue,
+        queue_maxsize=10,
+        idle_timeout=60.0,
+        cleanup_interval=60.0,
+        stuck_timeout=60.0,
+    )
+    manager._queue_manager = qmgr
+
+    await qmgr.enqueue("feishu", "feishu:sess", 10, {"text": "card"})
+    await asyncio.wait_for(ch.started.wait(), timeout=1)
+    ch.hang_next = False
+    await qmgr.enqueue("feishu", "feishu:sess", 20, {"text": "hello"})
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        if ("feishu", "feishu:sess", 20) in qmgr._queues:
+            break
+        await asyncio.sleep(0.02)
+
+    assert ("feishu", "feishu:sess", 10) in qmgr._queues
+    assert ("feishu", "feishu:sess", 20) in qmgr._queues
+    # p10 consumer is still the original wedged one; p20 is a new queue.
+    p10 = qmgr._queues[("feishu", "feishu:sess", 10)]
+    assert not p10.consumer_task.done()
+    await qmgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_steal_stale_tracker_run_stops_old_producer() -> None:
+    tracker = MagicMock()
+    tracker.get_run_age_seconds = AsyncMock(return_value=10_000.0)
+    tracker.request_stop = AsyncMock(return_value=True)
+    host = MagicMock()
+    host._workspace = MagicMock(task_tracker=tracker)
+    host._STALE_TRACKER_RUN_SECONDS = BaseChannel._STALE_TRACKER_RUN_SECONDS
+    stolen = await BaseChannel._steal_stale_tracker_run(host, "chat-1")
+    assert stolen is True
+    tracker.request_stop.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_steal_recent_tracker_run_is_left_alone() -> None:
+    tracker = MagicMock()
+    tracker.get_run_age_seconds = AsyncMock(return_value=1.0)
+    tracker.request_stop = AsyncMock(return_value=True)
+    host = MagicMock()
+    host._workspace = MagicMock(task_tracker=tracker)
+    host._STALE_TRACKER_RUN_SECONDS = BaseChannel._STALE_TRACKER_RUN_SECONDS
+    stolen = await BaseChannel._steal_stale_tracker_run(host, "chat-1")
+    assert stolen is False
+    tracker.request_stop.assert_not_called()

--- a/tests/unit/app/channels/test_unified_queue_manager.py
+++ b/tests/unit/app/channels/test_unified_queue_manager.py
@@ -108,6 +108,29 @@ class TestEnqueueAndCreate:
         assert first is second
 
     @pytest.mark.asyncio
+    async def test_dead_consumer_is_replaced_on_enqueue(self):
+        async def wait_forever(q, *_args):
+            await asyncio.Event().wait()
+
+        mgr = UnifiedQueueManager(
+            consumer_fn=wait_forever,
+            queue_maxsize=10,
+        )
+        await mgr.enqueue("feishu", "feishu:sess", 10, "card")
+        state = mgr._queues[("feishu", "feishu:sess", 10)]
+        orphan = state.consumer_task
+        # Simulate a done task whose finally failed to pop the key.
+        done = asyncio.get_running_loop().create_future()
+        done.set_result(None)
+        state.consumer_task = done  # type: ignore[assignment]
+        await mgr.enqueue("feishu", "feishu:sess", 10, "next")
+        replaced = mgr._queues[("feishu", "feishu:sess", 10)]
+        assert replaced.consumer_task is not done
+        assert not replaced.consumer_task.done()
+        orphan.cancel()
+        await mgr.stop_all()
+
+    @pytest.mark.asyncio
     async def test_different_keys_create_different_queues(
         self,
         manager: UnifiedQueueManager,
@@ -223,6 +246,68 @@ class TestCleanupLoop:
         await asyncio.sleep(0.4)
         assert ("console", "console:u1", 0) not in manager._queues
         await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_replaces_stuck_consumer_with_waiting_items(self):
+        started = asyncio.Event()
+        seen: list[str] = []
+
+        async def get_then_hang(q, *_args):
+            item = await q.get()
+            seen.append(item)
+            started.set()
+            await asyncio.Event().wait()
+
+        mgr = UnifiedQueueManager(
+            consumer_fn=get_then_hang,
+            queue_maxsize=10,
+            idle_timeout=60.0,
+            cleanup_interval=0.02,
+            stuck_timeout=0.05,
+            cancel_timeout=0.05,
+        )
+        mgr.start_cleanup_loop()
+        await mgr.enqueue("feishu", "feishu:sess", 10, "card")
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await mgr.enqueue("feishu", "feishu:sess", 10, "later")
+        first = mgr._queues[("feishu", "feishu:sess", 10)]
+        await asyncio.sleep(0.25)
+        assert ("feishu", "feishu:sess", 10) in mgr._queues
+        replaced = mgr._queues[("feishu", "feishu:sess", 10)]
+        assert replaced is not first
+        assert replaced.consumer_task is not first.consumer_task
+        assert "later" in seen or replaced.queue.qsize() >= 1
+        await mgr.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_cancel_timeout_does_not_block_loop(self):
+        started = asyncio.Event()
+
+        async def ignore_cancel(q, *_args):
+            await q.get()
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await asyncio.Event().wait()
+
+        mgr = UnifiedQueueManager(
+            consumer_fn=ignore_cancel,
+            queue_maxsize=10,
+            idle_timeout=0.05,
+            cleanup_interval=0.02,
+            stuck_timeout=60.0,
+            cancel_timeout=0.05,
+        )
+        mgr.start_cleanup_loop()
+        await mgr.enqueue("feishu", "feishu:sess", 10, "card")
+        await asyncio.wait_for(started.wait(), timeout=1)
+        # Queue is empty (item already taken) and last_activity is stale
+        # → idle cleanup must not hang the loop on uncancellable cancel.
+        await asyncio.sleep(0.3)
+        assert mgr._cleanup_task is not None
+        assert not mgr._cleanup_task.done()
+        await mgr.stop_all()
 
     @pytest.mark.asyncio
     async def test_cleanup_loop_survives_exceptions(

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -241,6 +241,59 @@ async def test_request_stop_returns_false_when_no_run():
     assert await tracker.request_stop("missing") is False
 
 
+@pytest.mark.asyncio
+async def test_get_run_age_seconds_none_when_idle():
+    tracker = TaskTracker()
+    assert await tracker.get_run_age_seconds("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_get_run_age_seconds_for_live_run():
+    tracker = TaskTracker()
+    started = asyncio.Event()
+
+    async def long_stream(_payload):
+        started.set()
+        await asyncio.sleep(60)
+        yield "never"
+
+    await tracker.attach_or_start(
+        "run-age",
+        payload=None,
+        stream_fn=long_stream,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    age = await tracker.get_run_age_seconds("run-age")
+    assert age is not None
+    assert age >= 0
+    await tracker.request_stop("run-age", timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_request_stop_timeout_does_not_hang():
+    tracker = TaskTracker()
+    started = asyncio.Event()
+
+    async def ignore_cancel(_payload):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.Event().wait()
+        if False:  # pylint: disable=using-constant-test
+            yield "never"
+
+    await tracker.attach_or_start(
+        "run-hang",
+        payload=None,
+        stream_fn=ignore_cancel,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    stopped = await tracker.request_stop("run-hang", timeout=0.05)
+    assert stopped is True
+
+
+
 # ---------------------------------------------------------------------------
 # Error path: producer exception broadcasts an error SSE.
 # ---------------------------------------------------------------------------

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -851,8 +851,13 @@ class TestConsumeWithTracker:
         async def mock_attach_or_start(*args, **kwargs):
             return (MagicMock(), False)  # (queue, is_new) - is_new=False
 
+        async def mock_get_age(*args, **kwargs):
+            return 1.0  # recent run: keep ignore path
+
         mock_task_tracker = MagicMock()
         mock_task_tracker.attach_or_start = mock_attach_or_start
+        mock_task_tracker.get_run_age_seconds = mock_get_age
+        mock_task_tracker.request_stop = AsyncMock(return_value=True)
 
         mock_workspace.chat_manager = mock_chat_manager
         mock_workspace.task_tracker = mock_task_tracker
@@ -880,6 +885,7 @@ class TestConsumeWithTracker:
             )
 
         # Test passed if we reach here (warning was logged for is_new=False)
+        mock_task_tracker.request_stop.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What Problem This Solves

A wedged Feishu high-priority handle could keep its per-session queue consumer alive without making progress. Later messages reused that QueueKey, idle cleanup skipped the non-empty queue, and a leftover TaskTracker run dropped follow-ups as "already running", so the session went silently unresponsive. Root cause is broader than p10 vs p20: one stuck handle plus a stale tracker run seals the session.

## Description

Replace dead consumers on enqueue; reclaim non-empty queues whose consumer has made no progress for too long (cleanup wait is itself time-bounded). Bound each `_process_batch` / handle with a timeout so one hang cannot block `queue.get()` forever; if cancellation is swallowed, abandon after a grace period and continue. Stop stale TaskTracker runs so the next message can start a new producer. Surface enqueue timeout as a warning instead of silently dropping. Add unit tests for queue lifecycle, consume timeout, and tracker recovery.

**Related Issue:** Fixes #7534

**Security Considerations:** N/A — session queue lifecycle only; no new auth surface.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Tests

## Checklist

- [x] I ran tests locally (`pytest`) and they pass
- [x] Ready for review

## Testing

```bash
PYTHONPATH=src python3 -m pytest tests/unit/app/channels/test_unified_queue_manager.py tests/unit/app/channels/test_consume_queue.py tests/unit/app/test_task_tracker.py -q --noconftest
```

(45 passed)

## Evidence

Before: a stuck Feishu high-priority handle left a live-but-idle queue consumer and a stale TaskTracker run; follow-ups were dropped as already running and the session stayed silent.
After: dead consumers are replaced on enqueue, hung batches time out, stale tracker runs are cleared, and enqueue timeout is logged. Unit tests cover queue lifecycle, consume timeout, and tracker recovery.
