### PR TITLE
fix(telegram): render Markdown tables as <pre> instead of raw pipes

### DIFF
--- a/src/qwenpaw/app/channels/telegram/format_html.py
+++ b/src/qwenpaw/app/channels/telegram/format_html.py
@@ -19,6 +19,134 @@ def _escape_html(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+# Markdown table cell: at least 3 dashes with optional alignment colons.
+_TABLE_DELIMITER_CELL_RE = re.compile(r"^:?-{3,}:?$")
+
+
+def _split_table_row(line: str) -> list[str]:
+    """Split a Markdown table row into cells (outer pipes optional)."""
+    stripped = line.strip().removeprefix("|").removesuffix("|")
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _parse_table_delimiter(line: str) -> list[str] | None:
+    """Return per-column alignment if the line is a table delimiter row."""
+    cells = _split_table_row(line)
+    aligns: list[str] = []
+    for cell in cells:
+        if not _TABLE_DELIMITER_CELL_RE.match(cell):
+            return None
+        left = cell.startswith(":")
+        right = cell.endswith(":")
+        if left and right:
+            aligns.append("center")
+        elif right:
+            aligns.append("right")
+        else:
+            aligns.append("left")
+    return aligns
+
+
+def _flatten_table_cell(cell: str, placeholders: list[str]) -> str:
+    """Replace code/link placeholder tokens in a cell with plain text.
+
+    Table cells stay plain text so no nested tags (unsafe in Telegram
+    ``<pre>``) and no raw tokens ever leak into the rendered block.
+    """
+
+    def _inner(m: re.Match) -> str:
+        idx = int(m.group(1))
+        if 0 <= idx < len(placeholders):
+            return re.sub(r"<[^>]*>", "", placeholders[idx])
+        return m.group(0)
+
+    return re.sub(r"\x00PH(\d+)\x00", _inner, cell)
+
+
+def _render_table_block(
+    header: list[str],
+    aligns: list[str],
+    body: list[list[str]],
+    placeholders: list[str],
+) -> str:
+    """Render header/aligns/body rows as a padded ``<pre>`` HTML block."""
+    header = [_flatten_table_cell(c, placeholders) for c in header]
+    body = [
+        [_flatten_table_cell(c, placeholders) for c in row] for row in body
+    ]
+    widths = [0] * len(header)
+    for row in [header, *body]:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def _fmt(cell: str, idx: int) -> str:
+        align = aligns[idx] if idx < len(aligns) else "left"
+        if align == "right":
+            return cell.rjust(widths[idx])
+        if align == "center":
+            return cell.center(widths[idx])
+        return cell.ljust(widths[idx])
+
+    rendered = [" | ".join(_fmt(c, i) for i, c in enumerate(header))]
+    rendered.append("-+-".join("-" * w for w in widths))
+    for row in body:
+        rendered.append(" | ".join(_fmt(c, i) for i, c in enumerate(row)))
+    html = f"<pre>{_escape_html(chr(10).join(rendered))}</pre>"
+    token_idx = len(placeholders)
+    placeholders.append(html)
+    return f"\x00PH{token_idx}\x00"
+
+
+def _extract_table_blocks(text: str, placeholders: list[str]) -> str:
+    """Replace Markdown table blocks with ``<pre>`` placeholder tokens.
+
+    A table requires a header line containing ``|``, a delimiter line
+    containing ``|`` whose cells all match ``:?-{3,}:?``, matching column
+    counts, and at least one body row. Spoilers, code blocks, lone pipes
+    and malformed delimiters never qualify.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        header_line = lines[i]
+        delim_line = lines[i + 1] if i + 1 < len(lines) else ""
+        if (
+            "|" in header_line
+            and "|" in delim_line
+            and (aligns := _parse_table_delimiter(delim_line)) is not None
+            and len(header := _split_table_row(header_line)) == len(aligns)
+        ):
+            body_rows: list[list[str]] = []
+            j = i + 2
+            while j < len(lines):
+                body_line = lines[j]
+                if body_line.strip() == "" or "|" not in body_line:
+                    break
+                cells = _split_table_row(body_line)
+                if len(cells) != len(header):
+                    break
+                # A second delimiter-looking row ends the table.
+                if _parse_table_delimiter(body_line) is not None:
+                    break
+                body_rows.append(cells)
+                j += 1
+            if body_rows:
+                out.append(
+                    _render_table_block(
+                        header,
+                        aligns,
+                        body_rows,
+                        placeholders,
+                    ),
+                )
+                i = j
+                continue
+        out.append(lines[i])
+        i += 1
+    return "\n".join(out)
+
+
 def markdown_to_telegram_html(text: str) -> str:
     """Convert standard Markdown text to Telegram Bot API HTML.
 
@@ -31,6 +159,7 @@ def markdown_to_telegram_html(text: str) -> str:
     - Blockquotes (> …) → <blockquote>
     - Unordered lists (* / - ) → •
     - Spoilers (||text||) → <tg-spoiler>
+    - Markdown tables → <pre> (monospace block)
     - Bold (**text**), Italic (*text*), Bold+Italic (***text***)
     - Strikethrough (~~text~~)
     """
@@ -79,6 +208,12 @@ def markdown_to_telegram_html(text: str) -> str:
         return _ph(f'<a href="{url}">{link_text}</a>')
 
     text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _link, text)
+
+    # Markdown tables → <pre> (Telegram HTML has no <table>).
+    # Runs on raw text (sees "|" and delimiter row), after fenced/inline
+    # code and links are placeholder-protected, and before HTML escaping
+    # so cell content is still escaped exactly once during rendering.
+    text = _extract_table_blocks(text, placeholders)
 
     # ── Phase 2: escape HTML in remaining text ─────────────────────────
     text = _escape_html(text)

--- a/tests/unit/channels/test_telegram_format_html.py
+++ b/tests/unit/channels/test_telegram_format_html.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Focused unit tests for Markdown table handling in Telegram HTML output.
+
+Covers Issue #7585: Markdown tables must not be echoed back with raw
+``|`` / ``---`` syntax. They are rendered as a ``<pre>`` monospace block.
+
+Run:
+    pytest tests/unit/channels/test_telegram_format_html.py -q
+"""
+from __future__ import annotations
+
+from qwenpaw.app.channels.telegram.format_html import markdown_to_telegram_html
+
+
+class TestTelegramMarkdownTable:
+    def test_basic_table_becomes_pre(self):
+        out = markdown_to_telegram_html("| A | B |\n|---|---|\n| 1 | 2 |")
+        assert "<pre>" in out
+        assert "|---|---|" not in out
+        assert "A" in out and "1" in out
+
+    def test_issue_example_table(self):
+        md = "| 期限 | 总利息 |\n|------|--------|\n| 30 年 | 91 万 |"
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" in out
+        assert "|------|--------|" not in out
+        assert "91 万" in out
+
+    def test_alignment_markers_accepted(self):
+        md = "| L | C | R |\n|:---|:---:|---:|\n| a | b | c |"
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" in out
+        assert "|:---|:---:|---:|" not in out
+        assert "a" in out and "b" in out and "c" in out
+
+    def test_surrounding_prose_preserved(self):
+        md = "before\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nafter"
+        out = markdown_to_telegram_html(md)
+        assert "before" in out
+        assert "after" in out
+        assert "<pre>" in out
+
+    def test_table_cells_are_html_escaped(self):
+        md = "| A | B |\n|---|---|\n| <script> | A & B |"
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" in out
+        assert "&lt;script&gt;" in out
+        assert "A &amp; B" in out
+        assert "<script>" not in out
+
+    def test_fenced_code_with_pipes_not_converted_to_table(self):
+        md = "```\na | b\n--|--\n```"
+        out = markdown_to_telegram_html(md)
+        assert "--|--" in out  # raw code content preserved
+        assert "-+-" not in out  # no table separator injected
+
+    def test_spoiler_still_works(self):
+        out = markdown_to_telegram_html("||secret||")
+        assert out == "<tg-spoiler>secret</tg-spoiler>"
+        assert "<pre>" not in out
+
+    def test_plain_pipe_text_not_converted(self):
+        out = markdown_to_telegram_html("foo | bar")
+        assert out == "foo | bar"
+        assert "<pre>" not in out
+
+    def test_malformed_table_not_converted(self):
+        md = "| A | B |\n| xx | yy |\n| 1 | 2 |"
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" not in out
+        assert "| xx | yy |" in out
+
+    def test_table_with_inline_code_cell_stays_plain_text(self):
+        md = "| Name | Value |\n| --- | --- |\n| x | `a|b` |"
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" in out
+        assert "a|b" in out
+        assert "<code>" not in out
+        assert "\x00" not in out
+
+    def test_table_with_link_cell_stays_plain_text(self):
+        md = (
+            "| Name | URL |\n| --- | --- |\n"
+            "| QwenPaw | [site](https://example.com) |"
+        )
+        out = markdown_to_telegram_html(md)
+        assert "<pre>" in out
+        assert "site" in out
+        assert "<a " not in out
+        assert "\x00" not in out


### PR DESCRIPTION
Fixes #7585.

## What Problem This Solves
`markdown_to_telegram_html()` had no Markdown table handling, so `|` / `---` were HTML-escaped and sent verbatim. On Telegram this renders as unreadable raw pipes and dashes.

## Fix
Detect GFM-style tables in Phase 1 (after fenced/inline code and links are placeholder-protected, before HTML escaping) and render a padded `<pre>` monospace block (Telegram HTML has no `<table>`). A table requires: a header line containing `|`, a delimiter line containing `|` whose cells all match `:?-{3,}:?` (`:---` / `---:` / `:---:` accepted for alignment), matching column counts, and at least one body row.

Cells are deliberately plain text: code/link spans inside cells are flattened to inner text, so no nested tags (safe for Telegram `<pre>` rendering) and no raw placeholder tokens ever leak into the block. Spoilers (`||secret||`), fenced/inline code, lone `foo | bar`, and malformed delimiters are explicitly not converted. `strip_markdown()` is unchanged, and no new dependencies are added.

## Testing
- `pytest tests/unit/channels/test_telegram_format_html.py` → 11 passed (new focused tests: basic table, alignment markers, surrounding prose, HTML escaping, fenced code, spoiler, plain pipe text, malformed delimiter, table+inline-code cell, table+link cell, issue example)
- `pytest tests/contract/channels/test_telegram_contract.py` → 19 passed
- `./scripts/check-channels.sh --changed` → all checks passed
- `pre-commit run` (scoped to changed files) → all hooks green
- 18-case non-table regression corpus → byte-identical output before/after

## Evidence
`| 期限 | 总利息 |` / `|------|--------|` / `| 30 年 | 91 万 |` now renders as `<pre>期限   | 总利息\n-----+-----\n30 年 | 91 万</pre>` instead of raw pipes.

## Known limitations
- CJK column alignment is best-effort (`len()`-based widths, no new deps) — readability over pixel-perfect alignment.
- Link targets inside cells are not preserved (link text only).
- Header + delimiter with no body rows is left unconverted (conservative).