### PR TITLE
fix(app): fire workspace_created hooks after agent reload

### DIFF
--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -636,6 +636,16 @@ class MultiAgentManager:
                     old_instance = self.agents[agent_id]
                     self.agents[agent_id] = new_instance
                     candidate_committed = True
+
+            # Fire workspace_created hooks so plugins re-register slash
+            # commands / modes / tools into the reloaded instance —
+            # same contract as the lazy-load path in get_agent().
+            await self._fire_workspace_created_hooks(
+                {
+                    "agent_id": agent_id,
+                    "workspace_dir": str(agent_ref.workspace_dir),
+                },
+            )
         except BaseException as error:
             if candidate_committed:
                 raise

--- a/tests/unit/app/test_multi_agent_reload_hooks.py
+++ b/tests/unit/app/test_multi_agent_reload_hooks.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for workspace_created hooks fired by reload_agent.
+
+``/daemon restart`` rebuilds a workspace in-process via
+``MultiAgentManager.reload_agent``.  Plugin-contributed slash commands,
+modes and tools only enter a freshly built workspace through its
+``workspace_created`` hooks: the startup hook runs once per process, so
+a reload that skipped the hooks left the replacement instance without
+any plugin registrations until the whole app restarted.
+
+The fix fires the hooks right after the atomic swap, under the same
+contract as the lazy-load path in ``get_agent``:
+
+- the hooks run only after ``self.agents`` already maps the agent to
+  the replacement instance (plugins resolve the workspace through the
+  registry's workspace manager at hook run time);
+- the ``workspace_info`` payload matches the lazy-load payload;
+- a failing hook must not roll back or crash the committed reload;
+- a candidate that fails to start is never announced to plugins.
+"""
+
+# Pytest fixtures intentionally provide setup-only arguments to tests.
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qwenpaw.app.multi_agent_manager import MultiAgentManager
+from qwenpaw.plugins.registry import PluginRegistry
+
+AGENT_ID = "agent"
+WORKSPACE_DIR = "/tmp/ws/agent"
+HOOK_PAYLOAD = {"agent_id": AGENT_ID, "workspace_dir": WORKSPACE_DIR}
+
+
+def _fake_workspace() -> MagicMock:
+    ws = MagicMock()
+    ws.start = AsyncMock()
+    ws.stop = AsyncMock()
+    ws.set_manager = MagicMock()
+    ws.set_task_tracker = MagicMock()
+    ws.set_reusable_components = AsyncMock()
+    ws._service_manager.services.get.return_value = None
+    ws._service_manager.get_reusable_services.return_value = {}
+    ws.task_tracker.snapshot_active_tasks = AsyncMock(return_value=[])
+    return ws
+
+
+@pytest.fixture
+def fresh_plugin_registry():
+    """Isolate the PluginRegistry singleton for the current test."""
+    old_singleton = PluginRegistry._instance
+    PluginRegistry._instance = None
+    yield PluginRegistry()
+    PluginRegistry._instance = old_singleton
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    mgr = MultiAgentManager()
+    old_instance = _fake_workspace()
+    mgr.agents[AGENT_ID] = old_instance
+
+    profile = SimpleNamespace(workspace_dir=WORKSPACE_DIR)
+    fake_config = SimpleNamespace(
+        agents=SimpleNamespace(profiles={AGENT_ID: profile}),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.multi_agent_manager.load_config",
+        lambda: fake_config,
+    )
+    monkeypatch.setattr(
+        mgr,
+        "_graceful_stop_old_instance",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        mgr,
+        "_mark_rejected_reusable_services_for_cleanup",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        mgr,
+        "_setup_workspace_plugins",
+        AsyncMock(),
+    )
+    return mgr, old_instance
+
+
+@pytest.fixture
+def hook_spy(monkeypatch):
+    """AsyncMock standing in for the classmethod hook dispatch."""
+    spy = AsyncMock()
+    monkeypatch.setattr(
+        MultiAgentManager,
+        "_fire_workspace_created_hooks",
+        spy,
+    )
+    return spy
+
+
+async def test_reload_fires_hooks_with_lazy_load_payload(
+    manager,
+    hook_spy,
+):
+    """A committed reload fires the hooks once with the expected payload."""
+    mgr, _old_instance = manager
+    new_instance = _fake_workspace()
+    mgr._create_workspace = lambda agent_id, workspace_dir: new_instance
+
+    assert await mgr.reload_agent(AGENT_ID) is True
+
+    hook_spy.assert_awaited_once_with(HOOK_PAYLOAD)
+
+
+async def test_hooks_run_after_swap_and_target_new_instance(
+    manager,
+    fresh_plugin_registry,
+):
+    """Hooks resolve the replacement workspace, never the old one.
+
+    Mirrors the real plugin path (``_get_workspace_from_info``): a hook
+    that receives no explicit ``workspace`` key looks the instance up
+    through the registry's workspace manager, so it only lands on the
+    new instance when the fire happens *after* the atomic swap.
+    """
+    mgr, old_instance = manager
+    fresh_plugin_registry.set_workspace_manager(mgr)
+    new_instance = _fake_workspace()
+    mgr._create_workspace = lambda agent_id, workspace_dir: new_instance
+
+    invocations = []
+
+    def plugin_hook(workspace_info: dict) -> None:
+        ws = workspace_info.get("workspace")
+        if ws is None:
+            ws = (
+                PluginRegistry()
+                .get_workspace_manager()
+                .agents.get(
+                    workspace_info["agent_id"],
+                )
+            )
+        invocations.append((workspace_info, ws))
+        ws.plugins.slash_command_registry.register("plugin-cmd")
+
+    # Not reload-safe: only the post-swap fire may run this hook —
+    # exactly the path the daemon-restart bug used to skip.
+    fresh_plugin_registry.register_workspace_created_hook(
+        plugin_id="test-plugin",
+        hook_name="re_register_plugin_cmd",
+        callback=plugin_hook,
+    )
+
+    assert await mgr.reload_agent(AGENT_ID) is True
+
+    fired = [info for info, _ws in invocations if "workspace" not in info]
+    assert fired == [HOOK_PAYLOAD]
+    for _info, ws in invocations:
+        assert ws is new_instance
+    new_registry = new_instance.plugins.slash_command_registry
+    new_registry.register.assert_called_once_with("plugin-cmd")
+    old_registry = old_instance.plugins.slash_command_registry
+    old_registry.register.assert_not_called()
+
+
+async def test_failing_hook_does_not_break_committed_reload(
+    manager,
+    fresh_plugin_registry,
+):
+    """A crashing hook is isolated; the reload still finishes."""
+    mgr, _old_instance = manager
+    fresh_plugin_registry.set_workspace_manager(mgr)
+    new_instance = _fake_workspace()
+    mgr._create_workspace = lambda agent_id, workspace_dir: new_instance
+
+    def broken_hook(workspace_info: dict) -> None:
+        raise RuntimeError("plugin hook crashed")
+
+    healthy_calls = []
+
+    def healthy_hook(workspace_info: dict) -> None:
+        healthy_calls.append(workspace_info)
+
+    fresh_plugin_registry.register_workspace_created_hook(
+        plugin_id="test-plugin",
+        hook_name="broken",
+        callback=broken_hook,
+        priority=10,
+    )
+    fresh_plugin_registry.register_workspace_created_hook(
+        plugin_id="test-plugin",
+        hook_name="healthy",
+        callback=healthy_hook,
+        priority=20,
+    )
+
+    assert await mgr.reload_agent(AGENT_ID) is True
+    assert mgr.agents[AGENT_ID] is new_instance
+    assert healthy_calls == [HOOK_PAYLOAD]
+
+
+async def test_failed_candidate_start_skips_hooks(
+    manager,
+    hook_spy,
+):
+    """A candidate that fails to start is never announced to plugins."""
+    mgr, old_instance = manager
+    new_instance = _fake_workspace()
+    new_instance.start = AsyncMock(side_effect=RuntimeError("boom"))
+    mgr._create_workspace = lambda agent_id, workspace_dir: new_instance
+
+    assert await mgr.reload_agent(AGENT_ID) is False
+    assert mgr.agents[AGENT_ID] is old_instance
+    hook_spy.assert_not_awaited()
+
+
+async def test_lazy_load_and_reload_fire_identical_payload(
+    monkeypatch,
+    hook_spy,
+):
+    """reload_agent sends exactly the workspace_info get_agent sends."""
+    mgr = MultiAgentManager()  # empty: force the lazy-load path first
+    monkeypatch.setattr(
+        mgr,
+        "_setup_workspace_plugins",
+        AsyncMock(),
+    )
+    profile = SimpleNamespace(workspace_dir=WORKSPACE_DIR)
+    fake_config = SimpleNamespace(
+        agents=SimpleNamespace(profiles={AGENT_ID: profile}),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.multi_agent_manager.load_config",
+        lambda: fake_config,
+    )
+    mgr._create_workspace = lambda agent_id, workspace_dir: _fake_workspace()
+
+    await mgr.get_agent(AGENT_ID)
+    assert await mgr.reload_agent(AGENT_ID) is True
+
+    assert hook_spy.await_count == 2
+    lazy_load_args = hook_spy.await_args_list[0].args
+    reload_args = hook_spy.await_args_list[1].args
+    assert reload_args == lazy_load_args == (HOOK_PAYLOAD,)


### PR DESCRIPTION
## Description

`/daemon restart` performs an in-process zero-downtime reload via `MultiAgentManager.reload_agent()`, which rebuilds the agent workspace but never fired `workspace_created` hooks. Plugin-contributed slash commands, modes, tools and runtime hooks reach a fresh workspace only through those hooks (the startup hook runs once per process), so after a reload every plugin registration vanished from the replacement workspace — e.g. a plugin's `/feishu-plus` command stopped dispatching — until the whole app process was restarted.

This PR fires `_fire_workspace_created_hooks()` right after the atomic swap in `reload_agent()`, under the same contract as the lazy-load path in `get_agent()`:

- hooks run only after `self.agents` already maps the agent to the replacement
  instance (plugins resolve the workspace through the registry's workspace
  manager at hook run time), so registrations land on the new instance;
- the `workspace_info` payload is identical to the lazy-load payload;
- per-hook error isolation is preserved — a crashing hook cannot roll back or
  crash a committed reload;
- a candidate that fails to start is never announced to plugins.

**Related Issue:** N/A (reported while debugging a plugin losing its commands after `/daemon restart`)

**Security Considerations:** None — the change only reuses the existing `workspace_created` hook dispatch for already-loaded plugins; no new code paths, credentials, or config handling are introduced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

Unit tests: `pytest tests/unit/app/test_multi_agent_reload_hooks.py` — 5 new regression tests covering:

1. a committed reload fires the hooks once with the lazy-load payload;
2. hooks resolve the **replacement** workspace (post-swap ordering) and never touch the old instance — uses a non-`reload_safe` hook, i.e. exactly the registration class the bug dropped;
3. a failing hook is isolated; the reload still commits and returns success;
4. a candidate whose `start()` fails is never announced to plugins;
5. `get_agent()` (lazy load) and `reload_agent()` fire identical payloads.

Regression proof: with the source fix stashed (`git stash -- src/...`), tests 1–3 and 5 fail and test 4 still passes; restored, all 5 pass.

Manual check: start the app with a plugin that registers a slash command → verify the command dispatches → run `/daemon restart` → the command still dispatches on the replacement workspace (before this fix it disappeared).

## Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
Lint GitHub Actions workflow files.......................................Passed

pytest tests/unit/app/test_multi_agent_reload_hooks.py
==================================================== test session starts ====================================================
platform linux -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/boringcat/github/QwenPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, respx-0.23.1, timeout-2.4.0, asyncio-1.4.0, hypothesis-6.167.1, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 5 items

tests/unit/app/test_multi_agent_reload_hooks.py .....                                                                 [100%]

==================================================== 5 passed in 0.47s =====================================================

pytest tests/unit/app/test_multi_agent_reload_guard.py \
  tests/unit/app/test_multi_agent_manager_startup.py \
  tests/unit/plugins/test_plugin_api_extensions.py
==================================================== test session starts ===================================================
platform linux -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/boringcat/github/QwenPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, respx-0.23.1, timeout-2.4.0, asyncio-1.4.0, hypothesis-6.167.1, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 51 items

tests/unit/app/test_multi_agent_reload_guard.py ....                                                                  [  7%]
tests/unit/app/test_multi_agent_manager_startup.py .........................                                          [ 56%]
tests/unit/plugins/test_plugin_api_extensions.py ......................                                               [100%]

==================================================== 51 passed in 2.67s ====================================================
```

## Additional Notes

- `reload_safe` hooks may now run twice per reload (once via `_setup_workspace_plugins` on the candidate before the swap, once via the new post-swap fire). Plugin-side registration is idempotent (`_register_spec_to_workspace` already swallows the "already registered" `ValueError`), so this is safe — but plugin authors should keep `workspace_created` callbacks idempotent.
- The blast radius of the original bug was larger than slash commands: `register_mode`, `register_tool` and `register_runtime_hook` follow the same startup + `workspace_created` dual-hook pattern and were all lost after a reload; this fix restores all of them.
