### PR TITLE
fix(console): enqueue follow-up messages when chat task is running

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -564,7 +564,8 @@ class BaseChannel(ABC):
                 exc_info=True,
             )
 
-        queue, is_new = await self._workspace.task_tracker.attach_or_start(
+        tracker = self._workspace.task_tracker
+        queue, is_new = await tracker.attach_or_start(
             chat.id,
             payload,
             self._stream_with_tracker,
@@ -572,12 +573,21 @@ class BaseChannel(ABC):
             on_finished=self._workspace.chat_manager.mark_chat_finished,
         )
 
+        if not is_new:
+            await tracker.detach_subscriber(chat.id, queue)
+            while await tracker.get_status(chat.id) == "running":
+                await asyncio.sleep(0.05)
+            queue, is_new = await tracker.attach_or_start(
+                chat.id,
+                payload,
+                self._stream_with_tracker,
+                owner=self._workspace,
+                on_finished=self._workspace.chat_manager.mark_chat_finished,
+            )
+
         if is_new:
             try:
-                async for _ in self._workspace.task_tracker.stream_from_queue(
-                    queue,
-                    chat.id,
-                ):
+                async for _ in tracker.stream_from_queue(queue, chat.id):
                     pass
             except asyncio.CancelledError:
                 logger.info(
@@ -587,10 +597,9 @@ class BaseChannel(ABC):
                 raise
         else:
             logger.warning(
-                f"Message ignored (task already running): "
+                f"Message ignored (task still running): "
                 f"chat_id={chat.id} "
-                f"session={sanitize_log_value(session_id[:30])}. "
-                f"This should not happen with UnifiedQueueManager.",
+                f"session={sanitize_log_value(session_id[:30])}.",
             )
 
     _STREAMABLE_TYPES = {"reasoning", "message"}

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -334,6 +334,17 @@ def _empty_sse_response() -> StreamingResponse:
     )
 
 
+def _enqueue_console_followup(workspace, native_payload: dict[str, Any]) -> None:
+    """Queue a follow-up console message for the session queue consumer."""
+    channel_manager = workspace.channel_manager
+    if channel_manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel manager not available",
+        )
+    channel_manager.enqueue("console", native_payload)
+
+
 def _tail_text_file(
     path: Path,
     *,
@@ -430,13 +441,8 @@ async def post_console_chat(
         )
         if not is_new_run:
             await tracker.detach_subscriber(chat.id, queue)
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "A task is already running for this chat. Wait for it "
-                    "to finish or use a different session_id."
-                ),
-            )
+            _enqueue_console_followup(workspace, native_payload)
+            return _empty_sse_response()
 
         # Title generation is only needed when starting a new run.
         if first_text and chat.name == name:

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -16,8 +16,9 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
 
 from qwenpaw.app.routers.console import _extract_session_and_payload
 from qwenpaw.app.task_tracker import TaskTracker
@@ -181,12 +182,12 @@ async def test_reconnect_with_active_run_replays_buffer_and_marker(
 
 
 @pytest.mark.asyncio
-async def test_new_message_rejects_active_run(
+async def test_new_message_enqueues_when_active_run(
     app,
     console_workspace,
     monkeypatch,
 ):
-    """A non-reconnect payload must not silently attach to an active run."""
+    """A non-reconnect payload must enqueue when a run is already active."""
     from starlette.requests import Request
     from qwenpaw.app.routers import console
 
@@ -203,6 +204,7 @@ async def test_new_message_rejects_active_run(
         "_persist_pending_project_dirs",
         AsyncMock(side_effect=lambda _ws, chat, _payload: chat),
     )
+    console_workspace.channel_manager.enqueue = MagicMock()
 
     request = Request(
         scope={
@@ -215,29 +217,32 @@ async def test_new_message_rejects_active_run(
     )
 
     try:
-        with pytest.raises(HTTPException) as exc_info:
-            await console.post_console_chat(
-                request_data={
-                    "session_id": "console:default",
-                    "user_id": "default",
-                    "channel": "console",
-                    "input": [
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": "new message"},
-                            ],
-                        },
-                    ],
-                },
-                request=request,
-            )
+        response = await console.post_console_chat(
+            request_data={
+                "session_id": "console:default",
+                "user_id": "default",
+                "channel": "console",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "new message"},
+                        ],
+                    },
+                ],
+            },
+            request=request,
+        )
     finally:
         release.set()
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == (
-        "A task is already running for this chat. Wait for it to finish or "
-        "use a different session_id."
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/event-stream"
+    console_workspace.channel_manager.enqueue.assert_called_once()
+    enqueue_payload = (
+        console_workspace.channel_manager.enqueue.call_args[0][1]
     )
+    first_part = enqueue_payload["content_parts"][0]
+    text = first_part.get("text") if isinstance(first_part, dict) else first_part.text
+    assert text == "new message"
     assert console_workspace.console_channel.stream_calls == []

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -839,20 +839,33 @@ class TestConsumeWithTracker:
 
         mock_chat_manager.get_or_create_chat.assert_called_once()
 
-    async def test_consume_with_tracker_existing_task_logs_warning(
+    async def test_consume_with_tracker_waits_for_idle_then_starts(
         self,
         base_channel,
     ):
-        """When task already exists, should log warning and not start new."""
+        """When a router-started run is active, wait and start a new run."""
         mock_workspace = MagicMock()
         mock_chat_manager = AsyncMock()
 
-        # Create async mock that returns is_new=False
+        attach_calls = 0
+
         async def mock_attach_or_start(*args, **kwargs):
-            return (MagicMock(), False)  # (queue, is_new) - is_new=False
+            nonlocal attach_calls
+            attach_calls += 1
+            return (MagicMock(), attach_calls > 1)
+
+        async def mock_get_status(_chat_id):
+            return "idle"
+
+        async def mock_stream(*args, **kwargs):
+            if False:
+                yield None
 
         mock_task_tracker = MagicMock()
         mock_task_tracker.attach_or_start = mock_attach_or_start
+        mock_task_tracker.detach_subscriber = AsyncMock()
+        mock_task_tracker.get_status = mock_get_status
+        mock_task_tracker.stream_from_queue = mock_stream
 
         mock_workspace.chat_manager = mock_chat_manager
         mock_workspace.task_tracker = mock_task_tracker
@@ -879,7 +892,8 @@ class TestConsumeWithTracker:
                 mock_payload,
             )
 
-        # Test passed if we reach here (warning was logged for is_new=False)
+        assert attach_calls == 2
+        mock_task_tracker.detach_subscriber.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What Problem This Solves

While a chat already had an active run, POST /console/chat returned HTTP 409 (A task is already running...) even for follow-up text/file messages. Users expected the new message to be queued rather than rejected.

## Description

When a session already has an active run, enqueue the new console payload through the channel manager instead of returning 409. The session queue consumer waits for the in-flight run to finish before starting the next turn.

**Related Issue:** Fixes #7559

**Security Considerations:** N/A — same console auth path; only changes busy-session handling.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [x] Tests

## Checklist

- [x] I ran tests locally (pytest) and they pass
- [x] Ready for review

## Testing

pytest tests/unit/app/routers/test_console_chat_reconnect.py tests/unit/channels/test_base_core.py -q

## Evidence

Before: mid-run console POST returned 409 with detail that a task is already running.
After: the same request is enqueued; unit coverage asserts enqueue-on-active-run instead of 409.
