### PR TITLE
fix(console): preserve selected loop mode query

### DIFF
--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -23,6 +23,8 @@ const {
   mockSetSelectedAgent,
   mockGetTranscriptionProviderType,
   mockCopyText,
+  mockBeginLoopModeSubmission,
+  mockRequiresQwenPawModel,
 } = vi.hoisted(() => ({
   mockListProviders: vi.fn(),
   mockGetActiveModels: vi.fn(),
@@ -33,6 +35,8 @@ const {
   mockSetSelectedAgent: vi.fn(),
   mockGetTranscriptionProviderType: vi.fn(),
   mockCopyText: vi.fn().mockResolvedValue(undefined),
+  mockBeginLoopModeSubmission: vi.fn((text: string) => text),
+  mockRequiresQwenPawModel: vi.fn(() => true),
 }));
 
 let capturedOptions: any = null;
@@ -233,7 +237,7 @@ vi.mock("@/stores/loopStore", () => ({
       })),
     },
   ),
-  beginLoopModeSubmission: vi.fn((text: string) => text),
+  beginLoopModeSubmission: mockBeginLoopModeSubmission,
   fetchActiveLoopMode: vi.fn(() => Promise.resolve(null)),
   fetchAvailableLoopModes: vi.fn(() => Promise.resolve([])),
   markLoopModeRunning: vi.fn(),
@@ -324,7 +328,7 @@ vi.mock("@/stores/messageQueueStore", () => ({
 }));
 
 vi.mock("@/utils/agentBackend", () => ({
-  requiresQwenPawModel: vi.fn(() => true),
+  requiresQwenPawModel: mockRequiresQwenPawModel,
   supportsAgentAttachments: vi.fn(() => true),
 }));
 
@@ -506,6 +510,10 @@ describe("ChatPage coverage", () => {
     chatExtensions.__resetForTests();
     capturedOptions = null;
     mockCopyText.mockClear();
+    mockBeginLoopModeSubmission.mockReset();
+    mockBeginLoopModeSubmission.mockImplementation((text: string) => text);
+    mockRequiresQwenPawModel.mockReset();
+    mockRequiresQwenPawModel.mockReturnValue(true);
     mockListProviders.mockResolvedValue([
       {
         id: "openai",
@@ -1038,21 +1046,64 @@ describe("ChatPage coverage", () => {
     }
   });
 
-  // ── handleBeforeSubmit: non-owner tab enqueues ─────────────────────────
-  it("handleBeforeSubmit returns false for non-owner tab and enqueues", async () => {
+  // ── handleBeforeSubmit: SDK query override ─────────────────────────────
+  it("returns the prepared query after the SDK captures input data", async () => {
+    mockBeginLoopModeSubmission.mockImplementation(
+      (text: string) => `/goal ${text}`,
+    );
     renderWithProviders(<ChatPage />, {
       initialEntries: ["/chat/test-session"],
     });
     await screen.findByTestId("chat-ui");
 
     const beforeSubmit = capturedOptions?.sender?.beforeSubmit;
-    if (typeof beforeSubmit === "function") {
-      // The default mock makes the component an owner (holdOwnershipLock calls cb immediately)
-      // So beforeSubmit should return true for owner
-      const result = await beforeSubmit();
-      // Owner path: returns true
-      expect(typeof result).toBe("boolean");
-    }
+    expect(typeof beforeSubmit).toBe("function");
+
+    const inputData = {
+      query: "do the task",
+      fileList: [
+        {
+          uid: "file-1",
+          name: "notes.txt",
+          response: { url: "/files/notes.txt" },
+        },
+      ],
+      mentions: [{ value: "@reviewer", type: "user" }],
+    };
+    const capturedQuery = inputData.query;
+    const result = await beforeSubmit(inputData);
+    const submitted = {
+      ...inputData,
+      query:
+        typeof result === "object" && result.query !== undefined
+          ? result.query
+          : capturedQuery,
+    };
+
+    expect(result).toEqual({
+      proceed: true,
+      query: "/goal do the task",
+    });
+    expect(submitted.query).toBe("/goal do the task");
+    expect(submitted.fileList).toEqual(inputData.fileList);
+    expect(submitted.mentions).toEqual(inputData.mentions);
+  });
+
+  it("leaves the query unchanged for a non-QwenPaw backend", async () => {
+    mockRequiresQwenPawModel.mockReturnValue(false);
+    mockBeginLoopModeSubmission.mockImplementation(
+      (text: string) => `/goal ${text}`,
+    );
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/test-session"],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const beforeSubmit = capturedOptions?.sender?.beforeSubmit;
+    const result = await beforeSubmit({ query: "do the task" });
+
+    expect(result).toEqual({ proceed: true, query: "do the task" });
+    expect(mockBeginLoopModeSubmission).not.toHaveBeenCalled();
   });
 
   // ── sender attachments trigger renders ─────────────────────────────────

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1,6 +1,8 @@
 import {
   AgentScopeRuntimeWebUI,
   IAgentScopeRuntimeWebUIOptions,
+  type IAgentScopeRuntimeWebUIInputData,
+  type IAgentScopeRuntimeWebUISenderBeforeSubmitResult,
   type IAgentScopeRuntimeWebUIRef,
 } from "@agentscope-ai/chat";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -2860,15 +2862,16 @@ export default function ChatPage() {
         value: skill.name,
         description: "",
       }));
-    const handleBeforeSubmit = async () => {
+    const handleBeforeSubmit = async (
+      inputData: IAgentScopeRuntimeWebUIInputData,
+    ): Promise<boolean | IAgentScopeRuntimeWebUISenderBeforeSubmitResult> => {
       if (isComposingRef.current) return false;
       // Single-tab ownership: non-owner tabs are queue-only. Re-route every
       // submit (Enter / send button / programmatic) to the shared queue and
       // abort the actual SDK send. The owner tab will pick the item up via
       // cross-tab broadcast and send it.
       if (!isOwnerRef.current) {
-        const textarea = getActiveSenderTextarea();
-        const val = textarea?.value.trim() ?? "";
+        const val = inputData.query.trim();
         if (!val) return false;
         const currentQ = useMessageQueueStore
           .getState()
@@ -2896,6 +2899,7 @@ export default function ChatPage() {
           channel: enqueueIdentity.channel,
         });
         pendingFileListRef.current = [];
+        const textarea = getActiveSenderTextarea();
         if (textarea) setTextareaValue(textarea, "");
         // Clear sender attachment preview (deferred to next tick)
         clearSenderAttachments();
@@ -2908,18 +2912,19 @@ export default function ChatPage() {
       // Clear pending attachments when sending directly (not through queue)
       pendingFileListRef.current = [];
 
+      const prepared = usesQwenPawBackend
+        ? beginLoopModeSubmission(inputData.query)
+        : inputData.query;
+      pendingSenderClearRef.current = prepared;
+
       const textarea = getActiveSenderTextarea();
       if (textarea) {
-        const prepared = usesQwenPawBackend
-          ? beginLoopModeSubmission(textarea.value)
-          : textarea.value;
         if (prepared !== textarea.value) {
           setTextareaValue(textarea, prepared);
         }
-        pendingSenderClearRef.current = prepared;
       }
 
-      return true;
+      return { proceed: true, query: prepared };
     };
 
     // ── Resolve plugin extension snapshots ────────────────────────────────

--- a/console/src/stores/loopStore.test.ts
+++ b/console/src/stores/loopStore.test.ts
@@ -17,6 +17,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   useLoopStore,
   DEFAULT_LOOP_MODE,
+  beginLoopModeSubmission,
+  prepareLoopModeMessage,
   type LoopModeInfo,
 } from "./loopStore";
 
@@ -36,11 +38,19 @@ const customMode: LoopModeInfo = {
   source: "custom",
 };
 
+const missionMode: LoopModeInfo = {
+  id: "mission",
+  name: "Mission Mode",
+  slash_command: "mission",
+  description: "Run a structured mission",
+  source: "builtin",
+};
+
 describe("loopStore state transitions (A#85096690)", () => {
   beforeEach(() => {
     useLoopStore.setState({
       selectedModeId: "default",
-      availableModes: [DEFAULT_LOOP_MODE, goalMode, customMode],
+      availableModes: [DEFAULT_LOOP_MODE, goalMode, missionMode, customMode],
       sessionState: "idle",
       activeMode: null,
       catalogLoading: false,
@@ -130,5 +140,39 @@ describe("loopStore state transitions (A#85096690)", () => {
     const state = useLoopStore.getState();
     expect(state.sessionState).toBe("running");
     expect(state.activeMode).toEqual(customMode);
+  });
+
+  it.each([
+    ["goal", goalMode, "do the task", "/goal do the task"],
+    ["mission", missionMode, "build it", "/mission build it"],
+    ["custom", customMode, "review it", "/review review it"],
+  ])("prepares a selected %s mode command", (_label, mode, text, expected) => {
+    useLoopStore.getState().setSelectedMode(mode.id);
+
+    expect(prepareLoopModeMessage(text)).toBe(expected);
+  });
+
+  it("leaves default mode messages unchanged", () => {
+    expect(prepareLoopModeMessage("hello")).toBe("hello");
+  });
+
+  it("does not duplicate a manually entered loop command", () => {
+    useLoopStore.getState().setSelectedMode(goalMode.id);
+
+    expect(beginLoopModeSubmission("/goal do the task")).toBe(
+      "/goal do the task",
+    );
+  });
+
+  it("leaves unrelated slash commands unchanged", () => {
+    useLoopStore.getState().setSelectedMode(goalMode.id);
+
+    expect(beginLoopModeSubmission("/clear")).toBe("/clear");
+  });
+
+  it("leaves follow-up text unchanged while a loop is active", () => {
+    useLoopStore.getState().setSessionMode(goalMode, "running");
+
+    expect(beginLoopModeSubmission("continue")).toBe("continue");
   });
 });


### PR DESCRIPTION
Returns the prepared loop query through the SDK beforeSubmit result.

Uses inputData.query as the submission source of truth.

Keeps queue-only submissions aligned with the SDK-provided query.

Preserves SDK-provided attachments and mentions.

Prevents duplicate loop prefixes and preserves unrelated slash commands.

Adds regression coverage for built-in and custom modes, active loops, non-QwenPaw backends, and the SDK capture-before-hook order.

Fixes  #7552

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
