### PR TITLE
fix(tool_calls): log exceptions in coordinator _drain()

### DIFF
--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -715,6 +715,11 @@ class ToolCoordinator:
             )
             entry.end_state = "interrupted"
         except Exception as exc:
+            logger.exception(
+                "Tool handler failed for %s/%s",
+                entry.ctx.tool_name,
+                entry.ctx.tool_call_id,
+            )
             entry.final_response = ToolResponse(
                 content=[
                     TextBlock(type="text", text=f"Tool error: {exc}"),

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator
 
@@ -1475,3 +1476,55 @@ async def test_request_offload_rejects_short_kill_without_bound():
         force=True,
     )
     await asyncio.wait_for(task, timeout=2)
+
+
+@pytest.fixture()
+def _coordinator_caplog(caplog: pytest.LogCaptureFixture):
+    """Capture logs from qwenpaw.tool_calls._coordinator."""
+    target = logging.getLogger("qwenpaw")
+    old_propagate = target.propagate
+    target.propagate = True
+    with caplog.at_level(
+        logging.ERROR,
+        logger="qwenpaw.tool_calls._coordinator",
+    ):
+        yield
+    target.propagate = old_propagate
+
+
+@pytest.mark.asyncio
+async def test_drain_logs_handler_exception(_coordinator_caplog, caplog):
+    """Exceptions in next_handler must be logged with traceback."""
+    coordinator = ToolCoordinator()
+    tool_call = _ToolCall(id="call-drain-err", name="boom_tool")
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        raise RuntimeError("handler exploded")
+        yield _text_response(tool_call.id, "unreachable")  # pragma: no cover
+
+    events = await _collect(
+        coordinator.execute(
+            tool_call=tool_call,
+            next_handler=next_handler,
+            session_id="session-drain-err",
+            agent_id="agent-1",
+            root_session_id="root-1",
+        ),
+    )
+
+    assert len(events) == 1
+    response = events[0]
+    assert response.state == ToolResultState.ERROR
+    assert "Tool error: handler exploded" in response.content[0].text
+
+    error_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+        and "Tool handler failed" in record.getMessage()
+    ]
+    assert len(error_records) == 1
+    assert error_records[0].exc_info is not None
+    assert error_records[0].exc_info[0] is RuntimeError

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -1501,8 +1501,9 @@ async def test_drain_logs_handler_exception(_coordinator_caplog, caplog):
     async def next_handler(
         tool_call: _ToolCall,
     ) -> AsyncGenerator[Any, None]:
+        if False:  # pragma: no cover
+            yield _text_response(tool_call.id, "unreachable")
         raise RuntimeError("handler exploded")
-        yield _text_response(tool_call.id, "unreachable")  # pragma: no cover
 
     events = await _collect(
         coordinator.execute(

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -1498,12 +1498,14 @@ async def test_drain_logs_handler_exception(_coordinator_caplog, caplog):
     coordinator = ToolCoordinator()
     tool_call = _ToolCall(id="call-drain-err", name="boom_tool")
 
+    should_fail = True
+
     async def next_handler(
         tool_call: _ToolCall,
     ) -> AsyncGenerator[Any, None]:
-        if False:  # pragma: no cover
-            yield _text_response(tool_call.id, "unreachable")
-        raise RuntimeError("handler exploded")
+        if should_fail:
+            raise RuntimeError("handler exploded")
+        yield _text_response(tool_call.id, "unreachable")
 
     events = await _collect(
         coordinator.execute(


### PR DESCRIPTION
## What Problem This Solves

When a tool handler raises inside tool_calls/_coordinator.py _drain(), the exception was caught and only str(exc) was returned to the model. Nothing was written with logger.exception, so operators could not see the stack or where the failure originated.

## Description

Call logger.exception (full traceback) when next_handler raises, while still returning a safe Tool error string to the model. Adds a unit test that a raised exception is logged.

**Related Issue:** Fixes #7572

**Security Considerations:** N/A — logging only; no new auth or channel surface.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Checklist

- [x] I ran tests locally (pytest) and they pass
- [x] Ready for review

## Testing

pytest tests/unit/tool_calls/test_coordinator_completion.py -q

## Evidence

Before: a raised exception in _drain produced only a one-line model-facing string; no traceback in logs.
After: logger.exception records the full stack, and the model still receives a safe Tool error. Unit test asserts the exception path is logged.
