### PR TITLE
refactor(memory): unify automatic memory lifecycle and actions

### DIFF
--- a/console/src/api/modules/agents.ts
+++ b/console/src/api/modules/agents.ts
@@ -16,12 +16,13 @@ export interface ReMeComponentMemoryUsage {
   human: string;
 }
 
-export interface MemoryCaptureTaskStatus {
+export interface AutoMemoryTaskStatus {
   task_id: string;
   status: "pending" | "running" | "completed" | "failed" | "cancelled";
   queued_at: string | null;
   finished_at: string | null;
   message_count: number;
+  trigger: "periodic" | "manual" | "compact" | "new" | string;
   result: string | null;
   error: string | null;
 }
@@ -40,7 +41,7 @@ export interface ReMeMemoryStatusResponse {
       enabled: boolean;
       interval: number;
     };
-    tasks: MemoryCaptureTaskStatus[];
+    tasks: AutoMemoryTaskStatus[];
     recent: {
       last_error: string | null;
     };

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3012,11 +3012,17 @@
     "memoryQueueIdleSummary": "Idle · no pending jobs",
     "memoryAutoRecordDisabledHint": "Automatic conversation memory is off",
     "memoryAutoMemoryEnabledSummary": "Auto-memory enabled · runs every {{interval}} turns",
-    "memoryRuntimeActivityDescription": "Memory capture jobs from automatic and manual actions run sequentially without blocking the current conversation",
+    "memoryRuntimeActivityDescription": "Auto-memory jobs from automatic and manual actions run sequentially without blocking the current conversation",
     "memoryLastError": "Most recent error",
     "memoryNeverRun": "No activity yet",
-    "memoryRecentTasks": "Recent memory capture jobs",
-    "memoryRecentTasksEmpty": "No memory capture jobs yet",
+    "autoMemoryRecentTasks": "Recent auto-memory jobs",
+    "autoMemoryRecentTasksEmpty": "No auto-memory jobs yet",
+    "autoMemoryTrigger": {
+      "periodic": "Periodic",
+      "manual": "Manual",
+      "compact": "Context compact",
+      "new": "New conversation"
+    },
     "memoryTaskMessages": "{{count}} messages processed",
     "memoryTaskNoResult": "The job has not returned content yet",
     "memoryTaskStatus": {
@@ -3038,7 +3044,7 @@
       "keyword_index": "Keyword index"
     },
     "memoryStatusDisabled": "Disabled",
-    "memoryJournalTitle": "Memory capture",
+    "memoryJournalTitle": "Auto-memory",
     "memoryJournalDescription": "Continuously extract searchable memories from conversations and external knowledge sources",
     "memoryConversationJournalTitle": "Conversation memory",
     "memoryExternalSourcesDevelopingLabel": "More coming",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2870,11 +2870,17 @@
     "memoryQueueIdleSummary": "空闲 · 无等待任务",
     "memoryAutoRecordDisabledHint": "自动对话记忆已关闭",
     "memoryAutoMemoryEnabledSummary": "自动记忆已开启 · 每 {{interval}} 轮对话触发",
-    "memoryRuntimeActivityDescription": "自动记忆和手动操作触发的记忆沉淀任务会在后台依次处理，不会阻塞当前对话",
+    "memoryRuntimeActivityDescription": "自动和手动触发的自动记忆任务会在后台依次处理，不会阻塞当前对话",
     "memoryLastError": "最近一次错误",
     "memoryNeverRun": "暂无记录",
-    "memoryRecentTasks": "最近的记忆沉淀任务",
-    "memoryRecentTasksEmpty": "最近还没有记忆沉淀任务",
+    "autoMemoryRecentTasks": "最近的自动记忆任务",
+    "autoMemoryRecentTasksEmpty": "最近还没有自动记忆任务",
+    "autoMemoryTrigger": {
+      "periodic": "周期触发",
+      "manual": "手动触发",
+      "compact": "上下文压缩",
+      "new": "新会话"
+    },
     "memoryTaskMessages": "处理 {{count}} 条消息",
     "memoryTaskNoResult": "任务尚未返回内容",
     "memoryTaskStatus": {
@@ -2896,7 +2902,7 @@
       "keyword_index": "关键词索引"
     },
     "memoryStatusDisabled": "已关闭",
-    "memoryJournalTitle": "记忆沉淀",
+    "memoryJournalTitle": "自动记忆",
     "memoryJournalDescription": "从对话和外部知识源中持续提取并沉淀可检索的记忆",
     "memoryConversationJournalTitle": "对话记忆",
     "memoryExternalSourcesDevelopingLabel": "持续开发中",

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx
@@ -597,7 +597,7 @@ describe("ReMe runtime status", () => {
       screen.getByText("agentConfig.memoryAutoMemoryEnabledSummary"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("agentConfig.memoryRecentTasksEmpty"),
+      screen.getByText("agentConfig.autoMemoryRecentTasksEmpty"),
     ).toBeInTheDocument();
 
     fireEvent.click(diagnosticsButton);

--- a/console/src/pages/Agent/Config/components/ReMeStatusModal.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeStatusModal.tsx
@@ -127,7 +127,7 @@ export function ReMeStatusModal({
               ) : null}
               <div className={styles.memoryAutoMemoryHistory}>
                 <div className={styles.memoryAutoMemoryHistoryHeader}>
-                  <strong>{t("agentConfig.memoryRecentTasks")}</strong>
+                  <strong>{t("agentConfig.autoMemoryRecentTasks")}</strong>
                 </div>
                 {tasks?.length ? (
                   <div className={styles.memoryAutoMemoryHistoryList}>
@@ -143,6 +143,10 @@ export function ReMeStatusModal({
                             )}
                           </strong>
                           <small>
+                            {t(`agentConfig.autoMemoryTrigger.${run.trigger}`, {
+                              defaultValue: run.trigger,
+                            })}
+                            {" · "}
                             {t("agentConfig.memoryTaskMessages", {
                               count: run.message_count,
                             })}
@@ -158,7 +162,7 @@ export function ReMeStatusModal({
                   </div>
                 ) : (
                   <p className={styles.memoryAutoMemoryHistoryEmpty}>
-                    {t("agentConfig.memoryRecentTasksEmpty")}
+                    {t("agentConfig.autoMemoryRecentTasksEmpty")}
                   </p>
                 )}
               </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pyyaml>=6.0",
     "wcmatch>=10.0",
     "json-repair>=0.30.0",
+    "jsonschema>=4.0.0",
     "segno>=1.6.6",
     "modelscope>=1.35.0",
     "huggingface_hub>=0.20.0",

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -20,6 +20,7 @@ from .middlewares import (
     manual_compact_memory_by_handler,
     reset_auto_memory_turn_state,
 )
+from .memory.action_provider import MemoryActionProvider
 from .utils.context_stats import format_history_str
 from ..config.config import load_agent_config, get_model_max_input_length
 from ..constant import DEBUG_HISTORY_FILE, MAX_LOAD_HISTORY_COUNT
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 #   - ``new`` overlaps the dedicated ACP ``new_session`` affordance (clients
 #     start a fresh session natively); ``/clear`` covers the in-session
 #     "start over" need, so ``/new`` is not advertised over ACP.
-#   - ``history``, ``plan``, ``compact_str``, ``summarize_status``,
+#   - ``history``, ``plan``, ``compact_str``, ``auto_memory_status``,
 #     ``message``, ``dump_history``, ``load_history``, ``proactive`` are
 #     internal/programmatic.
 # Descriptions mirror the console command palette copy
@@ -82,7 +83,7 @@ class ConversationCommandHandlerMixin:
             "clear",
             "history",
             "compact_str",
-            "summarize_status",
+            "auto_memory_status",
             "message",
             "dump_history",
             "load_history",
@@ -433,8 +434,9 @@ class CommandHandler(ConversationCommandHandlerMixin):
             compress_stats.get("evicted", inferred_evicted) or 0,
         )
         if self._has_memory_manager():
-            self.memory_manager.add_summarize_task(
+            self.memory_manager.submit_auto_memory(
                 messages=messages,
+                trigger="compact",
                 session_id=self._current_session_id(),
             )
             self._discard_submitted_pending_markers(messages)
@@ -633,7 +635,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
             self._set_summary("")
             reset_auto_memory_turn_state(self._state)
             return await self._make_system_msg(
-                "**No messages to summarize.**\n\n"
+                "**No messages for auto-memory.**\n\n"
                 "- Current memory is empty\n"
                 "- Compressed summary is clear\n"
                 "- Plan state cleared\n"
@@ -647,8 +649,9 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 "- Enable memory manager to use this feature",
             )
 
-        self.memory_manager.add_summarize_task(
+        self.memory_manager.submit_auto_memory(
             messages=messages,
+            trigger="new",
             session_id=self._current_session_id(),
         )
         self._set_summary("")
@@ -657,7 +660,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         reset_auto_memory_turn_state(self._state)
         return await self._make_system_msg(
             "**New Conversation Started!**\n\n"
-            "- Summary task started in background\n"
+            "- Auto-memory task started in background\n"
             "- Plan state cleared\n"
             "- Ready for new conversation",
             metadata={"clear_plan": True},
@@ -812,31 +815,32 @@ class CommandHandler(ConversationCommandHandlerMixin):
 
         return ""
 
-    async def _process_summarize_status(
+    async def _process_auto_memory_status(
         self,
         _messages: list[Msg],
         _args: str = "",
     ) -> Msg:
-        """Process /summarize_status command to show all status."""
+        """Process /auto_memory_status to show queued task status."""
         if not self._has_memory_manager():
             return await self._make_system_msg(
                 "**Memory Manager Disabled**\n\n"
-                "- Cannot list summary task status\n"
+                "- Cannot list auto-memory task status\n"
                 "- Enable memory manager to use this feature",
             )
 
-        task_list = self.memory_manager.list_summarize_status()
+        task_list = self.memory_manager.list_auto_memory_tasks()
         if not task_list:
             return await self._make_system_msg(
-                "**No Summary Tasks**\n\n"
-                "- No summary tasks have been started",
+                "**No Auto-memory Tasks**\n\n"
+                "- No auto-memory tasks have been started",
             )
 
-        status_lines = ["**Summary Task Status**\n\n"]
+        status_lines = ["**Auto-memory Task Status**\n\n"]
         for info in task_list:
             status_lines.append(
                 f"- **{info['task_id']}**\n"
                 f"  - Start: {info['start_time']}\n"
+                f"  - Trigger: {info['trigger']}\n"
                 f"  - Status: {info['status']}\n",
             )
             if info["status"] == "completed" and info["result"]:
@@ -860,17 +864,32 @@ class CommandHandler(ConversationCommandHandlerMixin):
             )
 
         hint = args.strip()
+        provider = self.memory_manager
+        if not isinstance(provider, MemoryActionProvider):
+            return await self._make_system_msg(
+                "**Auto-dream Unavailable**\n\n"
+                "- This memory backend does not support auto-dream",
+            )
         try:
             if hint:
-                await self.memory_manager.dream(hint=hint)
+                response = await provider.run_action("auto_dream", hint=hint)
             else:
-                await self.memory_manager.dream()
+                response = await provider.run_action("auto_dream")
         except Exception as e:
             logger.exception("auto-dream failed: %s", e)
             return await self._make_system_msg(
                 f"**Auto-dream Failed**\n\n- Error: {e}",
             )
 
+        if response is None:
+            return await self._make_system_msg(
+                "**Auto-dream Unavailable**\n\n- Memory backend is not ready",
+            )
+        if not response.success:
+            return await self._make_system_msg(
+                "**Auto-dream Failed**\n\n"
+                f"- Error: {response.answer or 'Unknown ReMe error'}",
+            )
         return await self._make_system_msg(
             "**Auto-dream Complete**\n\n"
             "- Ran one auto-dream memory optimization pass",
@@ -890,8 +909,14 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 "QwenPaw to enable this feature",
             )
 
+        provider = self.memory_manager
+        if not isinstance(provider, MemoryActionProvider):
+            return await self._make_system_msg(
+                "**ReMe Status Unavailable**\n\n"
+                "- This memory backend does not support ReMe actions",
+            )
         try:
-            response = await self.memory_manager.reme_status()
+            response = await provider.run_action("status")
         except Exception as e:
             logger.exception("ReMe status failed: %s", e)
             return await self._make_system_msg(
@@ -978,8 +1003,9 @@ class CommandHandler(ConversationCommandHandlerMixin):
             )
 
         try:
-            await self.memory_manager.auto_memory(
+            self.memory_manager.submit_auto_memory(
                 memory_messages,
+                trigger="manual",
                 session_id=self._current_session_id(),
                 reply_id=reply_ids[-1],
                 reply_ids=reply_ids,

--- a/src/qwenpaw/agents/memory/__init__.py
+++ b/src/qwenpaw/agents/memory/__init__.py
@@ -4,6 +4,12 @@
 from typing import TYPE_CHECKING
 
 from .agent_md_manager import AgentMdManager
+from .action_provider import (
+    MemoryActionProvider,
+    MemoryActionResponse,
+    MemoryActionResult,
+    MemoryActionSpec,
+)
 from .base_memory_manager import BaseMemoryManager
 from .reme_light_memory_manager import ReMeLightMemoryManager
 from .adbpg_memory_manager import (
@@ -34,6 +40,10 @@ if TYPE_CHECKING:  # pragma: no cover
 # pylint: disable=undefined-all-variable
 __all__ = [
     "AgentMdManager",
+    "MemoryActionProvider",
+    "MemoryActionResponse",
+    "MemoryActionResult",
+    "MemoryActionSpec",
     "BaseMemoryManager",
     "ReMeLightMemoryManager",
     "ADBPGMemoryManager",

--- a/src/qwenpaw/agents/memory/action_provider.py
+++ b/src/qwenpaw/agents/memory/action_provider.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""User-callable capabilities exposed by memory backends."""
+
+from dataclasses import dataclass
+from typing import Any, Protocol, TypedDict, runtime_checkable
+
+
+class MemoryActionSpec(TypedDict):
+    """Description and JSON Schema for one memory action."""
+
+    description: str
+    parameters: dict[str, Any]
+
+
+class MemoryActionResult(Protocol):
+    """Structural result returned by a memory action."""
+
+    success: bool
+    answer: Any
+    metadata: dict[str, Any] | None
+
+
+@dataclass
+class MemoryActionResponse:
+    """Backend-independent response for host-managed memory actions."""
+
+    success: bool
+    answer: Any = None
+    metadata: dict[str, Any] | None = None
+
+
+@runtime_checkable
+class MemoryActionProvider(Protocol):
+    """Contract for backends that expose callable memory actions."""
+
+    async def list_actions(self) -> dict[str, MemoryActionSpec]:
+        """Return the actions currently available to callers."""
+
+    async def run_action(
+        self,
+        action: str,
+        **kwargs: Any,
+    ) -> MemoryActionResult | None:
+        """Validate and execute an available action."""

--- a/src/qwenpaw/agents/memory/adbpg_memory_manager.py
+++ b/src/qwenpaw/agents/memory/adbpg_memory_manager.py
@@ -7,9 +7,8 @@ Context compaction is handled natively by AgentScope's
 ``ToolResultPruningMiddleware``. This class only manages long-term
 memory storage and retrieval.
 """
-import asyncio
+
 import logging
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +21,12 @@ from .adbpg_client import (
     ADBPGMemoryClient,
 )
 from .adbpg_prompts import ADBPG_MEMORY_GUIDANCE_EN, ADBPG_MEMORY_GUIDANCE_ZH
-from .base_memory_manager import BaseMemoryManager, memory_registry
+from .base_memory_manager import (
+    AutoMemorySearchOptions,
+    BaseMemoryManager,
+    NO_RELEVANT_MEMORIES,
+    memory_registry,
+)
 from ...config.config import load_agent_config
 from ...exceptions import ConfigurationException as ConfigurationError
 from ...utils.io_utils import run_sync_io
@@ -47,7 +51,6 @@ class ADBPGMemoryManager(BaseMemoryManager):
         self._effective_user_id: str = "shared"
         self._effective_run_id: str = "shared"
         self._persisted_msg_ids: set[str] = set()
-        self._pending_add_tasks: set[asyncio.Task[None]] = set()
 
     # ------------------------------------------------------------------
     # Abstract methods (required)
@@ -114,15 +117,8 @@ class ADBPGMemoryManager(BaseMemoryManager):
             )
             self._client = None
 
-    async def close(self) -> bool:
+    async def _close_backend(self) -> bool:
         """Clean up resources."""
-        if self._pending_add_tasks:
-            await asyncio.gather(
-                *list(self._pending_add_tasks),
-                return_exceptions=True,
-            )
-            self._pending_add_tasks.clear()
-
         client = self._client
         self._client = None
         if client is None:
@@ -134,11 +130,6 @@ class ADBPGMemoryManager(BaseMemoryManager):
             logger.exception("ADBPG close failed")
             return False
 
-    def get_memory_config(self) -> Any:
-        """Return ADBPG memory configuration."""
-        agent_config = load_agent_config(self.agent_id)
-        return agent_config.running.adbpg_memory_config
-
     def get_memory_prompt(self) -> str:
         """Return ADBPG memory guidance prompt."""
         agent_config = load_agent_config(self.agent_id)
@@ -149,10 +140,6 @@ class ADBPGMemoryManager(BaseMemoryManager):
         }
         return prompts.get(language, ADBPG_MEMORY_GUIDANCE_EN)
 
-    def list_memory_tools(self) -> list[Callable[..., ToolChunk]]:
-        """Return memory tools exposed to the agent."""
-        return [self.memory_search]
-
     def get_auto_memory_interval(self) -> int:
         """Persist ADBPG user messages every turn."""
         return 1
@@ -161,29 +148,10 @@ class ADBPGMemoryManager(BaseMemoryManager):
     # Optional methods (override)
     # ------------------------------------------------------------------
 
-    async def summarize(self, messages: list[Msg], **_kwargs) -> str:
-        """Persist user messages to ADBPG via fire-and-forget."""
-        if self._client is None:
-            return ""
-        user_messages = self._filter_user_messages(messages)
-        if not user_messages:
-            return ""
-        for single in user_messages:
-            self._schedule_add([single])
-        return (
-            f"Persisted {len(user_messages)} user message(s) "
-            f"to ADBPG for agent '{self.agent_id}'."
-        )
-
-    async def auto_memory_search(
+    async def get_auto_memory_search_options(
         self,
-        messages: list[Msg] | Msg,
-        agent_name: str = "",
-        **kwargs: Any,
-    ) -> dict | None:
-        """Auto-search ADBPG memory before the model call."""
-        del agent_name
-        del kwargs
+    ) -> AutoMemorySearchOptions | None:
+        """Return configured ADBPG automatic recall settings."""
         if self._client is None:
             return None
 
@@ -193,32 +161,10 @@ class ADBPGMemoryManager(BaseMemoryManager):
         search_cfg = getattr(memory_cfg, "auto_memory_search_config", None)
         if not getattr(search_cfg, "enabled", False):
             return None
-
-        msgs = [messages] if isinstance(messages, Msg) else list(messages)
-        query = self._build_query(msgs)
-        if not query:
-            return None
-
-        max_results = max(1, int(getattr(search_cfg, "max_results", 3)))
-        result = await self.memory_search(
-            query=query,
-            max_results=max_results,
-        )
-        text = self._tool_chunk_text(result).strip()
-        if not text or text == "No relevant memories found.":
-            return None
-
-        assistant_msg = self._build_auto_memory_search_msg(
-            query=query,
-            max_results=max_results,
-            text=text,
+        return AutoMemorySearchOptions(
+            max_results=max(1, int(getattr(search_cfg, "max_results", 3))),
             estimate_divisor=estimate_divisor,
         )
-        return {
-            "query": query,
-            "text": text,
-            "msg": msgs + [assistant_msg],
-        }
 
     def _load_auto_search_config(self) -> tuple[Any, float]:
         """Load ADBPG search settings and token estimate configuration."""
@@ -230,35 +176,42 @@ class ADBPGMemoryManager(BaseMemoryManager):
 
     async def auto_memory(
         self,
-        all_messages: list[Msg],
-        **kwargs,
-    ) -> None:
+        messages: list[Msg],
+        **kwargs: Any,
+    ) -> str:
         """Persist new user messages to ADBPG every turn.
 
         ADBPG server-side handles fact extraction, so we persist on every
         turn (interval=1) without filtering by interval config.
         """
+        del kwargs
         if self._client is None:
-            return
+            return ""
 
-        all_messages = self._messages_without_auto_memory_search(all_messages)
+        messages = self._messages_without_auto_memory_search(messages)
 
         # Only persist messages not already sent
         new_messages = [
             msg
-            for msg in all_messages
+            for msg in messages
             if msg.role == "user" and msg.id not in self._persisted_msg_ids
         ]
         if not new_messages:
-            return
+            return ""
 
         user_messages = self._filter_user_messages(new_messages)
-        for single in user_messages:
-            self._schedule_add([single])
-
-        # Track persisted message IDs
-        for msg in new_messages:
+        for msg, single in zip(new_messages, user_messages, strict=True):
+            await self._client.add_memory(
+                messages=[single],
+                user_id=self._effective_user_id,
+                run_id=self._effective_run_id,
+                agent_id=self._effective_agent_id,
+            )
             self._persisted_msg_ids.add(msg.id)
+        return (
+            f"Processed {len(user_messages)} user message(s) "
+            f"to ADBPG for agent '{self.agent_id}'."
+        )
 
     # ------------------------------------------------------------------
     # Tool function
@@ -269,6 +222,7 @@ class ADBPGMemoryManager(BaseMemoryManager):
         query: str,
         max_results: int = 5,
         min_score: float = 0.1,
+        **kwargs: Any,
     ) -> ToolChunk:
         """Search memories from both ADBPG and local memory files.
 
@@ -288,6 +242,7 @@ class ADBPGMemoryManager(BaseMemoryManager):
             `ToolChunk`:
                 Search results with source and content.
         """
+        del kwargs
         parts: list[str] = []
 
         # Source 1: ADBPG semantic search
@@ -313,13 +268,10 @@ class ADBPGMemoryManager(BaseMemoryManager):
 
         # Source 2: Local memory files (keyword match)
         try:
-            loop = asyncio.get_running_loop()
-            local_hits = await loop.run_in_executor(
-                None,
-                lambda: self._search_local_memory_files(
-                    query,
-                    max_results=max(max_results - len(parts), 3),
-                ),
+            local_hits = await run_sync_io(
+                self._search_local_memory_files,
+                query,
+                max_results=max(max_results - len(parts), 3),
             )
             for filepath, snippet in local_hits:
                 idx = len(parts) + 1
@@ -332,7 +284,7 @@ class ADBPGMemoryManager(BaseMemoryManager):
                 is_last=True,
                 state=ToolResultState.SUCCESS,
                 content=[
-                    TextBlock(type="text", text="No relevant memories found."),
+                    TextBlock(type="text", text=NO_RELEVANT_MEMORIES),
                 ],
             )
 
@@ -349,15 +301,6 @@ class ADBPGMemoryManager(BaseMemoryManager):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _tool_chunk_text(chunk: ToolChunk) -> str:
-        parts = []
-        for block in chunk.content or []:
-            text = getattr(block, "text", "")
-            if text:
-                parts.append(str(text))
-        return "\n".join(parts)
-
-    @staticmethod
     def _filter_user_messages(messages: list[Msg]) -> list[dict]:
         """Extract role=user messages for ADBPG storage."""
         return [
@@ -372,30 +315,6 @@ class ADBPGMemoryManager(BaseMemoryManager):
             for msg in messages
             if msg.role == "user"
         ]
-
-    def _schedule_add(self, user_messages: list[dict]) -> None:
-        """Schedule async memory persistence without blocking the reply."""
-        if self._client is None:
-            return
-        agent_id = self._effective_agent_id
-        user_id = self._effective_user_id
-        run_id = self._effective_run_id
-        client = self._client
-
-        async def _do_add() -> None:
-            try:
-                await client.add_memory(
-                    messages=user_messages,
-                    user_id=user_id,
-                    run_id=run_id,
-                    agent_id=agent_id,
-                )
-            except Exception as e:
-                logger.error(f"Background memory add failed: {e}")
-
-        task = asyncio.create_task(_do_add())
-        self._pending_add_tasks.add(task)
-        task.add_done_callback(self._pending_add_tasks.discard)
 
     def _search_local_memory_files(
         self,

--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -8,6 +8,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -28,12 +29,22 @@ from ..utils.registry import Registry
 
 logger = logging.getLogger(__name__)
 MAX_QUERY_CHARS = 50
-SUMMARY_WORKER_CLOSE_TIMEOUT_SECONDS = 5.0
-MAX_SUMMARY_TASK_HISTORY = 100
+AUTO_MEMORY_WORKER_CLOSE_TIMEOUT_SECONDS = 5.0
+MAX_AUTO_MEMORY_TASK_HISTORY = 100
 MAX_RUNTIME_TASK_HISTORY = 20
 MAX_RUNTIME_RESULT_CHARS = 4000
 MAX_RUNTIME_ERROR_CHARS = 240
-SUMMARY_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+AUTO_MEMORY_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+NO_RELEVANT_MEMORIES = "No relevant memories found."
+
+
+@dataclass(frozen=True)
+class AutoMemorySearchOptions:
+    """Backend-independent settings for automatic memory recall."""
+
+    max_results: int = 3
+    estimate_divisor: float = 4.0
+    max_context_bytes: int | None = None
 
 
 class BaseMemoryManager(ABC):
@@ -42,7 +53,7 @@ class BaseMemoryManager(ABC):
     Lifecycle:
         1. Instantiate with ``working_dir`` and ``agent_id``.
         2. ``await start()`` – initialize storage backend.
-        3. Use ``summarize()``, ``memory_search()``, etc. during session.
+        3. Use ``auto_memory()``, ``memory_search()``, etc. during session.
         4. ``await close()`` – flush and release resources.
 
     Attributes:
@@ -55,27 +66,32 @@ class BaseMemoryManager(ABC):
     def __init__(self, working_dir: str, agent_id: str):
         self.working_dir: str = working_dir
         self.agent_id: str = agent_id
-        self._summary_task_info: dict[str, dict[str, Any]] = {}
+        self._auto_memory_task_info: dict[str, dict[str, Any]] = {}
         self._task_counter: int = 0
-        self._task_queue: asyncio.Queue[
+        self._auto_memory_task_queue: asyncio.Queue[
             tuple[str, list[Msg], dict]
         ] = asyncio.Queue()
-        self._worker_task: asyncio.Task | None = None
-        self._worker_stopping = False
+        self._auto_memory_worker_task: asyncio.Task | None = None
+        self._auto_memory_worker_stopping = False
 
     @abstractmethod
     async def start(self) -> None:
         """Initialize the storage backend. Called once after instantiation."""
 
-    @abstractmethod
     async def close(self) -> bool:
-        """Flush pending state and release resources.
+        """Stop shared workers, then release backend-specific resources.
 
         Returns:
             ``True`` if shutdown completed cleanly.
         """
+        if not await self._shutdown_auto_memory_worker():
+            return False
+        return await self._close_backend()
 
-    @abstractmethod
+    async def _close_backend(self) -> bool:
+        """Release backend-specific resources after shared workers stop."""
+        return True
+
     def get_memory_prompt(self) -> str:
         """Return the memory guidance prompt for inclusion
         in the system prompt.
@@ -83,18 +99,24 @@ class BaseMemoryManager(ABC):
         Returns:
             Formatted memory guidance string.
         """
+        return ""
+
+    def list_memory_tools(self) -> list[Callable[..., ToolChunk]]:
+        """Return the standard memory-search tool when it is enabled."""
+        return [self.memory_search] if self.is_memory_search_enabled() else []
+
+    def is_memory_search_enabled(self) -> bool:
+        """Return whether ``memory_search`` is exposed to the agent."""
+        return True
 
     @abstractmethod
-    def list_memory_tools(self) -> list[Callable[..., ToolChunk]]:
-        """Return tool functions exposed to the agent for memory access.
-
-        Each returned callable may have any signature but must return a
-        ``ToolChunk``.  Implementations register whatever memory-related
-        tools make sense for the backend (e.g. semantic search, listing).
-
-        Returns:
-            Ordered list of tool functions to register with the agent toolkit.
-        """
+    async def memory_search(
+        self,
+        query: str,
+        max_results: int = 5,
+        **kwargs: Any,
+    ) -> ToolChunk:
+        """Search long-term memory and return a tool-compatible result."""
 
     def build_middlewares(self) -> list[MiddlewareBase]:
         """Return AgentScope middlewares contributed by this manager.
@@ -105,14 +127,6 @@ class BaseMemoryManager(ABC):
         from ..middlewares import MemoryMiddleware
 
         return [MemoryMiddleware(memory_manager=self)]
-
-    def get_memory_config(self) -> Any:
-        """Return backend-specific memory configuration.
-
-        The shared memory middleware uses this hook for optional lifecycle
-        controls without depending on a concrete backend's config path.
-        """
-        return None
 
     def list_cron_jobs(self) -> list[ServiceCronJob]:
         """Return background jobs contributed by this memory backend.
@@ -138,7 +152,7 @@ class BaseMemoryManager(ABC):
         query: str,
         max_results: int,
         text: str,
-        estimate_divisor: float | None = None,
+        estimate_divisor: float = 4.0,
     ) -> Msg:
         """Build the simulated assistant tool interaction for memory search."""
         tool_call_id = uuid.uuid4().hex
@@ -166,8 +180,6 @@ class BaseMemoryManager(ABC):
             output=[TextBlock(text=text)],
             state=ToolResultState.SUCCESS,
         )
-        if estimate_divisor is None:
-            estimate_divisor = self._get_token_estimate_divisor()
         estimated_input_tokens = sum(
             self._estimate_message_text_tokens(part, estimate_divisor)
             for part in (
@@ -243,47 +255,13 @@ class BaseMemoryManager(ABC):
             return 0
         return int(len(text.encode("utf-8")) / estimate_divisor + 0.5)
 
-    # pylint: disable=unused-argument
-    async def summarize(self, messages: list[Msg], **kwargs) -> str:
-        """Summarize conversation messages and persist to memory.
-
-        NOTE: This method is optional. Subclasses may override this method
-        to implement actual summarization. Base implementation returns empty
-        string, indicating no summarization support.
-
-        Args:
-            messages: Ordered conversation messages to summarize.
-            **kwargs: Implementation-specific options.
-
-        Returns:
-            Summary string, or empty string if not implemented.
-        """
-        return ""
-
-    # pylint: disable=unused-argument
-    async def dream(self, **kwargs) -> None:
-        """Optimize memory files via a background agent pass.
-
-        NOTE: This method is optional. Subclasses may override this method
-        to implement actual memory optimization. Base implementation does
-        nothing, indicating no dream support.
-
-        Runs a lightweight ReAct agent with file-editing tools to
-        consolidate redundant or outdated memory entries.
-        """
-        return None
-
-    async def reme_status(self) -> Any | None:
-        """Return ReMe runtime status when supported by the backend."""
-        return None
-
-    async def graph_snapshot(self) -> Any | None:
-        """Return a frontend-ready memory graph when supported."""
-        return None
-
-    async def rebuild_index(self, scope: str = "all") -> Any | None:
-        """Rebuild the memory search index when supported by the backend."""
-        return None
+    @abstractmethod
+    async def auto_memory(
+        self,
+        messages: list[Msg],
+        **kwargs: Any,
+    ) -> str:
+        """Extract and persist memory for one prepared message batch."""
 
     async def auto_memory_search(
         self,
@@ -291,10 +269,7 @@ class BaseMemoryManager(ABC):
         agent_name: str = "",
         **kwargs,
     ) -> dict | None:
-        """Auto-search memory before replying (pre_reply phase).
-
-        Implementations should check internal config to decide whether
-        auto search is enabled, and if so, retrieve relevant memory context.
+        """Auto-search memory before replying using the common recall flow.
 
         Args:
             messages: The incoming user message(s).
@@ -304,7 +279,73 @@ class BaseMemoryManager(ABC):
             None if auto-search is disabled or no relevant memory found.
             dict with updated kwargs if memory context should be merged.
         """
+        del agent_name, kwargs
+        options = await self.get_auto_memory_search_options()
+        if options is None:
+            return None
+
+        msgs = [messages] if isinstance(messages, Msg) else list(messages)
+        query = self._build_query(msgs)
+        if not query:
+            return None
+
+        max_results = max(1, int(options.max_results))
+        result = await self._search_for_auto_memory(
+            query=query,
+            options=options,
+        )
+        if result.state != ToolResultState.SUCCESS:
+            return None
+        text = self._tool_chunk_text(result).strip()
+        if self._is_empty_memory_search_result(text):
+            return None
+
+        assistant_msg = self._build_auto_memory_search_msg(
+            query=query,
+            max_results=max_results,
+            text=text,
+            estimate_divisor=options.estimate_divisor,
+        )
+        return {
+            "query": query,
+            "text": text,
+            "msg": msgs + [assistant_msg],
+        }
+
+    async def get_auto_memory_search_options(
+        self,
+    ) -> AutoMemorySearchOptions | None:
+        """Return auto-search settings, or ``None`` when it is disabled."""
         return None
+
+    async def _search_for_auto_memory(
+        self,
+        *,
+        query: str,
+        options: AutoMemorySearchOptions,
+    ) -> ToolChunk:
+        """Run the backend search used by automatic recall."""
+        return await self.memory_search(
+            query=query,
+            max_results=max(1, int(options.max_results)),
+        )
+
+    @staticmethod
+    def _tool_chunk_text(chunk: ToolChunk) -> str:
+        """Extract all textual content from a tool result."""
+        return "\n".join(
+            str(getattr(block, "text", ""))
+            for block in chunk.content or []
+            if getattr(block, "text", "")
+        )
+
+    @staticmethod
+    def _is_empty_memory_search_result(text: str) -> bool:
+        """Return whether a successful search contains no usable recall."""
+        return not text or text in {
+            NO_RELEVANT_MEMORIES,
+            "(no memory results)",
+        }
 
     @staticmethod
     def _build_query(messages: list[Msg]) -> str:
@@ -315,22 +356,6 @@ class BaseMemoryManager(ABC):
             if text:
                 return text[:MAX_QUERY_CHARS]
         return ""
-
-    async def auto_memory(
-        self,
-        all_messages: list[Msg],
-        **kwargs,
-    ) -> None:
-        """Periodically auto-extract memory from conversation.
-
-        Called during post_reply. Implementations should check internal
-        config (e.g. auto_memory_interval) and trigger memory extraction
-        at the configured cadence.
-
-        Args:
-            all_messages: All conversation messages.
-        """
-        return None
 
     @classmethod
     def _messages_without_auto_memory_search(
@@ -376,54 +401,93 @@ class BaseMemoryManager(ABC):
             sanitized.metadata.pop(AUTO_MEMORY_SEARCH_BLOCK_IDS_KEY, None)
         return sanitized
 
-    async def _summarize_worker(self) -> None:
-        """Background worker that processes summarize tasks serially."""
-        while not self._worker_stopping:
-            task_id, messages, kwargs = await self._task_queue.get()
-            if self._worker_stopping:
-                return
-            info = self._summary_task_info.get(task_id)
-            if info is None:
-                continue
-
-            info["status"] = "running"
-            logger.info(f"Summary task {task_id} started")
+    async def _auto_memory_worker(self) -> None:
+        """Process queued auto-memory tasks serially."""
+        while True:
+            (
+                task_id,
+                messages,
+                kwargs,
+            ) = await self._auto_memory_task_queue.get()
             try:
-                result = await self.summarize(messages=messages, **kwargs)
-                info["status"] = "completed"
-                info["result"] = result
-                logger.info(f"Summary task {task_id} completed")
-            except asyncio.CancelledError:
-                info["status"] = "cancelled"
-                logger.info(f"Summary task {task_id} cancelled")
-                raise
-            except BaseException as e:
-                info["status"] = "failed"
-                info["error"] = str(e)
-                logger.error(f"Summary task {task_id} failed: {e}")
-            finally:
-                info["finished_at"] = datetime.now(timezone.utc)
-                self._prune_summary_task_info()
+                info = self._auto_memory_task_info.get(task_id)
+                if info is None:
+                    continue
 
-    async def _shutdown_summarize_worker(
+                info["status"] = "running"
+                logger.info("Auto-memory task %s started", task_id)
+                try:
+                    result = await self.auto_memory(
+                        messages=messages,
+                        **kwargs,
+                    )
+                    info["status"] = "completed"
+                    info["result"] = result
+                    logger.info("Auto-memory task %s completed", task_id)
+                except asyncio.CancelledError:
+                    info["status"] = "cancelled"
+                    logger.info("Auto-memory task %s cancelled", task_id)
+                    raise
+                except Exception as e:
+                    info["status"] = "failed"
+                    info["error"] = str(e)
+                    logger.error("Auto-memory task %s failed: %s", task_id, e)
+                finally:
+                    info["finished_at"] = datetime.now(timezone.utc)
+                    self._prune_auto_memory_task_info()
+            finally:
+                self._auto_memory_task_queue.task_done()
+
+            if (
+                self._auto_memory_worker_stopping
+                and self._auto_memory_task_queue.empty()
+            ):
+                return
+
+    async def _shutdown_auto_memory_worker(
         self,
-        timeout: float = SUMMARY_WORKER_CLOSE_TIMEOUT_SECONDS,
+        timeout: float = AUTO_MEMORY_WORKER_CLOSE_TIMEOUT_SECONDS,
     ) -> bool:
-        """Stop the summary worker without allowing shutdown to hang.
+        """Stop the auto-memory worker without allowing shutdown to hang.
 
         The stopping flag is required in addition to ``Task.cancel()``:
         cancellation may be consumed by a nested model/job call. In that
-        case the worker exits after the current summarize call returns rather
+        case the worker exits after the current auto-memory call returns rather
         than looping back to an empty queue forever.
         """
-        self._worker_stopping = True
-        worker = self._worker_task
+        self._auto_memory_worker_stopping = True
+        worker = self._auto_memory_worker_task
         if worker is None:
             return True
 
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        queue_drained = asyncio.create_task(
+            self._auto_memory_task_queue.join(),
+        )
+        done, _pending = await asyncio.wait(
+            {queue_drained},
+            timeout=max(0.0, deadline - loop.time()),
+        )
+        if not done:
+            queue_drained.cancel()
+            await asyncio.gather(queue_drained, return_exceptions=True)
+            logger.warning(
+                "Auto-memory queue did not drain within %.1fs; "
+                "cancelling remaining work: agent_id=%s",
+                timeout,
+                self.agent_id,
+            )
+
         if not worker.done():
             worker.cancel()
-            done, _pending = await asyncio.wait({worker}, timeout=timeout)
+            # Give cancellation an event-loop turn even when draining used the
+            # complete timeout budget.
+            await asyncio.sleep(0)
+            done, _pending = await asyncio.wait(
+                {worker},
+                timeout=max(0.0, deadline - loop.time()),
+            )
             if not done:
                 # A second cancellation handles the common case where the
                 # first one was swallowed and the worker has since reached
@@ -431,90 +495,128 @@ class BaseMemoryManager(ABC):
                 # bound: a coroutine is allowed to suppress cancellation.
                 worker.cancel()
                 logger.error(
-                    "Summary worker did not stop within %.1fs: agent_id=%s",
+                    "Auto-memory worker did not stop within %.1fs: "
+                    "agent_id=%s",
                     timeout,
                     self.agent_id,
                 )
                 return False
 
-        self._worker_task = None
+        while not self._auto_memory_task_queue.empty():
+            try:
+                (
+                    task_id,
+                    _messages,
+                    _kwargs,
+                ) = self._auto_memory_task_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            info = self._auto_memory_task_info.get(task_id)
+            if info is not None and info.get("status") == "pending":
+                info["status"] = "cancelled"
+                info["finished_at"] = datetime.now(timezone.utc)
+            self._auto_memory_task_queue.task_done()
+
+        self._auto_memory_worker_task = None
+        self._prune_auto_memory_task_info()
         return True
 
-    def add_summarize_task(self, messages: list[Msg], **kwargs):
-        """Schedule a background summarization task without blocking.
+    def submit_auto_memory(
+        self,
+        messages: list[Msg],
+        *,
+        trigger: str = "manual",
+        **kwargs: Any,
+    ) -> str:
+        """Submit an auto-memory task without blocking and return its ID.
 
         Tasks are executed serially in FIFO order. If no task is running,
         execution starts immediately; otherwise the task queues.
 
         Args:
-            messages: Messages to pass to ``summarize()``.
-            **kwargs: Forwarded to ``summarize()``.
+            messages: Messages to pass to ``auto_memory()``.
+            **kwargs: Forwarded to ``auto_memory()``.
         """
+        if self._auto_memory_worker_stopping:
+            raise RuntimeError("Auto-memory worker is shutting down")
+
         # Ensure worker is running
-        self._worker_stopping = False
-        if self._worker_task is None or self._worker_task.done():
-            self._worker_task = asyncio.create_task(self._summarize_worker())
+        if (
+            self._auto_memory_worker_task is None
+            or self._auto_memory_worker_task.done()
+        ):
+            self._auto_memory_worker_task = asyncio.create_task(
+                self._auto_memory_worker(),
+            )
 
         self._task_counter += 1
         task_id = f"task_{self._task_counter}"
 
-        self._summary_task_info[task_id] = {
+        self._auto_memory_task_info[task_id] = {
             "task_id": task_id,
             "start_time": datetime.now(timezone.utc),
             "status": "pending",
             "message_count": len(messages),
+            "trigger": trigger,
             "result": None,
             "error": None,
             "finished_at": None,
         }
 
         # Enqueue for serial execution
-        self._task_queue.put_nowait((task_id, messages, kwargs))
+        self._auto_memory_task_queue.put_nowait((task_id, messages, kwargs))
+        return task_id
 
-    def _prune_summary_task_info(self) -> None:
+    def _prune_auto_memory_task_info(self) -> None:
         """Keep active tasks and only the latest terminal task history."""
         terminal_ids = [
             task_id
-            for task_id, info in self._summary_task_info.items()
-            if info["status"] in SUMMARY_TERMINAL_STATUSES
+            for task_id, info in self._auto_memory_task_info.items()
+            if info["status"] in AUTO_MEMORY_TERMINAL_STATUSES
         ]
-        for task_id in terminal_ids[:-MAX_SUMMARY_TASK_HISTORY]:
-            self._summary_task_info.pop(task_id, None)
+        for task_id in terminal_ids[:-MAX_AUTO_MEMORY_TASK_HISTORY]:
+            self._auto_memory_task_info.pop(task_id, None)
 
     def _update_task_statuses(self) -> None:
         """Update status for pending/running tasks if worker was cancelled."""
-        if self._worker_task is None:
+        if self._auto_memory_worker_task is None:
             return
-        if not self._worker_task.done():
+        if not self._auto_memory_worker_task.done():
             return
 
         # Worker finished - update any running tasks
-        for task_id, info in self._summary_task_info.items():
+        for task_id, info in self._auto_memory_task_info.items():
             if info["status"] == "running":
-                if self._worker_task.cancelled():
+                if self._auto_memory_worker_task.cancelled():
                     info["status"] = "cancelled"
                     info["finished_at"] = datetime.now(timezone.utc)
                     logger.info(
-                        f"Summary task {task_id} cancelled (worker stopped)",
+                        "Auto-memory task %s cancelled (worker stopped)",
+                        task_id,
                     )
                 else:
-                    exc = self._worker_task.exception()
+                    exc = self._auto_memory_worker_task.exception()
                     if exc is not None:
                         info["status"] = "failed"
                         info["error"] = str(exc)
                         info["finished_at"] = datetime.now(timezone.utc)
-                        logger.error(f"Summary task {task_id} failed: {exc}")
-        self._prune_summary_task_info()
+                        logger.error(
+                            "Auto-memory task %s failed: %s",
+                            task_id,
+                            exc,
+                        )
+        self._prune_auto_memory_task_info()
 
-    def list_summarize_status(self) -> list[dict]:
-        """Return status of all summary tasks as list of dicts.
+    def list_auto_memory_tasks(self) -> list[dict]:
+        """Return the status of all queued auto-memory tasks.
 
         Each dict contains:
             - task_id: Unique identifier
             - start_time: When the task was enqueued
+            - trigger: Why the task was submitted
             - status: "pending", "running", "completed",
                 "failed", or "cancelled"
-            - result: Summary result (if completed)
+            - result: Auto-memory result (if completed)
             - error: Error message (if failed)
 
         Returns:
@@ -523,12 +625,13 @@ class BaseMemoryManager(ABC):
         self._update_task_statuses()
 
         result = []
-        for _task_id, info in self._summary_task_info.items():
+        for _task_id, info in self._auto_memory_task_info.items():
             result.append(
                 {
                     "task_id": info["task_id"],
                     "start_time": info["start_time"].isoformat(),
                     "status": info["status"],
+                    "trigger": info.get("trigger", "manual"),
                     "result": info["result"],
                     "error": info["error"],
                 },
@@ -542,16 +645,16 @@ class BaseMemoryManager(ABC):
     ) -> dict[str, Any]:
         """Return a sanitized operational snapshot for status UIs.
 
-        Memory-capture history includes the same bounded result text used for
-        inbox notifications. The shared summarize queue contains periodic
+        Auto-memory history includes the same bounded result text used for
+        inbox notifications. The shared auto-memory queue contains periodic
         auto-memory work as well as user-triggered ``/new`` and ``/compact``
-        captures, so callers must not present every record as auto-memory.
+        work, so callers must preserve each task's trigger context.
         It deliberately excludes messages, session identifiers, and task
         kwargs.
         """
         self._update_task_statuses()
 
-        task_infos = list(self._summary_task_info.values())
+        task_infos = list(self._auto_memory_task_info.values())
         pending_tasks = sum(
             info.get("status") == "pending" for info in task_infos
         )
@@ -559,8 +662,8 @@ class BaseMemoryManager(ABC):
             info.get("status") == "running" for info in task_infos
         )
 
-        worker = self._worker_task
-        if self._worker_stopping:
+        worker = self._auto_memory_worker_task
+        if self._auto_memory_worker_stopping:
             worker_status = "stopping"
         elif running_tasks:
             worker_status = "busy"
@@ -589,9 +692,11 @@ class BaseMemoryManager(ABC):
         interval = max(
             0,
             int(
-                self.get_auto_memory_interval()
-                if auto_memory_interval is None
-                else auto_memory_interval,
+                (
+                    self.get_auto_memory_interval()
+                    if auto_memory_interval is None
+                    else auto_memory_interval
+                ),
             ),
         )
 
@@ -626,6 +731,7 @@ class BaseMemoryManager(ABC):
                         0,
                         int(info.get("message_count") or 0),
                     ),
+                    "trigger": str(info.get("trigger") or "manual"),
                     "result": _bounded_text(
                         info.get("result"),
                         MAX_RUNTIME_RESULT_CHARS,
@@ -640,7 +746,7 @@ class BaseMemoryManager(ABC):
         return {
             "worker": {
                 "status": worker_status,
-                "queue_pending": self._task_queue.qsize(),
+                "queue_pending": self._auto_memory_task_queue.qsize(),
                 "tasks_running": running_tasks,
             },
             "auto_memory": {

--- a/src/qwenpaw/agents/memory/dummy.py
+++ b/src/qwenpaw/agents/memory/dummy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """No-op memory manager – disables all memory functionality."""
-from collections.abc import Callable
 
+from agentscope.message import Msg
 from agentscope.middleware import MiddlewareBase
 from agentscope.tool import ToolChunk
 
@@ -21,17 +21,32 @@ class NoopMemoryManager(BaseMemoryManager):
     async def start(self) -> None:
         """No-op: nothing to initialize."""
 
-    async def close(self) -> bool:
-        """No-op: nothing to release."""
-        return True
-
     def get_memory_prompt(self) -> str:
         """Return empty prompt – no memory guidance needed."""
         return ""
 
-    def list_memory_tools(self) -> list[Callable[..., ToolChunk]]:
-        """Return empty list – no memory tools exposed."""
-        return []
+    def is_memory_search_enabled(self) -> bool:
+        """Return false because the disabled backend exposes no tools."""
+        return False
+
+    async def memory_search(
+        self,
+        query: str,
+        max_results: int = 5,
+        **kwargs,
+    ) -> ToolChunk:
+        """Reject searches against the disabled backend."""
+        del query, max_results, kwargs
+        raise RuntimeError("Memory manager is disabled")
+
+    async def auto_memory(
+        self,
+        messages: list[Msg],
+        **kwargs,
+    ) -> str:
+        """Discard auto-memory requests for the disabled backend."""
+        del messages, kwargs
+        return ""
 
     def build_middlewares(self) -> list[MiddlewareBase]:
         """Return empty list – no memory middlewares."""

--- a/src/qwenpaw/agents/memory/powercontext_memory_manager.py
+++ b/src/qwenpaw/agents/memory/powercontext_memory_manager.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from functools import wraps
@@ -14,7 +13,13 @@ from agentscope.tool import ToolChunk
 
 from ...config.config import PowerContextMemoryConfig, load_agent_config
 from ...config.utils import get_or_create_powercontext_installation_id
-from .base_memory_manager import BaseMemoryManager, memory_registry
+from ...utils.io_utils import run_sync_io
+from .base_memory_manager import (
+    AutoMemorySearchOptions,
+    BaseMemoryManager,
+    NO_RELEVANT_MEMORIES,
+    memory_registry,
+)
 from .powercontext_client import (
     MAX_MEMORY_TEXT_BYTES,
     TRUNCATION_MARKER,
@@ -41,7 +46,6 @@ class PowerContextMemoryManager(BaseMemoryManager):
         self._client: PowerContextMemoryClient | None = None
         self._config: PowerContextMemoryConfig | None = None
         self._resolved_scope_id = ""
-        self._pending: set[asyncio.Task[None]] = set()
 
     async def start(self) -> None:
         cfg = load_agent_config(
@@ -74,15 +78,8 @@ class PowerContextMemoryManager(BaseMemoryManager):
             self._client = None
             self._resolved_scope_id = ""
 
-    async def close(self) -> bool:
-        # ``/new`` and ``/compact`` can start the inherited summarize worker.
-        # Stop it before draining writes: otherwise it could schedule a new
-        # remote write while this method is closing the HTTP client.
-        if not await self._shutdown_summarize_worker():
-            return False
-        if self._pending:
-            await asyncio.gather(*self._pending, return_exceptions=True)
-            self._pending.clear()
+    async def _close_backend(self) -> bool:
+        """Close the remote client after shared auto-memory work stops."""
         client, self._client = self._client, None
         self._resolved_scope_id = ""
         if client is None:
@@ -101,11 +98,6 @@ class PowerContextMemoryManager(BaseMemoryManager):
                 ),
             )
             return False
-
-    def get_memory_config(self) -> Any:
-        return load_agent_config(
-            self.agent_id,
-        ).running.powercontext_memory_config
 
     def get_memory_prompt(self) -> str:
         if self._client is None:
@@ -144,101 +136,110 @@ class PowerContextMemoryManager(BaseMemoryManager):
     def get_auto_memory_interval(self) -> int:
         return 1 if self._client is not None else 0
 
-    async def auto_memory_search(
+    async def get_auto_memory_search_options(
         self,
-        messages: list[Msg] | Msg,
-        agent_name: str = "",
-        **kwargs: Any,
-    ) -> dict | None:
-        del agent_name
-        del kwargs
-        if self._client is None or not getattr(
-            self._config.auto_memory_search_config,
-            "enabled",
-            True,
+    ) -> AutoMemorySearchOptions | None:
+        """Return configured PowerContext automatic recall settings."""
+        config = self._config
+        if (
+            self._client is None
+            or config is None
+            or not getattr(
+                config.auto_memory_search_config,
+                "enabled",
+                True,
+            )
         ):
             return None
-        msgs = [messages] if isinstance(messages, Msg) else list(messages)
-        query = self._build_query(msgs)
-        if not query:
-            return None
-        max_results = getattr(
-            self._config.auto_memory_search_config,
-            "max_results",
-            3,
+        search_config = config.auto_memory_search_config
+        return AutoMemorySearchOptions(
+            max_results=max(
+                1,
+                int(getattr(search_config, "max_results", 3)),
+            ),
+            estimate_divisor=await run_sync_io(
+                self._get_token_estimate_divisor,
+            ),
+            max_context_bytes=max(
+                0,
+                int(
+                    getattr(
+                        search_config,
+                        "max_context_bytes",
+                        DEFAULT_MAX_CONTEXT_BYTES,
+                    ),
+                ),
+            ),
         )
-        max_context_bytes = getattr(
-            self._config.auto_memory_search_config,
-            "max_context_bytes",
-            DEFAULT_MAX_CONTEXT_BYTES,
+
+    async def _search_for_auto_memory(
+        self,
+        *,
+        query: str,
+        options: AutoMemorySearchOptions,
+    ) -> ToolChunk:
+        """Search within PowerContext's complete synthetic-message budget."""
+        max_results = max(1, int(options.max_results))
+        max_context_bytes = (
+            DEFAULT_MAX_CONTEXT_BYTES
+            if options.max_context_bytes is None
+            else options.max_context_bytes
         )
-        result = await self._search_memories(
+        return await self._search_memories(
             query,
             max_results,
             max_context_bytes=self._auto_search_result_budget(
                 query=query,
                 max_results=max_results,
                 max_context_bytes=max_context_bytes,
+                estimate_divisor=options.estimate_divisor,
             ),
         )
-        if result.state != ToolResultState.SUCCESS:
-            return None
-        text = self._chunk_text(result)
-        if not text or text == "No relevant memories found.":
-            return None
-        return {
-            "query": query,
-            "text": text,
-            "msg": msgs
-            + [
-                self._build_auto_memory_search_msg(
-                    query=query,
-                    max_results=max_results,
-                    text=text,
-                ),
-            ],
-        }
 
     async def auto_memory(
         self,
-        all_messages: list[Msg],
+        messages: list[Msg],
         **kwargs: Any,
-    ) -> None:
+    ) -> str:
         del kwargs
         if self._client is None:
-            return
-        all_messages = self._messages_without_auto_memory_search(all_messages)
+            return ""
+        messages = self._messages_without_auto_memory_search(messages)
         user = [
             m.get_text_content().strip()
-            for m in all_messages
+            for m in messages
             if m.role == "user" and m.get_text_content().strip()
         ]
         assistant = [
             m.get_text_content().strip()
-            for m in all_messages
+            for m in messages
             if m.role == "assistant" and m.get_text_content().strip()
         ]
         if not user:
-            return
+            return ""
         text = "用户目标/输入:\n" + "\n".join(user[-3:])
         if assistant:
             text += "\n\nAgent结果:\n" + "\n".join(assistant[-2:])
-        self._schedule_remember(
-            "task_state",
-            truncate_utf8_text(text, marker=TRUNCATION_MARKER),
-        )
-
-    async def summarize(self, messages: list[Msg], **kwargs: Any) -> str:
-        await self.auto_memory(messages, **kwargs)
-        return ""
+        try:
+            await self._client.remember(
+                kind="task_state",
+                text=truncate_utf8_text(text, marker=TRUNCATION_MARKER),
+            )
+        except Exception as exc:
+            # The shared worker records and logs the raised exception. Ensure
+            # backend credentials cannot be copied into either surface.
+            raise RuntimeError(self._safe_exception_summary(exc)) from exc
+        return "Saved auto-memory to PowerContext."
 
     async def memory_search(
         self,
         query: str,
         max_results: int = 5,
         min_score: float = 0.0,
+        **kwargs: Any,
     ) -> ToolChunk:
         """Search PowerContext memories and include their exact Citation."""
+        del kwargs
         return await self._search_memories(
             query,
             max_results,
@@ -317,7 +318,7 @@ class PowerContextMemoryManager(BaseMemoryManager):
         rendered_result = (
             POWERCONTEXT_UNTRUSTED_HISTORY_NOTICE + "\n\n" + "\n\n".join(parts)
             if parts
-            else "No relevant memories found."
+            else NO_RELEVANT_MEMORIES
         )
         if (
             was_truncated
@@ -437,40 +438,11 @@ class PowerContextMemoryManager(BaseMemoryManager):
             content=[TextBlock(type="text", text=text)],
         )
 
-    def _schedule_remember(self, kind: str, text: str) -> None:
-        client = self._client
-        if client is None:
-            return
-
-        async def write() -> None:
-            try:
-                await client.remember(kind=kind, text=text)
-            except Exception as exc:
-                token = str(
-                    getattr(getattr(client, "config", None), "token", ""),
-                )
-                logger.warning(
-                    "PowerContext memory write failed: %s",
-                    safe_powercontext_exception_summary(exc, token=token),
-                )
-
-        task = asyncio.create_task(write())
-        self._pending.add(task)
-        task.add_done_callback(self._pending.discard)
-
     def _safe_exception_summary(self, exc: BaseException) -> str:
         token = str(
             getattr(getattr(self._client, "config", None), "token", ""),
         )
         return safe_powercontext_exception_summary(exc, token=token)
-
-    @staticmethod
-    def _chunk_text(chunk: ToolChunk) -> str:
-        return "\n".join(
-            str(getattr(block, "text", ""))
-            for block in chunk.content or []
-            if getattr(block, "text", "")
-        )
 
     def _auto_search_result_budget(
         self,
@@ -478,12 +450,14 @@ class PowerContextMemoryManager(BaseMemoryManager):
         query: str,
         max_results: int,
         max_context_bytes: int,
+        estimate_divisor: float = 4.0,
     ) -> int:
         """Reserve bytes for synthetic tool metadata before retrieval text."""
         message = self._build_auto_memory_search_msg(
             query=query,
             max_results=max_results,
             text="",
+            estimate_divisor=estimate_divisor,
         )
         overhead = 0
         for block in message.content:

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -7,16 +7,31 @@ ReMe's application/job framework.
 """
 
 import asyncio
+from copy import deepcopy
 import hashlib
 import logging
 import os
 from contextlib import asynccontextmanager
+from functools import partial
 from typing import Any, TYPE_CHECKING
 
 from agentscope.message import Msg, TextBlock, ToolResultState
 from agentscope.tool import ToolChunk
+from jsonschema.exceptions import SchemaError, best_match
+from jsonschema.validators import validator_for
 
-from .base_memory_manager import BaseMemoryManager, memory_registry
+from .action_provider import (
+    MemoryActionProvider,
+    MemoryActionResponse,
+    MemoryActionResult,
+    MemoryActionSpec,
+)
+from .base_memory_manager import (
+    AUTO_MEMORY_WORKER_CLOSE_TIMEOUT_SECONDS,
+    AutoMemorySearchOptions,
+    BaseMemoryManager,
+    memory_registry,
+)
 from .embedding_model import EmbeddingTestResult
 from .prompts import build_memory_guidance_prompt
 from .reme_config import get_reme_app_config
@@ -72,7 +87,61 @@ os.environ.setdefault("REME_DISABLE_LOGURU", "true")
 NO_MEMORY_RESULTS = "(no memory results)"
 INBOX_RESULT_HOOK_KEY = "qwenpaw_memory_result_hook"
 _REME_SESSION_ID_HASH_PREFIX = "qpsid_sha256_"
+_REME_LLM_ACTIONS = frozenset(
+    {"auto_dream", "auto_memory", "daily_paper", "auto_fin"},
+)
+_HOST_MEMORY_ACTIONS: dict[str, MemoryActionSpec] = {
+    "undo_reindex": {
+        "description": (
+            "Restore the embedding configuration associated with the "
+            "current index."
+        ),
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
 _REQUIRED_REME_VERSION = "0.4.1.11"
+
+
+def _consume_detached_task_result(task: asyncio.Task[Any]) -> None:
+    """Consume a timed-out lifecycle task once cancellation finishes."""
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        pass
+
+
+def _validate_reme_action_kwargs(
+    action: str,
+    parameters: dict[str, Any],
+    kwargs: dict[str, Any],
+) -> None:
+    """Validate action arguments against the job's public JSON Schema."""
+    schema = deepcopy(parameters)
+    schema.setdefault("type", "object")
+    # Memory actions have a strict keyword-only boundary even when a ReMe job
+    # omits JSON Schema's permissive additionalProperties default.
+    schema.setdefault("additionalProperties", False)
+    validator_type = validator_for(schema)
+    try:
+        validator_type.check_schema(schema)
+    except SchemaError as exc:
+        raise RuntimeError(
+            f"Memory action '{action}' exposes an invalid JSON Schema: "
+            f"{exc.message}",
+        ) from exc
+
+    error = best_match(validator_type(schema).iter_errors(kwargs))
+    if error is None:
+        return
+    location = "".join(f"[{part!r}]" for part in error.absolute_path)
+    if location:
+        location = f" at {location}"
+    raise ValueError(
+        f"Invalid arguments for memory action '{action}'{location}: "
+        f"{error.message}",
+    )
 
 
 class _ReMeContractError(RuntimeError):
@@ -141,7 +210,7 @@ def _tool_chunk(text: str, *, ok: bool = True) -> ToolChunk:
 
 @memory_registry.register("remelight")
 # pylint: disable-next=too-many-public-methods
-class ReMeLightMemoryManager(BaseMemoryManager):
+class ReMeLightMemoryManager(BaseMemoryManager, MemoryActionProvider):
     """Memory manager backed by ReMe.
 
     ReMe uses the QwenPaw workspace root as its vault.  Daily memory,
@@ -227,18 +296,55 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             return
 
     async def close(self) -> bool:
-        """Close ReMe and clean up background summary worker state."""
-        async with self._exclusive_reme_lifecycle("close"):
-            return await self._close_reme_unlocked()
+        """Close the worker and ReMe within one shared deadline."""
+        loop = asyncio.get_running_loop()
+        timeout = AUTO_MEMORY_WORKER_CLOSE_TIMEOUT_SECONDS
+        deadline = loop.time() + timeout
 
-    async def _close_reme_unlocked(self) -> bool:
+        # The worker may itself hold a ReMe lease. Stop it before waiting for
+        # all leases, otherwise close could wait forever before reaching the
+        # worker's bounded shutdown path.
+        if not await self._shutdown_auto_memory_worker(timeout=timeout):
+            return False
+
+        async def close_reme() -> bool:
+            async with self._exclusive_reme_lifecycle("close"):
+                return await self._close_reme_unlocked(
+                    shutdown_worker=False,
+                )
+
+        close_task = asyncio.create_task(close_reme())
+        done, _pending = await asyncio.wait(
+            {close_task},
+            timeout=max(0.0, deadline - loop.time()),
+        )
+        if not done:
+            close_task.cancel()
+            close_task.add_done_callback(_consume_detached_task_result)
+            logger.error(
+                "ReMe did not close within %.1fs: agent_id=%s",
+                timeout,
+                self.agent_id,
+            )
+            return False
+        return close_task.result()
+
+    async def _close_reme_unlocked(
+        self,
+        *,
+        shutdown_worker: bool = True,
+    ) -> bool:
         """Close ReMe after the caller has quiesced all ReMe jobs."""
         logger.info(
             "ReMeLightMemoryManager closing: agent_id=%s",
             self.agent_id,
         )
 
-        worker_stopped = await self._shutdown_summarize_worker()
+        worker_stopped = True
+        if shutdown_worker:
+            worker_stopped = await self._shutdown_auto_memory_worker()
+            if not worker_stopped:
+                return False
 
         if self._reme is not None:
             try:
@@ -294,7 +400,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             digest_dir=getattr(cfg, "digest_dir", "digest"),
         )
 
-    def get_memory_config(self) -> Any:
+    def _load_memory_config(self) -> Any:
         """Return ReMe Light memory configuration."""
         agent_config = load_agent_config(self.agent_id)
         return agent_config.running.reme_light_memory_config
@@ -304,14 +410,17 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if self._reme is None or not getattr(self._reme, "is_started", False):
             return []
 
-        cfg = self.get_memory_config()
+        cfg = self._load_memory_config()
         jobs: list[ServiceCronJob] = []
         if cfg.dream_cron_enabled and cfg.dream_cron:
             jobs.append(
                 ServiceCronJob(
                     key="dream",
                     cron=cfg.dream_cron,
-                    callback=self.dream,
+                    callback=partial(
+                        self._run_scheduled_action,
+                        "auto_dream",
+                    ),
                     misfire_grace_seconds=600,
                     jitter_seconds=60,
                 ),
@@ -322,7 +431,10 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 ServiceCronJob(
                     key="daily-paper",
                     cron=cfg.daily_paper_cron,
-                    callback=self.daily_paper,
+                    callback=partial(
+                        self._run_scheduled_action,
+                        "daily_paper",
+                    ),
                     misfire_grace_seconds=600,
                 ),
             )
@@ -331,17 +443,18 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 ServiceCronJob(
                     key="auto-fin",
                     cron=cfg.auto_fin_cron,
-                    callback=self.auto_fin,
+                    callback=partial(
+                        self._run_scheduled_action,
+                        "auto_fin",
+                    ),
                     misfire_grace_seconds=600,
                 ),
             )
         return jobs
 
-    def list_memory_tools(self):
-        """Return memory tool functions to register with the agent toolkit."""
-        if not self.get_memory_config().memory_search_enabled:
-            return []
-        return [self.memory_search]
+    def is_memory_search_enabled(self) -> bool:
+        """Return whether the agent-facing search tool is enabled."""
+        return bool(self._load_memory_config().memory_search_enabled)
 
     def get_auto_memory_interval(self) -> int:
         """Return ReMe light auto-memory cadence from agent config."""
@@ -352,6 +465,22 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if interval is None:
             return 0
         return int(interval)
+
+    async def get_auto_memory_search_options(
+        self,
+    ) -> AutoMemorySearchOptions | None:
+        """Return configured ReMe automatic recall settings."""
+        agent_config = await load_agent_config_async(self.agent_id)
+        memory_config = agent_config.running.reme_light_memory_config
+        search_config = memory_config.auto_memory_search_config
+        if not search_config.enabled:
+            return None
+        return AutoMemorySearchOptions(
+            max_results=max(1, int(search_config.max_results)),
+            estimate_divisor=self._resolve_token_estimate_divisor(
+                agent_config,
+            ),
+        )
 
     async def _update_qwenpaw_model(self) -> None:
         """Reuse QwenPaw's active model in ReMe's default LLM component."""
@@ -382,8 +511,9 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
     async def _reload_embedding_config_unlocked(self) -> bool:
         """Recreate embedded ReMe while the caller owns the lifecycle lock."""
-        await self._close_reme_unlocked()
-        self._worker_stopping = False
+        if not await self._close_reme_unlocked():
+            return False
+        self._auto_memory_worker_stopping = False
         await run_sync_io(self._initialize_reme)
         await self.start()
         self._tested_embedding = None
@@ -517,7 +647,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
     ) -> bool:
         if name not in RESULT_JOB_NAMES:
             return False
-        memory_config = await run_sync_io(self.get_memory_config)
+        memory_config = await run_sync_io(self._load_memory_config)
         return await emit_job_result(
             agent_id=self.agent_id,
             memory_config=memory_config,
@@ -540,6 +670,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         query: str,
         max_results: int = 5,
         min_score: float = 0,
+        **kwargs: Any,
     ) -> ToolChunk:
         """Search memory files semantically.
 
@@ -567,6 +698,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 Search results formatted with paths, line numbers, and
                 content.
         """
+        del kwargs
         query = query.strip()
         if not query:
             return _tool_chunk("Error: query cannot be empty", ok=False)
@@ -673,7 +805,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
     ) -> list[int] | None:
         return await call_reranker_api(query, documents, config)
 
-    async def summarize(
+    async def auto_memory(
         self,
         messages: list[Msg],
         **kwargs: Any,
@@ -681,11 +813,14 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         """Persist conversation messages through ReMe auto-memory."""
         if not messages:
             return ""
+        messages = self._messages_without_auto_memory_search(messages)
+        if not messages:
+            return ""
 
         session_id = str(kwargs.get("session_id") or "")
         if not session_id:
             logger.warning(
-                "ReMe summarize skipped; session_id is empty: "
+                "ReMe auto-memory skipped; session_id is empty: "
                 "agent_id=%s messages=%s",
                 self.agent_id,
                 len(messages),
@@ -703,160 +838,112 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             return ""
         return str(response.answer or "")
 
-    async def auto_memory_search(
+    async def list_actions(self) -> dict[str, MemoryActionSpec]:
+        """Describe every memory action currently available to callers."""
+        async with self._reme_job_lease():
+            reme = self._reme
+            if reme is None or not getattr(reme, "is_started", False):
+                return {}
+            jobs = getattr(getattr(reme, "context", None), "jobs", {})
+            actions: dict[str, MemoryActionSpec] = {
+                name: {
+                    "description": str(getattr(job, "description", "") or ""),
+                    "parameters": deepcopy(
+                        dict(getattr(job, "parameters", {}) or {}),
+                    ),
+                }
+                for name, job in jobs.items()
+                if getattr(job, "enable_serve", True)
+            }
+            actions.update(deepcopy(_HOST_MEMORY_ACTIONS))
+            return actions
+
+    async def run_action(
         self,
-        messages: list[Msg] | Msg,
-        agent_name: str = "",
+        action: str,
         **kwargs: Any,
-    ) -> dict | None:
-        """Auto-search memory and expose it as a completed tool interaction."""
-        del agent_name
-        del kwargs
-        agent_config = await load_agent_config_async(self.agent_id)
-        memory_cfg = agent_config.running.reme_light_memory_config
-        if not memory_cfg.auto_memory_search_config.enabled:
-            return None
-
-        msgs = [messages] if isinstance(messages, Msg) else list(messages)
-        query = self._build_query(msgs)
-        if not query:
-            return None
-
-        search_cfg = memory_cfg.auto_memory_search_config
-
-        cap = max(1, search_cfg.max_results)
-        reranker_config = await self._get_reranker_config()
-        # Over-fetch when reranker is enabled: take N * multiplier
-        # candidates, rerank, then return top-N.
-        effective_limit = (
-            cap * reranker_config.candidate_multiplier
-            if reranker_config
-            else cap
-        )
-        response = await self._run_reme_job(
-            "search",
-            query=query,
-            limit=effective_limit,
-            min_score=0,
-        )
-        if response is None or not response.success:
-            return None
-
-        await self._rerank_and_cap_response(
-            query,
-            response,
-            cap,
-            reranker_config,
-        )
-
-        text = str(response.answer or "").strip()
-        if not text:
-            return None
-
-        assistant_msg = self._build_auto_memory_search_msg(
-            query=query,
-            max_results=cap,
-            text=text,
-            estimate_divisor=self._resolve_token_estimate_divisor(
-                agent_config,
-            ),
-        )
-        return {
-            "query": query,
-            "text": text,
-            "msg": msgs + [assistant_msg],
-        }
-
-    async def auto_memory(
-        self,
-        all_messages: list[Msg],
-        **kwargs: Any,
-    ) -> None:
-        """Auto-extract memory for a prepared reply batch."""
-        if not all_messages:
-            return
-        all_messages = self._messages_without_auto_memory_search(all_messages)
-        if not all_messages:
-            return
-        session_id = str(kwargs.get("session_id") or "")
-        if not session_id:
-            logger.warning(
-                "ReMe auto_memory skipped; session_id is empty: "
-                "agent_id=%s messages=%s",
-                self.agent_id,
-                len(all_messages),
+    ) -> MemoryActionResult | None:
+        """Validate and execute one available memory action."""
+        async with self._reme_job_lease():
+            reme = self._reme
+            if reme is None or not getattr(reme, "is_started", False):
+                return None
+            if action in _HOST_MEMORY_ACTIONS:
+                parameters = _HOST_MEMORY_ACTIONS[action]["parameters"]
+            else:
+                jobs = getattr(getattr(reme, "context", None), "jobs", {})
+                job = jobs.get(action)
+                if job is None or not getattr(job, "enable_serve", True):
+                    raise ValueError(
+                        f"Unknown or unavailable memory action: {action}",
+                    )
+                parameters = dict(getattr(job, "parameters", {}) or {})
+            _validate_reme_action_kwargs(
+                action,
+                parameters,
+                kwargs,
             )
-            return
+            if action not in {"reindex", "undo_reindex"}:
+                return await self._run_reme_job(
+                    action,
+                    needs_llm=action in _REME_LLM_ACTIONS,
+                    raise_on_error=True,
+                    lifecycle_locked=True,
+                    **kwargs,
+                )
 
-        self.add_summarize_task(
-            messages=all_messages,
-            session_id=session_id,
-        )
+        # Host-managed actions acquire the exclusive lifecycle lock and must
+        # therefore run after releasing the ordinary ReMe job lease.
+        if action == "reindex":
+            return await self._rebuild_index(
+                str(kwargs.get("scope", "all")),
+            )
+        restored = await self._undo_reindex()
+        return MemoryActionResponse(success=True, answer=restored)
 
-    async def dream(self, **kwargs: Any) -> None:
-        """Run one ReMe auto-dream pass."""
-        response = await self._run_reme_job(
-            "auto_dream",
-            needs_llm=True,
-            date=str(kwargs.get("date") or ""),
-            hint=str(kwargs.get("hint") or ""),
-        )
-        if response is not None and not response.success:
-            raise RuntimeError(str(response.answer))
-
-    async def daily_paper(self, **kwargs: Any) -> None:
-        """Build one Daily Paper brief and publish its result to inbox."""
-        cfg = await run_sync_io(self.get_memory_config)
-        response = await self._run_reme_job(
-            "daily_paper",
-            needs_llm=True,
-            raise_on_error=True,
-            date=str(kwargs.get("date") or ""),
-            force=bool(kwargs.get("force", False)),
-            use_hf_mirror=bool(
-                kwargs.get(
-                    "use_hf_mirror",
-                    cfg.daily_paper_use_hf_mirror,
-                ),
-            ),
-            topics=str(kwargs.get("topics", cfg.daily_paper_topics) or ""),
-        )
-        if response is None:
-            raise RuntimeError("ReMe is not started; Daily Paper did not run")
-        if not response.success:
-            raise RuntimeError(str(response.answer))
-
-    async def auto_fin(self, **kwargs: Any) -> None:
-        """Build one Auto Fin report and publish its result to inbox."""
-        cfg = await run_sync_io(self.get_memory_config)
-        response = await self._run_reme_job(
-            "auto_fin",
-            needs_llm=True,
-            raise_on_error=True,
-            date=str(kwargs.get("date") or ""),
-            topics=str(kwargs.get("topics", cfg.auto_fin_topics) or ""),
-            window_hours=float(
-                kwargs.get("window_hours", cfg.auto_fin_window_hours),
-            ),
-        )
-        if response is None:
-            raise RuntimeError("ReMe is not started; Auto Fin did not run")
-        if not response.success:
-            raise RuntimeError(str(response.answer))
-
-    async def reme_status(self) -> "Response | None":
-        """Return embedded ReMe component memory estimates and process RSS."""
-        return await self._run_reme_job("status")
-
-    async def graph_snapshot(self) -> "Response | None":
-        """Return the complete indexed wikilink graph for the console."""
-        return await self._run_reme_job("graph_snapshot")
-
-    async def rebuild_index(self, scope: str = "all") -> "Response | None":
+    async def _rebuild_index(
+        self,
+        scope: str = "all",
+    ) -> MemoryActionResult | None:
+        """Execute the host-managed reindex implementation."""
         return await self._embedding_service().rebuild_index(scope)
 
-    async def undo_embedding_reindex(self) -> EmbeddingModelConfig:
+    async def _undo_reindex(self) -> EmbeddingModelConfig:
+        """Execute the host-managed embedding rollback implementation."""
         return await self._embedding_service().undo_reindex()
+
+    async def _run_scheduled_action(self, action: str) -> None:
+        """Run one configured action on behalf of the cron service."""
+        kwargs: dict[str, Any]
+        if action == "auto_dream":
+            kwargs = {"date": "", "hint": ""}
+        else:
+            cfg = await run_sync_io(self._load_memory_config)
+            if action == "daily_paper":
+                kwargs = {
+                    "date": "",
+                    "force": False,
+                    "use_hf_mirror": bool(
+                        cfg.daily_paper_use_hf_mirror,
+                    ),
+                    "topics": str(cfg.daily_paper_topics or ""),
+                }
+            elif action == "auto_fin":
+                kwargs = {
+                    "date": "",
+                    "topics": str(cfg.auto_fin_topics or ""),
+                    "window_hours": float(cfg.auto_fin_window_hours),
+                }
+            else:
+                raise ValueError(f"Unsupported scheduled action: {action}")
+
+        response = await self.run_action(action, **kwargs)
+        if response is None:
+            raise RuntimeError(
+                f"Memory action '{action}' is unavailable",
+            )
+        if not response.success:
+            raise RuntimeError(str(response.answer))
 
     @property
     def is_reindexing(self) -> bool:

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -511,9 +511,8 @@ class ReMeLightMemoryManager(BaseMemoryManager, MemoryActionProvider):
 
     async def _reload_embedding_config_unlocked(self) -> bool:
         """Recreate embedded ReMe while the caller owns the lifecycle lock."""
-        if not await self._close_reme_unlocked():
+        if not await self._close_reme_unlocked(shutdown_worker=False):
             return False
-        self._auto_memory_worker_stopping = False
         await run_sync_io(self._initialize_reme)
         await self.start()
         self._tested_embedding = None

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -275,7 +275,10 @@ class MemoryMiddleware(MiddlewareBase):
                         turn_markers=pending_markers,
                     )
                     if not automation_request:
-                        await self._flush_auto_memory(agent)
+                        await self._flush_auto_memory(
+                            agent,
+                            trigger="compact",
+                        )
             except Exception:
                 logger.exception(
                     "MemoryMiddleware post-compression auto-memory flush "
@@ -287,6 +290,7 @@ class MemoryMiddleware(MiddlewareBase):
         agent: "Agent",
         *,
         count: int | None = None,
+        trigger: str = "periodic",
     ) -> None:
         if self._is_automation_request(agent):
             logger.debug(
@@ -330,8 +334,9 @@ class MemoryMiddleware(MiddlewareBase):
             return
 
         try:
-            await self._memory_manager.auto_memory(
+            self._memory_manager.submit_auto_memory(
                 messages,
+                trigger=trigger,
                 session_id=self._agent_session_id(agent),
             )
         except Exception:

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -23,6 +23,7 @@ from qwenpaw.exceptions import (
 from ...agents.memory.reme_embedding import (
     EmbeddingReindexUnavailableError,
 )
+from ...agents.memory.action_provider import MemoryActionProvider
 from ...agents.utils.file_handling import read_text_file_with_encoding_fallback
 from ..mail.driver_config import (
     ENTERPRISE_MAIL_PROVIDERS as _ENTERPRISE_MAIL_PROVIDERS,
@@ -185,10 +186,10 @@ class MemoryWorkerRuntimeStatus(BaseModel):
     tasks_running: int
 
 
-class MemoryCaptureTaskStatus(BaseModel):
-    """One bounded memory-capture record, newest records returned first.
+class AutoMemoryTaskStatus(BaseModel):
+    """One bounded auto-memory record, newest records returned first.
 
-    Records share the summarize queue used by periodic auto-memory and the
+    Records share the auto-memory queue used by periodic auto-memory and the
     user-triggered ``/new`` and ``/compact`` commands.
     """
 
@@ -197,6 +198,7 @@ class MemoryCaptureTaskStatus(BaseModel):
     queued_at: str | None = None
     finished_at: str | None = None
     message_count: int = 0
+    trigger: str = "manual"
     result: str | None = None
     error: str | None = None
 
@@ -219,7 +221,7 @@ class MemoryRuntimeStatus(BaseModel):
 
     worker: MemoryWorkerRuntimeStatus
     auto_memory: AutoMemoryRuntimeStatus
-    tasks: list[MemoryCaptureTaskStatus] = Field(default_factory=list)
+    tasks: list[AutoMemoryTaskStatus] = Field(default_factory=list)
     recent: RecentMemoryRuntimeStatus
     reindexing: bool
     embedding_reindex_required: bool = False
@@ -1344,8 +1346,13 @@ async def rebuild_agent_memory_index(
             detail="Memory manager is not available",
         )
 
+    if not isinstance(memory_manager, MemoryActionProvider):
+        raise HTTPException(
+            status_code=501,
+            detail="Memory backend does not support actions",
+        )
     try:
-        response = await memory_manager.rebuild_index(scope)
+        response = await memory_manager.run_action("reindex", scope=scope)
     except EmbeddingReindexUnavailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except RuntimeError as exc:
@@ -1397,15 +1404,27 @@ async def undo_agent_memory_reindex(
             detail="Memory manager is not available",
         )
 
+    if not isinstance(memory_manager, MemoryActionProvider):
+        raise HTTPException(
+            status_code=501,
+            detail="Memory backend does not support actions",
+        )
     try:
-        restored = await memory_manager.undo_embedding_reindex()
+        response = await memory_manager.run_action("undo_reindex")
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except RuntimeError as exc:
         if str(exc) == "Memory index rebuild is already running":
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-    return restored
+    if response is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Memory action 'undo_reindex' is unavailable",
+        )
+    if not response.success:
+        raise HTTPException(status_code=500, detail=str(response.answer))
+    return EmbeddingModelConfig.model_validate(response.answer)
 
 
 @router.get(
@@ -1492,8 +1511,13 @@ async def get_agent_memory_status(
             detail="Memory manager is not available",
         )
 
+    if not isinstance(memory_manager, MemoryActionProvider):
+        raise HTTPException(
+            status_code=501,
+            detail="Memory backend does not support actions",
+        )
     try:
-        response = await memory_manager.reme_status()
+        response = await memory_manager.run_action("status")
     except RuntimeError as exc:
         message = str(exc)
         if not (
@@ -1582,7 +1606,12 @@ async def get_agent_memory_graph(
             detail="Memory manager is not available",
         )
 
-    response = await memory_manager.graph_snapshot()
+    if not isinstance(memory_manager, MemoryActionProvider):
+        raise HTTPException(
+            status_code=501,
+            detail="Memory backend does not support actions",
+        )
+    response = await memory_manager.run_action("graph_snapshot")
     if response is None:
         raise HTTPException(
             status_code=503,

--- a/src/qwenpaw/runtime/builtin_commands.py
+++ b/src/qwenpaw/runtime/builtin_commands.py
@@ -271,7 +271,7 @@ _CONVERSATION_COMMANDS = frozenset(
         "clear",
         "history",
         "compact_str",
-        "summarize_status",
+        "auto_memory_status",
         "message",
         "dump_history",
         "load_history",

--- a/tests/integration/test_conversation_commands.py
+++ b/tests/integration/test_conversation_commands.py
@@ -333,11 +333,11 @@ def test_recall_history_invalid_op(
 
 @pytest.mark.integration
 @pytest.mark.p2
-def test_summarize_status_and_proactive_commands(
+def test_auto_memory_status_and_proactive_commands(
     app_server,
     provider,  # pylint: disable=redefined-outer-name,unused-argument
 ):
-    """/summarize_status and /proactive report subsystem state.
+    """/auto_memory_status and /proactive report subsystem state.
 
     Test purpose:
       - Cover two more command_handler branches (compaction status and
@@ -345,7 +345,7 @@ def test_summarize_status_and_proactive_commands(
     """
     user = "integ-cmd-status"
     assert (
-        _send(app_server, user_id=user, text="/summarize_status").get(
+        _send(app_server, user_id=user, text="/auto_memory_status").get(
             "status",
         )
         == "finished"

--- a/tests/integration/test_reme_embedding_contract.py
+++ b/tests/integration/test_reme_embedding_contract.py
@@ -180,7 +180,7 @@ async def test_disabled_embedding_reindex_preserves_real_reme_vectors(
             ) as update_config,
             pytest.raises(EmbeddingReindexUnavailableError),
         ):
-            await manager.rebuild_index("embedding")
+            await manager._rebuild_index("embedding")
 
         np.testing.assert_array_equal(chunk.embedding, original_embedding)
         assert file_store._embedding_rebuild_pending is False

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -252,8 +252,13 @@ class AutoMemoryMsgBuilder(BaseMemoryManager):
     def get_memory_prompt(self) -> str:
         return ""
 
-    def list_memory_tools(self) -> list:
-        return []
+    async def memory_search(self, query: str, **_kwargs):
+        del query
+        return None
+
+    async def auto_memory(self, messages: list[Msg], **_kwargs) -> str:
+        del messages
+        return ""
 
 
 @pytest.fixture

--- a/tests/unit/agents/memory/test_adbpg_memory_manager.py
+++ b/tests/unit/agents/memory/test_adbpg_memory_manager.py
@@ -103,3 +103,40 @@ async def test_adbpg_auto_memory_search_respects_disabled_config(tmp_path):
 
     assert result is None
     manager.memory_search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_adbpg_auto_memory_waits_for_backend_processing(tmp_path):
+    manager = ADBPGMemoryManager(str(tmp_path), "agent-1")
+    client = SimpleNamespace(add_memory=AsyncMock())
+    manager._client = client
+    message = _user_msg("remember this")
+
+    result = await manager.auto_memory([message])
+
+    assert (
+        result == "Processed 1 user message(s) to ADBPG for agent 'agent-1'."
+    )
+    client.add_memory.assert_awaited_once()
+    assert message.id in manager._persisted_msg_ids
+
+
+@pytest.mark.asyncio
+async def test_adbpg_auto_memory_tracks_each_success_before_later_failure(
+    tmp_path,
+):
+    manager = ADBPGMemoryManager(str(tmp_path), "agent-1")
+    client = SimpleNamespace(
+        add_memory=AsyncMock(
+            side_effect=[None, RuntimeError("second write failed")],
+        ),
+    )
+    manager._client = client
+    first = _user_msg("first")
+    second = _user_msg("second")
+
+    with pytest.raises(RuntimeError, match="second write failed"):
+        await manager.auto_memory([first, second])
+
+    assert first.id in manager._persisted_msg_ids
+    assert second.id not in manager._persisted_msg_ids

--- a/tests/unit/agents/memory/test_base_memory_manager.py
+++ b/tests/unit/agents/memory/test_base_memory_manager.py
@@ -3,8 +3,7 @@
 """Tests for BaseMemoryManager abstract base class."""
 
 import asyncio
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from agentscope.message import Msg, TextBlock
@@ -27,9 +26,6 @@ def _make_concrete_class():
         async def start(self):
             pass
 
-        async def close(self):
-            return True
-
         def get_memory_prompt(self) -> str:
             return ""
 
@@ -51,6 +47,9 @@ def _make_concrete_class():
 
         async def memory_search(self, query, **_kwargs):
             return None
+
+        async def auto_memory(self, messages, **_kwargs):
+            return ""
 
         def get_in_memory_memory(self, **_kwargs):
             return None
@@ -90,78 +89,86 @@ class TestBaseMemoryManagerInit:
     def test_agent_id_is_stored(self, manager):
         assert manager.agent_id == "test-agent"
 
-    def test_summary_task_info_starts_empty(self, manager):
-        assert manager._summary_task_info == {}
+    def test_auto_memory_task_info_starts_empty(self, manager):
+        assert manager._auto_memory_task_info == {}
 
     def test_task_counter_starts_at_zero(self, manager):
         assert manager._task_counter == 0
 
-    def test_worker_task_is_none_initially(self, manager):
-        assert manager._worker_task is None
+    def test_auto_memory_worker_task_is_none_initially(self, manager):
+        assert manager._auto_memory_worker_task is None
+
+    async def test_close_stops_worker_before_backend(self, manager):
+        manager._shutdown_auto_memory_worker = AsyncMock(return_value=True)
+        manager._close_backend = AsyncMock(return_value=True)
+
+        assert await manager.close() is True
+        manager._shutdown_auto_memory_worker.assert_awaited_once_with()
+        manager._close_backend.assert_awaited_once_with()
 
 
 # ---------------------------------------------------------------------------
-# TestBaseMemoryManagerAddSummarizeTask
+# TestBaseMemoryManagerSubmitAutoMemory
 # ---------------------------------------------------------------------------
 
 
-class TestBaseMemoryManagerAddSummarizeTask:
-    """P1: Tests for add_summarize_task."""
+class TestBaseMemoryManagerSubmitAutoMemory:
+    """P1: Tests for submit_auto_memory."""
 
     async def test_adds_task_info_entry(self, manager):
-        """Scheduling a task creates an entry in _summary_task_info."""
+        """Scheduling a task creates an entry in _auto_memory_task_info."""
         msgs = [MagicMock()]
-        manager.add_summarize_task(msgs)
-        assert len(manager._summary_task_info) == 1
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        manager.submit_auto_memory(msgs)
+        assert len(manager._auto_memory_task_info) == 1
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass
 
     async def test_task_starts_as_pending(self, manager):
         """New task has status 'pending'."""
-        manager.add_summarize_task([MagicMock()])
-        info = list(manager._summary_task_info.values())[0]
+        manager.submit_auto_memory([MagicMock()])
+        info = list(manager._auto_memory_task_info.values())[0]
         assert info["status"] == "pending"
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass
 
     async def test_counter_increments_per_task(self, manager):
         """Each call increments the task counter."""
-        manager.add_summarize_task([MagicMock()])
-        manager.add_summarize_task([MagicMock()])
+        manager.submit_auto_memory([MagicMock()])
+        manager.submit_auto_memory([MagicMock()])
         assert manager._task_counter == 2
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass
 
-    async def test_worker_task_created(self, manager):
+    async def test_auto_memory_worker_task_created(self, manager):
         """Scheduling a task starts the background worker."""
-        manager.add_summarize_task([MagicMock()])
-        assert manager._worker_task is not None
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        manager.submit_auto_memory([MagicMock()])
+        assert manager._auto_memory_worker_task is not None
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass
 
     async def test_task_info_does_not_retain_worker(self, manager):
-        manager.add_summarize_task([MagicMock()])
+        manager.submit_auto_memory([MagicMock()])
 
-        info = next(iter(manager._summary_task_info.values()))
+        info = next(iter(manager._auto_memory_task_info.values()))
         assert "task" not in info
 
-        await manager._shutdown_summarize_worker()
+        await manager._shutdown_auto_memory_worker()
 
     async def test_keeps_only_latest_terminal_tasks(
         self,
@@ -170,45 +177,45 @@ class TestBaseMemoryManagerAddSummarizeTask:
     ):
         monkeypatch.setattr(
             base_memory_manager,
-            "MAX_SUMMARY_TASK_HISTORY",
+            "MAX_AUTO_MEMORY_TASK_HISTORY",
             2,
         )
         completed = asyncio.Event()
         calls = 0
 
-        async def summarize(*_args, **_kwargs):
+        async def auto_memory(*_args, **_kwargs):
             nonlocal calls
             calls += 1
             if calls == 3:
                 completed.set()
             return f"result-{calls}"
 
-        manager.summarize = summarize
+        manager.auto_memory = auto_memory
         for _ in range(3):
-            manager.add_summarize_task([MagicMock()])
+            manager.submit_auto_memory([MagicMock()])
 
         await asyncio.wait_for(completed.wait(), timeout=1)
         await asyncio.sleep(0)
 
-        assert list(manager._summary_task_info) == ["task_2", "task_3"]
-        await manager._shutdown_summarize_worker()
+        assert list(manager._auto_memory_task_info) == ["task_2", "task_3"]
+        await manager._shutdown_auto_memory_worker()
 
     def test_pruning_keeps_non_terminal_tasks(self, manager, monkeypatch):
         monkeypatch.setattr(
             base_memory_manager,
-            "MAX_SUMMARY_TASK_HISTORY",
+            "MAX_AUTO_MEMORY_TASK_HISTORY",
             1,
         )
-        manager._summary_task_info = {
+        manager._auto_memory_task_info = {
             "task_1": {"status": "completed"},
             "task_2": {"status": "running"},
             "task_3": {"status": "failed"},
             "task_4": {"status": "pending"},
         }
 
-        manager._prune_summary_task_info()
+        manager._prune_auto_memory_task_info()
 
-        assert list(manager._summary_task_info) == [
+        assert list(manager._auto_memory_task_info) == [
             "task_2",
             "task_3",
             "task_4",
@@ -228,14 +235,73 @@ class TestBaseMemoryManagerAddSummarizeTask:
             except asyncio.CancelledError:
                 return "completed after cancellation"
 
-        manager.summarize = swallow_cancellation
-        manager.add_summarize_task([MagicMock()])
+        manager.auto_memory = swallow_cancellation
+        manager.submit_auto_memory([MagicMock()])
         await started.wait()
 
-        stopped = await manager._shutdown_summarize_worker(timeout=0.5)
+        stopped = await manager._shutdown_auto_memory_worker(timeout=0.5)
 
         assert stopped is True
-        assert manager._worker_task is None
+        assert manager._auto_memory_worker_task is None
+
+    async def test_shutdown_drains_queued_work_before_stopping(self, manager):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        completed: list[str] = []
+
+        async def auto_memory(messages, **_kwargs):
+            started.set()
+            await release.wait()
+            completed.append(messages[0])
+            return "saved"
+
+        manager.auto_memory = auto_memory
+        manager.submit_auto_memory(["first"])
+        manager.submit_auto_memory(["second"])
+        await started.wait()
+
+        shutdown = asyncio.create_task(
+            manager._shutdown_auto_memory_worker(timeout=0.5),
+        )
+        await asyncio.sleep(0)
+        assert not shutdown.done()
+
+        release.set()
+        assert await shutdown is True
+        assert completed == ["first", "second"]
+        assert manager._auto_memory_worker_task is None
+
+    async def test_submit_rejected_while_worker_is_shutting_down(
+        self,
+        manager,
+    ):
+        manager._auto_memory_worker_stopping = True
+
+        with pytest.raises(RuntimeError, match="shutting down"):
+            manager.submit_auto_memory([MagicMock()])
+
+    async def test_shutdown_timeout_cancels_active_and_queued_work(
+        self,
+        manager,
+    ):
+        started = asyncio.Event()
+
+        async def blocked_auto_memory(*_args, **_kwargs):
+            started.set()
+            await asyncio.sleep(3600)
+
+        manager.auto_memory = blocked_auto_memory
+        manager.submit_auto_memory([MagicMock()])
+        manager.submit_auto_memory([MagicMock()])
+        await started.wait()
+
+        stopped = await manager._shutdown_auto_memory_worker(timeout=0.01)
+
+        assert stopped is True
+        assert manager._auto_memory_task_queue.empty()
+        assert {
+            info["status"] for info in manager._auto_memory_task_info.values()
+        } == {"cancelled"}
 
     async def test_shutdown_timeout_is_bounded(self, manager):
         """Repeated cancellation suppression cannot hang close."""
@@ -251,23 +317,23 @@ class TestBaseMemoryManagerAddSummarizeTask:
                     continue
 
         worker = asyncio.create_task(ignore_cancellation())
-        manager._worker_task = worker
+        manager._auto_memory_worker_task = worker
         await started.wait()
 
-        stopped = await manager._shutdown_summarize_worker(timeout=0.01)
+        stopped = await manager._shutdown_auto_memory_worker(timeout=0.01)
 
         assert stopped is False
         keep_running.set()
         worker.cancel()
         await asyncio.wait({worker}, timeout=0.5)
 
-    def test_runtime_status_includes_bounded_memory_capture_tasks(
+    def test_runtime_status_includes_bounded_auto_memory_tasks(
         self,
         manager,
     ):
         manager.get_auto_memory_interval = MagicMock(return_value=5)
         long_result = "r" * (base_memory_manager.MAX_RUNTIME_RESULT_CHARS + 10)
-        manager._summary_task_info = {
+        manager._auto_memory_task_info = {
             "task_1": {
                 "task_id": "task_1",
                 "status": "completed",
@@ -325,6 +391,7 @@ class TestBaseMemoryManagerAddSummarizeTask:
                 "queued_at": "2026-08-10T00:59:00+00:00",
                 "finished_at": "2026-08-10T01:00:00+00:00",
                 "message_count": 2,
+                "trigger": "manual",
                 "result": None,
                 "error": "e" * 240,
             },
@@ -334,6 +401,7 @@ class TestBaseMemoryManagerAddSummarizeTask:
                 "queued_at": "2026-08-09T23:59:00+00:00",
                 "finished_at": "2026-08-10T00:00:00+00:00",
                 "message_count": 4,
+                "trigger": "manual",
                 "result": long_result[
                     : base_memory_manager.MAX_RUNTIME_RESULT_CHARS
                 ],
@@ -397,27 +465,12 @@ class TestAutoMemorySearchSanitization:
     def test_builds_mock_assistant_msg_with_configured_estimated_usage(
         self,
         manager,
-        monkeypatch,
     ):
-        def fake_load_agent_config(agent_id):
-            assert agent_id == "test-agent"
-            return SimpleNamespace(
-                running=SimpleNamespace(
-                    light_context_config=SimpleNamespace(
-                        token_count_estimate_divisor=2,
-                    ),
-                ),
-            )
-
-        monkeypatch.setattr(
-            "qwenpaw.config.config.load_agent_config",
-            fake_load_agent_config,
-        )
-
         msg = manager._build_auto_memory_search_msg(
             query="hello",
             max_results=2,
             text="remembered fact",
+            estimate_divisor=2,
         )
 
         assert msg.role == "assistant"
@@ -434,6 +487,25 @@ class TestAutoMemorySearchSanitization:
             "output_tokens": 0,
             "estimate_divisor": 2,
         }
+
+    def test_build_message_uses_in_memory_default_without_config_io(
+        self,
+        manager,
+    ):
+        manager._get_token_estimate_divisor = MagicMock(
+            side_effect=AssertionError("must not read configuration"),
+        )
+
+        msg = manager._build_auto_memory_search_msg(
+            query="hello",
+            max_results=2,
+            text="remembered fact",
+        )
+
+        assert (
+            msg.metadata["auto_memory_search_usage"]["estimate_divisor"] == 4.0
+        )
+        manager._get_token_estimate_divisor.assert_not_called()
 
     def test_keeps_regular_reply_blocks(self, manager):
         auto_block = TextBlock(text="memory result")
@@ -470,37 +542,37 @@ class TestAutoMemorySearchSanitization:
 
 
 # ---------------------------------------------------------------------------
-# TestBaseMemoryManagerListSummarizeStatus
+# TestBaseMemoryManagerListAutoMemoryTasks
 # ---------------------------------------------------------------------------
 
 
-class TestBaseMemoryManagerListSummarizeStatus:
-    """P1: Tests for list_summarize_status."""
+class TestBaseMemoryManagerListAutoMemoryTasks:
+    """P1: Tests for list_auto_memory_tasks."""
 
     def test_returns_empty_when_no_tasks(self, manager):
-        result = manager.list_summarize_status()
+        result = manager.list_auto_memory_tasks()
         assert result == []
 
     async def test_returns_status_for_pending_task(self, manager):
-        manager.add_summarize_task([MagicMock()])
-        statuses = manager.list_summarize_status()
+        manager.submit_auto_memory([MagicMock()])
+        statuses = manager.list_auto_memory_tasks()
         assert len(statuses) == 1
         assert statuses[0]["status"] == "pending"
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass
 
     async def test_status_dict_has_required_keys(self, manager):
-        manager.add_summarize_task([MagicMock()])
-        status = manager.list_summarize_status()[0]
+        manager.submit_auto_memory([MagicMock()])
+        status = manager.list_auto_memory_tasks()[0]
         for key in ("task_id", "start_time", "status", "result", "error"):
             assert key in status
-        if manager._worker_task:
-            manager._worker_task.cancel()
+        if manager._auto_memory_worker_task:
+            manager._auto_memory_worker_task.cancel()
             try:
-                await manager._worker_task
+                await manager._auto_memory_worker_task
             except (asyncio.CancelledError, Exception):
                 pass

--- a/tests/unit/agents/memory/test_memory_actions.py
+++ b/tests/unit/agents/memory/test_memory_actions.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for optional memory actions exposed by ReMe."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qwenpaw.agents.memory.reme_light_memory_manager import (
+    ReMeLightMemoryManager,
+)
+
+
+def _job(*, parameters=None, enable_serve=True):
+    return SimpleNamespace(
+        description="test action",
+        parameters=parameters or {"type": "object", "properties": {}},
+        enable_serve=enable_serve,
+    )
+
+
+def _manager_with_jobs(jobs):
+    manager = object.__new__(ReMeLightMemoryManager)
+    manager._reme = SimpleNamespace(
+        is_started=True,
+        context=SimpleNamespace(jobs=jobs),
+    )
+
+    @asynccontextmanager
+    async def lease():
+        yield
+
+    manager._reme_job_lease = lease
+    manager._run_reme_job = AsyncMock(
+        return_value=SimpleNamespace(success=True, answer="ok", metadata={}),
+    )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_list_actions_only_exposes_servable_jobs() -> None:
+    manager = _manager_with_jobs(
+        {"status": _job(), "background": _job(enable_serve=False)},
+    )
+
+    actions = await manager.list_actions()
+
+    assert set(actions) == {"status", "undo_reindex"}
+    assert actions["status"]["description"] == "test action"
+
+
+@pytest.mark.asyncio
+async def test_run_action_validates_arguments_before_execution() -> None:
+    manager = _manager_with_jobs(
+        {
+            "search": _job(
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer", "enum": [1, 2]},
+                    },
+                    "required": ["query"],
+                },
+            ),
+        },
+    )
+
+    with pytest.raises(ValueError, match="'query' is a required property"):
+        await manager.run_action("search")
+    with pytest.raises(ValueError, match="Additional properties"):
+        await manager.run_action("search", query="x", extra=True)
+    with pytest.raises(ValueError, match="is not of type 'integer'"):
+        await manager.run_action("search", query="x", limit="2")
+    with pytest.raises(ValueError, match="is not one of"):
+        await manager.run_action("search", query="x", limit=3)
+
+    manager._run_reme_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_action_honors_nested_json_schema_constraints() -> None:
+    manager = _manager_with_jobs(
+        {
+            "traverse": _job(
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "oneOf": [
+                                {"type": "string", "pattern": r"^memory/"},
+                                {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "minItems": 1,
+                                },
+                            ],
+                        },
+                        "depth": {"type": "integer", "minimum": 0},
+                    },
+                },
+            ),
+        },
+    )
+
+    with pytest.raises(ValueError, match="should be non-empty"):
+        await manager.run_action("traverse", path=[])
+    with pytest.raises(ValueError, match="less than the minimum"):
+        await manager.run_action("traverse", path="memory/day.md", depth=-1)
+
+    await manager.run_action(
+        "traverse",
+        path=["memory/day.md"],
+        depth=1,
+    )
+    manager._run_reme_job.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_action_marks_llm_jobs_and_rejects_hidden_jobs() -> None:
+    manager = _manager_with_jobs(
+        {
+            "auto_dream": _job(
+                parameters={
+                    "type": "object",
+                    "properties": {"hint": {"type": "string"}},
+                },
+            ),
+            "hidden": _job(enable_serve=False),
+        },
+    )
+
+    await manager.run_action("auto_dream", hint="recent topics")
+
+    manager._run_reme_job.assert_awaited_once_with(
+        "auto_dream",
+        needs_llm=True,
+        raise_on_error=True,
+        lifecycle_locked=True,
+        hint="recent topics",
+    )
+    with pytest.raises(ValueError, match="Unknown or unavailable"):
+        await manager.run_action("hidden")
+
+
+@pytest.mark.asyncio
+async def test_run_action_routes_host_managed_embedding_actions() -> None:
+    manager = _manager_with_jobs(
+        {
+            "reindex": _job(
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "scope": {
+                            "type": "string",
+                            "enum": ["all", "bm25", "embedding"],
+                        },
+                    },
+                },
+            ),
+        },
+    )
+    embedding = SimpleNamespace(
+        rebuild_index=AsyncMock(
+            return_value=SimpleNamespace(success=True, answer="rebuilt"),
+        ),
+        undo_reindex=AsyncMock(return_value={"model_name": "indexed"}),
+    )
+    manager._embedding_service = lambda: embedding
+
+    rebuilt = await manager.run_action("reindex", scope="embedding")
+    restored = await manager.run_action("undo_reindex")
+
+    assert rebuilt.answer == "rebuilt"
+    assert restored.success is True
+    assert restored.answer == {"model_name": "indexed"}
+    embedding.rebuild_index.assert_awaited_once_with("embedding")
+    embedding.undo_reindex.assert_awaited_once_with()

--- a/tests/unit/agents/memory/test_powercontext_memory_manager.py
+++ b/tests/unit/agents/memory/test_powercontext_memory_manager.py
@@ -333,24 +333,48 @@ async def test_auto_memory_schedules_structured_write(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_close_stops_inherited_summary_worker_before_client_close(
+async def test_auto_memory_worker_redacts_token_from_failure_status(
+    tmp_path,
+    caplog,
+):
+    token = "pc-secret-token-should-not-leak"
+    manager = PowerContextMemoryManager(str(tmp_path), "agent-1")
+    manager._client = SimpleNamespace(
+        config=SimpleNamespace(token=token),
+        remember=AsyncMock(side_effect=RuntimeError(token)),
+        close=AsyncMock(),
+    )
+
+    manager.submit_auto_memory([user("goal A")])
+    await manager._auto_memory_task_queue.join()
+
+    status = manager.get_runtime_status()
+    assert token not in caplog.text
+    assert token not in status["recent"]["last_error"]
+    assert "<redacted>" in caplog.text
+    assert "<redacted>" in status["recent"]["last_error"]
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_close_stops_inherited_auto_memory_worker_before_client_close(
     tmp_path,
 ):
     manager = PowerContextMemoryManager(str(tmp_path), "agent-1")
 
     async def assert_worker_is_stopped() -> None:
-        assert manager._worker_task is None
+        assert manager._auto_memory_worker_task is None
 
     client = SimpleNamespace(close=AsyncMock())
     client.close.side_effect = assert_worker_is_stopped
     manager._client = client
-    manager.add_summarize_task([user("queued summary")])
-    worker = manager._worker_task
+    manager.submit_auto_memory([user("queued auto-memory")])
+    worker = manager._auto_memory_worker_task
 
     assert worker is not None
     assert not worker.done()
     assert await manager.close() is True
-    assert manager._worker_task is None
+    assert manager._auto_memory_worker_task is None
     assert worker.done()
     client.close.assert_awaited_once()
 

--- a/tests/unit/agents/memory/test_reme_close.py
+++ b/tests/unit/agents/memory/test_reme_close.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Regression tests for bounded ReMe shutdown."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qwenpaw.agents.memory.base_memory_manager import BaseMemoryManager
+from qwenpaw.agents.memory.reme_light_memory_manager import (
+    ReMeLightMemoryManager,
+)
+
+
+@pytest.mark.asyncio
+async def test_close_is_bounded_when_auto_memory_never_releases_lease(
+    monkeypatch,
+) -> None:
+    manager = object.__new__(ReMeLightMemoryManager)
+    BaseMemoryManager.__init__(manager, working_dir="", agent_id="bot")
+    manager._lifecycle_writer_lock = asyncio.Lock()
+    manager._lifecycle_condition = asyncio.Condition()
+    manager._lifecycle_operation = None
+    manager._active_reme_jobs = 0
+    manager._reme = SimpleNamespace(close=AsyncMock())
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stuck_auto_memory(*_args, **_kwargs) -> str:
+        async with manager._reme_job_lease():
+            started.set()
+            while not release.is_set():
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    continue
+        return "saved"
+
+    manager.auto_memory = stuck_auto_memory
+    manager.submit_auto_memory([])
+    worker = manager._auto_memory_worker_task
+    assert worker is not None
+    await started.wait()
+    monkeypatch.setattr(
+        "qwenpaw.agents.memory.reme_light_memory_manager."
+        "AUTO_MEMORY_WORKER_CLOSE_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    try:
+        assert await asyncio.wait_for(manager.close(), timeout=0.2) is False
+        manager._reme.close.assert_not_awaited()
+    finally:
+        release.set()
+        await asyncio.wait_for(worker, timeout=0.2)

--- a/tests/unit/agents/memory/test_reme_daily_paper.py
+++ b/tests/unit/agents/memory/test_reme_daily_paper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
-"""Focused tests for the embedded ReMe Daily Paper entry point."""
+"""Focused tests for scheduled ReMe actions and memory guidance."""
 
 import asyncio
 from types import SimpleNamespace
@@ -17,20 +17,18 @@ from qwenpaw.agents.memory.reme_light_memory_manager import (
 @pytest.mark.asyncio
 async def test_daily_paper_runs_with_qwenpaw_model_and_defaults() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-    manager._run_reme_job = AsyncMock(
+    manager.run_action = AsyncMock(
         return_value=SimpleNamespace(success=True, answer="done"),
     )
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         daily_paper_use_hf_mirror=False,
         daily_paper_topics="",
     )
 
-    await manager.daily_paper()
+    await manager._run_scheduled_action("daily_paper")
 
-    manager._run_reme_job.assert_awaited_once_with(
+    manager.run_action.assert_awaited_once_with(
         "daily_paper",
-        needs_llm=True,
-        raise_on_error=True,
         date="",
         force=False,
         use_hf_mirror=False,
@@ -41,20 +39,18 @@ async def test_daily_paper_runs_with_qwenpaw_model_and_defaults() -> None:
 @pytest.mark.asyncio
 async def test_daily_paper_passes_configured_source_preferences() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-    manager._run_reme_job = AsyncMock(
+    manager.run_action = AsyncMock(
         return_value=SimpleNamespace(success=True, answer="done"),
     )
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         daily_paper_use_hf_mirror=True,
         daily_paper_topics="agent memory",
     )
 
-    await manager.daily_paper()
+    await manager._run_scheduled_action("daily_paper")
 
-    manager._run_reme_job.assert_awaited_once_with(
+    manager.run_action.assert_awaited_once_with(
         "daily_paper",
-        needs_llm=True,
-        raise_on_error=True,
         date="",
         force=False,
         use_hf_mirror=True,
@@ -65,20 +61,18 @@ async def test_daily_paper_passes_configured_source_preferences() -> None:
 @pytest.mark.asyncio
 async def test_auto_fin_passes_configured_topics_and_window() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-    manager._run_reme_job = AsyncMock(
+    manager.run_action = AsyncMock(
         return_value=SimpleNamespace(success=True, answer="done"),
     )
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         auto_fin_topics="黄金,AI",
         auto_fin_window_hours=12,
     )
 
-    await manager.auto_fin()
+    await manager._run_scheduled_action("auto_fin")
 
-    manager._run_reme_job.assert_awaited_once_with(
+    manager.run_action.assert_awaited_once_with(
         "auto_fin",
-        needs_llm=True,
-        raise_on_error=True,
         date="",
         topics="黄金,AI",
         window_hours=12.0,
@@ -88,42 +82,57 @@ async def test_auto_fin_passes_configured_topics_and_window() -> None:
 @pytest.mark.asyncio
 async def test_daily_paper_fails_when_reme_is_unavailable() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-    manager._run_reme_job = AsyncMock(return_value=None)
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager.run_action = AsyncMock(return_value=None)
+    manager._load_memory_config = lambda: SimpleNamespace(
         daily_paper_use_hf_mirror=False,
         daily_paper_topics="",
     )
 
-    with pytest.raises(RuntimeError, match="ReMe is not started"):
-        await manager.daily_paper()
+    with pytest.raises(RuntimeError, match="is unavailable"):
+        await manager._run_scheduled_action("daily_paper")
 
 
 @pytest.mark.asyncio
 async def test_daily_paper_reports_the_real_execution_failure() -> None:
-    """An unreachable source must not be reported as "ReMe is not started"."""
+    """An execution failure must not be reported as action unavailability."""
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
     manager._reme = SimpleNamespace(
         is_started=True,
         run_job=AsyncMock(side_effect=ConnectionError("mirror unreachable")),
+        context=SimpleNamespace(
+            jobs={
+                "daily_paper": SimpleNamespace(
+                    enable_serve=True,
+                    parameters={
+                        "properties": {
+                            "date": {"type": "string"},
+                            "force": {"type": "boolean"},
+                            "use_hf_mirror": {"type": "boolean"},
+                            "topics": {"type": "string"},
+                        },
+                    },
+                ),
+            },
+        ),
     )
     manager._lifecycle_condition = asyncio.Condition()
     manager._lifecycle_operation = None
     manager._active_reme_jobs = 0
     manager._update_qwenpaw_model = AsyncMock()
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         daily_paper_use_hf_mirror=True,
         daily_paper_topics="",
     )
 
     with pytest.raises(ConnectionError, match="mirror unreachable"):
-        await manager.daily_paper()
+        await manager._run_scheduled_action("daily_paper")
 
 
 @pytest.mark.asyncio
 async def test_daily_paper_result_is_delivered_to_inbox() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
     manager.agent_id = "agent-1"
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         daily_paper_inbox_push_enabled=True,
     )
     response = SimpleNamespace(
@@ -157,13 +166,13 @@ async def test_daily_paper_result_is_delivered_to_inbox() -> None:
 
 def test_memory_search_tool_exposure_has_an_independent_switch() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         memory_search_enabled=False,
     )
 
     assert not manager.list_memory_tools()
 
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         memory_search_enabled=True,
     )
     assert manager.list_memory_tools() == [manager.memory_search]
@@ -241,7 +250,7 @@ def test_zh_memory_prompt_describes_the_four_memory_surfaces() -> None:
 def test_reme_declares_its_enabled_cron_jobs() -> None:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
     manager._reme = SimpleNamespace(is_started=True)
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         dream_cron_enabled=True,
         dream_cron="0 23 * * *",
         daily_paper_cron_enabled=True,
@@ -253,13 +262,14 @@ def test_reme_declares_its_enabled_cron_jobs() -> None:
     jobs = manager.list_cron_jobs()
 
     assert [job.key for job in jobs] == ["dream", "daily-paper", "auto-fin"]
-    assert jobs[0].callback.__self__ is manager
-    assert jobs[0].callback.__func__ is ReMeLightMemoryManager.dream
+    assert jobs[0].callback.func.__self__ is manager
+    assert jobs[0].callback.func.__func__ is (
+        ReMeLightMemoryManager._run_scheduled_action
+    )
+    assert jobs[0].callback.args == ("auto_dream",)
     assert jobs[0].jitter_seconds == 60
-    assert jobs[1].callback.__self__ is manager
-    assert jobs[1].callback.__func__ is ReMeLightMemoryManager.daily_paper
-    assert jobs[2].callback.__self__ is manager
-    assert jobs[2].callback.__func__ is ReMeLightMemoryManager.auto_fin
+    assert jobs[1].callback.args == ("daily_paper",)
+    assert jobs[2].callback.args == ("auto_fin",)
 
 
 @pytest.mark.asyncio
@@ -281,7 +291,7 @@ async def test_automatic_search_works_when_agent_tool_is_hidden() -> None:
     agent_config = SimpleNamespace(
         running=SimpleNamespace(reme_light_memory_config=memory_config),
     )
-    manager.get_memory_config = lambda: memory_config
+    manager._load_memory_config = lambda: memory_config
 
     with patch(
         "qwenpaw.agents.memory.reme_light_memory_manager."

--- a/tests/unit/agents/memory/test_reme_embedding_update.py
+++ b/tests/unit/agents/memory/test_reme_embedding_update.py
@@ -170,7 +170,7 @@ async def test_manual_reindex_clears_persisted_requirement() -> None:
             side_effect=update_config,
         ) as update_config_mock,
     ):
-        response = await manager.rebuild_index()
+        response = await manager._rebuild_index()
 
     assert response.success is True
     assert profile.running.reme_light_memory_config.needs_reindex is False
@@ -209,7 +209,7 @@ async def test_reindex_rejects_disabled_target_without_mutation() -> None:
             match="requires an enabled embedding configuration",
         ),
     ):
-        await manager.rebuild_index("embedding")
+        await manager._rebuild_index("embedding")
 
     assert memory_config.needs_reindex is True
     assert memory_config.pending_reindex_embedding_config == indexed
@@ -244,7 +244,7 @@ async def test_all_reindex_rejects_disabled_embedding() -> None:
             match="all-scope index rebuild requires an enabled",
         ),
     ):
-        await manager.rebuild_index("all")
+        await manager._rebuild_index("all")
 
     assert memory_config.needs_reindex is True
     assert memory_config.pending_reindex_embedding_config == indexed
@@ -266,7 +266,7 @@ async def test_reindex_returns_unavailable_when_reme_is_not_started(
         "qwenpaw.agents.memory.reme_light_memory_manager."
         "load_agent_config_async",
     ) as load_config:
-        response = await manager.rebuild_index("embedding")
+        response = await manager._rebuild_index("embedding")
 
     assert response is None
     load_config.assert_not_awaited()
@@ -307,7 +307,7 @@ async def test_reindex_cancellation_after_persist_still_closes_live_gate() -> (
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await manager.rebuild_index("embedding")
+        await manager._rebuild_index("embedding")
 
     assert memory_config.needs_reindex is True
     assert memory_config.pending_reindex_embedding_config is None
@@ -349,7 +349,7 @@ async def test_reindex_does_not_clear_a_new_vector_space_requirement() -> None:
             side_effect=update_config,
         ),
     ):
-        response = await manager.rebuild_index()
+        response = await manager._rebuild_index()
 
     assert response.success is True
     assert memory_config.needs_reindex is True
@@ -393,7 +393,7 @@ async def test_reindex_cancel_regates_newer_vector_space() -> None:
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await manager.rebuild_index("embedding")
+        await manager._rebuild_index("embedding")
 
     assert memory_config.embedding_model_config == newer
     assert memory_config.needs_reindex is True
@@ -435,7 +435,7 @@ async def test_reindex_regates_vectors_when_state_persistence_fails() -> None:
         ),
         pytest.raises(OSError, match="disk full"),
     ):
-        await manager.rebuild_index("embedding")
+        await manager._rebuild_index("embedding")
 
     assert memory_config.needs_reindex is True
     require_rebuild = manager._reme.file_store.require_embedding_rebuild
@@ -471,7 +471,7 @@ async def test_failed_embedding_reindex_keeps_vector_search_disabled() -> None:
             side_effect=update_config,
         ),
     ):
-        response = await manager.rebuild_index("embedding")
+        response = await manager._rebuild_index("embedding")
 
     assert response.success is False
     assert memory_config.needs_reindex is True
@@ -508,7 +508,7 @@ async def test_cancelled_embedding_reindex_keeps_restart_gate_persisted() -> (
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await manager.rebuild_index("embedding")
+        await manager._rebuild_index("embedding")
 
     assert memory_config.needs_reindex is True
     assert memory_config.pending_reindex_embedding_config is None
@@ -536,7 +536,7 @@ async def test_undo_restores_indexed_config_under_reindex_lock() -> None:
         "update_agent_config_async",
         side_effect=update_config,
     ):
-        restored = await manager.undo_embedding_reindex()
+        restored = await manager._undo_reindex()
 
     assert restored == indexed
     assert memory_config.embedding_model_config == indexed
@@ -579,7 +579,7 @@ async def test_undo_cancel_after_persist_reloads_runtime() -> (None):
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await manager.undo_embedding_reindex()
+        await manager._undo_reindex()
 
     assert memory_config.embedding_model_config == indexed
     assert memory_config.needs_reindex is False
@@ -627,7 +627,7 @@ async def test_failed_undo_restores_pending_config_and_runtime() -> None:
             match="pending embedding runtime was restored",
         ),
     ):
-        await manager.undo_embedding_reindex()
+        await manager._undo_reindex()
 
     assert memory_config.embedding_model_config == pending
     assert memory_config.needs_reindex is True
@@ -666,7 +666,7 @@ async def test_failed_undo_reports_pending_runtime_recovery_failure() -> None:
             match="pending embedding runtime could not be loaded",
         ),
     ):
-        await manager.undo_embedding_reindex()
+        await manager._undo_reindex()
 
     assert memory_config.embedding_model_config == pending
     assert memory_config.needs_reindex is True
@@ -758,7 +758,7 @@ async def test_reindex_and_embedding_update_share_lifecycle_boundary() -> None:
             side_effect=update_config,
         ),
     ):
-        reindex = asyncio.create_task(manager.rebuild_index())
+        reindex = asyncio.create_task(manager._rebuild_index())
         await reindex_started.wait()
         update = asyncio.create_task(
             manager.apply_tested_embedding(new_config),

--- a/tests/unit/agents/memory/test_reme_inbox_notifications.py
+++ b/tests/unit/agents/memory/test_reme_inbox_notifications.py
@@ -16,7 +16,7 @@ from qwenpaw.agents.memory.reme_inbox import build_payload
 def _manager() -> ReMeLightMemoryManager:
     manager = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
     manager.agent_id = "agent-1"
-    manager.get_memory_config = lambda: SimpleNamespace(
+    manager._load_memory_config = lambda: SimpleNamespace(
         auto_memory_inbox_push_enabled=True,
         auto_dream_inbox_push_enabled=True,
         auto_fin_inbox_push_enabled=True,

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -14,6 +14,22 @@ from qwenpaw.agents.memory.dummy import NoopMemoryManager
 from qwenpaw.agents.middlewares import auto_memory_turn_state
 
 
+class _ActionMemoryManager:
+    """Small structural MemoryActionProvider test double."""
+
+    enabled = True
+
+    def __init__(self, response=None):
+        self._response = response
+        self.run_action_mock = AsyncMock(return_value=response)
+
+    async def list_actions(self):
+        return {}
+
+    async def run_action(self, action: str, **kwargs):
+        return await self.run_action_mock(action, **kwargs)
+
+
 def _make_agent():
     """Build a minimal fake agent satisfying CommandHandler's expectations."""
     agent = MagicMock()
@@ -103,7 +119,7 @@ async def test_new_discards_auto_memory_state_after_summary_is_accepted() -> (
     auto_memory_turn_state(agent.state)["pending"] = ["turn-1"]
     memory_manager = MagicMock()
     memory_manager.enabled = True
-    memory_manager.add_summarize_task = MagicMock()
+    memory_manager.submit_auto_memory = MagicMock()
 
     await CommandHandler(
         agent_name="QwenPaw",
@@ -111,7 +127,7 @@ async def test_new_discards_auto_memory_state_after_summary_is_accepted() -> (
         memory_manager=memory_manager,
     ).handle_command("/new")
 
-    memory_manager.add_summarize_task.assert_called_once()
+    memory_manager.submit_auto_memory.assert_called_once()
     assert not agent.state.context
     assert auto_memory_turn_state(agent.state)["pending"] == []
 
@@ -260,8 +276,9 @@ async def test_system_prompt_command_returns_current_prompt() -> None:
 @pytest.mark.asyncio
 async def test_dream_command_runs_auto_dream_with_hint() -> None:
     agent = _make_agent()
-    memory_manager = MagicMock()
-    memory_manager.dream = AsyncMock()
+    memory_manager = _ActionMemoryManager(
+        SimpleNamespace(success=True, answer="", metadata={}),
+    )
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -271,10 +288,29 @@ async def test_dream_command_runs_auto_dream_with_hint() -> None:
     msg = await handler.handle_command("/dream consolidate recent topics")
 
     assert handler.is_command("/dream")
-    memory_manager.dream.assert_awaited_once_with(
+    memory_manager.run_action_mock.assert_awaited_once_with(
+        "auto_dream",
         hint="consolidate recent topics",
     )
     assert "Auto-dream Complete" in msg.get_text_content()
+
+
+@pytest.mark.asyncio
+async def test_dream_command_reports_unsuccessful_response() -> None:
+    agent = _make_agent()
+    memory_manager = _ActionMemoryManager(
+        SimpleNamespace(success=False, answer="dream rejected", metadata={}),
+    )
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        memory_manager=memory_manager,
+    )
+
+    msg = await handler.handle_command("/dream")
+
+    assert "Auto-dream Failed" in msg.get_text_content()
+    assert "dream rejected" in msg.get_text_content()
 
 
 @pytest.mark.asyncio
@@ -288,11 +324,28 @@ async def test_dream_command_requires_memory_manager() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_memory_status_lists_queued_tasks() -> None:
+    agent = _make_agent()
+    memory_manager = MagicMock(enabled=True)
+    memory_manager.list_auto_memory_tasks.return_value = []
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        memory_manager=memory_manager,
+    )
+
+    msg = await handler.handle_command("/auto_memory_status")
+
+    assert handler.is_command("/auto_memory_status")
+    assert "No Auto-memory Tasks" in msg.get_text_content()
+    memory_manager.list_auto_memory_tasks.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_reme_status_reports_memory_and_count_warning() -> None:
     agent = _make_agent()
-    memory_manager = MagicMock()
-    memory_manager.reme_status = AsyncMock(
-        return_value=SimpleNamespace(
+    memory_manager = _ActionMemoryManager(
+        SimpleNamespace(
             success=True,
             answer=(
                 "Memory (estimated component object size)\n"
@@ -313,7 +366,7 @@ async def test_reme_status_reports_memory_and_count_warning() -> None:
     text = msg.get_text_content()
 
     assert handler.is_command("/reme_status")
-    memory_manager.reme_status.assert_awaited_once_with()
+    memory_manager.run_action_mock.assert_awaited_once_with("status")
     assert "Process RSS       80.00 MiB" in text
     assert "may be counted more than once" in text
     assert "EMBEDDING_STORE" in text
@@ -366,7 +419,7 @@ async def test_memorize_defaults_to_latest_reply_group() -> None:
         _msg("assistant", "a2", msg_id="r2"),
     ]
     memory_manager = MagicMock()
-    memory_manager.auto_memory = AsyncMock()
+    memory_manager.submit_auto_memory = MagicMock()
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -375,13 +428,14 @@ async def test_memorize_defaults_to_latest_reply_group() -> None:
 
     msg = await handler.handle_command("/memorize")
 
-    memory_manager.auto_memory.assert_awaited_once()
-    await_args = memory_manager.auto_memory.await_args
-    assert await_args is not None
-    args, kwargs = await_args
+    memory_manager.submit_auto_memory.assert_called_once()
+    call_args = memory_manager.submit_auto_memory.call_args
+    assert call_args is not None
+    args, kwargs = call_args
     assert [m.get_text_content() for m in args[0]] == ["u2", "a2"]
     assert kwargs == {
         "session_id": "session-1",
+        "trigger": "manual",
         "reply_id": "r2",
         "reply_ids": ["r2"],
     }
@@ -400,7 +454,7 @@ async def test_memorize_count_selects_latest_reply_groups() -> None:
         _msg("assistant", "a3", msg_id="r3"),
     ]
     memory_manager = MagicMock()
-    memory_manager.auto_memory = AsyncMock()
+    memory_manager.submit_auto_memory = MagicMock()
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -409,10 +463,10 @@ async def test_memorize_count_selects_latest_reply_groups() -> None:
 
     msg = await handler.handle_command("/memorize 2")
 
-    memory_manager.auto_memory.assert_awaited_once()
-    await_args = memory_manager.auto_memory.await_args
-    assert await_args is not None
-    args, kwargs = await_args
+    memory_manager.submit_auto_memory.assert_called_once()
+    call_args = memory_manager.submit_auto_memory.call_args
+    assert call_args is not None
+    args, kwargs = call_args
     assert [m.get_text_content() for m in args[0]] == [
         "u2",
         "a2",
@@ -434,7 +488,7 @@ async def test_memorize_falls_back_to_assistant_replies_by_role() -> None:
         _msg("assistant", "a2", name="ConfiguredName", msg_id="r2"),
     ]
     memory_manager = MagicMock()
-    memory_manager.auto_memory = AsyncMock()
+    memory_manager.submit_auto_memory = MagicMock()
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -443,10 +497,10 @@ async def test_memorize_falls_back_to_assistant_replies_by_role() -> None:
 
     msg = await handler.handle_command("/memorize")
 
-    memory_manager.auto_memory.assert_awaited_once()
-    await_args = memory_manager.auto_memory.await_args
-    assert await_args is not None
-    args, kwargs = await_args
+    memory_manager.submit_auto_memory.assert_called_once()
+    call_args = memory_manager.submit_auto_memory.call_args
+    assert call_args is not None
+    args, kwargs = call_args
     assert [m.get_text_content() for m in args[0]] == ["u2", "a2"]
     assert kwargs["reply_id"] == "r2"
     assert kwargs["reply_ids"] == ["r2"]
@@ -461,7 +515,7 @@ async def test_memorize_one_matches_explicit_one() -> None:
         _msg("assistant", "a1", msg_id="r1"),
     ]
     memory_manager = MagicMock()
-    memory_manager.auto_memory = AsyncMock()
+    memory_manager.submit_auto_memory = MagicMock()
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -470,10 +524,10 @@ async def test_memorize_one_matches_explicit_one() -> None:
 
     await handler.handle_command("/memorize 1")
 
-    memory_manager.auto_memory.assert_awaited_once()
-    await_args = memory_manager.auto_memory.await_args
-    assert await_args is not None
-    args, kwargs = await_args
+    memory_manager.submit_auto_memory.assert_called_once()
+    call_args = memory_manager.submit_auto_memory.call_args
+    assert call_args is not None
+    args, kwargs = call_args
     assert [m.get_text_content() for m in args[0]] == ["u1", "a1"]
     assert kwargs["reply_ids"] == ["r1"]
 
@@ -482,7 +536,7 @@ async def test_memorize_one_matches_explicit_one() -> None:
 async def test_memorize_rejects_invalid_count() -> None:
     agent = _make_agent()
     memory_manager = MagicMock()
-    memory_manager.auto_memory = AsyncMock()
+    memory_manager.submit_auto_memory = MagicMock()
     handler = CommandHandler(
         agent_name="QwenPaw",
         agent=agent,
@@ -491,7 +545,7 @@ async def test_memorize_rejects_invalid_count() -> None:
 
     msg = await handler.handle_command("/memorize two")
 
-    memory_manager.auto_memory.assert_not_awaited()
+    memory_manager.submit_auto_memory.assert_not_called()
     assert "Invalid Count" in msg.get_text_content()
 
 

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -70,7 +70,7 @@ def _make_memory_manager(*, interval: int = 1):
     mm = MagicMock()
     mm.agent_id = "test-agent"
     mm.get_auto_memory_interval.return_value = interval
-    mm.auto_memory = AsyncMock()
+    mm.submit_auto_memory = MagicMock()
     mm.auto_memory_search = AsyncMock(return_value=None)
     mm.get_memory_prompt.return_value = ""
     return mm
@@ -418,7 +418,7 @@ class TestOnReplyAutomationSkip:
         state = _turn_state(agent)
         assert not state["pending"]
         assert not state["seen"]
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_user_triggers_auto_memory(self):
@@ -435,7 +435,7 @@ class TestOnReplyAutomationSkip:
         async for _ in gen:
             pass
 
-        mm.auto_memory.assert_awaited_once()
+        mm.submit_auto_memory.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_internal_user_message_is_excluded_from_memory(self):
@@ -470,8 +470,12 @@ class TestOnReplyAutomationSkip:
         async for _ in mw.on_reply(agent, {}, _next):
             pass
 
-        mm.auto_memory.assert_awaited_once()
-        assert mm.auto_memory.await_args.args[0] == [query, reply, final_reply]
+        mm.submit_auto_memory.assert_called_once()
+        assert mm.submit_auto_memory.call_args.args[0] == [
+            query,
+            reply,
+            final_reply,
+        ]
 
     @pytest.mark.asyncio
     async def test_interval_state_survives_middleware_rebuild(self):
@@ -492,7 +496,7 @@ class TestOnReplyAutomationSkip:
         async for _ in gen1:
             pass
 
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
         assert _turn_state(agent1)["pending"] == ["turn-1"]
 
         agent2 = _make_agent(source="user")
@@ -521,7 +525,7 @@ class TestOnReplyAutomationSkip:
         async for _ in gen2:
             pass
 
-        mm.auto_memory.assert_awaited_once()
+        mm.submit_auto_memory.assert_called_once()
         assert not _turn_state(agent2)["pending"]
 
     @pytest.mark.asyncio
@@ -543,17 +547,17 @@ class TestOnReplyAutomationSkip:
 
         for turn_number in range(1, 5):
             await reply(turn_number)
-            mm.auto_memory.assert_not_awaited()
+            mm.submit_auto_memory.assert_not_called()
 
         await reply(5)
-        mm.auto_memory.assert_awaited_once()
-        assert [msg.id for msg in mm.auto_memory.await_args.args[0]] == [
+        mm.submit_auto_memory.assert_called_once()
+        assert [msg.id for msg in mm.submit_auto_memory.call_args.args[0]] == [
             f"turn-{idx}" for idx in range(1, 6)
         ]
         assert not _turn_state(agent)["pending"]
 
         await reply(6)
-        mm.auto_memory.assert_awaited_once()
+        mm.submit_auto_memory.assert_called_once()
         assert _turn_state(agent)["pending"] == ["turn-6"]
 
 
@@ -574,7 +578,7 @@ class TestOnCompressContextAutomationSkip:
         await mw.on_compress_context(agent, {}, next_handler)
 
         next_handler.assert_awaited_once_with()
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_heartbeat_does_not_inspect_compression(self):
@@ -611,7 +615,7 @@ class TestOnCompressContextAutomationSkip:
 
         assert "turn-1" in _turn_state(agent)["snapshots"]
         assert _turn_state(agent)["pending"] == ["turn-1"]
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_normal_request_may_flush_on_compress(self):
@@ -627,8 +631,8 @@ class TestOnCompressContextAutomationSkip:
 
         await mw.on_compress_context(agent, {}, next_handler)
 
-        mm.auto_memory.assert_awaited_once()
-        assert mm.auto_memory.await_args.args[0][0].id == "turn-1"
+        mm.submit_auto_memory.assert_called_once()
+        assert mm.submit_auto_memory.call_args.args[0][0].id == "turn-1"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -722,12 +726,12 @@ class TestOnCompressContextAutomationSkip:
         assert Msg.model_validate(raw_snapshot[0]).get_text_content() == (
             "remember me"
         )
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
 
         await mw._flush_auto_memory(agent)
-        assert mm.auto_memory.await_args.args[0][0].get_text_content() == (
-            "remember me"
-        )
+        assert mm.submit_auto_memory.call_args.args[0][
+            0
+        ].get_text_content() == ("remember me")
 
 
 class TestDidCompressContext:
@@ -779,7 +783,7 @@ class TestFlushAutoMemoryDefensiveGuard:
         await mw._flush_auto_memory(agent)
 
         assert _turn_state(agent)["pending"] == ["m1", "m2"]
-        mm.auto_memory.assert_not_awaited()
+        mm.submit_auto_memory.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_normal_request_flushes(self):
@@ -792,13 +796,16 @@ class TestFlushAutoMemoryDefensiveGuard:
 
         await mw._flush_auto_memory(agent)
 
-        mm.auto_memory.assert_awaited_once()
+        mm.submit_auto_memory.assert_called_once()
         assert not _turn_state(agent)["pending"]
 
     @pytest.mark.asyncio
     async def test_failed_submission_keeps_pending_for_next_turn_retry(self):
         mm = _make_memory_manager()
-        mm.auto_memory.side_effect = [RuntimeError("submit failed"), None]
+        mm.submit_auto_memory.side_effect = [
+            RuntimeError("submit failed"),
+            None,
+        ]
         mw = MemoryMiddleware(memory_manager=mm)
         agent = _make_agent(source="user")
         agent.state = AgentState(session_id="session-1")
@@ -816,8 +823,8 @@ class TestFlushAutoMemoryDefensiveGuard:
             agent.state.model_dump(mode="json"),
         )
         await mw._flush_auto_memory(agent)
-        assert mm.auto_memory.await_count == 2
-        assert mm.auto_memory.await_args.args[0][0].id == "turn-1"
+        assert mm.submit_auto_memory.call_count == 2
+        assert mm.submit_auto_memory.call_args.args[0][0].id == "turn-1"
         assert not _turn_state(agent)["pending"]
         assert not _turn_state(agent)["snapshots"]
 
@@ -831,7 +838,7 @@ class TestFlushAutoMemoryDefensiveGuard:
 
         await mw._flush_auto_memory(agent)
 
-        assert [msg.id for msg in mm.auto_memory.await_args.args[0]] == [
+        assert [msg.id for msg in mm.submit_auto_memory.call_args.args[0]] == [
             "turn-2",
         ]
         assert not _turn_state(agent)["pending"]
@@ -848,7 +855,7 @@ class TestFlushAutoMemoryDefensiveGuard:
 
         await mw._flush_auto_memory(agent, count=1)
 
-        assert [msg.id for msg in mm.auto_memory.await_args.args[0]] == [
+        assert [msg.id for msg in mm.submit_auto_memory.call_args.args[0]] == [
             "turn-2",
         ]
         assert not _turn_state(agent)["pending"]

--- a/tests/unit/agents/test_react_agent_compression.py
+++ b/tests/unit/agents/test_react_agent_compression.py
@@ -43,12 +43,12 @@ class _MemoryManager:
     async def auto_memory(self, _messages: list[Msg], **_kwargs: Any) -> None:
         self._events.append("auto_memory")
 
-    def add_summarize_task(
+    def submit_auto_memory(
         self,
         messages: list[Msg],
         **_kwargs: Any,
     ) -> None:
-        self._events.append("handler_memory")
+        self._events.append("auto_memory")
         self.submitted.append([msg.get_text_content() for msg in messages])
 
 
@@ -172,6 +172,6 @@ async def test_manual_compact_submits_auto_memory_once() -> None:
 
     await handler.handle_command("/compact")
 
-    assert events == ["scroll", "handler_memory"]
+    assert events == ["scroll", "auto_memory"]
     assert memory_manager.submitted == [["remember this", "answer-1"]]
     assert not auto_memory_turn_state(agent.state)["pending"]

--- a/tests/unit/app/routers/test_agents_router.py
+++ b/tests/unit/app/routers/test_agents_router.py
@@ -22,6 +22,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from qwenpaw.agents.memory.action_provider import MemoryActionProvider
 from qwenpaw.agents.memory.reme_embedding import (
     EmbeddingReindexUnavailableError,
 )
@@ -590,8 +591,8 @@ def test_rebuild_memory_index_runs_reme_job(
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
     reindex_response = MagicMock(success=True, answer="done")
-    memory_manager = MagicMock()
-    memory_manager.rebuild_index = AsyncMock(return_value=reindex_response)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=reindex_response)
     manager_mock.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
     )
@@ -615,7 +616,10 @@ def test_rebuild_memory_index_runs_reme_job(
         "status": "completed",
         "scope": "embedding",
     }
-    memory_manager.rebuild_index.assert_awaited_once_with("embedding")
+    memory_manager.run_action.assert_awaited_once_with(
+        "reindex",
+        scope="embedding",
+    )
 
 
 def test_rebuild_memory_index_rejects_concurrent_run(
@@ -624,8 +628,8 @@ def test_rebuild_memory_index_rejects_concurrent_run(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.rebuild_index = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         side_effect=RuntimeError("Memory index rebuild is already running"),
     )
     manager_mock.get_agent = AsyncMock(
@@ -653,8 +657,8 @@ def test_rebuild_memory_index_rejects_disabled_embedding(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.rebuild_index = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         side_effect=EmbeddingReindexUnavailableError(
             "Embedding index rebuild requires an enabled embedding "
             "configuration",
@@ -688,8 +692,8 @@ def test_rebuild_all_rejects_disabled_embedding(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.rebuild_index = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         side_effect=EmbeddingReindexUnavailableError(
             "An all-scope index rebuild requires an enabled embedding "
             "configuration",
@@ -727,8 +731,10 @@ def test_undo_pending_embedding_reindex_restores_indexed_config(
     memory_config.embedding_model_config.model_name = "pending-model"
     memory_config.pending_reindex_embedding_config = indexed
     memory_config.needs_reindex = True
-    memory_manager = MagicMock(is_reindexing=False)
-    memory_manager.undo_embedding_reindex = AsyncMock(return_value=indexed)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
+        return_value=MagicMock(success=True, answer=indexed),
+    )
     manager_mock.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
     )
@@ -748,7 +754,7 @@ def test_undo_pending_embedding_reindex_restores_indexed_config(
 
     assert response.status_code == 200
     assert response.json()["model_name"] == "indexed-model"
-    memory_manager.undo_embedding_reindex.assert_awaited_once_with()
+    memory_manager.run_action.assert_awaited_once_with("undo_reindex")
 
 
 def test_undo_pending_embedding_reindex_rejects_unknown_agent(
@@ -810,8 +816,8 @@ def test_get_memory_runtime_status_does_not_run_a_reme_job(
         "embedding_reindex_undo_available": True,
     }
     memory_manager = MagicMock()
-    memory_manager.get_runtime_status.return_value = runtime_status
-    memory_manager.reme_status = AsyncMock()
+    memory_manager.get_runtime_status = MagicMock(return_value=runtime_status)
+    memory_manager.run_action = AsyncMock()
     manager_mock.get_loaded_agent.return_value = MagicMock(
         memory_manager=memory_manager,
     )
@@ -830,7 +836,7 @@ def test_get_memory_runtime_status_does_not_run_a_reme_job(
 
     assert response.status_code == 200
     assert response.json() == runtime_status
-    memory_manager.reme_status.assert_not_awaited()
+    memory_manager.run_action.assert_not_awaited()
 
 
 def test_get_memory_status_returns_structured_reme_metrics(
@@ -855,8 +861,8 @@ def test_get_memory_status_returns_structured_reme_metrics(
             },
         },
     )
-    memory_manager = MagicMock()
-    memory_manager.reme_status = AsyncMock(return_value=status_response)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=status_response)
     runtime_status = {
         "worker": {
             "status": "busy",
@@ -875,7 +881,7 @@ def test_get_memory_status_returns_structured_reme_metrics(
         "embedding_reindex_required": False,
         "embedding_reindex_undo_available": False,
     }
-    memory_manager.get_runtime_status.return_value = runtime_status
+    memory_manager.get_runtime_status = MagicMock(return_value=runtime_status)
     manager_mock.get_loaded_agent.return_value = MagicMock(
         memory_manager=memory_manager,
     )
@@ -897,7 +903,7 @@ def test_get_memory_status_returns_structured_reme_metrics(
         **status_response.metadata["status"]["memory"],
         "runtime": runtime_status,
     }
-    memory_manager.reme_status.assert_awaited_once_with()
+    memory_manager.run_action.assert_awaited_once_with("status")
     memory_manager.get_runtime_status.assert_called_once_with(
         auto_memory_interval=5,
     )
@@ -909,8 +915,8 @@ def test_get_memory_status_rejects_invalid_payload(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.reme_status = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         return_value=MagicMock(success=True, metadata={}),
     )
     manager_mock.get_loaded_agent.return_value = MagicMock(
@@ -968,8 +974,8 @@ def test_get_memory_status_returns_503_while_reme_dependency_is_starting(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.reme_status = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         side_effect=RuntimeError(
             "Dependency keyword_index:default accessed before start()",
         ),
@@ -1002,8 +1008,8 @@ def test_get_memory_status_does_not_mask_unexpected_runtime_error(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.reme_status = AsyncMock(
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(
         side_effect=RuntimeError("unexpected failure"),
     )
     manager_mock.get_loaded_agent.return_value = MagicMock(
@@ -1058,8 +1064,8 @@ def test_get_memory_graph_returns_reme_snapshot(
             ],
         },
     )
-    memory_manager = MagicMock()
-    memory_manager.graph_snapshot = AsyncMock(return_value=graph_response)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=graph_response)
     manager_mock.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
     )
@@ -1096,7 +1102,7 @@ def test_get_memory_graph_returns_reme_snapshot(
             },
         ],
     }
-    memory_manager.graph_snapshot.assert_awaited_once_with()
+    memory_manager.run_action.assert_awaited_once_with("graph_snapshot")
 
 
 @pytest.mark.asyncio
@@ -1115,8 +1121,8 @@ async def test_get_memory_graph_config_io_does_not_block_loop(
         success=True,
         answer={"version": 1, "nodes": [], "edges": []},
     )
-    memory_manager = MagicMock()
-    memory_manager.graph_snapshot = AsyncMock(return_value=graph_response)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=graph_response)
     manager = MagicMock()
     manager.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
@@ -1178,8 +1184,8 @@ def test_get_memory_graph_maps_nested_memory_roots(
             "edges": [],
         },
     )
-    memory_manager = MagicMock()
-    memory_manager.graph_snapshot = AsyncMock(return_value=graph_response)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=graph_response)
     manager_mock.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
     )
@@ -1210,8 +1216,8 @@ def test_get_memory_graph_reports_unavailable_reme(
     manager_mock,
 ):
     agent_config = AgentProfileConfig(id="bot", name="Bot")
-    memory_manager = MagicMock()
-    memory_manager.graph_snapshot = AsyncMock(return_value=None)
+    memory_manager = MagicMock(spec=MemoryActionProvider)
+    memory_manager.run_action = AsyncMock(return_value=None)
     manager_mock.get_agent = AsyncMock(
         return_value=MagicMock(memory_manager=memory_manager),
     )

--- a/website/public/docs/commands.en.md
+++ b/website/public/docs/commands.en.md
@@ -58,7 +58,7 @@ Optionally, add a one-shot instruction to guide which supported information the 
 ```
 **New Conversation Started!**
 
-- Summary task started in background
+- Auto-memory task started in background
 - Ready for new conversation
 ```
 
@@ -460,14 +460,14 @@ Git deduplicates identical content, and automatic GC removes old refs according 
 
 Commands for viewing and managing conversation history.
 
-| Command             | Response Content              |
-| ------------------- | ----------------------------- |
-| `/history`          | 📋 Message list + Token stats |
-| `/message`          | 📄 Specified message details  |
-| `/compact_str`      | 📝 Compressed summary content |
-| `/summarize_status` | 📊 Summary task status        |
-| `/dump_history`     | 📁 Exported history file path |
-| `/load_history`     | ✅ History load result        |
+| Command               | Response Content              |
+| --------------------- | ----------------------------- |
+| `/history`            | 📋 Message list + Token stats |
+| `/message`            | 📄 Specified message details  |
+| `/compact_str`        | 📝 Compressed summary content |
+| `/auto_memory_status` | 📊 Auto-memory task status    |
+| `/dump_history`       | 📁 Exported history file path |
+| `/load_history`       | ✅ History load result        |
 
 ---
 
@@ -583,30 +583,32 @@ Status: in_progress
 
 ---
 
-### /summarize_status - View Summary Task Status
+### /auto_memory_status - View Auto-memory Task Status
 
-Display the running status of all background summary tasks, including task ID, start time, and execution results.
+Display the running status of all background auto-memory tasks, including task ID, start time, and execution results.
 
 ```
-/summarize_status
+/auto_memory_status
 ```
 
 **Example response:**
 
 ```
-**Summary Task Status**
+**Auto-memory Task Status**
 
 - **task-001**
   - Start: 2024-01-15 10:30:00
+  - Trigger: compact
   - Status: completed
   - Result: User requested help building a user authentication system...
 - **task-002**
   - Start: 2024-01-15 10:35:00
+  - Trigger: periodic
   - Status: failed
-  - Error: Summary generation timeout
+  - Error: Auto-memory processing timeout
 ```
 
-> 💡 Using `/compact` or `/new` automatically starts a summary task in the background. Use this command to check its execution status.
+> 💡 Using `/compact` or `/new` automatically starts an auto-memory task in the background. Use this command to check its execution status.
 
 ---
 

--- a/website/public/docs/commands.zh.md
+++ b/website/public/docs/commands.zh.md
@@ -58,7 +58,7 @@
 ```
 **New Conversation Started!**
 
-- Summary task started in background
+- Auto-memory task started in background
 - Ready for new conversation
 ```
 
@@ -460,14 +460,14 @@ Git 会对相同内容去重，自动垃圾回收也会按保留策略删除旧�
 
 查看和管理对话历史的命令。
 
-| 命令                | 返回内容                 |
-| ------------------- | ------------------------ |
-| `/history`          | 📋 消息列表 + Token 统计 |
-| `/message`          | 📄 指定消息详情          |
-| `/compact_str`      | 📝 压缩摘要内容          |
-| `/summarize_status` | 📊 摘要任务状态          |
-| `/dump_history`     | 📁 历史导出文件路径      |
-| `/load_history`     | ✅ 历史加载结果          |
+| 命令                  | 返回内容                 |
+| --------------------- | ------------------------ |
+| `/history`            | 📋 消息列表 + Token 统计 |
+| `/message`            | 📄 指定消息详情          |
+| `/compact_str`        | 📝 压缩摘要内容          |
+| `/auto_memory_status` | 📊 自动记忆任务状态      |
+| `/dump_history`       | 📁 历史导出文件路径      |
+| `/load_history`       | ✅ 历史加载结果          |
 
 ---
 
@@ -583,30 +583,32 @@ Status: in_progress
 
 ---
 
-### /summarize_status - 查看摘要任务状态
+### /auto_memory_status - 查看自动记忆任务状态
 
-显示所有后台摘要任务的运行状态，包括任务 ID、开始时间和执行结果。
+显示所有后台自动记忆任务的运行状态，包括任务 ID、开始时间和执行结果。
 
 ```
-/summarize_status
+/auto_memory_status
 ```
 
 **返回示例：**
 
 ```
-**Summary Task Status**
+**Auto-memory Task Status**
 
 - **task-001**
   - Start: 2024-01-15 10:30:00
+  - Trigger: compact
   - Status: completed
   - Result: 用户请求帮助构建用户认证系统...
 - **task-002**
   - Start: 2024-01-15 10:35:00
+  - Trigger: periodic
   - Status: failed
-  - Error: Summary generation timeout
+  - Error: Auto-memory processing timeout
 ```
 
-> 💡 使用 `/compact` 或 `/new` 时会自动在后台启动摘要任务，可通过此命令查看其执行情况。
+> 💡 使用 `/compact` 或 `/new` 时会自动在后台启动自动记忆任务，可通过此命令查看其执行情况。
 
 ---
 

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -418,6 +418,17 @@ Legacy `inbox_push_enabled` is migration input only. It initializes any missing 
 
 The long-term memory page shows background jobs, the waiting queue, resource use, and index-component status.
 
+Conversation capture uses one FIFO Auto-Memory worker per Agent. Periodic
+capture, `/memorize`, context compaction, and `/new` all submit work to this
+same queue; each status record identifies its `periodic`, `manual`, `compact`,
+or `new` trigger. Use `/auto_memory_status` to inspect these tasks from a
+conversation. Shutdown uses one five-second deadline to stop this worker,
+quiesce active ReMe jobs, and close ReMe; it reports failure instead of waiting
+indefinitely or replacing a backend that is still in use. ReMe maintenance
+operations such as status, graph snapshots, reindexing, and embedding rollback
+use the memory-action interface, validate arguments against each action's full
+JSON Schema, and do not enter the Auto-Memory queue.
+
 <p align="center">
   <img src="https://img.alicdn.com/imgextra/i3/O1CN01hrPfLUAdE1C2Fz5c_!!6000000006909-0-tps-1112-1312.jpg" alt="ReMe background activity, resource usage, and index component status" />
 </p>

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -392,6 +392,15 @@ BM25 擅长“宁德时代”“CATL”“碳酸锂”这类明确名称；向�
 
 长期记忆页面可以查看后台任务、等待队列、资源占用和索引组件状态。
 
+每个 Agent 的对话记忆沉淀由一个 FIFO Auto-Memory worker 统一处理。周期触发、
+`/memorize`、上下文压缩和 `/new` 都会向同一队列提交任务；每条状态记录会标明
+`periodic`、`manual`、`compact` 或 `new` 触发来源。可在对话中使用
+`/auto_memory_status` 查看这些任务。关闭时会用同一个五秒 deadline 停止 worker、
+等待正在执行的 ReMe job 退出并关闭 ReMe；如果无法按时完成，则返回失败，而不会
+无限等待或替换仍在使用的 backend。ReMe 的状态查询、图谱快照、索引重建和
+Embedding 配置撤销统一通过 memory action 接口执行，参数会按照每个 action 的完整
+JSON Schema 校验，且不会进入 Auto-Memory 队列。
+
 <p align="center">
   <img src="https://img.alicdn.com/imgextra/i3/O1CN01hrPfLUAdE1C2Fz5c_!!6000000006909-0-tps-1112-1312.jpg" alt="ReMe 后台活动、资源占用和索引组件状态" />
 </p>


### PR DESCRIPTION
## Description

This PR performs a deliberate breaking refactor of the memory-manager contract so automatic memory capture, recall, background execution, and optional backend actions have clear and consistent ownership.

### What changed

#### Unified automatic-memory lifecycle

- Replaces the summary-specific worker API with a backend-independent automatic-memory queue:
  - `add_summarize_task(...)` becomes `submit_auto_memory(...)`.
  - `list_summarize_status()` becomes `list_auto_memory_tasks()`.
  - worker/task state is renamed from summary terminology to automatic-memory terminology.
- Makes `memory_search(...)` and `auto_memory(...)` explicit backend contracts on `BaseMemoryManager`.
- Moves common automatic recall behavior into `BaseMemoryManager`, with backend-provided `AutoMemorySearchOptions` and an overridable search hook.
- Serializes automatic-memory writes through one FIFO worker. ReMe shutdown uses one five-second deadline across worker shutdown, lifecycle-lease quiescing, and backend close; it returns failure instead of hanging or replacing a backend still in use.
- Records a trigger for every task (`periodic`, `manual`, `compact`, or `new`) so runtime status accurately explains why work was submitted.

#### Backend migrations

- Migrates ReMe Light, ADBPG, PowerContext, and the no-op backend to the new contract.
- Removes backend-specific fire-and-forget task sets from ADBPG and PowerContext; persistence now runs through the shared queue.
- Preserves ReMe reranking behavior through the common `memory_search(...)` path.
- Keeps PowerContext's network-governed search wrapper and explicit remember tool.
- Redacts the configured PowerContext token before automatic-memory failures reach shared worker logs or runtime status.

#### Optional memory actions

- Adds the runtime-checkable `MemoryActionProvider` protocol for optional user-callable backend capabilities.
- Exposes servable ReMe jobs through `list_actions()` and validates action arguments with a standards-compliant JSON Schema validator, including composition, nested items, patterns, and numeric constraints.
- Routes commands, API maintenance, embedding rollback, and scheduled Auto-Dream, Daily Paper, and Auto Fin execution through `run_action(...)`.
- Removes the public `dream`, `daily_paper`, `auto_fin`, `rebuild_index`, `undo_embedding_reindex`, and `get_memory_config` entry points; cron integration now uses a private action adapter.
- Retains the exclusive lifecycle boundary for embedding reindex operations.

#### Commands, API, and Console

- Replaces `/summarize_status` with `/auto_memory_status`; the legacy command is intentionally removed.
- Updates `/new`, `/compact`, and `/memorize` to submit work through the unified queue with the correct trigger.
- Adds task triggers to the memory runtime API model and Console types.
- Updates the ReMe status modal to display trigger labels and use automatic-memory terminology.
- Updates English and Chinese command documentation and Console translations.

### Breaking-change scope

This intentionally changes the Python memory-backend extension contract. Custom `BaseMemoryManager` implementations must now implement `memory_search(...)` and `auto_memory(...)`, use `_close_backend()` for backend-specific cleanup when relying on the shared `close()` implementation, and migrate summary-queue integrations to the automatic-memory APIs. `/auto_memory_status` is the sole status command after this migration.

**Related Issue:** None.

**Security Considerations:** PowerContext automatic-memory write failures are sanitized with the configured token before being logged or returned by the runtime status API. A regression test verifies that neither surface exposes the raw token.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

Not applicable: this PR changes the Console memory-status view but does not modify a messaging channel implementation.

## Testing

The backend test selection covers the shared queue, shutdown and cancellation behavior, automatic recall, each migrated backend, memory actions and schema validation, command dispatch, middleware compression behavior, router contracts, and conversation-command integration.

The Console test covers the updated ReMe status UI, and the TypeScript project build verifies the updated API types.

## Evidence

```text
PYTHONPATH=src:packages/qwenpawmail-mcp/src pytest -q \
  tests/unit/agents/memory \
  tests/unit/agents/test_command_handler.py \
  tests/unit/agents/test_memory_middleware.py \
  tests/unit/agents/test_react_agent_compression.py \
  tests/unit/agents/context/test_scroll_manager.py \
  tests/unit/app/routers/test_agents_router.py \
  tests/integration/test_conversation_commands.py \
  tests/integration/test_reme_embedding_contract.py

459 passed, 1 warning in 31.99s
```

```text
# Focused status-router rerun after resolving the latest-main conflict
58 passed, 1 warning in 1.87s
```

```text
# Review-finding regression tests: bounded ReMe close, pre-resolved token divisor, and full JSON Schema validation
60 passed in 1.51s
```

```text
npm run test:run -- src/pages/Agent/Config/components/ReMeLightMemoryCard.test.tsx

Test Files  1 passed (1)
Tests       34 passed (34)
```

```text
npm run format:check
# Console TypeScript and Prettier checks passed
```

```text
pnpm run format:check
# Website TypeScript and Prettier checks passed in a clean tracked-file set
```

```text
pre-commit run --all-files

Passed: Python AST, YAML/XML/TOML/JSON validation, encoding pragma,
private-key detection, whitespace, mypy, flake8, pylint, prettier,
and GitHub Actions workflow lint.

The first all-files run reformatted two changed Python files. The formatting
hooks were then rerun directly on the remaining changed file:

Add trailing commas......................................................Passed
black....................................................................Passed
```

## Additional Notes

- The branch is based directly on upstream `main` commit `163146ca0`, which remains the latest upstream commit at the time of this update.
- The memory-backend Python API changes are intentionally not shimmed; this is a full contract migration rather than a compatibility layer.
- `/summarize_status` is intentionally removed; `/auto_memory_status` is the sole status command.





