### PR TITLE
fix(chat): distinguish model errors from transport failures

### DIFF
--- a/console/src/pages/Chat/ChatPage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.test.tsx
@@ -28,6 +28,7 @@ const {
   mockSelectedAgent,
   mockSetSelectedAgent,
   mockGetTranscriptionProviderType,
+  mockDiscardLastUserMessage,
 } = vi.hoisted(() => ({
   mockListProviders: vi.fn(),
   mockGetActiveModels: vi.fn(),
@@ -37,6 +38,7 @@ const {
   mockSelectedAgent: vi.fn(() => "default"),
   mockSetSelectedAgent: vi.fn(),
   mockGetTranscriptionProviderType: vi.fn(),
+  mockDiscardLastUserMessage: vi.fn(),
 }));
 
 vi.mock("../../hooks/useAppMessage", () => ({
@@ -69,7 +71,14 @@ vi.mock("@agentscope-ai/chat", () => ({
   // render rightHeader so child components appear in the DOM
   AgentScopeRuntimeWebUI: vi.fn((props: any) => {
     capturedOptions = props.options;
-    return <div data-testid="chat-ui">{props.options?.theme?.rightHeader}</div>;
+    return (
+      <div data-testid="chat-ui">
+        {props.options?.theme?.rightHeader}
+        <div className="sender">
+          <textarea data-testid="sender-input" />
+        </div>
+      </div>
+    );
   }),
   useChatAnywhereSessionsState: vi.fn(() => ({
     sessions: [],
@@ -111,6 +120,16 @@ vi.mock("@/api/modules/agent", () => ({
   TranscriptionError: class TranscriptionError extends Error {},
 }));
 
+vi.mock("@/api/modules/skill", () => ({
+  skillApi: { listSkills: vi.fn(() => Promise.resolve([])) },
+}));
+
+vi.mock("@/stores/uploadLimitStore", () => ({
+  useUploadLimitStore: {
+    getState: vi.fn(() => ({ uploadMaxSizeMb: 10 })),
+  },
+}));
+
 vi.mock("antd", async (importOriginal) => {
   const actual = await importOriginal<typeof import("antd")>();
   return {
@@ -131,10 +150,20 @@ vi.mock("@/api/config", () => ({
 }));
 
 vi.mock("@/stores/agentStore", () => ({
-  useAgentStore: vi.fn(() => ({
-    selectedAgent: mockSelectedAgent(),
-    setSelectedAgent: mockSetSelectedAgent,
-  })),
+  useAgentStore: Object.assign(
+    vi.fn(() => ({
+      agents: [{ id: "default", backend: "qwenpaw" }],
+      getLastChatId: vi.fn(() => undefined),
+      removeLastChatId: vi.fn(),
+      selectedAgent: mockSelectedAgent(),
+      setLastChatId: vi.fn(),
+      setSelectedAgent: mockSetSelectedAgent,
+    })),
+    {
+      getState: vi.fn(() => ({ selectedAgent: mockSelectedAgent() })),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  ),
 }));
 
 vi.mock("@/contexts/ThemeContext", () => ({
@@ -148,14 +177,39 @@ vi.mock("./sessionApi", () => ({
     onSessionSelected: null,
     onSessionCreated: null,
     getRealIdForSession: vi.fn(() => null),
+    getBackendSessionId: vi.fn((sessionId: string) => sessionId),
+    getEffectiveSessionId: vi.fn((sessionId: string) => sessionId),
+    getSessionIdentity: vi.fn(() => ({
+      sessionId: "",
+      userId: "console-user",
+      channel: "console",
+    })),
+    discardLastUserMessage: mockDiscardLastUserMessage,
+    isUnresolvedLocalSession: vi.fn(() => false),
+    resetWindowIdentity: vi.fn(),
     setLastUserMessage: vi.fn(),
+    trackNavigatedSession: vi.fn(),
+    triggerResolve: vi.fn(),
+    isSessionSwitching: false,
+    lastActiveChatId: null,
+    preferredChatId: null,
   },
 }));
 
 vi.mock("./OptionsPanel/defaultConfig", () => ({
-  default: { theme: { leftHeader: {} }, api: {} },
+  default: {
+    theme: {
+      leftHeader: {},
+      bubbleList: { userMessageAnchors: { variant: "navigator" } },
+    },
+    api: {},
+  },
   getDefaultConfig: vi.fn(() => ({
-    theme: { leftHeader: {} },
+    theme: {
+      leftHeader: {},
+      bubbleList: { userMessageAnchors: { variant: "navigator" } },
+    },
+    api: {},
     welcome: {},
     sender: {},
   })),
@@ -203,6 +257,7 @@ describe("ChatPage", () => {
   beforeEach(() => {
     chatExtensions.__resetForTests();
     capturedOptions = null;
+    localStorage.clear();
     mockListProviders.mockResolvedValue(mockProviders);
     mockGetActiveModels.mockResolvedValue(mockActiveModel);
     mockUploadFile.mockResolvedValue({
@@ -229,7 +284,6 @@ describe("ChatPage", () => {
   it("renders child components ModelSelector / ChatActionGroup / ChatHeaderTitle", async () => {
     renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
     await screen.findByTestId("chat-ui");
-    console.log("DOM:", document.body.innerHTML.substring(0, 500));
     expect(screen.getByTestId("model-selector")).toBeInTheDocument();
     expect(screen.getByTestId("action-group")).toBeInTheDocument();
     expect(screen.getByTestId("header-title")).toBeInTheDocument();
@@ -237,55 +291,98 @@ describe("ChatPage", () => {
 
   // ── customFetch: model not configured → show modal ────────────────────────
 
-  it("customFetch returns 400 and shows modal when model is not configured", async () => {
-    mockGetActiveModels.mockResolvedValue({ active_llm: undefined });
+  it("sends chat when the active-model refresh fails", async () => {
+    mockGetActiveModels.mockRejectedValue(new Error("network"));
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
     renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
     await screen.findByTestId("chat-ui");
 
-    // directly invoke capturedOptions.api.fetch (openclaw pattern)
     const response = await capturedOptions.api.fetch({
-      input: [],
+      input: [{ role: "user", content: "hello" }],
       signal: undefined,
     });
-    expect(response.status).toBe(400);
-    expect(
-      await screen.findByText("modelConfig.promptTitle"),
-    ).toBeInTheDocument();
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/console/chat",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(screen.queryByText("modelConfig.promptTitle")).toBeNull();
   });
 
-  it("shows model config modal when provider API throws", async () => {
-    mockGetActiveModels.mockRejectedValue(new Error("network"));
+  it("shows the modal for an explicit backend model error", async () => {
     renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
     await screen.findByTestId("chat-ui");
 
-    const response = await capturedOptions.api.fetch({
-      input: [],
-      signal: undefined,
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      );
     });
-    expect(response.status).toBe(400);
-    expect(
-      await screen.findByText("modelConfig.promptTitle"),
-    ).toBeInTheDocument();
+
+    expect(await screen.findByTestId("modal")).toBeInTheDocument();
+  });
+
+  it("does not show the modal for other backend errors", async () => {
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "AGENT_CONFIG_UNAVAILABLE", message: "offline" },
+        }),
+      );
+    });
+
+    expect(screen.queryByTestId("modal")).toBeNull();
+  });
+
+  it("terminates an empty reconnect stream for the SDK", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+
+    const response = await capturedOptions.api.reconnect({
+      session_id: "chat-1",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("CHAT_STREAM_INCOMPLETE");
   });
 
   // ── modal interaction ─────────────────────────────────────────────────────
 
   it("clicking Skip button closes the modal", async () => {
-    mockGetActiveModels.mockResolvedValue({ active_llm: undefined });
     const user = userEvent.setup();
     renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
     await screen.findByTestId("chat-ui");
 
-    await capturedOptions.api.fetch({ input: [], signal: undefined });
-    await screen.findByText("modelConfig.promptTitle");
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      );
+    });
+    await screen.findByTestId("modal");
 
-    await user.click(screen.getByText("modelConfig.skipButton"));
+    await user.click(screen.getByRole("button", { name: "Skip" }));
     // antd Modal has animations; wait for DOM removal
     await waitFor(
-      () =>
-        expect(
-          screen.queryByText("modelConfig.skipButton"),
-        ).not.toBeInTheDocument(),
+      () => expect(screen.queryByTestId("modal")).not.toBeInTheDocument(),
       { timeout: 3000 },
     );
   });
@@ -341,13 +438,226 @@ describe("ChatPage", () => {
       signal: undefined,
     });
 
-    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const chatCall = vi
+      .mocked(fetch)
+      .mock.calls.find(([url]) => url === "/api/console/chat");
+    const init = chatCall?.[1] as RequestInit;
     const body = JSON.parse(String(init.body)) as Record<string, unknown>;
-    expect(body.request_context).toEqual({
-      session_id: "session-1",
-      agent_id: "default",
-      datasource_id: "ds-123",
+    expect(body.request_context).toEqual(
+      expect.objectContaining({
+        session_id: "session-1",
+        agent_id: "default",
+        datasource_id: "ds-123",
+      }),
+    );
+  });
+
+  it("restores submitted text and draft after a network failure", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network"));
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "keep this message";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+
+    const response = await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "keep this message" }],
+      signal: undefined,
     });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      detail: { code: "CHAT_REQUEST_FAILED", message: "network" },
+    });
+    expect(textarea.value).toBe("keep this message");
+    expect(
+      JSON.parse(
+        localStorage.getItem("qwenpaw_chat_input_draft_default") || "{}",
+      ).value,
+    ).toBe("keep this message");
+  });
+
+  it("preserves cancellation semantics for an aborted chat request", async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException("aborted", "AbortError");
+    global.fetch = vi.fn().mockRejectedValue(abortError);
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "cancel this message";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+    controller.abort();
+
+    await expect(
+      capturedOptions.api.fetch({
+        input: [{ role: "user", content: "cancel this message" }],
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortError);
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      );
+    });
+    expect(textarea.value).toBe("");
+    expect(localStorage.getItem("qwenpaw_chat_input_draft_default")).toBeNull();
+  });
+
+  it("restores submitted text and opens the modal after an HTTP model error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      clone: () => ({
+        json: vi.fn().mockResolvedValue({
+          detail: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      }),
+    } as unknown as Response);
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "retry me";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+
+    await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "retry me" }],
+      signal: undefined,
+    });
+
+    expect(textarea.value).toBe("retry me");
+    expect(await screen.findByTestId("modal")).toBeInTheDocument();
+  });
+
+  it("restores submitted text for an SSE model configuration error", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "configure then retry";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+    await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "configure then retry" }],
+      signal: undefined,
+    });
+    expect(textarea.value).toBe("");
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      );
+    });
+
+    expect(textarea.value).toBe("configure then retry");
+  });
+
+  it("restores and clears pending state for unavailable agent config", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/chat-config"],
+    });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "retry after config recovers";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+    await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "retry after config recovers" }],
+      signal: undefined,
+    });
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "AGENT_CONFIG_UNAVAILABLE", message: "offline" },
+        }),
+      );
+    });
+
+    expect(textarea.value).toBe("retry after config recovers");
+    expect(mockDiscardLastUserMessage).toHaveBeenCalledWith(
+      "chat-config",
+      expect.any(String),
+    );
+    expect(screen.queryByTestId("modal")).toBeNull();
+  });
+
+  it("does not restore a submission that failed during execution", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    renderWithProviders(<ChatPage />, {
+      initialEntries: ["/chat/chat-execution"],
+    });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "do not run twice";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+    await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "do not run twice" }],
+      signal: undefined,
+    });
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_EXECUTION_ERROR", message: "upstream" },
+        }),
+      );
+    });
+
+    expect(textarea.value).toBe("");
+    expect(mockDiscardLastUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite newer input when restoring a failed submission", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    renderWithProviders(<ChatPage />, { initialEntries: ["/chat"] });
+    await screen.findByTestId("chat-ui");
+    const textarea = screen.getByTestId("sender-input") as HTMLTextAreaElement;
+    textarea.value = "old submission";
+    await capturedOptions.sender.beforeSubmit();
+    textarea.value = "";
+    await capturedOptions.api.fetch({
+      input: [{ role: "user", content: "old submission" }],
+      signal: undefined,
+    });
+    textarea.value = "newer input";
+
+    act(() => {
+      capturedOptions.api.responseParser(
+        JSON.stringify({
+          object: "response",
+          status: "failed",
+          error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+        }),
+      );
+    });
+
+    expect(textarea.value).toBe("newer input");
   });
 
   it("renders fallback metadata as an in-chat system message", async () => {
@@ -488,7 +798,7 @@ describe("ChatPage", () => {
     await screen.findByTestId("chat-ui");
 
     expect(capturedOptions.sender.allowSpeech).toBe(false);
-    expect(capturedOptions.sender.prefix).toBeUndefined();
+    expect(capturedOptions.sender.prefix.props.children[0]).toBeNull();
 
     act(() => {
       resolveProviderType({ transcription_provider_type: "disabled" });
@@ -505,7 +815,7 @@ describe("ChatPage", () => {
 
     await waitFor(() => {
       expect(capturedOptions.sender.allowSpeech).toBe(false);
-      expect(capturedOptions.sender.prefix).toBeTruthy();
+      expect(capturedOptions.sender.prefix.props.children[0]).toBeTruthy();
     });
   });
 
@@ -519,7 +829,7 @@ describe("ChatPage", () => {
 
     await waitFor(() => {
       expect(capturedOptions.sender.allowSpeech).toBe(true);
-      expect(capturedOptions.sender.prefix).toBeUndefined();
+      expect(capturedOptions.sender.prefix.props.children[0]).toBeNull();
     });
   });
 

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -155,12 +155,12 @@ export default function ModelSelector({
   }, []);
   const {
     activeModels,
+    commitActiveModels,
     fetchData,
     loading,
     loadError,
     providers,
     refreshActiveModels,
-    setActiveModels,
     setProviders,
   } = useModelSelectorData({
     agentId: selectedAgent,
@@ -400,7 +400,7 @@ export default function ModelSelector({
       ) {
         return;
       }
-      setActiveModels(
+      commitActiveModels(
         updated?.active_llm
           ? updated
           : {
@@ -408,7 +408,6 @@ export default function ModelSelector({
               active_llm: { provider_id: providerId, model: modelId },
             },
       );
-      publishActiveMaxInputLength(updated?.effective_max_input_length);
       rememberRecent(providerId, modelId);
     } catch (err) {
       if (

--- a/console/src/pages/Chat/ModelSelector/useModelSelectorData.test.tsx
+++ b/console/src/pages/Chat/ModelSelector/useModelSelectorData.test.tsx
@@ -14,15 +14,21 @@ vi.mock("./modelSelectorApi", () => ({
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 describe("useModelSelectorData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
   });
 
   it("keeps initial providers when active refresh finishes first", async () => {
@@ -67,5 +73,320 @@ describe("useModelSelectorData", () => {
     expect(result.current.activeModels).toEqual(refreshed);
     expect(onActiveModels).toHaveBeenCalledTimes(1);
     expect(onActiveModels).toHaveBeenCalledWith(refreshed);
+  });
+
+  it("refreshes the active model after the online event", async () => {
+    const initialModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-old" },
+    };
+    const refreshedModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-new" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: initialModels,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockResolvedValue(
+      refreshedModels,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(refreshedModels);
+    });
+  });
+
+  it("refreshes after a persisted pageshow event", async () => {
+    const initialModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-old" },
+    };
+    const refreshedModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-new" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: initialModels,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockResolvedValue(
+      refreshedModels,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const event = new Event("pageshow");
+    Object.defineProperty(event, "persisted", { value: true });
+    act(() => window.dispatchEvent(event));
+
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(refreshedModels);
+    });
+  });
+
+  it("does not refresh after a normal pageshow event", async () => {
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: null,
+      loadError: false,
+    });
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => window.dispatchEvent(new Event("pageshow")));
+
+    expect(modelSelectorApi.loadActiveModels).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the active model when the page becomes visible", async () => {
+    const initialModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-old" },
+    };
+    const refreshedModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-new" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: initialModels,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockResolvedValue(
+      refreshedModels,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(refreshedModels);
+    });
+  });
+
+  it("keeps the last model when a recovery refresh fails", async () => {
+    const initialModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-old" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: initialModels,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockRejectedValue(
+      new Error("network"),
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(initialModels);
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => {
+      expect(modelSelectorApi.loadActiveModels).toHaveBeenCalledOnce();
+    });
+    expect(result.current.activeModels).toEqual(initialModels);
+  });
+
+  it("applies an older initial result when a newer refresh fails", async () => {
+    const initial = deferred<{
+      providers: ProviderInfo[] | null;
+      activeModels: ActiveModelsInfo | null;
+      loadError: boolean;
+    }>();
+    const refresh = deferred<ActiveModelsInfo>();
+    const initialModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-old" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockReturnValue(
+      initial.promise,
+    );
+    vi.mocked(modelSelectorApi.loadActiveModels).mockReturnValue(
+      refresh.promise,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+
+    act(() => window.dispatchEvent(new Event("online")));
+    refresh.reject(new Error("network"));
+    initial.resolve({
+      providers: [],
+      activeModels: initialModels,
+      loadError: false,
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(initialModels);
+    });
+    expect(onActiveModels).toHaveBeenCalledOnce();
+  });
+
+  it("does not let an older initial result overwrite a newer refresh", async () => {
+    const initial = deferred<{
+      providers: ProviderInfo[] | null;
+      activeModels: ActiveModelsInfo | null;
+      loadError: boolean;
+    }>();
+    const refreshedModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-new" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockReturnValue(
+      initial.promise,
+    );
+    vi.mocked(modelSelectorApi.loadActiveModels).mockResolvedValue(
+      refreshedModels,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+
+    act(() => window.dispatchEvent(new Event("online")));
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(refreshedModels);
+    });
+    initial.resolve({
+      providers: [],
+      activeModels: {
+        active_llm: { provider_id: "openai", model: "gpt-old" },
+      },
+      loadError: false,
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.activeModels).toEqual(refreshedModels);
+    expect(onActiveModels).toHaveBeenCalledOnce();
+  });
+
+  it("does not let an older refresh overwrite an explicit model commit", async () => {
+    const recovery = deferred<ActiveModelsInfo>();
+    const committedModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-selected" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: null,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockReturnValue(
+      recovery.promise,
+    );
+    const onActiveModels = vi.fn();
+    const { result } = renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let refreshPromise: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refreshActiveModels();
+    });
+    act(() => result.current.commitActiveModels(committedModels));
+    recovery.resolve({
+      active_llm: { provider_id: "openai", model: "gpt-stale" },
+    });
+    await act(async () => refreshPromise);
+
+    expect(result.current.activeModels).toEqual(committedModels);
+    expect(onActiveModels).toHaveBeenCalledOnce();
+    expect(onActiveModels).toHaveBeenCalledWith(committedModels);
+  });
+
+  it("does not apply an old agent result after the agent changes", async () => {
+    const agentA = deferred<{
+      providers: ProviderInfo[] | null;
+      activeModels: ActiveModelsInfo | null;
+      loadError: boolean;
+    }>();
+    const agentBModels: ActiveModelsInfo = {
+      active_llm: { provider_id: "openai", model: "gpt-agent-b" },
+    };
+    vi.mocked(modelSelectorApi.loadModelSelectorData)
+      .mockReturnValueOnce(agentA.promise)
+      .mockResolvedValueOnce({
+        providers: [],
+        activeModels: agentBModels,
+        loadError: false,
+      });
+    const onActiveModels = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ agentId }) => useModelSelectorData({ agentId, onActiveModels }),
+      { initialProps: { agentId: "agent-a" } },
+    );
+
+    rerender({ agentId: "agent-b" });
+    await waitFor(() => {
+      expect(result.current.activeModels).toEqual(agentBModels);
+    });
+    agentA.resolve({
+      providers: [],
+      activeModels: {
+        active_llm: { provider_id: "openai", model: "gpt-agent-a" },
+      },
+      loadError: false,
+    });
+    await act(async () => agentA.promise);
+
+    expect(result.current.activeModels).toEqual(agentBModels);
+    expect(onActiveModels).toHaveBeenCalledOnce();
+    expect(onActiveModels).toHaveBeenCalledWith(agentBModels);
+  });
+
+  it("coalesces concurrent recovery events", async () => {
+    const refresh = deferred<ActiveModelsInfo>();
+    vi.mocked(modelSelectorApi.loadModelSelectorData).mockResolvedValue({
+      providers: [],
+      activeModels: null,
+      loadError: false,
+    });
+    vi.mocked(modelSelectorApi.loadActiveModels).mockReturnValue(
+      refresh.promise,
+    );
+    const onActiveModels = vi.fn();
+    renderHook(() =>
+      useModelSelectorData({ agentId: "default", onActiveModels }),
+    );
+    await waitFor(() => {
+      expect(modelSelectorApi.loadModelSelectorData).toHaveBeenCalledOnce();
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      const event = new Event("pageshow");
+      Object.defineProperty(event, "persisted", { value: true });
+      window.dispatchEvent(event);
+    });
+
+    expect(modelSelectorApi.loadActiveModels).toHaveBeenCalledOnce();
+    refresh.resolve({
+      active_llm: { provider_id: "openai", model: "gpt-new" },
+    });
   });
 });

--- a/console/src/pages/Chat/ModelSelector/useModelSelectorData.ts
+++ b/console/src/pages/Chat/ModelSelector/useModelSelectorData.ts
@@ -13,20 +13,49 @@ export function useModelSelectorData({
   onActiveModels,
 }: UseModelSelectorDataOptions) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  const [activeModels, setActiveModels] = useState<ActiveModelsInfo | null>(
-    null,
-  );
+  const [activeModels, setActiveModelsState] =
+    useState<ActiveModelsInfo | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
   const providersRequestRef = useRef(0);
   const activeRequestRef = useRef(0);
+  const lastAppliedActiveRequestRef = useRef(0);
+  const activeAgentRef = useRef(agentId);
+  const activeRefreshRef = useRef<{
+    agentId: string;
+    promise: Promise<void>;
+  } | null>(null);
+  activeAgentRef.current = agentId;
 
   const applyActiveModels = useCallback(
     (value: ActiveModelsInfo) => {
-      setActiveModels(value);
+      setActiveModelsState(value);
       onActiveModels(value);
     },
     [onActiveModels],
+  );
+
+  const commitActiveModels = useCallback(
+    (value: ActiveModelsInfo) => {
+      const requestId = ++activeRequestRef.current;
+      lastAppliedActiveRequestRef.current = requestId;
+      applyActiveModels(value);
+    },
+    [applyActiveModels],
+  );
+
+  const applyActiveModelsIfNewest = useCallback(
+    (requestId: number, requestAgentId: string, value: ActiveModelsInfo) => {
+      if (
+        requestAgentId !== activeAgentRef.current ||
+        requestId <= lastAppliedActiveRequestRef.current
+      ) {
+        return;
+      }
+      lastAppliedActiveRequestRef.current = requestId;
+      applyActiveModels(value);
+    },
+    [applyActiveModels],
   );
 
   const fetchData = useCallback(async () => {
@@ -38,8 +67,12 @@ export function useModelSelectorData({
       const result = await modelSelectorApi.loadModelSelectorData(agentId);
       if (providersRequestId !== providersRequestRef.current) return;
       if (result.providers) setProviders(result.providers);
-      if (result.activeModels && activeRequestId === activeRequestRef.current) {
-        applyActiveModels(result.activeModels);
+      if (result.activeModels) {
+        applyActiveModelsIfNewest(
+          activeRequestId,
+          agentId,
+          result.activeModels,
+        );
       }
       setLoadError(result.loadError);
       return result;
@@ -48,17 +81,56 @@ export function useModelSelectorData({
         setLoading(false);
       }
     }
-  }, [agentId, applyActiveModels]);
+  }, [agentId, applyActiveModelsIfNewest]);
 
-  const refreshActiveModels = useCallback(async () => {
+  const refreshActiveModels = useCallback(() => {
+    const inFlight = activeRefreshRef.current;
+    if (inFlight?.agentId === agentId) return inFlight.promise;
+
     const requestId = ++activeRequestRef.current;
-    const value = await modelSelectorApi.loadActiveModels(agentId);
-    if (requestId === activeRequestRef.current) applyActiveModels(value);
-  }, [agentId, applyActiveModels]);
+    const promise = modelSelectorApi
+      .loadActiveModels(agentId)
+      .then((value) => {
+        applyActiveModelsIfNewest(requestId, agentId, value);
+      })
+      .finally(() => {
+        if (activeRefreshRef.current?.promise === promise) {
+          activeRefreshRef.current = null;
+        }
+      });
+    activeRefreshRef.current = { agentId, promise };
+    return promise;
+  }, [agentId, applyActiveModelsIfNewest]);
 
   useEffect(() => {
     void fetchData();
   }, [fetchData]);
+
+  useEffect(() => {
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "hidden") return;
+      void refreshActiveModels().catch(() => {
+        // Keep the last known model when the backend is temporarily offline.
+      });
+    };
+
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) refreshWhenVisible();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") refreshWhenVisible();
+    };
+
+    window.addEventListener("online", refreshWhenVisible);
+    window.addEventListener("pageshow", handlePageShow);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("online", refreshWhenVisible);
+      window.removeEventListener("pageshow", handlePageShow);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [refreshActiveModels]);
 
   return {
     activeModels,
@@ -67,7 +139,7 @@ export function useModelSelectorData({
     loadError,
     providers,
     refreshActiveModels,
-    setActiveModels,
+    commitActiveModels,
     setProviders,
   };
 }

--- a/console/src/pages/Chat/chatResponseOutcome.test.ts
+++ b/console/src/pages/Chat/chatResponseOutcome.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getChatResponseOutcome,
+  isPreExecutionConfigurationError,
+  readChatResponseOutcome,
+  terminalizeChatResponse,
+} from "./chatResponseOutcome";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe("chat response outcomes", () => {
+  it.each([
+    "MODEL_NOT_CONFIGURED",
+    "AGENT_CONFIG_UNAVAILABLE",
+    "AGENT_CONFIG_STALE",
+    "CONFIGURATION_REQUIRED",
+  ])("classifies %s as a pre-execution configuration error", (code) => {
+    expect(isPreExecutionConfigurationError(code)).toBe(true);
+  });
+
+  it("does not classify an execution failure as safe to restore", () => {
+    expect(isPreExecutionConfigurationError("MODEL_EXECUTION_ERROR")).toBe(
+      false,
+    );
+  });
+
+  it("extracts an explicit failed response terminal", () => {
+    expect(
+      getChatResponseOutcome({
+        object: "response",
+        status: "failed",
+        error: { code: "AGENT_CONFIG_UNAVAILABLE", message: "offline" },
+      }),
+    ).toEqual({
+      status: "failed",
+      errorCode: "AGENT_CONFIG_UNAVAILABLE",
+      errorMessage: "offline",
+    });
+  });
+
+  it("reads a completed terminal across CRLF chunk boundaries", async () => {
+    const result = await readChatResponseOutcome(
+      streamFromChunks([
+        'data: {"object":"response","status":"in_progress"}\r\n\r',
+        '\ndata: {"object":"response","status":"completed"}',
+      ]),
+    );
+    expect(result).toEqual({
+      status: "completed",
+      errorCode: undefined,
+      errorMessage: undefined,
+    });
+  });
+
+  it("returns failed rather than treating clean EOF as success", async () => {
+    const result = await readChatResponseOutcome(
+      streamFromChunks([
+        "data: " +
+          JSON.stringify({
+            object: "response",
+            status: "failed",
+            error: { code: "AGENT_CONFIG_STALE", message: "reload" },
+          }) +
+          "\n\n",
+      ]),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.errorCode).toBe("AGENT_CONFIG_STALE");
+  });
+
+  it("returns null when EOF has no response terminal", async () => {
+    const result = await readChatResponseOutcome(
+      streamFromChunks(['data: {"type":"heartbeat"}\n\n']),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("keeps an explicit terminal when a trailing stream read fails", async () => {
+    const encoder = new TextEncoder();
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pulls === 0) {
+          pulls += 1;
+          controller.enqueue(
+            encoder.encode(
+              'data: {"object":"response","status":"completed"}\n\n',
+            ),
+          );
+          return;
+        }
+        controller.error(new Error("trailing usage disconnected"));
+      },
+    });
+
+    await expect(readChatResponseOutcome(body)).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("adds an incomplete terminal when a stream ends without one", async () => {
+    const response = terminalizeChatResponse(
+      new Response(streamFromChunks(['data: {"type":"heartbeat"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    await expect(readChatResponseOutcome(response.body)).resolves.toEqual({
+      status: "failed",
+      errorCode: "CHAT_STREAM_INCOMPLETE",
+      errorMessage: "Chat stream ended before completion",
+    });
+  });
+
+  it("adds an incomplete terminal when the response has no body", async () => {
+    const response = terminalizeChatResponse(
+      new Response(null, { status: 200 }),
+    );
+
+    await expect(readChatResponseOutcome(response.body)).resolves.toMatchObject(
+      {
+        status: "failed",
+        errorCode: "CHAT_STREAM_INCOMPLETE",
+      },
+    );
+  });
+
+  it("adds an incomplete terminal when the source stream errors", async () => {
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"type":"heartbeat"}\n\n'));
+        controller.error(new Error("connection lost"));
+      },
+    });
+    const response = terminalizeChatResponse(
+      new Response(source, { status: 200 }),
+    );
+
+    await expect(readChatResponseOutcome(response.body)).resolves.toMatchObject(
+      {
+        status: "failed",
+        errorCode: "CHAT_STREAM_INCOMPLETE",
+      },
+    );
+  });
+
+  it("does not enqueue after the SDK cancels an in-flight read", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise<void>(() => {
+          // Keep the source read pending until the wrapper is cancelled.
+        });
+      },
+    });
+    const response = terminalizeChatResponse(
+      new Response(source, { status: 200 }),
+    );
+    const reader = response.body!.getReader();
+    const pendingRead = reader.read();
+
+    await reader.cancel("aborted");
+    await expect(pendingRead).resolves.toMatchObject({ done: true });
+  });
+});

--- a/console/src/pages/Chat/chatResponseOutcome.ts
+++ b/console/src/pages/Chat/chatResponseOutcome.ts
@@ -1,0 +1,204 @@
+import { parseSseDataEvents } from "./sse";
+
+export type ChatResponseStatus = "completed" | "failed";
+
+export interface ChatResponseOutcome {
+  status: ChatResponseStatus;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+const INCOMPLETE_STREAM_ERROR = {
+  object: "response",
+  status: "failed",
+  error: {
+    code: "CHAT_STREAM_INCOMPLETE",
+    message: "Chat stream ended before completion",
+  },
+};
+
+const PRE_EXECUTION_CONFIGURATION_ERRORS = new Set([
+  "MODEL_NOT_CONFIGURED",
+  "AGENT_CONFIG_UNAVAILABLE",
+  "AGENT_CONFIG_STALE",
+  "CONFIGURATION_REQUIRED",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readErrorField(
+  payload: unknown,
+  field: "code" | "message",
+): string | undefined {
+  const record = asRecord(payload);
+  if (!record) return undefined;
+  for (const candidate of [record.error, record.detail, record]) {
+    const nested = asRecord(candidate);
+    if (typeof nested?.[field] === "string") {
+      return nested[field] as string;
+    }
+  }
+  return undefined;
+}
+
+export function getChatErrorCode(payload: unknown): string | undefined {
+  return readErrorField(payload, "code");
+}
+
+export function isModelNotConfiguredError(payload: unknown): boolean {
+  return getChatErrorCode(payload) === "MODEL_NOT_CONFIGURED";
+}
+
+export function getChatResponseOutcome(
+  payload: unknown,
+): ChatResponseOutcome | null {
+  const record = asRecord(payload);
+  if (
+    record?.object !== "response" ||
+    (record.status !== "completed" && record.status !== "failed")
+  ) {
+    return null;
+  }
+  return {
+    status: record.status,
+    errorCode: getChatErrorCode(record),
+    errorMessage: readErrorField(record, "message"),
+  };
+}
+
+export function isPreExecutionConfigurationError(
+  errorCode: string | undefined,
+): boolean {
+  return !!errorCode && PRE_EXECUTION_CONFIGURATION_ERRORS.has(errorCode);
+}
+
+/** Drain an SSE response and return its last explicit response terminal. */
+export async function readChatResponseOutcome(
+  body: ReadableStream<Uint8Array> | null,
+): Promise<ChatResponseOutcome | null> {
+  if (!body) return null;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let terminal: ChatResponseOutcome | null = null;
+
+  const consume = (events: string[]) => {
+    for (const raw of events) {
+      try {
+        const outcome = getChatResponseOutcome(JSON.parse(raw));
+        if (outcome) terminal = outcome;
+      } catch {
+        // Ignore malformed/non-JSON events and keep draining the response.
+      }
+    }
+  };
+
+  for (;;) {
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await reader.read();
+    } catch (error) {
+      if (terminal) return terminal;
+      throw error;
+    }
+    const { done, value } = result;
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parsed = parseSseDataEvents(buffer);
+    buffer = parsed.rest;
+    consume(parsed.events);
+  }
+
+  buffer += decoder.decode();
+  consume(parseSseDataEvents(buffer, true).events);
+  return terminal;
+}
+
+/**
+ * Ensure a streaming client receives a terminal event even when the transport
+ * closes without one. The SDK uses terminal events to leave the loading state.
+ */
+export function terminalizeChatResponse(response: Response): Response {
+  const encoder = new TextEncoder();
+  const terminalEvent = encoder.encode(
+    `data: ${JSON.stringify(INCOMPLETE_STREAM_ERROR)}\n\n`,
+  );
+
+  if (!response.body) {
+    const headers = new Headers(response.headers);
+    headers.set("Content-Type", "text/event-stream");
+    return new Response(terminalEvent, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  const source = response.body;
+  const reader = source.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let terminal: ChatResponseOutcome | null = null;
+  let closed = false;
+
+  const consume = (events: string[]) => {
+    for (const raw of events) {
+      try {
+        const outcome = getChatResponseOutcome(JSON.parse(raw));
+        if (outcome) terminal = outcome;
+      } catch {
+        // Ignore malformed events; the SDK will still receive a terminal.
+      }
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (closed) return;
+      try {
+        const result = await reader.read();
+        if (closed) return;
+        if (!result.done) {
+          controller.enqueue(result.value);
+          buffer += decoder.decode(result.value, { stream: true });
+          const parsed = parseSseDataEvents(buffer);
+          buffer = parsed.rest;
+          consume(parsed.events);
+          return;
+        }
+
+        buffer += decoder.decode();
+        consume(parseSseDataEvents(buffer, true).events);
+        if (!terminal) controller.enqueue(terminalEvent);
+        closed = true;
+        controller.close();
+      } catch {
+        if (closed) return;
+        if (!terminal) controller.enqueue(terminalEvent);
+        closed = true;
+        controller.close();
+      }
+    },
+    cancel(reason) {
+      closed = true;
+      void reader.cancel(reason).catch(() => {
+        // The source may already be closed when the SDK aborts the wrapper.
+      });
+    },
+  });
+
+  const headers = new Headers(response.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "text/event-stream");
+  }
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/console/src/pages/Chat/components/MessageQueuePanel.tsx
+++ b/console/src/pages/Chat/components/MessageQueuePanel.tsx
@@ -256,6 +256,8 @@ export default function MessageQueuePanel({
         const statusColor =
           item.status === "failed"
             ? "#ff4d4f"
+            : item.status === "unknown"
+            ? "#faad14"
             : item.status === "sending"
             ? "#1890ff"
             : "#52c41a";
@@ -349,6 +351,8 @@ export default function MessageQueuePanel({
                     color:
                       item.status === "failed"
                         ? "#ff4d4f"
+                        : item.status === "unknown"
+                        ? "#d48806"
                         : item.status === "sending"
                         ? "#1890ff"
                         : isDark
@@ -459,10 +463,17 @@ export default function MessageQueuePanel({
                     />
                   </Tooltip>
 
-                  {item.status === "failed" && (
+                  {(item.status === "failed" || item.status === "unknown") && (
                     <>
                       <Tooltip
-                        title={t("chat.queue.retry")}
+                        title={
+                          item.status === "unknown"
+                            ? t(
+                                "chat.queue.reconnect",
+                                "Reconnect and check status",
+                              )
+                            : t("chat.queue.retry")
+                        }
                         mouseEnterDelay={0.5}
                       >
                         <IconButton

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -164,7 +164,6 @@ import {
   toStoredName,
   copyText,
   extractCopyableText,
-  buildModelError,
   normalizeContentUrls,
   extractUserMessageText,
   extractTextFromMessage,
@@ -176,6 +175,14 @@ import {
   type CopyableResponse,
   type RuntimeLoadingBridgeApi,
 } from "./utils";
+import {
+  getChatResponseOutcome,
+  isModelNotConfiguredError,
+  isPreExecutionConfigurationError,
+  readChatResponseOutcome,
+  terminalizeChatResponse,
+  type ChatResponseOutcome,
+} from "./chatResponseOutcome";
 import {
   CHAT_BASE_PATH,
   buildChatPath,
@@ -283,6 +290,36 @@ async function waitForChatIdle(
   return false;
 }
 
+/** Reattach to a queue item whose previous stream ended without a terminal. */
+async function reconnectBackgroundQueueItem(
+  item: QueueItem,
+  backendSessionId: string,
+  signal: AbortSignal,
+): Promise<ChatResponseOutcome | null> {
+  try {
+    const headers = buildAuthHeaders();
+    if (item.agentId) headers["X-Agent-Id"] = item.agentId;
+    const response = await fetch(getApiUrl("/console/chat"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({
+        reconnect: true,
+        session_id: item.backendSessionId || backendSessionId,
+        user_id: item.userId || DEFAULT_USER_ID,
+        channel: item.channel || DEFAULT_CHANNEL,
+      }),
+      signal,
+    });
+    if (!response.ok) return null;
+    return await readChatResponseOutcome(response.body);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Convert a queue item's attachments array into the content-item format
  * expected by the backend POST body and by patchLastUserMessage.
@@ -357,6 +394,46 @@ async function startBackgroundQueue(
       const item = current[0];
       const clientMessageId = item.clientMessageId ?? item.id;
 
+      if (item.status === "unknown" || item.status === "sending") {
+        // A previous HTTP 200 was accepted by the server, but the stream did
+        // not prove completion (or is still in flight). Reconnect before
+        // considering a new send; a direct retry here could execute the same
+        // request twice after the page remounts.
+        const recovered = await reconnectBackgroundQueueItem(
+          item,
+          backendSessionId,
+          ctrl.signal,
+        );
+        if (ctrl.signal.aborted) break;
+        if (recovered?.status === "completed") {
+          useMessageQueueStore.getState().remove(queueKey, item.id);
+          continue;
+        }
+        if (recovered?.status === "failed") {
+          sessionApi.discardLastUserMessage(chatIdForStatus, clientMessageId);
+          useMessageQueueStore
+            .getState()
+            .setItemStatus(
+              queueKey,
+              item.id,
+              "failed",
+              recovered.errorMessage || i18n.t("chat.queue.sendFailed"),
+            );
+          break;
+        }
+        useMessageQueueStore
+          .getState()
+          .setItemStatus(
+            queueKey,
+            item.id,
+            "unknown",
+            i18n.t("chat.queue.reconnectNeeded", {
+              defaultValue: "Reconnect and check status",
+            }),
+          );
+        break;
+      }
+
       // Wait until the backend finishes the currently running task before
       // sending the next one. This preserves order task1 → task2 → task3
       // and prevents firing while task1 is still generating.
@@ -396,7 +473,7 @@ async function startBackgroundQueue(
         );
       }
 
-      let fetchSucceeded = false;
+      let responseOutcome: ChatResponseOutcome | null = null;
       // True once fetch() has resolved with an HTTP response. For a streaming
       // chat endpoint, this means the backend has already accepted the
       // request and started generating — the backend keeps producing the turn
@@ -449,48 +526,54 @@ async function startBackgroundQueue(
           sessionApi.discardLastUserMessage(chatIdForStatus, clientMessageId);
           throw new Error(`HTTP ${res.status}`);
         }
-        if (pendingRequest.projectDir) {
-          setPendingProjectDirectory(queueAgentId, queueKey, null);
-        }
         fetchStarted = true;
 
-        // Drain the stream; reaching `done` means the backend persisted the
-        // turn. Only then is it safe to remove the item from the queue.
-        const reader = res.body?.getReader();
-        if (reader) {
-          while (!ctrl.signal.aborted) {
-            const r = await reader.read();
-            if (r.done) break;
-          }
+        // Once accepted, keep draining even if the page takes foreground
+        // ownership. The queue item is removed only for an explicit completed
+        // terminal, never merely because the HTTP stream reached EOF.
+        responseOutcome = await readChatResponseOutcome(res.body);
+        if (
+          responseOutcome?.status === "completed" &&
+          pendingRequest.projectDir
+        ) {
+          setPendingProjectDirectory(queueAgentId, queueKey, null);
         }
-        fetchSucceeded = !ctrl.signal.aborted;
       } catch {
-        fetchSucceeded = false;
+        responseOutcome = null;
       }
 
-      if (ctrl.signal.aborted) {
-        if (fetchStarted) {
-          // Server connection was NOT aborted (no signal on fetch), so the
-          // backend will finish generating and persist this turn. Safe to
-          // remove — the foreground SDK will see it in history on reconnect.
-          useMessageQueueStore.getState().remove(queueKey, item.id);
-        } else {
-          // Request never made it out (aborted while waiting for status idle
-          // or before the response head arrived). Restore to pending so the
-          // foreground sender can pick it up.
-          useMessageQueueStore
-            .getState()
-            .setItemStatus(queueKey, item.id, "pending");
-        }
+      if (ctrl.signal.aborted && !fetchStarted) {
+        // Request never made it out (aborted while waiting for status idle
+        // or before the response head arrived). Restore to pending so the
+        // foreground sender can pick it up.
+        useMessageQueueStore
+          .getState()
+          .setItemStatus(queueKey, item.id, "pending");
         break;
       }
 
-      if (fetchSucceeded) {
-        // Backend finished generating → safe to remove from queue.
+      if (responseOutcome?.status === "completed") {
+        // The backend explicitly confirmed successful completion.
         useMessageQueueStore.getState().remove(queueKey, item.id);
+      } else if (fetchStarted && responseOutcome === null) {
+        // HTTP 200 means the backend accepted the request. A stream that ends
+        // without a terminal cannot be retried safely because the producer may
+        // still be running or may already have persisted the turn.
+        useMessageQueueStore
+          .getState()
+          .setItemStatus(
+            queueKey,
+            item.id,
+            "unknown",
+            i18n.t("chat.queue.reconnectNeeded", {
+              defaultValue: "Reconnect and check status",
+            }),
+          );
+        break;
       } else {
-        // Network/HTTP failure: keep the item visible with `failed` status
-        // so the user can retry from the queue panel on next visit.
+        // HTTP/network errors before acceptance and explicit failed terminals
+        // remain visible for an explicit user retry.
+        sessionApi.discardLastUserMessage(chatIdForStatus, clientMessageId);
         useMessageQueueStore
           .getState()
           .setItemStatus(
@@ -501,11 +584,15 @@ async function startBackgroundQueue(
           );
         break;
       }
+      if (ctrl.signal.aborted) break;
     }
-    useMessageQueueStore.getState().setCurrentSendingId(null);
+    if (_bgAborts.get(queueKey) === ctrl) {
+      useMessageQueueStore.getState().setCurrentSendingId(null);
+      _bgAborts.delete(queueKey);
+    }
   });
 
-  if (_bgAborts.get(queueKey) === ctrl) _bgAborts.delete(queueKey);
+  // A superseding sender owns cleanup after it replaces this controller.
 }
 
 /**
@@ -531,7 +618,11 @@ function startAllBackgroundQueues(excludeSessionId?: string) {
       if (!items || items.length === 0) continue;
       // Only start if there are actionable items
       const hasPending = items.some(
-        (it) => it.status === "pending" || it.status === "failed",
+        (it) =>
+          it.status === "pending" ||
+          it.status === "failed" ||
+          it.status === "unknown" ||
+          it.status === "sending",
       );
       if (!hasPending) continue;
       // Check runState: respect paused queues
@@ -625,10 +716,37 @@ function payloadRequestsHistoryClear(payload: unknown): boolean {
 }
 
 function payloadCompletesResponse(payload: unknown): boolean {
-  if (!payload || typeof payload !== "object") return false;
+  return getChatResponseOutcome(payload)?.status === "completed";
+}
 
-  const record = payload as Record<string, unknown>;
-  return record.object === "response" && record.status === "completed";
+function reconcileBackgroundQueueResponse(
+  queueSessionId: string,
+  outcome: ChatResponseOutcome,
+): void {
+  const queue = useMessageQueueStore.getState().getQueue(queueSessionId);
+  const activeItem = queue.find(
+    (item) => item.status === "sending" || item.status === "unknown",
+  );
+  if (!activeItem) return;
+
+  if (outcome.status === "completed") {
+    useMessageQueueStore.getState().remove(queueSessionId, activeItem.id);
+    useMessageQueueStore.getState().setCurrentSendingId(null);
+    return;
+  }
+
+  useMessageQueueStore
+    .getState()
+    .setItemStatus(
+      queueSessionId,
+      activeItem.id,
+      outcome.errorCode === "CHAT_STREAM_INCOMPLETE" ? "unknown" : "failed",
+      outcome.errorCode === "CHAT_STREAM_INCOMPLETE"
+        ? i18n.t("chat.queue.reconnectNeeded", {
+            defaultValue: "Reconnect and check status",
+          })
+        : outcome.errorMessage || i18n.t("chat.queue.sendFailed"),
+    );
 }
 
 function renderSuggestionLabel(command: string, description?: string) {
@@ -1018,6 +1136,14 @@ interface DraftState {
   value: string;
   selectionStart: number;
   selectionEnd: number;
+}
+
+interface PendingSubmission {
+  agentId: string;
+  clientMessageId: string | undefined;
+  draftKey: string;
+  sessionId?: string;
+  text: string;
 }
 
 function useChatInputDraft(isChatActive: () => boolean, agentId?: string) {
@@ -1501,6 +1627,20 @@ export default function ChatPage() {
       const q = messageQueueRef.current;
       if (q.length === 0) return;
       const next = q[0];
+      if (next.status === "unknown") {
+        const backendSessionId =
+          next.backendSessionId ||
+          sessionApi.getBackendSessionId(queueSessionId) ||
+          queueSessionId;
+        const chatIdForStatus =
+          sessionApi.getRealIdForSession(queueSessionId) || queueSessionId;
+        void startBackgroundQueue(
+          queueSessionId,
+          backendSessionId,
+          chatIdForStatus,
+        );
+        return;
+      }
       // Acquire the per-session send lock so concurrent tabs don't both fire
       // the same item. If another tab holds the lock, drop this attempt; the
       // cross-tab broadcast will refresh our queue and the next loading→idle
@@ -1869,6 +2009,7 @@ export default function ChatPage() {
   const navigateRef = useRef(navigate);
   const chatRef = useRef<IAgentScopeRuntimeWebUIRef>(null);
   const pendingSenderClearRef = useRef<string | null>(null);
+  const pendingSubmissionRef = useRef<PendingSubmission | null>(null);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -2105,6 +2246,24 @@ export default function ChatPage() {
       useMessageQueueStore.getState().setRunState(queueSessionId, "running");
       // Try to resume sending immediately
       if (!chatLoadingRef.current && isOwnerRef.current) {
+        const queue = useMessageQueueStore
+          .getState()
+          .getQueue(queueSessionId);
+        const head = queue[0];
+        if (head?.status === "unknown" || head?.status === "sending") {
+          const backendSessionId =
+            head.backendSessionId ||
+            sessionApi.getBackendSessionId(queueSessionId) ||
+            queueSessionId;
+          const chatIdForStatus =
+            sessionApi.getRealIdForSession(queueSessionId) || queueSessionId;
+          void startBackgroundQueue(
+            queueSessionId,
+            backendSessionId,
+            chatIdForStatus,
+          );
+          return;
+        }
         void withSendLock(queueSessionId, () => {
           const q = useMessageQueueStore.getState().getQueue(queueSessionId);
           if (q.length === 0) return;
@@ -2124,6 +2283,32 @@ export default function ChatPage() {
 
   const handleQueueRetry = useCallback(
     (id: string) => {
+      const currentQueue = useMessageQueueStore
+        .getState()
+        .getQueue(queueSessionId);
+      const target = currentQueue.find((it) => it.id === id);
+      if (!target) return;
+
+      if (target.status === "unknown" || target.status === "sending") {
+        // Recovery must reconnect first. Removing the item and submitting it
+        // directly would turn an uncertain server state into a duplicate run.
+        useMessageQueueStore.getState().setRunState(queueSessionId, "running");
+        if (!chatLoadingRef.current && isOwnerRef.current) {
+          const backendSessionId =
+            target.backendSessionId ||
+            sessionApi.getBackendSessionId(queueSessionId) ||
+            queueSessionId;
+          const chatIdForStatus =
+            sessionApi.getRealIdForSession(queueSessionId) || queueSessionId;
+          void startBackgroundQueue(
+            queueSessionId,
+            backendSessionId,
+            chatIdForStatus,
+          );
+        }
+        return;
+      }
+
       useMessageQueueStore
         .getState()
         .setItemStatus(queueSessionId, id, "pending");
@@ -2132,13 +2317,13 @@ export default function ChatPage() {
       if (!chatLoadingRef.current && isOwnerRef.current) {
         void withSendLock(queueSessionId, () => {
           const q = useMessageQueueStore.getState().getQueue(queueSessionId);
-          const target = q.find((it) => it.id === id);
-          if (!target) return;
+          const retryTarget = q.find((it) => it.id === id);
+          if (!retryTarget) return;
           useMessageQueueStore.getState().setCurrentSendingId(id);
           useMessageQueueStore.getState().remove(queueSessionId, id);
           chatRef.current?.input.submit({
-            query: beginLoopModeSubmission(target.text),
-            fileList: buildFileList(target),
+            query: beginLoopModeSubmission(retryTarget.text),
+            fileList: buildFileList(retryTarget),
           });
         });
       }
@@ -2538,6 +2723,28 @@ export default function ChatPage() {
     [t],
   );
 
+  const restorePendingSubmission = useCallback((clientMessageId?: string) => {
+    const pending = pendingSubmissionRef.current;
+    if (!pending || pending.clientMessageId !== clientMessageId) return;
+    pendingSubmissionRef.current = null;
+    draftSuppressed = false;
+
+    const textarea = getActiveSenderTextarea();
+    const draft: DraftState = {
+      value: pending.text,
+      selectionStart: pending.text.length,
+      selectionEnd: pending.text.length,
+    };
+    if (pending.agentId !== selectedAgentRef.current) {
+      localStorage.setItem(pending.draftKey, JSON.stringify(draft));
+      return;
+    }
+    if (textarea?.value) return;
+    if (textarea) setTextareaValue(textarea, pending.text);
+
+    localStorage.setItem(pending.draftKey, JSON.stringify(draft));
+  }, []);
+
   const customFetch = useCallback(
     async (data: {
       input?: Array<Record<string, unknown>>;
@@ -2551,40 +2758,24 @@ export default function ChatPage() {
         ...buildAuthHeaders(),
       };
 
-      if (usesQwenPawBackend) {
-        try {
-          const activeModels = await providerApi.getActiveModels({
-            scope: "effective",
-            agent_id: selectedAgent,
-          });
-          if (
-            !activeModels?.active_llm?.provider_id ||
-            !activeModels?.active_llm?.model
-          ) {
-            pendingSenderClearRef.current = null;
-            setShowModelPrompt(true);
-            return buildModelError();
-          }
-        } catch {
-          pendingSenderClearRef.current = null;
-          setShowModelPrompt(true);
-          return buildModelError();
-        }
-      }
-
-      const submittedValue = pendingSenderClearRef.current;
-      if (submittedValue !== null) {
-        clearSubmittedSenderInput(submittedValue);
-        pendingSenderClearRef.current = null;
-        localStorage.removeItem(getDraftStorageKey(selectedAgent));
-      }
-
       const { input = [], biz_params } = data;
       const session: SessionInfo = input[input.length - 1]?.session || {};
       const lastInput = input.slice(-1);
       const lastMsg = lastInput[0];
       const clientMessageId =
         lastMsg?.role === "user" ? createClientMessageId() : undefined;
+      const submittedValue = pendingSenderClearRef.current;
+      pendingSenderClearRef.current = null;
+      if (submittedValue !== null) {
+        pendingSubmissionRef.current = {
+          agentId: selectedAgent,
+          clientMessageId,
+          draftKey: getDraftStorageKey(selectedAgent),
+          text: submittedValue,
+        };
+        clearSubmittedSenderInput(submittedValue);
+        localStorage.removeItem(getDraftStorageKey(selectedAgent));
+      }
       const rewrittenLastMsg: Record<string, unknown> | undefined = lastMsg
         ? clientMessageId
           ? attachClientMessageId(lastMsg, clientMessageId)
@@ -2681,6 +2872,13 @@ export default function ChatPage() {
         sessionApi.getRealIdForSession(String(requestBody.session_id || "")) ??
         chatIdRef.current ??
         String(requestBody.session_id || "");
+      const pendingSubmission = pendingSubmissionRef.current;
+      if (
+        pendingSubmission &&
+        pendingSubmission.clientMessageId === clientMessageId
+      ) {
+        pendingSubmission.sessionId = backendChatId;
+      }
       if (backendChatId) {
         const userText = rewrittenInput
           .filter((m) => m.role === "user")
@@ -2710,15 +2908,60 @@ export default function ChatPage() {
 
       headlineStreamFilterRef.current = createHeadlineFilterState();
 
-      const response = await fetch(getApiUrl("/console/chat"), {
-        method: "POST",
-        headers,
-        body: JSON.stringify(requestBody),
-        signal: data.signal,
-      });
+      let response: Response;
+      try {
+        response = await fetch(getApiUrl("/console/chat"), {
+          method: "POST",
+          headers,
+          body: JSON.stringify(requestBody),
+          signal: data.signal,
+        });
+      } catch (error) {
+        if (backendChatId) {
+          sessionApi.discardLastUserMessage(backendChatId, clientMessageId);
+        }
+        if (data.signal?.aborted) {
+          if (
+            pendingSubmissionRef.current?.clientMessageId === clientMessageId
+          ) {
+            pendingSubmissionRef.current = null;
+          }
+          throw error;
+        }
+        restorePendingSubmission(clientMessageId);
+        return wrapChatResponseUsageStream(
+          new Response(
+            JSON.stringify({
+              detail: {
+                code: "CHAT_REQUEST_FAILED",
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "Chat request failed",
+              },
+            }),
+            {
+              status: 503,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+          chatRef,
+          usageTurn,
+        );
+      }
 
-      if (!response.ok && backendChatId) {
-        sessionApi.discardLastUserMessage(backendChatId, clientMessageId);
+      if (!response.ok) {
+        if (backendChatId) {
+          sessionApi.discardLastUserMessage(backendChatId, clientMessageId);
+        }
+        restorePendingSubmission(clientMessageId);
+        const errorPayload = await response
+          .clone()
+          .json()
+          .catch(() => null);
+        if (isModelNotConfiguredError(errorPayload)) {
+          setShowModelPrompt(true);
+        }
       }
 
       const localIdToResolve = sessionApi.lastActiveChatId ?? chatIdRef.current;
@@ -2729,9 +2972,18 @@ export default function ChatPage() {
         sessionApi.triggerResolve(localIdToResolve);
       }
 
-      return wrapChatResponseUsageStream(response, chatRef, usageTurn);
+      const streamResponse = response.ok
+        ? terminalizeChatResponse(response)
+        : response;
+      return wrapChatResponseUsageStream(streamResponse, chatRef, usageTurn);
     },
-    [extLists, selectedAgent, runningConfigApprovalLevel, usesQwenPawBackend],
+    [
+      extLists,
+      restorePendingSubmission,
+      selectedAgent,
+      runningConfigApprovalLevel,
+      usesQwenPawBackend,
+    ],
   );
 
   const handleFileUpload = useCallback(
@@ -3323,6 +3575,33 @@ export default function ChatPage() {
           markLoopModeRunning();
           sanitizeHeadlinePayload(payload, headlineStreamFilterRef.current);
 
+          const responseOutcome = getChatResponseOutcome(payload);
+          if (responseOutcome && !pendingSubmissionRef.current) {
+            // A foreground turn can overlap a background queue turn while the
+            // page is remounting. Its terminal must not remove the unrelated
+            // background item; the background sender will reconcile its own
+            // response or the next reconnect attempt will do so.
+            reconcileBackgroundQueueResponse(queueSessionId, responseOutcome);
+          }
+          if (
+            responseOutcome?.status === "failed" &&
+            isPreExecutionConfigurationError(responseOutcome.errorCode)
+          ) {
+            const pending = pendingSubmissionRef.current;
+            if (pending?.sessionId) {
+              sessionApi.discardLastUserMessage(
+                pending.sessionId,
+                pending.clientMessageId,
+              );
+            }
+            if (responseOutcome.errorCode === "MODEL_NOT_CONFIGURED") {
+              setShowModelPrompt(true);
+            }
+            restorePendingSubmission(pending?.clientMessageId);
+          } else if (responseOutcome) {
+            pendingSubmissionRef.current = null;
+          }
+
           for (const event of parseModelFallbackEvents(payload)) {
             const key = modelFallbackEventKey(event);
             if (pendingFallbackEventKeysRef.current.has(key)) continue;
@@ -3445,8 +3724,12 @@ export default function ChatPage() {
 
           // Fast-forward the replayed section: render the already
           // generated part instantly instead of re-animating it.
+          const replayResponse = wrapReplayFastForward(response);
+          const streamResponse = response.ok
+            ? terminalizeChatResponse(replayResponse)
+            : replayResponse;
           return wrapChatResponseUsageStream(
-            wrapReplayFastForward(response),
+            streamResponse,
             chatRef,
             usageTurn,
           );
@@ -3527,6 +3810,7 @@ export default function ChatPage() {
     customFetch,
     copyResponse,
     handleFileUpload,
+    restorePendingSubmission,
     t,
     i18n.language,
     isDark,

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -861,16 +861,24 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   /** Remove a pending message only when it still belongs to this request. */
   discardLastUserMessage(sessionId: string, clientMessageId?: string): void {
     if (!sessionId) return;
-    const cached = loadPendingUserMessage(sessionId);
-    if (!cached) return;
-    if (
-      clientMessageId &&
-      cached.clientMessageId &&
-      cached.clientMessageId !== clientMessageId
-    ) {
-      return;
+
+    const session = this.findSession(sessionId);
+    const storageIds = new Set<string>([sessionId]);
+    if (session?.id) storageIds.add(session.id);
+    if (session?.realId) storageIds.add(session.realId);
+
+    for (const storageId of storageIds) {
+      const cached = loadPendingUserMessage(storageId);
+      if (!cached) continue;
+      if (
+        clientMessageId &&
+        cached.clientMessageId &&
+        cached.clientMessageId !== clientMessageId
+      ) {
+        continue;
+      }
+      clearPendingUserMessage(storageId);
     }
-    clearPendingUserMessage(sessionId);
   }
 
   /**

--- a/console/src/pages/Chat/sse.test.ts
+++ b/console/src/pages/Chat/sse.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSseDataEvents } from "./sse";
+
+describe("parseSseDataEvents", () => {
+  it("retains a split CRLF boundary until the next chunk arrives", () => {
+    const first = parseSseDataEvents('data: {"part":1}\r\n\r');
+    expect(first.events).toEqual([]);
+
+    const second = parseSseDataEvents(`${first.rest}\ndata: next\r\n\r\n`);
+    expect(second.events).toEqual(['{"part":1}', "next"]);
+    expect(second.rest).toBe("");
+  });
+
+  it("joins multiple data fields and emits an unterminated tail on flush", () => {
+    const parsed = parseSseDataEvents("data: first\ndata: second", true);
+    expect(parsed.events).toEqual(["first\nsecond"]);
+    expect(parsed.rest).toBe("");
+  });
+
+  it("ignores comments and events without data fields", () => {
+    const parsed = parseSseDataEvents(": heartbeat\n\nevent: ping\n\n");
+    expect(parsed.events).toEqual([]);
+    expect(parsed.rest).toBe("");
+  });
+});

--- a/console/src/pages/Chat/sse.ts
+++ b/console/src/pages/Chat/sse.ts
@@ -1,0 +1,50 @@
+export interface ParsedSseData {
+  events: string[];
+  rest: string;
+}
+
+function findEventBoundary(
+  value: string,
+): { index: number; length: number } | null {
+  const boundaries = ["\r\n\r\n", "\n\n", "\r\r"]
+    .map((separator) => ({
+      index: value.indexOf(separator),
+      length: separator.length,
+    }))
+    .filter((candidate) => candidate.index >= 0)
+    .sort((left, right) => left.index - right.index);
+  return boundaries[0] ?? null;
+}
+
+function dataFromBlock(block: string): string | null {
+  const values: string[] = [];
+  for (const line of block.split(/\r\n|\r|\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const value = line.slice(5);
+    values.push(value.startsWith(" ") ? value.slice(1) : value);
+  }
+  return values.length > 0 ? values.join("\n") : null;
+}
+
+/** Incrementally extract SSE data fields while retaining an incomplete tail. */
+export function parseSseDataEvents(
+  buffer: string,
+  flush = false,
+): ParsedSseData {
+  const events: string[] = [];
+  let rest = buffer;
+  for (;;) {
+    const boundary = findEventBoundary(rest);
+    if (!boundary) break;
+    const data = dataFromBlock(rest.slice(0, boundary.index));
+    if (data !== null) events.push(data);
+    rest = rest.slice(boundary.index + boundary.length);
+  }
+
+  if (flush && rest.length > 0) {
+    const data = dataFromBlock(rest);
+    if (data !== null) events.push(data);
+    rest = "";
+  }
+  return { events, rest };
+}

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -191,6 +191,39 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-failed`)).toBe(null);
   });
 
+  it("discards both local and resolved cache keys after ID migration", () => {
+    testApi.sessionList = [
+      {
+        id: "1720000000000-local",
+        realId: "7f6627d4-2514-4f38-a3e8-423e32640691",
+        sessionId: "1720000000000-local",
+      },
+    ];
+    sessionApi.setLastUserMessage(
+      "1720000000000-local",
+      "failed request",
+      undefined,
+      "client-failed",
+    );
+    sessionApi.setLastUserMessage(
+      "7f6627d4-2514-4f38-a3e8-423e32640691",
+      "failed request",
+      undefined,
+      "client-failed",
+    );
+
+    sessionApi.discardLastUserMessage("1720000000000-local", "client-failed");
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}1720000000000-local`)).toBe(
+      null,
+    );
+    expect(
+      sessionStorage.getItem(
+        `${STORAGE_PREFIX}7f6627d4-2514-4f38-a3e8-423e32640691`,
+      ),
+    ).toBe(null);
+  });
+
   it("clears the cache on idle when history already contains the text", async () => {
     seedSessionList("chat-done");
     sessionApi.setLastUserMessage("chat-done", "persisted question");

--- a/console/src/pages/Chat/turnUsage.ts
+++ b/console/src/pages/Chat/turnUsage.ts
@@ -3,6 +3,7 @@ import type {
   IAgentScopeRuntimeWebUIRef,
   IAgentScopeRuntimeWebUIMessage,
 } from "@agentscope-ai/chat";
+import { parseSseDataEvents } from "./sse";
 import { useTurnUsageStore } from "./turnUsageStore";
 import type { TurnUsageToken } from "./turnUsageStore";
 
@@ -286,26 +287,6 @@ export function patchContextMaxInputLength(
   }
 }
 
-function parseSseDataLines(buffer: string): {
-  events: string[];
-  rest: string;
-} {
-  const events: string[] = [];
-  let rest = buffer;
-  for (;;) {
-    const sep = rest.indexOf("\n\n");
-    if (sep < 0) break;
-    const block = rest.slice(0, sep);
-    rest = rest.slice(sep + 2);
-    for (const line of block.split("\n")) {
-      if (line.startsWith("data: ")) {
-        events.push(line.slice(6));
-      }
-    }
-  }
-  return { events, rest };
-}
-
 function snapshotFromSsePayload(raw: string): TurnUsageSnapshot | null {
   // Fast path: skip the (second) JSON.parse for the vast majority of SSE
   // events — only `type: "turn_usage"` payloads are relevant here.
@@ -340,7 +321,7 @@ export function wrapChatResponseUsageStream(
       transform(chunk, controller) {
         controller.enqueue(chunk);
         buffer += decoder.decode(chunk, { stream: true });
-        const parsed = parseSseDataLines(buffer);
+        const parsed = parseSseDataEvents(buffer);
         buffer = parsed.rest;
         for (const raw of parsed.events) {
           const snap = snapshotFromSsePayload(raw);
@@ -349,7 +330,7 @@ export function wrapChatResponseUsageStream(
       },
       flush() {
         buffer += decoder.decode();
-        const parsed = parseSseDataLines(`${buffer}\n\n`);
+        const parsed = parseSseDataEvents(buffer, true);
         for (const raw of parsed.events) {
           const snap = snapshotFromSsePayload(raw);
           if (snap) pendingUsage = snap;

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, test, expect, vi } from "vitest";
 import {
   extractCopyableText,
   extractUserMessageText,
-  buildModelError,
+  hasModelConfigurationError,
   toStoredName,
   normalizeContentUrls,
   toDisplayUrl,
@@ -207,24 +207,33 @@ describe("clearSubmittedSenderInput", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildModelError
+// hasModelConfigurationError
 // ---------------------------------------------------------------------------
-describe("buildModelError", () => {
-  it("returns 400 status code", () => {
-    const response = buildModelError();
-    expect(response.status).toBe(400);
+describe("hasModelConfigurationError", () => {
+  it("matches the backend model-not-configured error code", () => {
+    expect(
+      hasModelConfigurationError({
+        error: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+      }),
+    ).toBe(true);
   });
 
-  it("response body contains error and message fields", async () => {
-    const response = buildModelError();
-    const body = await response.json();
-    expect(body).toHaveProperty("error");
-    expect(body).toHaveProperty("message");
+  it("matches a structured HTTP error detail", () => {
+    expect(
+      hasModelConfigurationError({
+        detail: { code: "MODEL_NOT_CONFIGURED", message: "missing" },
+      }),
+    ).toBe(true);
   });
 
-  it("Content-Type is application/json", () => {
-    const response = buildModelError();
-    expect(response.headers.get("Content-Type")).toBe("application/json");
+  test.each([
+    null,
+    {},
+    { error: "network" },
+    { error: { code: "AGENT_CONFIG_UNAVAILABLE" } },
+    { error: { code: "UNAUTHORIZED" } },
+  ])("does not misclassify other failures: %j", (payload) => {
+    expect(hasModelConfigurationError(payload)).toBe(false);
   });
 });
 

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -2,6 +2,7 @@
 // Types
 // ---------------------------------------------------------------------------
 import { chatApi } from "../../api/modules/chat";
+import { isModelNotConfiguredError } from "./chatResponseOutcome";
 export type CopyableContent = {
   type?: string;
   text?: string;
@@ -111,19 +112,9 @@ export function formatMessageTime(ts: number): string {
   return `${date.getFullYear()}-${month}-${day} ${time}`;
 }
 
-// ---------------------------------------------------------------------------
-// Error response utilities
-// ---------------------------------------------------------------------------
-
-/** Build a 400 error response when model is not configured. */
-export function buildModelError(): Response {
-  return new Response(
-    JSON.stringify({
-      error: "Model not configured",
-      message: "Please configure a model first",
-    }),
-    { status: 400, headers: { "Content-Type": "application/json" } },
-  );
+/** Check whether the backend explicitly reported a missing model. */
+export function hasModelConfigurationError(payload: unknown): boolean {
+  return isModelNotConfiguredError(payload);
 }
 
 // ---------------------------------------------------------------------------

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -5,7 +5,12 @@ import { createClientMessageId } from "../utils/clientMessageId";
 // Types
 // ---------------------------------------------------------------------------
 
-export type QueueItemStatus = "pending" | "sending" | "failed" | "sent";
+export type QueueItemStatus =
+  | "pending"
+  | "sending"
+  | "unknown"
+  | "failed"
+  | "sent";
 
 export type QueueRunState = "idle" | "running" | "paused" | "error";
 

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -105,8 +105,6 @@ export default defineConfig(({ command, mode }) => {
         "**/dist/**",
         // 旧测试用 node:test，与 vitest 不兼容，待迁移
         "**/testConnectionMessage.test.ts",
-        // ChatPage test causes worker crash - pre-existing issue, needs more mock setup
-        "**/pages/Chat/ChatPage.test.tsx",
         // Tauri modules require @tauri-apps/api which only exists in desktop builds
         "**/src/tauri/**",
       ],

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -12,6 +12,7 @@ from typing import Optional, TYPE_CHECKING
 from fastapi import Request
 from .multi_agent_manager import MultiAgentManager
 from ..config.utils import load_config
+from ..utils.io_utils import run_sync_io
 
 if TYPE_CHECKING:
     from .workspace import Workspace
@@ -90,12 +91,12 @@ async def get_agent_for_request(
     config = None
     if not target_agent_id:
         # Fallback to active agent from config
-        config = load_config()
+        config = await run_sync_io(load_config)
         target_agent_id = config.agents.active_agent or "default"
 
     # Check if agent exists and is enabled
     if config is None:
-        config = load_config()
+        config = await run_sync_io(load_config)
     if target_agent_id not in config.agents.profiles:
         raise HTTPException(
             status_code=404,

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -18,6 +18,7 @@ from fastapi import (
 from pydantic import BaseModel, Field, field_validator
 
 from qwenpaw.exceptions import (
+    AgentConfigConflictError,
     AppBaseException,
 )
 
@@ -782,18 +783,39 @@ async def get_active_models(
                 agent_model,
             )
             return _active_models_info(manager, agent_model)
-    except (
-        HTTPException,
-        OSError,
-        ValueError,
-        TypeError,
-        AppBaseException,
-    ) as exc:
+    except HTTPException:
+        raise
+    except AgentConfigConflictError as exc:
+        logger.warning(
+            "Agent model configuration changed while reading: %s",
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": exc.error_code or "AGENT_CONFIG_STALE",
+                "message": str(exc),
+            },
+        ) from exc
+    except (OSError, ValueError, TypeError, AppBaseException) as exc:
         logger.warning(
             "Failed to get agent-specific model: %s",
             exc,
             exc_info=True,
         )
+        error_code = getattr(exc, "error_code", None)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": error_code or "AGENT_CONFIG_UNAVAILABLE",
+                "message": (
+                    str(exc)
+                    if error_code
+                    else "Agent model configuration is temporarily unavailable"
+                ),
+            },
+        ) from exc
 
     global_model = manager.get_active_model()
     logger.info("Returning global model: %s", global_model)

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -33,6 +33,13 @@ from ..chats.session import SafeJSONSession
 from ..crons.manager import CronManager
 from ..crons.repo.json_repo import JsonJobRepository
 from ...config.config import load_agent_config
+from ...exceptions import ConfigurationException
+from ...runtime.configuration import (
+    is_config_independent_command,
+    load_runtime_agent_config,
+)
+from ...runtime.envelope import Envelope
+from ...utils.io_utils import run_sync_io
 from ...utils.logging import sanitize_log_value
 
 logger = logging.getLogger(__name__)
@@ -322,7 +329,53 @@ class Workspace:
 
         Drop-in replacement for the old ``Runner.stream_query()``.
         """
-        config = load_agent_config(self.agent_id)
+        request_agent_id = (
+            request.get("agent_id")
+            if isinstance(request, dict)
+            else getattr(request, "agent_id", None)
+        )
+        if request_agent_id and request_agent_id != self.agent_id:
+            session_id = (
+                request.get("session_id", "")
+                if isinstance(request, dict)
+                else getattr(request, "session_id", None) or ""
+            )
+            envelope = Envelope(session_id=session_id)
+            async for item in envelope.error_envelope(
+                "Request agent does not match the selected workspace",
+                "AGENT_ID_MISMATCH",
+            ):
+                yield item
+            return
+
+        try:
+            config = await load_runtime_agent_config(self.agent_id)
+        except ConfigurationException as exc:
+            if is_config_independent_command(request):
+                from ...runtime import Runtime
+
+                rt = Runtime(
+                    workspace=self,
+                    app_services=self._app_services,
+                    config_error=exc,
+                )
+                async for item in rt.run(request):
+                    yield item
+                return
+            session_id = (
+                request.get("session_id", "")
+                if isinstance(request, dict)
+                else getattr(request, "session_id", None) or ""
+            )
+            envelope = Envelope(
+                session_id=session_id,
+            )
+            async for item in envelope.error_envelope(
+                exc.message or str(exc),
+                exc.error_code or "CONFIGURATION_REQUIRED",
+            ):
+                yield item
+            return
         backend = config.backend
         if backend != "qwenpaw":
             settings = dict(getattr(config, "backend_settings", {}))
@@ -345,7 +398,7 @@ class Workspace:
             async for item in self.harness_runtime.stream(
                 backend=backend,
                 request=request,
-                cwd=self.workspace_dir.resolve(),
+                cwd=await run_sync_io(self.workspace_dir.resolve),
                 settings=settings,
             ):
                 yield item
@@ -353,7 +406,11 @@ class Workspace:
 
         from ...runtime import Runtime
 
-        rt = Runtime(workspace=self, app_services=self._app_services)
+        rt = Runtime(
+            workspace=self,
+            app_services=self._app_services,
+            agent_config=config,
+        )
         async for item in rt.run(request):
             yield item
 

--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -115,28 +115,29 @@ class ContextVarsSetupHook(LifecycleHook):
         set_current_approval_route(approval_route)
 
         agent_project_dir = None
-        try:
-            from ...config.config import load_agent_config
-
-            cfg = load_agent_config(ctx.agent_id)
-            running = cfg.running
-            pruning_cfg = (
-                running.light_context_config.tool_result_pruning_config
-            )
-            set_current_recent_max_bytes(
-                pruning_cfg.pruning_recent_msg_max_bytes,
-            )
-            set_current_shell_command_timeout(running.shell_command_timeout)
-            set_current_shell_command_executable(
-                running.shell_command_executable or None,
-            )
-            agent_project_dir = cfg.project_dir
-        except Exception:
-            logger.warning(
-                "contextvars_setup: config-derived vars failed; "
-                "tools may see defaults",
-                exc_info=True,
-            )
+        cfg = ctx.agent_config
+        if cfg is not None:
+            try:
+                running = cfg.running
+                pruning_cfg = (
+                    running.light_context_config.tool_result_pruning_config
+                )
+                set_current_recent_max_bytes(
+                    pruning_cfg.pruning_recent_msg_max_bytes,
+                )
+                set_current_shell_command_timeout(
+                    running.shell_command_timeout,
+                )
+                set_current_shell_command_executable(
+                    running.shell_command_executable or None,
+                )
+                agent_project_dir = cfg.project_dir
+            except Exception:
+                logger.warning(
+                    "contextvars_setup: config-derived vars failed; "
+                    "tools may see defaults",
+                    exc_info=True,
+                )
 
         from ...constant import WORKING_DIR
 

--- a/src/qwenpaw/providers/model_selection.py
+++ b/src/qwenpaw/providers/model_selection.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Effective model selection shared by request validation and runtime build."""
+
+from typing import Any
+
+from ..exceptions import ConfigurationException
+from . import provider_manager
+
+
+def require_effective_model(agent_config: Any) -> Any:
+    """Return the effective model or raise a stable configuration error."""
+    active = agent_config.active_model
+    if not (active and active.provider_id and active.model):
+        active = (
+            provider_manager.ProviderManager.get_instance().get_active_model()
+        )
+    if active is None or not active.provider_id or not active.model:
+        raise ConfigurationException(
+            "No active model configured; pick one in the UI",
+            config_key="active_model",
+            error_code="MODEL_NOT_CONFIGURED",
+        )
+    return active

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
 from ..agents.acp.meta import ACP_PROJECT_DIR_META_KEY
+from ..providers.model_selection import require_effective_model
+from .configuration import load_runtime_agent_config
 from ..utils.io_utils import run_sync_io
 from ..utils.logging import sanitize_log_value
 
@@ -269,12 +271,12 @@ class AgentBuilder:
             ensure_skills_initialized,
             resolve_effective_skills,
         )
-        from ..config.config import load_agent_config
         from ..constant import WORKING_DIR
-        from ..providers.provider_manager import ProviderManager
 
         agent_id = getattr(ctx, "agent_id", None) or "default"
-        agent_config = await run_sync_io(load_agent_config, agent_id)
+        agent_config = getattr(ctx, "agent_config", None)
+        if agent_config is None:
+            agent_config = await load_runtime_agent_config(agent_id)
         request_context = self._build_request_context(ctx)
         agent_config = self._apply_request_project(
             agent_config,
@@ -282,18 +284,7 @@ class AgentBuilder:
         )
         ctx.agent_config = agent_config
 
-        # Validate model availability.
-        active = agent_config.active_model
-        if not (active and active.provider_id and active.model):
-            active = ProviderManager.get_instance().get_active_model()
-        if active is None or not active.provider_id or not active.model:
-            from ..exceptions import ConfigurationException
-
-            raise ConfigurationException(
-                "No active model configured; pick one in the UI",
-                config_key="active_model",
-                error_code="MODEL_NOT_CONFIGURED",
-            )
+        active = await run_sync_io(require_effective_model, agent_config)
 
         workspace_dir = getattr(ctx, "workspace_dir", None)
 

--- a/src/qwenpaw/runtime/builtin_commands.py
+++ b/src/qwenpaw/runtime/builtin_commands.py
@@ -219,6 +219,10 @@ def _make_control_adapter(
             user_id=(getattr(request, "user_id", "") if request else "") or "",
             agent_id=getattr(ctx, "agent_id", "") or "",
             args=parsed_args,
+            agent_config=getattr(ctx, "agent_config", None),
+            agent_config_error=(getattr(ctx, "extras", {}) or {}).get(
+                "agent_config_error",
+            ),
         )
 
         try:

--- a/src/qwenpaw/runtime/commands/control/base.py
+++ b/src/qwenpaw/runtime/commands/control/base.py
@@ -28,6 +28,8 @@ class ControlContext:
         user_id: User ID from request
         agent_id: Agent ID for permission checks
         args: Parsed command arguments (command-specific)
+        agent_config: Per-request agent configuration snapshot
+        agent_config_error: Configuration load error, when unavailable
     """
 
     workspace: "Workspace"
@@ -37,6 +39,8 @@ class ControlContext:
     user_id: str
     agent_id: str
     args: Dict[str, Any]
+    agent_config: Any | None = None
+    agent_config_error: BaseException | None = None
 
 
 class BaseControlCommandHandler(ABC):

--- a/src/qwenpaw/runtime/commands/control/model_handler.py
+++ b/src/qwenpaw/runtime/commands/control/model_handler.py
@@ -11,9 +11,24 @@ import logging
 from typing import Any
 
 from ....utils.logging import sanitize_log_value
+from ...configuration import load_runtime_agent_config
 from .base import BaseControlCommandHandler, ControlContext
 
 logger = logging.getLogger(__name__)
+
+
+async def _get_agent_config(context: ControlContext) -> Any:
+    """Return the request snapshot, loading only for standalone calls."""
+    if context.agent_config is None:
+        if context.agent_config_error is not None:
+            raise context.agent_config_error
+        agent_id = (
+            context.agent_id
+            or getattr(context.workspace, "agent_id", None)
+            or "default"
+        )
+        context.agent_config = await load_runtime_agent_config(agent_id)
+    return context.agent_config
 
 
 class ModelCommandHandler(BaseControlCommandHandler):
@@ -109,11 +124,17 @@ class ModelCommandHandler(BaseControlCommandHandler):
         Returns:
             Formatted response with current model info
         """
-        workspace = context.workspace
-        agent_config = workspace.config
+        try:
+            agent_config = await _get_agent_config(context)
+        except Exception as exc:
+            logger.warning(
+                "Unable to read agent model configuration; using global model",
+                exc_info=True,
+            )
+            agent_config = None
 
         # Get agent-level active model
-        active_model = agent_config.active_model
+        active_model = agent_config.active_model if agent_config else None
 
         if active_model is None or not active_model.provider_id:
             # Fallback to global active model
@@ -152,10 +173,16 @@ class ModelCommandHandler(BaseControlCommandHandler):
         from ....providers.provider_manager import ProviderManager
 
         manager = ProviderManager.get_instance()
-        workspace = context.workspace
-
         # Get current active model
-        active_model = workspace.config.active_model
+        try:
+            agent_config = await _get_agent_config(context)
+        except Exception as exc:
+            logger.warning(
+                "Unable to read agent model configuration; using global model",
+                exc_info=True,
+            )
+            agent_config = None
+        active_model = agent_config.active_model if agent_config else None
         if active_model is None:
             active_model = manager.get_active_model()
 
@@ -293,8 +320,7 @@ class ModelCommandHandler(BaseControlCommandHandler):
         from ....config.config import update_agent_config_async
         from ....config.config import ModelSlotConfig as ModelSlot
 
-        workspace = context.workspace
-        agent_config = workspace.config
+        agent_config = await _get_agent_config(context)
 
         new_slot = ModelSlot(
             provider_id=provider_id,
@@ -343,8 +369,7 @@ class ModelCommandHandler(BaseControlCommandHandler):
         from ....config.config import update_agent_config_async
         from ....providers.provider_manager import ProviderManager
 
-        workspace = context.workspace
-        agent_config = workspace.config
+        agent_config = await _get_agent_config(context)
 
         # Get global active model
         manager = ProviderManager.get_instance()

--- a/src/qwenpaw/runtime/configuration.py
+++ b/src/qwenpaw/runtime/configuration.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Runtime-safe agent configuration loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..config.config import load_agent_config_async
+from ..exceptions import AppBaseException, ConfigurationException
+
+if TYPE_CHECKING:
+    from ..config.config import AgentProfileConfig
+
+
+def _request_last_user_text(request: Any) -> str:
+    """Extract the last user text without requiring agent configuration."""
+    raw_input = (
+        request.get("input", [])
+        if isinstance(request, dict)
+        else getattr(request, "input", [])
+    )
+    if not isinstance(raw_input, list) or not raw_input:
+        return ""
+    message = raw_input[-1]
+    content = (
+        message.get("content", [])
+        if isinstance(message, dict)
+        else getattr(message, "content", [])
+    )
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict):
+            text = item.get("text")
+        else:
+            text = getattr(item, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def is_config_independent_command(request: Any) -> bool:
+    """Return whether a request can be answered without agent config."""
+    text = _request_last_user_text(request)
+    if not text.startswith("/"):
+        return False
+    command_parts = text[1:].split(None, 1)
+    if not command_parts or command_parts[0].lower() != "model":
+        return False
+    normalized_args = (
+        command_parts[1].strip().lower() if len(command_parts) > 1 else ""
+    )
+    return (
+        not normalized_args
+        or normalized_args in {"help", "-h", "--help", "list", "info"}
+        or normalized_args.startswith("info ")
+    )
+
+
+async def load_runtime_agent_config(
+    agent_id: str,
+) -> "AgentProfileConfig":
+    """Load one agent configuration without blocking the event loop.
+
+    Configuration read failures use a stable error code so clients can
+    distinguish an unavailable configuration from a missing model.
+    """
+    try:
+        return await load_agent_config_async(agent_id)
+    except ConfigurationException as exc:
+        if exc.error_code:
+            raise
+        raise ConfigurationException(
+            "Agent model configuration is temporarily unavailable",
+            config_key=exc.config_key or "agent",
+            error_code="AGENT_CONFIG_UNAVAILABLE",
+        ) from exc
+    except (OSError, TypeError, ValueError, AppBaseException) as exc:
+        raise ConfigurationException(
+            "Agent model configuration is temporarily unavailable",
+            config_key="agent",
+            error_code="AGENT_CONFIG_UNAVAILABLE",
+        ) from exc

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -21,6 +21,10 @@ from typing import Any, AsyncGenerator
 
 from ..exceptions import ConfigurationException
 from .builder import AgentBuilder
+from .configuration import (
+    is_config_independent_command,
+    load_runtime_agent_config,
+)
 from .envelope import Envelope
 from .executor import AgentExecutor
 from .hooks import HookAction, HookContext
@@ -43,9 +47,13 @@ class Runtime:
         *,
         workspace: Any,
         app_services: Any,
+        agent_config: Any | None = None,
+        config_error: ConfigurationException | None = None,
     ) -> None:
         self.workspace = workspace
         self.app_services = app_services
+        self.agent_config = agent_config
+        self.config_error = config_error
 
     async def run(  # pylint: disable=too-many-branches,too-many-statements
         self,
@@ -61,6 +69,35 @@ class Runtime:
         skip_agent = False
 
         try:
+            workspace_agent_id = getattr(self.workspace, "agent_id", None)
+            request_agent_id = getattr(request, "agent_id", None)
+            if (
+                workspace_agent_id
+                and request_agent_id
+                and workspace_agent_id != request_agent_id
+            ):
+                raise ConfigurationException(
+                    "Request agent does not match the selected workspace",
+                    config_key="agent_id",
+                    error_code="AGENT_ID_MISMATCH",
+                )
+
+            if ctx.agent_config is None:
+                if self.config_error is not None:
+                    if not is_config_independent_command(request):
+                        raise self.config_error
+                    ctx.extras["agent_config_error"] = self.config_error
+                else:
+                    try:
+                        ctx.agent_config = await load_runtime_agent_config(
+                            ctx.agent_id,
+                        )
+                    except ConfigurationException as exc:
+                        if not is_config_independent_command(request):
+                            raise
+                        self.config_error = exc
+                        ctx.extras["agent_config_error"] = exc
+
             # --- [phase 1] PRE_DISPATCH ---
             r = await hooks.run(Phase.PRE_DISPATCH, ctx)
             if r.action == HookAction.SHORT_CIRCUIT:
@@ -482,8 +519,8 @@ class Runtime:
         # Prefer the workspace's resolved agent id over a bare "default", so an
         # agent selected by header (no body agent_id) loads its own config.
         agent_id = (
-            getattr(request, "agent_id", None)
-            or getattr(self.workspace, "agent_id", None)
+            getattr(self.workspace, "agent_id", None)
+            or getattr(request, "agent_id", None)
             or "default"
         )
         session_id = request.session_id
@@ -500,6 +537,7 @@ class Runtime:
             workspace=self.workspace,
             app_services=self.app_services,
             input_msgs=_request_input_to_msgs(request.input),
+            agent_config=self.agent_config,
         )
 
     @staticmethod

--- a/tests/unit/app/routers/test_provider_context_window.py
+++ b/tests/unit/app/routers/test_provider_context_window.py
@@ -3,12 +3,17 @@
 
 from types import SimpleNamespace
 
+import pytest
+from fastapi import HTTPException
+
+from qwenpaw.app.routers import providers as providers_router
 from qwenpaw.app.routers.providers import (
     ModelConfigRequest,
     _active_models_info,
     configure_model,
 )
 from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.exceptions import AgentConfigConflictError
 
 
 def test_active_models_info_uses_runtime_context_resolution():
@@ -44,3 +49,107 @@ async def test_configure_model_only_forwards_submitted_fields() -> None:
         "model_id": "gpt-test",
         "config": {"max_tokens": 4096},
     }
+
+
+def _provider_manager(active_model):
+    return SimpleNamespace(
+        get_active_model=lambda: active_model,
+        get_provider=lambda _provider_id: None,
+    )
+
+
+async def test_effective_model_falls_back_after_empty_agent_config(
+    monkeypatch,
+) -> None:
+    global_model = ModelSlotConfig(
+        provider_id="openai",
+        model="gpt-global",
+    )
+
+    async def load_agent_model(_request, _agent_id):
+        return None
+
+    monkeypatch.setattr(
+        providers_router,
+        "_load_agent_model",
+        load_agent_model,
+    )
+
+    result = await providers_router.get_active_models(
+        request=SimpleNamespace(),
+        manager=_provider_manager(global_model),
+        scope="effective",
+        agent_id="bot",
+    )
+
+    assert result.active_llm == global_model
+
+
+async def test_effective_model_returns_503_for_agent_config_failure(
+    monkeypatch,
+) -> None:
+    async def load_agent_model(_request, _agent_id):
+        raise OSError("config unavailable")
+
+    monkeypatch.setattr(
+        providers_router,
+        "_load_agent_model",
+        load_agent_model,
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await providers_router.get_active_models(
+            request=SimpleNamespace(),
+            manager=_provider_manager(None),
+            scope="effective",
+            agent_id="bot",
+        )
+
+    assert caught.value.status_code == 503
+    assert caught.value.detail["code"] == "AGENT_CONFIG_UNAVAILABLE"
+
+
+async def test_effective_model_preserves_agent_http_error(monkeypatch) -> None:
+    async def load_agent_model(_request, _agent_id):
+        raise HTTPException(status_code=404, detail="agent missing")
+
+    monkeypatch.setattr(
+        providers_router,
+        "_load_agent_model",
+        load_agent_model,
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await providers_router.get_active_models(
+            request=SimpleNamespace(),
+            manager=_provider_manager(None),
+            scope="effective",
+            agent_id="bot",
+        )
+
+    assert caught.value.status_code == 404
+    assert caught.value.detail == "agent missing"
+
+
+async def test_effective_model_preserves_stale_config_error_code(
+    monkeypatch,
+) -> None:
+    async def load_agent_model(_request, _agent_id):
+        raise AgentConfigConflictError("bot")
+
+    monkeypatch.setattr(
+        providers_router,
+        "_load_agent_model",
+        load_agent_model,
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await providers_router.get_active_models(
+            request=SimpleNamespace(),
+            manager=_provider_manager(None),
+            scope="effective",
+            agent_id="bot",
+        )
+
+    assert caught.value.status_code == 409
+    assert caught.value.detail["code"] == "AGENT_CONFIG_STALE"

--- a/tests/unit/app/test_agent_context_request.py
+++ b/tests/unit/app/test_agent_context_request.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent request context resolution."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.app import agent_context
+
+
+@pytest.mark.asyncio
+async def test_agent_config_load_runs_through_sync_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Offload the synchronous application config read."""
+    config = SimpleNamespace(
+        agents=SimpleNamespace(
+            active_agent="bot",
+            profiles={"bot": SimpleNamespace(enabled=True)},
+        ),
+    )
+    workspace = SimpleNamespace(agent_id="bot")
+    calls = []
+
+    async def run_sync_io(func, *args):
+        calls.append((func, args))
+        return config
+
+    class Manager:
+        async def get_agent(self, agent_id):
+            assert agent_id == "bot"
+            return workspace
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(),
+        headers={},
+        app=SimpleNamespace(
+            state=SimpleNamespace(multi_agent_manager=Manager()),
+        ),
+    )
+    monkeypatch.setattr(agent_context, "run_sync_io", run_sync_io)
+
+    result = await agent_context.get_agent_for_request(request)
+
+    assert result is workspace
+    assert calls == [(agent_context.load_config, ())]

--- a/tests/unit/providers/test_model_selection.py
+++ b/tests/unit/providers/test_model_selection.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Tests for shared effective model selection."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw.exceptions import ConfigurationException
+from qwenpaw.providers.model_selection import require_effective_model
+from qwenpaw.providers.provider_manager import ProviderManager
+
+
+def _model(provider_id: str, model: str):
+    return SimpleNamespace(provider_id=provider_id, model=model)
+
+
+def test_prefers_agent_model(monkeypatch) -> None:
+    manager = MagicMock()
+    monkeypatch.setattr(ProviderManager, "get_instance", lambda: manager)
+    agent_model = _model("openai", "gpt-agent")
+
+    selected = require_effective_model(
+        SimpleNamespace(active_model=agent_model),
+    )
+
+    assert selected is agent_model
+    manager.get_active_model.assert_not_called()
+
+
+def test_falls_back_to_global_model(monkeypatch) -> None:
+    manager = MagicMock()
+    global_model = _model("openai", "gpt-global")
+    manager.get_active_model.return_value = global_model
+    monkeypatch.setattr(ProviderManager, "get_instance", lambda: manager)
+
+    selected = require_effective_model(
+        SimpleNamespace(active_model=None),
+    )
+
+    assert selected is global_model
+
+
+def test_raises_structured_error_when_no_model_exists(monkeypatch) -> None:
+    manager = MagicMock()
+    manager.get_active_model.return_value = None
+    monkeypatch.setattr(ProviderManager, "get_instance", lambda: manager)
+
+    with pytest.raises(ConfigurationException) as caught:
+        require_effective_model(SimpleNamespace(active_model=None))
+
+    assert caught.value.error_code == "MODEL_NOT_CONFIGURED"

--- a/tests/unit/runtime/test_agent_config_io.py
+++ b/tests/unit/runtime/test_agent_config_io.py
@@ -7,10 +7,15 @@ from types import SimpleNamespace
 import pytest
 
 from qwenpaw.agents import model_factory
+from qwenpaw.app.workspace import workspace as workspace_module
+from qwenpaw.app.workspace.workspace import Workspace
 from qwenpaw.config import config as config_module
 from qwenpaw.exceptions import ConfigurationException
 from qwenpaw.providers import provider_manager
+from qwenpaw import runtime as runtime_package
+from qwenpaw.runtime import builder as builder_module
 from qwenpaw.runtime.builder import AgentBuilder
+from qwenpaw.runtime.configuration import load_runtime_agent_config
 
 
 @pytest.mark.asyncio
@@ -48,12 +53,236 @@ async def test_build_loads_agent_config_once_in_worker_thread(monkeypatch):
     with pytest.raises(
         ConfigurationException,
         match="No active model configured",
-    ):
+    ) as caught:
         await builder.build(ctx)
 
+    assert caught.value.error_code == "MODEL_NOT_CONFIGURED"
     assert len(calls) == 1
     assert calls[0][0] == "agent-1"
     assert calls[0][1] != caller_thread
+
+
+@pytest.mark.asyncio
+async def test_config_load_failure_has_stable_runtime_code(monkeypatch):
+    """Config read failures must not look like a missing model."""
+
+    def fail_config_read(_agent_id):
+        raise OSError("config offline")
+
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        fail_config_read,
+    )
+
+    with pytest.raises(ConfigurationException) as caught:
+        await load_runtime_agent_config("agent-1")
+
+    assert caught.value.error_code == "AGENT_CONFIG_UNAVAILABLE"
+    assert caught.value.config_key == "agent"
+    assert isinstance(caught.value.__cause__, OSError)
+
+
+@pytest.mark.asyncio
+async def test_config_load_preserves_existing_error_code(monkeypatch):
+    """Structured config errors retain their more specific classification."""
+
+    def fail_config_read(_agent_id):
+        raise ConfigurationException(
+            "config changed",
+            config_key="agent",
+            error_code="AGENT_CONFIG_STALE",
+        )
+
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        fail_config_read,
+    )
+
+    with pytest.raises(ConfigurationException) as caught:
+        await load_runtime_agent_config("agent-1")
+
+    assert caught.value.error_code == "AGENT_CONFIG_STALE"
+
+
+@pytest.mark.asyncio
+async def test_workspace_emits_failed_response_when_config_is_unavailable(
+    monkeypatch,
+):
+    """A config read failure must not become an empty successful SSE."""
+
+    async def fail_config_read(_agent_id):
+        raise ConfigurationException(
+            "config offline",
+            config_key="agent",
+            error_code="AGENT_CONFIG_UNAVAILABLE",
+        )
+
+    monkeypatch.setattr(
+        workspace_module,
+        "load_runtime_agent_config",
+        fail_config_read,
+    )
+    workspace = Workspace.__new__(Workspace)
+    workspace.agent_id = "agent-1"
+
+    events = [
+        event
+        async for event in workspace.stream_query(
+            SimpleNamespace(session_id="console:test"),
+        )
+    ]
+
+    assert len(events) == 1
+    assert events[0].object == "response"
+    assert events[0].status.value == "failed"
+    assert events[0].error == {
+        "code": "AGENT_CONFIG_UNAVAILABLE",
+        "message": "config offline",
+    }
+
+
+@pytest.mark.asyncio
+async def test_workspace_rejects_request_agent_mismatch() -> None:
+    """Workspace identity must remain the source of the config snapshot."""
+    workspace = Workspace.__new__(Workspace)
+    workspace.agent_id = "agent-a"
+
+    events = [
+        event
+        async for event in workspace.stream_query(
+            {
+                "agent_id": "agent-b",
+                "session_id": "console:test",
+            },
+        )
+    ]
+
+    assert events[-1].status.value == "failed"
+    assert events[-1].error["code"] == "AGENT_ID_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_workspace_routes_read_only_command_when_config_is_unavailable(
+    monkeypatch,
+) -> None:
+    """Read-only model commands are delegated to Runtime on config failure."""
+    config_error = ConfigurationException(
+        "config offline",
+        config_key="agent",
+        error_code="AGENT_CONFIG_UNAVAILABLE",
+    )
+
+    async def fail_config_read(_agent_id):
+        raise config_error
+
+    received = []
+
+    class FakeRuntime:
+        def __init__(self, *, workspace, app_services, config_error):
+            received.append((workspace, app_services, config_error))
+
+        async def run(self, request):
+            yield request
+
+    monkeypatch.setattr(
+        workspace_module,
+        "load_runtime_agent_config",
+        fail_config_read,
+    )
+    monkeypatch.setattr(runtime_package, "Runtime", FakeRuntime)
+    workspace = Workspace.__new__(Workspace)
+    workspace.agent_id = "agent-1"
+    workspace._app_services = "services"
+
+    request = {
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "/model help"}],
+            },
+        ],
+        "session_id": "console:test",
+    }
+    events = [event async for event in workspace.stream_query(request)]
+
+    assert events == [request]
+    assert received == [(workspace, "services", config_error)]
+
+
+@pytest.mark.asyncio
+async def test_workspace_injects_its_single_config_snapshot(monkeypatch):
+    """The runtime receives the same config object loaded by the workspace."""
+    config = SimpleNamespace(backend="qwenpaw")
+    load_calls = []
+    received = []
+
+    async def load_config(agent_id):
+        load_calls.append(agent_id)
+        return config
+
+    class FakeRuntime:
+        def __init__(self, *, workspace, app_services, agent_config):
+            received.append((workspace, app_services, agent_config))
+
+        async def run(self, request):
+            yield request
+
+    monkeypatch.setattr(
+        workspace_module,
+        "load_runtime_agent_config",
+        load_config,
+    )
+    monkeypatch.setattr(runtime_package, "Runtime", FakeRuntime)
+    workspace = Workspace.__new__(Workspace)
+    workspace.agent_id = "agent-1"
+    workspace.set_app_services("services")
+    request = SimpleNamespace(session_id="console:test")
+
+    events = [event async for event in workspace.stream_query(request)]
+
+    assert events == [request]
+    assert load_calls == ["agent-1"]
+    assert received == [(workspace, "services", config)]
+
+
+@pytest.mark.asyncio
+async def test_builder_reuses_injected_config_snapshot(monkeypatch):
+    """Builder must not reload a configuration already on HookContext."""
+    config = SimpleNamespace(
+        id="agent-1",
+        active_model=None,
+        coding_mode=None,
+    )
+
+    async def unexpected_load(_agent_id):
+        raise AssertionError("config must not be loaded twice")
+
+    monkeypatch.setattr(
+        builder_module,
+        "load_runtime_agent_config",
+        unexpected_load,
+    )
+    monkeypatch.setattr(
+        provider_manager,
+        "ProviderManager",
+        SimpleNamespace(
+            get_instance=lambda: SimpleNamespace(
+                get_active_model=lambda: None,
+            ),
+        ),
+    )
+    builder = AgentBuilder.__new__(AgentBuilder)
+    ctx = SimpleNamespace(
+        agent_id="agent-1",
+        agent_config=config,
+    )
+
+    with pytest.raises(ConfigurationException) as caught:
+        await builder.build(ctx)
+
+    assert caught.value.error_code == "MODEL_NOT_CONFIGURED"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_model_command_config.py
+++ b/tests/unit/runtime/test_model_command_config.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Tests for request-scoped configuration in the model command."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.runtime.commands.control.base import ControlContext
+from qwenpaw.runtime.commands.control import model_handler as model_module
+from qwenpaw.runtime.commands.control.model_handler import ModelCommandHandler
+from qwenpaw.exceptions import ConfigurationException
+
+
+@pytest.mark.asyncio
+async def test_model_command_uses_injected_config_snapshot() -> None:
+    """Showing the model must not touch the synchronous workspace property."""
+
+    class WorkspaceWithoutSyncConfig:
+        @property
+        def config(self):
+            raise AssertionError("synchronous config access is forbidden")
+
+    context = ControlContext(
+        workspace=WorkspaceWithoutSyncConfig(),
+        payload=None,
+        channel=None,
+        session_id="console:test",
+        user_id="test",
+        agent_id="agent-1",
+        args={},
+        agent_config=SimpleNamespace(
+            active_model=SimpleNamespace(
+                provider_id="openai",
+                model="gpt-test",
+            ),
+        ),
+    )
+
+    result = await ModelCommandHandler().handle(context)
+
+    assert "openai" in result
+    assert "gpt-test" in result
+
+
+@pytest.mark.asyncio
+async def test_model_command_falls_back_to_global_when_config_unavailable(
+    monkeypatch,
+) -> None:
+    """The read-only current-model command remains useful during outages."""
+    async def fail_config_read(_agent_id):
+        raise ConfigurationException(
+            "config offline",
+            config_key="agent",
+            error_code="AGENT_CONFIG_UNAVAILABLE",
+        )
+
+    class ProviderManagerStub:
+        @classmethod
+        def get_instance(cls):
+            return cls()
+
+        def get_active_model(self):
+            return SimpleNamespace(provider_id="openai", model="gpt-global")
+
+    monkeypatch.setattr(
+        model_module,
+        "load_runtime_agent_config",
+        fail_config_read,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.providers.provider_manager.ProviderManager",
+        ProviderManagerStub,
+    )
+    context = ControlContext(
+        workspace=SimpleNamespace(agent_id="agent-1"),
+        payload=None,
+        channel=None,
+        session_id="console:test",
+        user_id="test",
+        agent_id="agent-1",
+        args={},
+    )
+
+    result = await ModelCommandHandler().handle(context)
+
+    assert "openai" in result
+    assert "gpt-global" in result

--- a/tests/unit/runtime/test_model_validation_order.py
+++ b/tests/unit/runtime/test_model_validation_order.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for model validation after slash-command dispatch."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agentscope.message import Msg, TextBlock
+
+from qwenpaw.runtime import runtime as runtime_module
+from qwenpaw.exceptions import ConfigurationException
+from qwenpaw.runtime.hooks import HookResult
+from qwenpaw.runtime.runtime import Runtime
+from qwenpaw.runtime.configuration import is_config_independent_command
+from qwenpaw.runtime.slash_command_registry import (
+    CommandSpec,
+    SlashCommandRegistry,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/model", True),
+        ("/model help", True),
+        ("/model info openai:gpt-4", True),
+        ("/model openai:gpt-4", False),
+        ("hello", False),
+    ],
+)
+def test_config_independent_model_command_classification(
+    text,
+    expected,
+) -> None:
+    """Only read-only model commands bypass agent config loading."""
+    request = {
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+            },
+        ],
+    }
+
+    assert is_config_independent_command(request) is expected
+
+
+@pytest.mark.asyncio
+async def test_model_command_runs_before_agent_model_validation(
+    monkeypatch,
+) -> None:
+    """A model-management command must work without building an agent."""
+    received_args = []
+
+    async def handle_model(_ctx, args):
+        received_args.append(args)
+        return Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(type="text", text="available models")],
+        )
+
+    registry = SlashCommandRegistry()
+    registry.register(
+        CommandSpec(
+            name="model",
+            handler=handle_model,
+            category="control",
+        ),
+    )
+    hooks = SimpleNamespace(run=AsyncMock(return_value=HookResult()))
+    workspace = SimpleNamespace(
+        agent_id="default",
+        plugins=SimpleNamespace(
+            hook_registry=hooks,
+            modes=[],
+            slash_command_registry=registry,
+        ),
+        workspace_dir=None,
+    )
+    builder = MagicMock(side_effect=AssertionError("builder must not run"))
+    monkeypatch.setattr(runtime_module, "AgentBuilder", builder)
+    runtime = Runtime(
+        workspace=workspace,
+        app_services=None,
+        agent_config=SimpleNamespace(id="default"),
+    )
+
+    events = [
+        event
+        async for event in runtime.run(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [
+                            {"type": "text", "text": "/model list"},
+                        ],
+                    },
+                ],
+                "session_id": "console:test",
+                "user_id": "test",
+            },
+        )
+    ]
+
+    assert received_args == ["list"]
+    builder.assert_not_called()
+    assert events[-1].object == "response"
+    assert events[-1].status.value == "completed"
+
+
+@pytest.mark.asyncio
+async def test_read_only_model_command_runs_when_config_unavailable() -> None:
+    """Help/list commands remain usable during a temporary config outage."""
+    registry = SlashCommandRegistry()
+
+    async def handle_model(_ctx, args):
+        assert args == "help"
+        return Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(type="text", text="model help")],
+        )
+
+    registry.register(
+        CommandSpec(
+            name="model",
+            handler=handle_model,
+            category="control",
+        ),
+    )
+    workspace = SimpleNamespace(
+        agent_id="default",
+        plugins=SimpleNamespace(
+            hook_registry=SimpleNamespace(
+                run=AsyncMock(return_value=HookResult()),
+            ),
+            modes=[],
+            slash_command_registry=registry,
+        ),
+        workspace_dir=None,
+    )
+    runtime = Runtime(
+        workspace=workspace,
+        app_services=None,
+        config_error=ConfigurationException(
+            "config offline",
+            config_key="agent",
+            error_code="AGENT_CONFIG_UNAVAILABLE",
+        ),
+    )
+
+    events = [
+        event
+        async for event in runtime.run(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [
+                            {"type": "text", "text": "/model help"},
+                        ],
+                    },
+                ],
+                "session_id": "console:test",
+                "user_id": "test",
+            },
+        )
+    ]
+
+    assert events[-1].object == "response"
+    assert events[-1].status.value == "completed"
+
+
+@pytest.mark.asyncio
+async def test_runtime_rejects_request_agent_mismatch() -> None:
+    """A request cannot execute with a different workspace agent snapshot."""
+    hooks = SimpleNamespace(run=AsyncMock(return_value=HookResult()))
+    workspace = SimpleNamespace(
+        agent_id="agent-a",
+        plugins=SimpleNamespace(
+            hook_registry=hooks,
+            modes=[],
+            slash_command_registry=SlashCommandRegistry(),
+        ),
+        workspace_dir=None,
+    )
+    runtime = Runtime(workspace=workspace, app_services=None)
+
+    events = []
+    try:
+        async for event in runtime.run(
+            {
+                "agent_id": "agent-b",
+                "input": [],
+                "session_id": "console:test",
+                "user_id": "test",
+            },
+        ):
+            events.append(event)
+    except ConfigurationException:
+        pass
+
+    assert events[-1].status.value == "failed"
+    assert events[-1].error["code"] == "AGENT_ID_MISMATCH"


### PR DESCRIPTION
## Summary

- Remove the blocking pre-send active-model check in the chat page.
- Only show the model configuration prompt when the backend explicitly returns
  `MODEL_NOT_CONFIGURED`.
- Preserve network, timeout, authentication, and 5xx errors instead of
  converting them into a misleading model configuration error.
- Add terminal handling for empty, incomplete, or interrupted SSE streams.
- Reconnect `sending` and `unknown` queue items before retrying to prevent
  duplicate execution.
- Load agent configuration and model metadata without blocking the asyncio
  event loop.
- Distinguish unavailable configuration, stale configuration, and missing
  model errors on the backend.
- Allow read-only `/model` commands to work while agent configuration is
  temporarily unavailable.
- Add request-scoped configuration snapshots and agent identity validation.

## Root Cause

The frontend treated every failure from
`GET /api/models/active?scope=effective&agent_id=...` as
“model not configured”. After a page had been idle, a network transition,
sleep/wake cycle, or stale proxy connection could make this request fail even
though the model configuration was still valid.

The frontend then:

1. Displayed the model configuration dialog.
2. Constructed a local HTTP 400 response.
3. Prevented the actual `/api/console/chat` request from being sent.

This caused the UI to show a configured model and report that no model was
configured at the same time.

## Testing

- Frontend targeted Vitest: 42 passed.
- Backend targeted pytest: 31 passed.
- TypeScript build check: `npx tsc -b --noEmit`.
- Python compilation: `python -m compileall -q src/qwenpaw tests/unit`.
- Diff validation: `git diff --check`.

The full frontend suite has one pre-existing failure in
`src/pages/Chat/tests/replaySdkIntegration.test.ts`, caused by CRLF fixture
framing. It is unrelated to this change.