### PR TITLE
[Bug]: Loop mode picked from the composer menu never reaches the backend (Goal/Mission run in the default loop)

### DIFF
--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -233,11 +233,17 @@ vi.mock("@/stores/loopStore", () => ({
       })),
     },
   ),
+  beginLoopModeMessageSubmission: vi.fn(
+    (message: Record<string, unknown>) => message,
+  ),
   beginLoopModeSubmission: vi.fn((text: string) => text),
   fetchActiveLoopMode: vi.fn(() => Promise.resolve(null)),
   fetchAvailableLoopModes: vi.fn(() => Promise.resolve([])),
   markLoopModeRunning: vi.fn(),
   prepareLoopModeMessage: vi.fn((text: string) => text),
+  prepareLoopModeMessageSubmission: vi.fn(
+    (message: Record<string, unknown>) => message,
+  ),
 }));
 
 vi.mock("@/stores/sidebarModeStore", () => ({

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -44,11 +44,13 @@ import ModelSelector from "./ModelSelector";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useAgentStore } from "../../stores/agentStore";
 import {
+  beginLoopModeMessageSubmission,
   beginLoopModeSubmission,
   fetchActiveLoopMode,
   fetchAvailableLoopModes,
   markLoopModeRunning,
   prepareLoopModeMessage,
+  prepareLoopModeMessageSubmission,
   useLoopStore,
 } from "../../stores/loopStore";
 import { buildLoopSlashSuggestions } from "./loopSlashSuggestions";
@@ -2530,6 +2532,14 @@ export default function ChatPage() {
         "Content-Type": "application/json",
         ...buildAuthHeaders(),
       };
+      const { input = [], biz_params } = data;
+      const session: SessionInfo = input[input.length - 1]?.session || {};
+      const lastInput = input.slice(-1);
+      const lastMsg = lastInput[0];
+      const preparedLastMsg =
+        usesQwenPawBackend && lastMsg
+          ? prepareLoopModeMessageSubmission(lastMsg)
+          : lastMsg;
 
       if (usesQwenPawBackend) {
         try {
@@ -2552,6 +2562,11 @@ export default function ChatPage() {
         }
       }
 
+      const submittedLastMsg =
+        usesQwenPawBackend && preparedLastMsg
+          ? beginLoopModeMessageSubmission(preparedLastMsg)
+          : preparedLastMsg;
+
       const submittedValue = pendingSenderClearRef.current;
       if (submittedValue !== null) {
         clearSubmittedSenderInput(submittedValue);
@@ -2559,17 +2574,16 @@ export default function ChatPage() {
         localStorage.removeItem(getDraftStorageKey(selectedAgent));
       }
 
-      const { input = [], biz_params } = data;
-      const session: SessionInfo = input[input.length - 1]?.session || {};
-      const lastInput = input.slice(-1);
-      const lastMsg = lastInput[0];
       const clientMessageId =
-        lastMsg?.role === "user" ? createClientMessageId() : undefined;
-      const rewrittenLastMsg: Record<string, unknown> | undefined = lastMsg
-        ? clientMessageId
-          ? attachClientMessageId(lastMsg, clientMessageId)
-          : lastMsg
-        : undefined;
+        submittedLastMsg?.role === "user"
+          ? createClientMessageId()
+          : undefined;
+      const rewrittenLastMsg: Record<string, unknown> | undefined =
+        submittedLastMsg
+          ? clientMessageId
+            ? attachClientMessageId(submittedLastMsg, clientMessageId)
+            : submittedLastMsg
+          : undefined;
       const rewrittenInput: Array<Record<string, unknown>> =
         rewrittenLastMsg?.content && Array.isArray(rewrittenLastMsg.content)
           ? [
@@ -2911,7 +2925,7 @@ export default function ChatPage() {
       const textarea = getActiveSenderTextarea();
       if (textarea) {
         const prepared = usesQwenPawBackend
-          ? beginLoopModeSubmission(textarea.value)
+          ? prepareLoopModeMessage(textarea.value)
           : textarea.value;
         if (prepared !== textarea.value) {
           setTextareaValue(textarea, prepared);

--- a/console/src/stores/loopStore.test.ts
+++ b/console/src/stores/loopStore.test.ts
@@ -15,6 +15,8 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  beginLoopModeMessageSubmission,
+  prepareLoopModeMessageSubmission,
   useLoopStore,
   DEFAULT_LOOP_MODE,
   type LoopModeInfo,
@@ -36,11 +38,19 @@ const customMode: LoopModeInfo = {
   source: "custom",
 };
 
+const missionMode: LoopModeInfo = {
+  id: "mission",
+  name: "Mission Mode",
+  slash_command: "mission",
+  description: "Run a multi-agent mission",
+  source: "builtin",
+};
+
 describe("loopStore state transitions (A#85096690)", () => {
   beforeEach(() => {
     useLoopStore.setState({
       selectedModeId: "default",
-      availableModes: [DEFAULT_LOOP_MODE, goalMode, customMode],
+      availableModes: [DEFAULT_LOOP_MODE, goalMode, missionMode, customMode],
       sessionState: "idle",
       activeMode: null,
       catalogLoading: false,
@@ -130,5 +140,69 @@ describe("loopStore state transitions (A#85096690)", () => {
     const state = useLoopStore.getState();
     expect(state.sessionState).toBe("running");
     expect(state.activeMode).toEqual(customMode);
+  });
+
+  it.each([
+    ["goal", "/goal Fix the failing tests", goalMode],
+    ["mission", "/mission Build the feature", missionMode],
+  ])(
+    "adds the selected %s mode to string message content",
+    (_, expected, mode) => {
+      useLoopStore.getState().setSelectedMode(mode.id);
+
+      const message = beginLoopModeMessageSubmission({
+        role: "user",
+        content: expected.replace(/^\/\w+ /, ""),
+      });
+
+      expect(message.content).toBe(expected);
+      expect(useLoopStore.getState().sessionState).toBe("starting");
+      expect(useLoopStore.getState().activeMode).toEqual(mode);
+    },
+  );
+
+  it("adds the selected mode to the text part of multimodal content", () => {
+    useLoopStore.getState().setSelectedMode("goal");
+
+    const message = beginLoopModeMessageSubmission({
+      role: "user",
+      content: [
+        { type: "image_url", image_url: { url: "data:image/png;base64,x" } },
+        { type: "text", text: "Describe this image" },
+      ],
+    });
+
+    expect(message.content).toEqual([
+      { type: "image_url", image_url: { url: "data:image/png;base64,x" } },
+      { type: "text", text: "/goal Describe this image" },
+    ]);
+  });
+
+  it("preserves an explicit loop command instead of adding the selected mode", () => {
+    useLoopStore.getState().setSelectedMode("goal");
+
+    const message = beginLoopModeMessageSubmission({
+      role: "user",
+      content: [{ type: "text", text: "/mission Build the feature" }],
+    });
+
+    expect(message.content).toEqual([
+      { type: "text", text: "/mission Build the feature" },
+    ]);
+    expect(useLoopStore.getState().activeMode).toEqual(missionMode);
+  });
+
+  it("preserves the selected mode while asynchronous request checks run", () => {
+    useLoopStore.getState().setSelectedMode("goal");
+    const prepared = prepareLoopModeMessageSubmission({
+      role: "user",
+      content: "Fix the failing tests",
+    });
+
+    useLoopStore.getState().resetSessionMode();
+    const submitted = beginLoopModeMessageSubmission(prepared);
+
+    expect(submitted.content).toBe("/goal Fix the failing tests");
+    expect(useLoopStore.getState().activeMode).toEqual(goalMode);
   });
 });

--- a/console/src/stores/loopStore.ts
+++ b/console/src/stores/loopStore.ts
@@ -173,6 +173,51 @@ export function beginLoopModeSubmission(text: string): string {
   return prepared;
 }
 
+function transformLoopModeMessage(
+  message: Record<string, unknown>,
+  transform: (text: string) => string,
+): Record<string, unknown> {
+  if (message.role !== "user") return message;
+  if (typeof message.content === "string") {
+    return {
+      ...message,
+      content: transform(message.content),
+    };
+  }
+  if (!Array.isArray(message.content)) return message;
+
+  let prepared = false;
+  const content = message.content.map((part) => {
+    if (
+      prepared ||
+      !part ||
+      typeof part !== "object" ||
+      (part as Record<string, unknown>).type !== "text" ||
+      typeof (part as Record<string, unknown>).text !== "string"
+    ) {
+      return part;
+    }
+    prepared = true;
+    return {
+      ...(part as Record<string, unknown>),
+      text: transform((part as Record<string, unknown>).text as string),
+    };
+  });
+  return prepared ? { ...message, content } : message;
+}
+
+export function prepareLoopModeMessageSubmission(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  return transformLoopModeMessage(message, prepareLoopModeMessage);
+}
+
+export function beginLoopModeMessageSubmission(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  return transformLoopModeMessage(message, beginLoopModeSubmission);
+}
+
 export function markLoopModeRunning(): void {
   useLoopStore.getState().setRunningMode();
 }


### PR DESCRIPTION
Fixed the Console loop-mode submission bug.

Root cause: `beforeSubmit` updated the textarea after the chat SDK had already captured its value, so the UI entered `starting` while the backend received the unprefixed message.

Changes:

- Apply the selected mode to the final user message at the request boundary.
- Preserve the selected mode across asynchronous model-configuration checks.
- Keep explicit slash commands authoritative.
- Support string and multimodal message content.
- Added regression coverage for Goal, Mission, explicit commands, and async request preparation.

Validation:

- `git diff --check` passed.
- Vitest could not start because this isolated worktree has no `console/node_modules` (`vitest.mjs` is missing). Dependencies were not downloaded because network access was not authorized.

Closes #7552