### PR TITLE
feat(config): add env_context.show_about_line to opt out of About identity line

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -176,19 +176,32 @@ def build_env_context(
     """
     parts = []
 
-    # Runtime identity
-    powered = f", powered by {active_model_name}" if active_model_name else ""
-    parts.append(
-        f"- About: You are a personal AI assistant{powered}. "
-        f"You operate in QwenPaw, an open-source agent "
-        f"framework built by AgentScope team from Qwen lab.",
+    # Runtime identity. The framework-attribution group (About / GitHub /
+    # Docs lines) can be omitted via config: env_context.show_about_line =
+    # False — for agents whose persona is fully defined in SOUL.md /
+    # PROFILE.md. Environment facts (OS / shell / dirs) always stay.
+    show_about_line = bool(
+        getattr(
+            getattr(load_config(), "env_context", None),
+            "show_about_line",
+            True,
+        ),
     )
-    parts.append(
-        "- GitHub: https://github.com/agentscope-ai/QwenPaw",
-    )
-    parts.append(
-        "- Docs: https://qwenpaw.agentscope.io/",
-    )
+    if show_about_line:
+        powered = (
+            f", powered by {active_model_name}" if active_model_name else ""
+        )
+        parts.append(
+            f"- About: You are a personal AI assistant{powered}. "
+            f"You operate in QwenPaw, an open-source agent "
+            f"framework built by AgentScope team from Qwen lab.",
+        )
+        parts.append(
+            "- GitHub: https://github.com/agentscope-ai/QwenPaw",
+        )
+        parts.append(
+            "- Docs: https://qwenpaw.agentscope.io/",
+        )
     parts.append(
         f"- OS: {platform.system()} {platform.release()} "
         f"({platform.machine()})",

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -3065,6 +3065,18 @@ class BrowserConfig(BaseModel):
         return value
 
 
+class EnvContextConfig(BaseModel):
+    """Environment context block settings for the system prompt."""
+
+    show_about_line: bool = Field(
+        default=True,
+        description="Whether to include the framework-attribution group "
+        "(the 'About: You are a personal AI assistant ...' line plus the "
+        "GitHub/Docs lines) in the env context. Set to False for agents "
+        "whose persona is fully defined in SOUL.md / PROFILE.md.",
+    )
+
+
 class Config(BaseModel):
     """Root config (config.json)."""
 
@@ -3078,6 +3090,11 @@ class Config(BaseModel):
     acp: ACPConfig = Field(default_factory=ACPConfig)
     browser: BrowserConfig = Field(default_factory=BrowserConfig)
     show_tool_details: bool = True
+    env_context: EnvContextConfig = Field(
+        default_factory=EnvContextConfig,
+        description="Settings for the env context block prepended to the "
+        "system prompt.",
+    )
     user_timezone: str = Field(
         default_factory=detect_system_timezone,
         description="User IANA timezone (e.g. Asia/Shanghai). "

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -14,6 +14,7 @@ from qwenpaw.app.chats.utils import (
     _normalize_msg_timestamp,
     _resolve_content_url,
     agentscope_msg_to_message,
+    build_env_context,
     clean_display_text,
     strip_injected_skill_block,
 )
@@ -506,3 +507,53 @@ def test_clean_title_truncates_long_title():
     long_title = "x" * 200
     result = _clean_title(long_title)
     assert len(result) <= 80
+
+
+# ---------------------------------------------------------------------------
+# build_env_context / env_context.show_about_line
+# ---------------------------------------------------------------------------
+
+
+def _patch_env_config(show_about_line):
+    cfg = SimpleNamespace(
+        user_timezone="UTC",
+        env_context=SimpleNamespace(show_about_line=show_about_line),
+    )
+    return patch(
+        "qwenpaw.app.chats.utils.load_config",
+        return_value=cfg,
+    )
+
+
+def test_build_env_context_includes_about_line_by_default():
+    with _patch_env_config(True):
+        ctx = build_env_context(active_model_name="qwen-max")
+    assert "You are a personal AI assistant, powered by qwen-max" in ctx
+    assert "- GitHub: https://github.com/agentscope-ai/QwenPaw" in ctx
+    assert "- Docs: https://qwenpaw.agentscope.io/" in ctx
+
+
+def test_build_env_context_omits_framework_attribution_when_disabled():
+    with _patch_env_config(False):
+        ctx = build_env_context(active_model_name="qwen-max")
+    assert "You are a personal AI assistant" not in ctx
+    # The whole framework-attribution group goes with it.
+    assert "- GitHub: https://github.com/agentscope-ai/QwenPaw" not in ctx
+    assert "- Docs: https://qwenpaw.agentscope.io/" not in ctx
+    # Environment facts always stay.
+    assert "- OS:" in ctx
+
+
+def test_build_env_context_keeps_request_fields_when_disabled():
+    with _patch_env_config(False):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            channel="console",
+            working_dir="/tmp/ws",
+        )
+    assert "- Channel: console" in ctx
+    assert "- User ID: u1" in ctx
+    assert "- Session ID: s1" in ctx
+    assert "- Working directory: /tmp/ws" in ctx
+    assert "You are a personal AI assistant" not in ctx

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -195,6 +195,9 @@ Stores globally shared configuration:
       }
     }
   },
+  "env_context": {
+    "show_about_line": true
+  },
   "last_api": {
     "host": "127.0.0.1",
     "port": 8088
@@ -205,14 +208,15 @@ Stores globally shared configuration:
 
 **Global config.json field descriptions:**
 
-| Field                 | Type           | Default             | Description                                                  |
-| --------------------- | -------------- | ------------------- | ------------------------------------------------------------ |
-| `agents.active_agent` | string         | `"default"`         | Currently active agent ID                                    |
-| `agents.profiles`     | object         | `{}`                | Agent profile references (key is agent_id)                   |
-| `last_api.host`       | string \| null | `null`              | Host address from last `qwenpaw app` start                   |
-| `last_api.port`       | int \| null    | `null`              | Port from last `qwenpaw app` start                           |
-| `show_tool_details`   | bool           | `true`              | Whether to show tool call/return details in channel messages |
-| `user_timezone`       | string         | _(system timezone)_ | IANA timezone name (e.g., `"Asia/Shanghai"`)                 |
+| Field                         | Type           | Default             | Description                                                                                            |
+| ----------------------------- | -------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `agents.active_agent`         | string         | `"default"`         | Currently active agent ID                                                                              |
+| `agents.profiles`             | object         | `{}`                | Agent profile references (key is agent_id)                                                             |
+| `env_context.show_about_line` | bool           | `true`              | Whether to prepend the framework attribution group (About / GitHub / Docs lines) to each system prompt |
+| `last_api.host`               | string \| null | `null`              | Host address from last `qwenpaw app` start                                                             |
+| `last_api.port`               | int \| null    | `null`              | Port from last `qwenpaw app` start                                                                     |
+| `show_tool_details`           | bool           | `true`              | Whether to show tool call/return details in channel messages                                           |
+| `user_timezone`               | string         | _(system timezone)_ | IANA timezone name (e.g., `"Asia/Shanghai"`)                                                           |
 
 **`agents.profiles[agent_id]` reference fields:**
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -138,6 +138,9 @@ QwenPaw 会在单个服务进程内串行写入智能体配置，并拒绝基于
       }
     }
   },
+  "env_context": {
+    "show_about_line": true
+  },
   "last_api": {
     "host": "127.0.0.1",
     "port": 8088
@@ -149,14 +152,15 @@ QwenPaw 会在单个服务进程内串行写入智能体配置，并拒绝基于
 
 **全局 config.json 字段说明：**
 
-| 字段                  | 类型           | 默认值         | 说明                                  |
-| --------------------- | -------------- | -------------- | ------------------------------------- |
-| `agents.active_agent` | string         | `"default"`    | 当前激活的智能体 ID                   |
-| `agents.profiles`     | object         | `{}`           | 智能体配置引用字典（key 为 agent_id） |
-| `last_api.host`       | string \| null | `null`         | 上次 `qwenpaw app` 启动的主机地址     |
-| `last_api.port`       | int \| null    | `null`         | 上次 `qwenpaw app` 启动的端口         |
-| `show_tool_details`   | bool           | `true`         | 是否在频道消息中显示工具调用/返回详情 |
-| `user_timezone`       | string         | _（系统时区）_ | IANA 时区名称（如 `"Asia/Shanghai"`） |
+| 字段                          | 类型           | 默认值         | 说明                                                               |
+| ----------------------------- | -------------- | -------------- | ------------------------------------------------------------------ |
+| `agents.active_agent`         | string         | `"default"`    | 当前激活的智能体 ID                                                |
+| `agents.profiles`             | object         | `{}`           | 智能体配置引用字典（key 为 agent_id）                              |
+| `env_context.show_about_line` | bool           | `true`         | 是否在每条 system prompt 前拼接框架署名组（About / GitHub / Docs） |
+| `last_api.host`               | string \| null | `null`         | 上次 `qwenpaw app` 启动的主机地址                                  |
+| `last_api.port`               | int \| null    | `null`         | 上次 `qwenpaw app` 启动的端口                                      |
+| `show_tool_details`           | bool           | `true`         | 是否在频道消息中显示工具调用/返回详情                              |
+| `user_timezone`               | string         | _（系统时区）_ | IANA 时区名称（如 `"Asia/Shanghai"`）                              |
 
 **`agents.profiles[agent_id]`** 引用字段：
 


### PR DESCRIPTION
## Description

`build_env_context()` unconditionally prepends a hardcoded framework-attribution group to every system prompt:

```
- About: You are a personal AI assistant, powered by {model}. You operate in QwenPaw, an open-source agent framework built by AgentScope team from Qwen lab.
- GitHub: https://github.com/agentscope-ai/QwenPaw
- Docs: https://qwenpaw.agentscope.io/
```

Agents whose persona is fully defined in SOUL.md / PROFILE.md end up with this group sitting on top of (and competing with) their persona in every request. The visual-compression pipeline (`static_context.py`) already carries a regex whose job is to strip exactly this block for its own path — the leak is a known nuisance.

This PR adds an opt-out config switch `env_context.show_about_line` (default `true`, so behavior is unchanged for anyone who doesn't touch the new key). What it changes:

- `config.py`: new `EnvContextConfig` model; `Config.env_context` field.
- `app/chats/utils.py`: `build_env_context()` gates the About/GitHub/Docs group behind `load_config().env_context.show_about_line`. Environment facts (OS / shell / dirs / request fields) always stay.
- `tests/unit/app/chats/test_utils.py`: 3 unit tests (default present / absent when disabled / request fields kept).
- `website/public/docs/config.en.md` / `config.zh.md`: document the new field in the Global config.json reference table and config example.

config.json example:

```json
{
  "env_context": {
    "show_about_line": false
  }
}
```

**Related Issue:** Fixes #7540

**Security Considerations:** Config handling only — an optional nested key with a `true` default; no secrets, auth, or network behavior touched. Read via the existing `load_config()` path inside `build_env_context()`; a missing key yields exactly the old behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. `pytest tests/unit/app/chats/test_utils.py -q` — includes the 3 new tests.
2. Manual: set `"env_context": {"show_about_line": false}` in `config.json`, send a message via console/channel, and inspect the outgoing LLM payload — the About/GitHub/Docs group disappears. Remove the key or set `true` (config hot-reloads on file change) and it returns.

## Evidence

New unit tests (Windows, Python 3.13 venv):

```bash
pytest tests/unit/app/chats/test_utils.py -q
# 44 passed — 3 new: default present / absent when disabled / request fields kept
```

Full unit suite:

```bash
pytest tests/unit -q
# 10201 passed, 104 skipped, 1 failed
# the 1 failure (test_policy.py::TestFileTargetResolution::test_absolute_path_unchanged)
# is a pre-existing Windows-only assumption (os.path.isabs("/etc/passwd")) in a file
# this PR does not touch; the Linux CI matrix covers it.
```

Instance-level end-to-end — real qwenpaw service, real `config.json`, message through the REST API, full LLM payload captured at the provider boundary — run on **Windows (3.13 venv)** and **Linux (Docker, official 2.2.0 image with this change loaded)**:

- `show_about_line=false` → captured system prompt contains no About/GitHub/Docs lines
- flipped back to `true` (mtime hot-reload) → lines restored
- captured payload length delta: **250 chars = the exact length of the three attribution lines**

`pre-commit run --files` on all touched files: black / flake8 / pylint / mypy pass.

## Additional Notes

- On this Windows machine a full `pre-commit run --all-files` trips 3 pre-existing mypy errors in upstream `shutdown_cmd.py` (Windows/mypy-version quirk, file untouched by this PR), so that checklist box is left unticked rather than claimed; hooks pass on every file this PR touches, and the Linux Pre-commit CI is the authoritative run.
- Local verification used the `.[dev,test]` extras (skipping `full`'s whisper/torch chain); CI covers the full matrix.
- Documentation: the new field is documented in the global config reference table and example of the docs website (`website/public/docs/config.en.md` / `config.zh.md`), included as the second commit of this PR.
