### PR TITLE
feat(feishu): auto-collapse reasoning streaming card after finalize

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -52,6 +52,11 @@ from .constants import (
     FEISHU_FILE_MAX_BYTES,
     FEISHU_NICKNAME_CACHE_MAX,
     FEISHU_PROCESSED_IDS_MAX,
+    FEISHU_REASONING_PANEL_DONE_TITLE,
+    FEISHU_REASONING_PANEL_ELEMENT_ID,
+    FEISHU_REASONING_PANEL_TITLE,
+    FEISHU_UNUSED_CARD_ERROR_TEXT,
+    FEISHU_UNUSED_CARD_SUCCESS_TEXT,
     FEISHU_STALE_MSG_THRESHOLD_MS,
     FEISHU_STREAM_ELEMENT_ID,
     FEISHU_STREAM_MIN_INTERVAL_S,
@@ -291,6 +296,11 @@ class FeishuChannel(BaseChannel):
         # session_id -> (receive_id, receive_id_type) for send
         self._receive_id_store: Dict[str, Tuple[str, str]] = {}
         self._receive_id_lock = asyncio.Lock()
+        # session_id -> request holding an unconsumed pre-created streaming
+        # card. Lets the response-cycle finally hook clean up a placeholder
+        # no answer stream consumed (cancel path has no other channel hook).
+        # Popped at cycle end; turns are serialized per session upstream.
+        self._pending_precreated: Dict[str, Any] = {}
         # open_id -> nickname (from Contact API) for sender display
         self._nickname_cache: Dict[str, str] = {}
         self._nickname_cache_lock = asyncio.Lock()
@@ -2042,8 +2052,14 @@ class FeishuChannel(BaseChannel):
         receive_id_type: str,
         receive_id: str,
         initial_text: str = "...",
+        collapsible: bool = False,
     ) -> Optional[Dict[str, str]]:
         """Create a CardKit streaming card and send it as a message.
+
+        When ``collapsible`` is True (reasoning streams), the streaming
+        markdown is wrapped in a JSON 2.0 ``collapsible_panel`` that starts
+        expanded. The inner markdown keeps ``FEISHU_STREAM_ELEMENT_ID`` so
+        streaming content updates need no change.
 
         Returns ``{"card_id": ..., "message_id": ...}`` or ``None``.
         """
@@ -2056,17 +2072,31 @@ class FeishuChannel(BaseChannel):
         )
 
         element_id = FEISHU_STREAM_ELEMENT_ID
+        markdown_element = {
+            "tag": "markdown",
+            "content": initial_text,
+            "element_id": element_id,
+        }
+        if collapsible:
+            top_element = {
+                "tag": "collapsible_panel",
+                "element_id": FEISHU_REASONING_PANEL_ELEMENT_ID,
+                "expanded": True,
+                "header": {
+                    "title": {
+                        "tag": "plain_text",
+                        "content": FEISHU_REASONING_PANEL_TITLE,
+                    },
+                },
+                "elements": [markdown_element],
+            }
+        else:
+            top_element = markdown_element
         card_json = {
             "schema": "2.0",
             "config": {"streaming_mode": True},
             "body": {
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": initial_text,
-                        "element_id": element_id,
-                    },
-                ],
+                "elements": [top_element],
             },
         }
 
@@ -2238,6 +2268,68 @@ class FeishuChannel(BaseChannel):
             )
             return False
 
+    async def _collapse_reasoning_panel(
+        self,
+        card_id: str,
+        sequence: int,
+    ) -> bool:
+        """Collapse the reasoning panel via CardKit element PATCH.
+
+        ``sequence`` must exceed the finalize settings sequence. A patch
+        failure only logs (same tolerance as other streaming updates) so a
+        stuck-expanded panel never fails the whole answer.
+        """
+        if not self._client or not card_id:
+            return False
+
+        from lark_oapi.api.cardkit.v1 import (
+            PatchCardElementRequest,
+            PatchCardElementRequestBody,
+        )
+
+        partial_element = json.dumps(
+            {
+                "expanded": False,
+                "header": {
+                    "title": {
+                        "tag": "plain_text",
+                        "content": FEISHU_REASONING_PANEL_DONE_TITLE,
+                    },
+                },
+            },
+            ensure_ascii=False,
+        )
+
+        try:
+            req = (
+                PatchCardElementRequest.builder()
+                .card_id(card_id)
+                .element_id(FEISHU_REASONING_PANEL_ELEMENT_ID)
+                .request_body(
+                    PatchCardElementRequestBody.builder()
+                    .partial_element(partial_element)
+                    .sequence(sequence)
+                    .uuid(str(_uuid.uuid4()))
+                    .build(),
+                )
+                .build()
+            )
+            resp = await self._client.cardkit.v1.card_element.apatch(req)
+            if not resp.success():
+                logger.warning(
+                    "feishu collapse reasoning panel failed: code=%s msg=%s",
+                    resp.code,
+                    resp.msg,
+                )
+                return False
+            return True
+        except Exception:
+            logger.warning(
+                "feishu collapse reasoning panel exception",
+                exc_info=True,
+            )
+            return False
+
     # ------------------------------------------------------------------
     # Streaming hooks (CardKit card mode)
     # ------------------------------------------------------------------
@@ -2280,9 +2372,12 @@ class FeishuChannel(BaseChannel):
         receive_id_type, receive_id = recv
         state = self._get_feishu_stream_state(send_meta)
 
-        # Reuse pre-created card for the first arriving segment.
+        # Reasoning streams need a collapsible panel baked in at creation, so
+        # they never reuse the plain-markdown pre-created placeholder (it stays
+        # reserved for the later answer segment).
+        is_reasoning = stream_type == "reasoning"
         card_info = getattr(request, "_precreated_card", None)
-        if card_info:
+        if card_info and not is_reasoning:
             setattr(request, "_precreated_card", None)
         else:
             initial = self._build_stream_display_text(
@@ -2294,6 +2389,7 @@ class FeishuChannel(BaseChannel):
                 receive_id_type,
                 receive_id,
                 initial_text=initial,
+                collapsible=is_reasoning,
             )
 
         if card_info:
@@ -2301,6 +2397,7 @@ class FeishuChannel(BaseChannel):
                 "card_id": card_info["card_id"],
                 "message_id": card_info["message_id"],
                 "sequence": 0,
+                "collapsible": is_reasoning,
             }
 
     async def on_streaming_delta(
@@ -2383,6 +2480,16 @@ class FeishuChannel(BaseChannel):
             sequence=card_state["sequence"],
         )
 
+        # Reasoning cards collapse their panel after finalize so long thinking
+        # traces don't push the final answer away. The patch reuses the next
+        # sequence; its failure is tolerated inside the helper.
+        if card_state.get("collapsible"):
+            card_state["sequence"] += 1
+            await self._collapse_reasoning_panel(
+                card_id,
+                sequence=card_state["sequence"],
+            )
+
         # Track last sent message_id for DONE reaction
         message_id = card_state.get("message_id")
         if message_id:
@@ -2399,9 +2506,90 @@ class FeishuChannel(BaseChannel):
         send_meta: Dict[str, Any],
     ) -> None:
         """Add DONE reaction to the last sent message."""
+        await self._finalize_unused_precreated_card(
+            request,
+            FEISHU_UNUSED_CARD_SUCCESS_TEXT,
+        )
         last_msg_id = send_meta.get("_last_sent_message_id")
         if last_msg_id:
             await self._add_reaction(last_msg_id, "DONE")
+
+    async def _on_consume_error(
+        self,
+        request: Any,
+        to_handle: str,
+        err_text: str,
+    ) -> None:
+        """Finalize an orphaned placeholder (non-success stamp), then
+        deliver the error text."""
+        await self._finalize_unused_precreated_card(
+            request,
+            FEISHU_UNUSED_CARD_ERROR_TEXT,
+        )
+        await super()._on_consume_error(request, to_handle, err_text)
+
+    async def _finish_response_cycle(self, session_id: str) -> None:
+        """Finalize an unconsumed placeholder, then run base cleanup.
+
+        Base invokes this in a finally block, so it also fires on task
+        cancellation, which has no other channel hook. Only the placeholder
+        this flow may have left behind is touched: consumed cards are
+        skipped via the nulled attribute, the reasoning card's own
+        cancel/stuck behavior is unchanged, and nothing here catches
+        CancelledError, so cancellation still propagates.
+        """
+        request = (
+            self._pending_precreated.pop(session_id, None)
+            if session_id
+            else None
+        )
+        if request is not None:
+            await self._finalize_unused_precreated_card(
+                request,
+                FEISHU_UNUSED_CARD_ERROR_TEXT,
+            )
+        await super()._finish_response_cycle(session_id)
+
+    async def _finalize_unused_precreated_card(
+        self,
+        request: Any,
+        done_text: str,
+    ) -> None:
+        """Best-effort finalize of a placeholder no segment consumed.
+
+        Reasoning streams never consume ``request._precreated_card`` (they
+        need panel structure at creation), so when no answer stream follows
+        — truncated thinking, generation error, cancellation — the bare
+        "..." card would linger. Stamp it and close streaming mode instead.
+        Mirrors DingTalk's unused-card finalize. Never raises; never touches
+        a card the answer consumed (consumption nulls the attribute, and the
+        cycle-end mapping is popped exactly once).
+        """
+        card_info = getattr(request, "_precreated_card", None)
+        if not card_info:
+            return
+        setattr(request, "_precreated_card", None)
+        try:
+            card_id = card_info.get("card_id")
+            if not card_id:
+                return
+            # The placeholder never received streaming updates, so its
+            # sequence base is 0: content update first, then settings.
+            await self._update_streaming_text(
+                card_id,
+                done_text,
+                sequence=1,
+            )
+            await self._finalize_streaming_card(
+                card_id,
+                summary_text=done_text,
+                sequence=2,
+            )
+        except Exception:
+            logger.debug(
+                "feishu finalize unused precreated card failed",
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Interactive cards (tool_guard approval, etc.)
@@ -2502,6 +2690,12 @@ class FeishuChannel(BaseChannel):
                 )
                 if card_info:
                     setattr(request, "_precreated_card", card_info)
+                    # Register for the cycle-end hook: if no answer stream
+                    # consumes this placeholder (cancel path has no other
+                    # channel hook), _finish_response_cycle finalizes it.
+                    session_id = getattr(request, "session_id", "") or ""
+                    if session_id:
+                        self._pending_precreated[session_id] = request
             except Exception:
                 logger.debug(
                     "feishu streaming card pre-creation failed",

--- a/src/qwenpaw/app/channels/feishu/constants.py
+++ b/src/qwenpaw/app/channels/feishu/constants.py
@@ -39,3 +39,21 @@ FEISHU_STREAM_MIN_INTERVAL_S = 0.15
 
 # Element ID for the markdown component inside the streaming card.
 FEISHU_STREAM_ELEMENT_ID = "streaming_content"
+
+# Element ID for the collapsible panel wrapping the reasoning markdown.
+# CardKit requires <= 20 chars, starting with a letter.
+FEISHU_REASONING_PANEL_ELEMENT_ID = "reasoning_panel"
+
+# Panel header while reasoning streams / after it completes.
+FEISHU_REASONING_PANEL_TITLE = "💭 思考过程"
+FEISHU_REASONING_PANEL_DONE_TITLE = "思考过程（已完成·点击展开）"
+
+# Final stamp for a pre-created placeholder no stream segment consumed on
+# the success path. Static one-shot text, not a live status card.
+FEISHU_UNUSED_CARD_SUCCESS_TEXT = "✅ 任务已完成"
+
+# Final stamp for the same placeholder on error/cancel paths. Must never
+# claim success. Wording reuses DingTalk's AI_CARD_RECOVERY_FINAL_TEXT.
+FEISHU_UNUSED_CARD_ERROR_TEXT = (
+    "⚠️ 上一次回复处理中断，已自动结束。请重新发送你的问题。"
+)

--- a/tests/unit/channels/test_feishu.py
+++ b/tests/unit/channels/test_feishu.py
@@ -3575,3 +3575,549 @@ class TestProcessQuotedMessage:
         # quoted label should be first, reply should be last
         assert text_parts[0].startswith("[quoted message:")
         assert text_parts[-1] == "Reply"
+
+
+# =============================================================================
+# Tests for reasoning collapsible panel (Issue #7570)
+# =============================================================================
+
+
+def _mock_cardkit_create(mock_client, card_id="card_001"):
+    """Wire a MagicMock client for CreateCard success."""
+    resp = MagicMock()
+    resp.success.return_value = True
+    resp.data.card_id = card_id
+    mock_client.cardkit.v1.card.acreate = AsyncMock(return_value=resp)
+    return resp
+
+
+def _create_request_body(mock_client):
+    """Return the parsed card_json sent to CreateCard."""
+    req = mock_client.cardkit.v1.card.acreate.call_args[0][0]
+    return json.loads(req.request_body.data)
+
+
+class TestReasoningCollapsiblePanel:
+    """Reasoning stream cards collapse after finalize; answer cards don't."""
+
+    @pytest.fixture
+    def real_lark_sdk(self):
+        """Restore the real lark_oapi SDK for CardKit builder assertions.
+
+        tests/conftest.py replaces ``sys.modules["lark_oapi"]`` with a
+        MagicMock (safety net for envs without the SDK), which breaks the
+        lazy ``from lark_oapi.api.cardkit.v1 import ...`` used by the
+        channel helpers. lark-oapi is a required dependency, so tests that
+        assert on real builder output temporarily restore it.
+        """
+        import sys
+
+        popped = {}
+        for key in [
+            k
+            for k in sys.modules
+            if k == "lark_oapi" or k.startswith("lark_oapi.")
+        ]:
+            popped[key] = sys.modules.pop(key)
+        try:
+            import lark_oapi.api.cardkit.v1  # noqa: F401
+        except ImportError:
+            sys.modules.update(popped)
+            pytest.skip("lark_oapi SDK without cardkit v1 API")
+        try:
+            yield
+        finally:
+            for key in [
+                k
+                for k in sys.modules
+                if k == "lark_oapi" or k.startswith("lark_oapi.")
+            ]:
+                sys.modules.pop(key, None)
+            sys.modules.update(popped)
+
+    @pytest.mark.asyncio
+    async def test_create_reasoning_card_uses_collapsible_panel(
+        self,
+        feishu_channel,
+        real_lark_sdk,
+    ):
+        """Reasoning card: expanded panel wrapping markdown on top."""
+        from qwenpaw.app.channels.feishu.constants import (
+            FEISHU_STREAM_ELEMENT_ID,
+        )
+
+        mock_client = MagicMock()
+        _mock_cardkit_create(mock_client, card_id="card_r")
+        feishu_channel._client = mock_client
+        feishu_channel._send_message = AsyncMock(return_value="msg_r")
+
+        info = await feishu_channel._create_streaming_card(
+            "chat_id",
+            "oc_1",
+            initial_text="...",
+            collapsible=True,
+        )
+
+        assert info == {"card_id": "card_r", "message_id": "msg_r"}
+        body = _create_request_body(mock_client)
+        assert body["schema"] == "2.0"
+        assert body["config"] == {"streaming_mode": True}
+        (top,) = body["body"]["elements"]
+        assert top["tag"] == "collapsible_panel"
+        assert top["expanded"] is True
+        # element_id must satisfy CardKit constraints (<=20 chars, letter-led).
+        assert 0 < len(top["element_id"]) <= 20
+        assert top["element_id"][0].isalpha()
+        assert "思考过程" in top["header"]["title"]["content"]
+        # Inner markdown keeps the streaming element id so updates need no
+        # change.
+        (inner,) = top["elements"]
+        assert inner["tag"] == "markdown"
+        assert inner["element_id"] == FEISHU_STREAM_ELEMENT_ID
+        assert inner["content"] == "..."
+
+    @pytest.mark.asyncio
+    async def test_create_answer_card_stays_plain(
+        self,
+        feishu_channel,
+        real_lark_sdk,
+    ):
+        """Default (answer) card keeps the plain markdown structure."""
+        from qwenpaw.app.channels.feishu.constants import (
+            FEISHU_STREAM_ELEMENT_ID,
+        )
+
+        mock_client = MagicMock()
+        _mock_cardkit_create(mock_client)
+        feishu_channel._client = mock_client
+        feishu_channel._send_message = AsyncMock(return_value="msg_1")
+
+        await feishu_channel._create_streaming_card(
+            "chat_id",
+            "oc_1",
+            initial_text="...",
+        )
+
+        body = _create_request_body(mock_client)
+        (top,) = body["body"]["elements"]
+        assert top["tag"] == "markdown"
+        assert top["element_id"] == FEISHU_STREAM_ELEMENT_ID
+        assert "collapsible_panel" not in json.dumps(body)
+
+    @pytest.mark.asyncio
+    async def test_reasoning_start_skips_precreated_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Reasoning needs panel structure at creation, so it must not consume
+        the plain-markdown precreated placeholder (reserved for answer)."""
+        feishu_channel.streaming_enabled = True
+        feishu_channel._get_receive_for_send = AsyncMock(
+            return_value=("chat_id", "oc_test"),
+        )
+        feishu_channel._create_streaming_card = AsyncMock(
+            return_value={"card_id": "card_r", "message_id": "msg_r"},
+        )
+
+        request = MagicMock()
+        request._precreated_card = {"card_id": "pre", "message_id": "pm"}
+        send_meta = {}
+        await feishu_channel.on_streaming_start(
+            request=request,
+            to_handle="feishu:sw:test",
+            event=MagicMock(),
+            send_meta=send_meta,
+            stream_type="reasoning",
+        )
+
+        # Placeholder untouched; fresh collapsible card created instead.
+        assert request._precreated_card == {
+            "card_id": "pre",
+            "message_id": "pm",
+        }
+        _, kwargs = feishu_channel._create_streaming_card.call_args
+        assert kwargs.get("collapsible") is True
+        card_state = send_meta["_fs_stream"]["cards"]["reasoning"]
+        assert card_state["card_id"] == "card_r"
+        assert card_state["collapsible"] is True
+
+    @pytest.mark.asyncio
+    async def test_message_start_reuses_precreated_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Regression guard: answer segments keep consuming the placeholder."""
+        feishu_channel.streaming_enabled = True
+        feishu_channel._get_receive_for_send = AsyncMock(
+            return_value=("chat_id", "oc_test"),
+        )
+        feishu_channel._create_streaming_card = AsyncMock()
+
+        request = MagicMock()
+        request._precreated_card = {"card_id": "pre", "message_id": "pm"}
+        send_meta = {}
+        await feishu_channel.on_streaming_start(
+            request=request,
+            to_handle="feishu:sw:test",
+            event=MagicMock(),
+            send_meta=send_meta,
+            stream_type="message",
+        )
+
+        feishu_channel._create_streaming_card.assert_not_called()
+        card_state = send_meta["_fs_stream"]["cards"]["message"]
+        assert card_state["card_id"] == "pre"
+        assert card_state["collapsible"] is False
+
+    @pytest.mark.asyncio
+    async def test_reasoning_end_collapses_after_settings(
+        self,
+        feishu_channel,
+    ):
+        """Finalize order: content update -> settings -> panel patch, with
+        strictly increasing sequence."""
+        from unittest.mock import call
+
+        from qwenpaw.app.channels.feishu.utils import normalize_feishu_md
+
+        send_meta = {
+            "_fs_stream": {
+                "cards": {
+                    "reasoning": {
+                        "card_id": "card_r",
+                        "message_id": "msg_r",
+                        "sequence": 5,
+                        "collapsible": True,
+                    },
+                },
+            },
+        }
+        feishu_channel._update_streaming_text = AsyncMock()
+        feishu_channel._finalize_streaming_card = AsyncMock()
+        feishu_channel._collapse_reasoning_panel = AsyncMock()
+        parent = MagicMock()
+        parent.attach_mock(
+            feishu_channel._update_streaming_text,
+            "update",
+        )
+        parent.attach_mock(
+            feishu_channel._finalize_streaming_card,
+            "finalize",
+        )
+        parent.attach_mock(
+            feishu_channel._collapse_reasoning_panel,
+            "collapse",
+        )
+
+        await feishu_channel.on_streaming_end(
+            request=MagicMock(),
+            to_handle="feishu:sw:test",
+            event=MagicMock(),
+            send_meta=send_meta,
+            stream_type="reasoning",
+            accumulated_text="thought",
+        )
+
+        display = feishu_channel._build_stream_display_text(
+            "reasoning",
+            "thought",
+            send_meta,
+        )
+        expected_final = normalize_feishu_md(display)
+        assert parent.mock_calls == [
+            call.update("card_r", expected_final, sequence=6),
+            call.finalize("card_r", summary_text="thought", sequence=7),
+            call.collapse("card_r", sequence=8),
+        ]
+        assert send_meta["_last_sent_message_id"] == "msg_r"
+
+    @pytest.mark.asyncio
+    async def test_message_end_never_collapses(self, feishu_channel):
+        """Answer cards finalize exactly as before (no panel patch)."""
+        send_meta = {
+            "_fs_stream": {
+                "cards": {
+                    "message": {
+                        "card_id": "card_m",
+                        "message_id": "msg_m",
+                        "sequence": 2,
+                        "collapsible": False,
+                    },
+                },
+            },
+        }
+        feishu_channel._update_streaming_text = AsyncMock()
+        feishu_channel._finalize_streaming_card = AsyncMock()
+        feishu_channel._collapse_reasoning_panel = AsyncMock()
+
+        await feishu_channel.on_streaming_end(
+            request=MagicMock(),
+            to_handle="feishu:sw:test",
+            event=MagicMock(),
+            send_meta=send_meta,
+            stream_type="message",
+            accumulated_text="answer",
+        )
+
+        feishu_channel._collapse_reasoning_panel.assert_not_called()
+        feishu_channel._finalize_streaming_card.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_collapse_patch_payload_is_json_string(
+        self,
+        feishu_channel,
+        real_lark_sdk,
+    ):
+        """Patch body uses partial_element (JSON string), panel element id,
+        and the caller sequence."""
+        from qwenpaw.app.channels.feishu.constants import (
+            FEISHU_REASONING_PANEL_ELEMENT_ID,
+        )
+
+        resp = MagicMock()
+        resp.success.return_value = True
+        mock_client = MagicMock()
+        mock_client.cardkit.v1.card_element.apatch = AsyncMock(
+            return_value=resp,
+        )
+        feishu_channel._client = mock_client
+
+        result = await feishu_channel._collapse_reasoning_panel(
+            "card_r",
+            sequence=8,
+        )
+
+        assert result is True
+        req = mock_client.cardkit.v1.card_element.apatch.call_args[0][0]
+        assert req.element_id == FEISHU_REASONING_PANEL_ELEMENT_ID
+        assert req.card_id == "card_r"
+        partial = req.request_body.partial_element
+        assert isinstance(partial, str)
+        payload = json.loads(partial)
+        assert payload["expanded"] is False
+        assert "已完成" in payload["header"]["title"]["content"]
+        assert req.request_body.sequence == 8
+        assert req.request_body.uuid
+
+    @pytest.mark.asyncio
+    async def test_collapse_patch_failure_is_tolerated(
+        self,
+        feishu_channel,
+        real_lark_sdk,
+    ):
+        """A failed collapse patch must not raise / fail the whole answer."""
+        mock_client = MagicMock()
+        bad = MagicMock()
+        bad.success.return_value = False
+        bad.code = 12345
+        bad.msg = "boom"
+        mock_client.cardkit.v1.card_element.apatch = AsyncMock(
+            return_value=bad,
+        )
+        feishu_channel._client = mock_client
+        assert (
+            await feishu_channel._collapse_reasoning_panel(
+                "card_r",
+                sequence=9,
+            )
+            is False
+        )
+
+        mock_client.cardkit.v1.card_element.apatch = AsyncMock(
+            side_effect=RuntimeError("net down"),
+        )
+        assert (
+            await feishu_channel._collapse_reasoning_panel(
+                "card_r",
+                sequence=9,
+            )
+            is False
+        )
+
+    # ------------------------------------------------------------------
+    # Orphan placeholder: reasoning ran but no answer stream followed.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_process_completed_finalizes_unconsumed_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """No answer segment consumed the placeholder: process-completed must
+        not leave a bare "..." card behind."""
+        feishu_channel._update_streaming_text = AsyncMock(
+            return_value=True,
+        )
+        feishu_channel._finalize_streaming_card = AsyncMock(
+            return_value=True,
+        )
+        feishu_channel._add_reaction = AsyncMock()
+
+        request = MagicMock()
+        request._precreated_card = {
+            "card_id": "card_pre",
+            "message_id": "msg_pre",
+        }
+        await feishu_channel._on_process_completed(
+            request,
+            "feishu:sw:test",
+            {},
+        )
+
+        assert request._precreated_card is None
+        feishu_channel._update_streaming_text.assert_called_once()
+        args, kwargs = feishu_channel._update_streaming_text.call_args
+        assert args[0] == "card_pre"
+        assert kwargs.get("sequence") == 1
+        assert "✅" in args[1]
+        feishu_channel._finalize_streaming_card.assert_called_once()
+        _, fkwargs = feishu_channel._finalize_streaming_card.call_args
+        assert fkwargs.get("sequence") == 2
+
+    @pytest.mark.asyncio
+    async def test_process_completed_skips_consumed_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Placeholder already consumed by the answer: completed path must
+        not touch streaming APIs for it."""
+        feishu_channel._update_streaming_text = AsyncMock()
+        feishu_channel._finalize_streaming_card = AsyncMock()
+        feishu_channel._add_reaction = AsyncMock()
+
+        request = MagicMock()
+        request._precreated_card = None
+        await feishu_channel._on_process_completed(
+            request,
+            "feishu:sw:test",
+            {},
+        )
+
+        feishu_channel._update_streaming_text.assert_not_called()
+        feishu_channel._finalize_streaming_card.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_consume_error_finalizes_unconsumed_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Generation error after reasoning: placeholder still finalized,
+        but NEVER with a success stamp, and the error text is delivered."""
+        from qwenpaw.app.channels.feishu.constants import (
+            FEISHU_UNUSED_CARD_ERROR_TEXT,
+        )
+
+        feishu_channel._update_streaming_text = AsyncMock(
+            return_value=True,
+        )
+        feishu_channel._finalize_streaming_card = AsyncMock(
+            return_value=True,
+        )
+        feishu_channel.send_content_parts = AsyncMock(
+            return_value="err_msg_id",
+        )
+
+        request = MagicMock()
+        request._precreated_card = {
+            "card_id": "card_pre",
+            "message_id": "msg_pre",
+        }
+        request.channel_meta = {}
+        await feishu_channel._on_consume_error(
+            request,
+            "feishu:sw:test",
+            "Internal error",
+        )
+
+        assert request._precreated_card is None
+        feishu_channel._update_streaming_text.assert_called_once()
+        args, _ = feishu_channel._update_streaming_text.call_args
+        assert args[1] == FEISHU_UNUSED_CARD_ERROR_TEXT
+        assert "✅" not in args[1]
+        assert "已完成" not in args[1]
+        _, fkwargs = feishu_channel._finalize_streaming_card.call_args
+        assert "✅" not in fkwargs.get("summary_text", "")
+        # Error delivery preserved.
+        feishu_channel.send_content_parts.assert_called_once()
+        parts = feishu_channel.send_content_parts.call_args[0][1]
+        assert parts[0].text == "Internal error"
+
+    @pytest.mark.asyncio
+    async def test_cancel_finalizes_unconsumed_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Task cancelled after reasoning: unconsumed placeholder must
+        not stay a bare card, stamp must not claim success."""
+        from qwenpaw.app.channels.base import BaseChannel
+        from qwenpaw.app.channels.feishu.constants import (
+            FEISHU_UNUSED_CARD_ERROR_TEXT,
+        )
+
+        feishu_channel.streaming_enabled = True
+        feishu_channel._create_streaming_card = AsyncMock(
+            return_value={"card_id": "card_pre", "message_id": "msg_pre"},
+        )
+        feishu_channel._update_streaming_text = AsyncMock(
+            return_value=True,
+        )
+        feishu_channel._finalize_streaming_card = AsyncMock(
+            return_value=True,
+        )
+
+        request = MagicMock()
+        request.session_id = "sess_cancel"
+        request.channel_meta = {
+            "feishu_receive_id": "oc_test",
+            "feishu_receive_id_type": "chat_id",
+        }
+        await feishu_channel._before_consume_process(request)
+        # Reasoning started its own collapsible card; placeholder untouched.
+        assert request._precreated_card == {
+            "card_id": "card_pre",
+            "message_id": "msg_pre",
+        }
+
+        with patch.object(
+            BaseChannel,
+            "_finish_response_cycle",
+            new=AsyncMock(),
+        ) as base_finish:
+            await feishu_channel._finish_response_cycle("sess_cancel")
+
+        assert request._precreated_card is None
+        assert "sess_cancel" not in feishu_channel._pending_precreated
+        feishu_channel._update_streaming_text.assert_called_once()
+        args, kwargs = feishu_channel._update_streaming_text.call_args
+        assert args[0] == "card_pre"
+        assert args[1] == FEISHU_UNUSED_CARD_ERROR_TEXT
+        assert "✅" not in args[1]
+        assert kwargs.get("sequence") == 1
+        base_finish.assert_awaited_once_with("sess_cancel")
+
+    @pytest.mark.asyncio
+    async def test_finish_response_cycle_skips_consumed_placeholder(
+        self,
+        feishu_channel,
+    ):
+        """Placeholder already consumed: cycle-end must not touch the
+        streaming APIs, but base cleanup still runs."""
+        from qwenpaw.app.channels.base import BaseChannel
+
+        feishu_channel._update_streaming_text = AsyncMock()
+        feishu_channel._finalize_streaming_card = AsyncMock()
+        request = MagicMock()
+        request._precreated_card = None
+        feishu_channel._pending_precreated["sess_done"] = request
+
+        with patch.object(
+            BaseChannel,
+            "_finish_response_cycle",
+            new=AsyncMock(),
+        ) as base_finish:
+            await feishu_channel._finish_response_cycle("sess_done")
+
+        feishu_channel._update_streaming_text.assert_not_called()
+        feishu_channel._finalize_streaming_card.assert_not_called()
+        assert "sess_done" not in feishu_channel._pending_precreated
+        base_finish.assert_awaited_once_with("sess_done")


### PR DESCRIPTION
Fixes #7570.

## What Problem This Solves

Feishu currently renders reasoning streams as ordinary Markdown streaming cards. For models with long reasoning traces, that reasoning remains fully expanded after generation completes and pushes the final answer far down the conversation.

This change keeps reasoning visible and expanded while it is streaming, then automatically collapses the reasoning panel after finalization so the final answer remains prominent. Answer-card behavior is unchanged.

## What Changes

- Reasoning stream cards use a JSON 2.0 `collapsible_panel`, initially expanded, with the existing inner `streaming_content` element id unchanged.
- After content/settings finalization, the reasoning panel is collapsed through the CardKit element PATCH API using the next sequence number.
- The normal answer path remains unchanged.
- If the pre-created `"..."` placeholder is never consumed by an answer stream:
  - successful completion finalizes it as `✅ 任务已完成`;
  - error/cancellation finalizes it with the existing DingTalk-style non-success wording;
  - error/cancellation never shows a false success state.
- Cleanup/finalize failures are best-effort and never suppress the real answer or error.
- No BaseChannel lifecycle changes, raw HTTP calls, or new dependencies are introduced.

## Evidence

Before this change, the Feishu reasoning card is a plain streaming Markdown card and there is no final element PATCH that collapses it, so completed reasoning remains expanded.

With this change:

1. reasoning card creation produces a JSON 2.0 `collapsible_panel` with `expanded: true`;
2. streaming updates continue targeting the unchanged `streaming_content` element;
3. finalization completes content/settings updates first;
4. the CardKit element PATCH then sets the reasoning panel to `expanded: false`;
5. answer cards remain on the existing path.

Regression coverage also verifies the newly exposed unused-placeholder lifecycle:
- success with no answer stream does not leave a bare `"..."`;
- error never displays `✅ 任务已完成`;
- cancellation handles only the still-unconsumed placeholder and continues normal cancellation propagation.

Issue #7570 also contains reporter-provided live CardKit validation and a screenshot demonstrating the intended collapse behavior. This PR independently validates the payload structure, call ordering, answer regression, error handling, and cancellation handling in tests.

Live visual verification against a real Feishu client is still recommended as a residual check; this PR does not claim that was performed in the contributor's local environment.

## Testing

- `tests/unit/channels/test_feishu.py` + Feishu contract tests:
  **197 passed, 1 skipped** (skip pre-existing)
- 13 focused `TestReasoningCollapsiblePanel` regression cases cover:
  panel structure, answer regression, placeholder consume/skip behavior,
  content/settings/PATCH ordering and sequence, PATCH payload shape,
  failure tolerance, and orphan handling on success/error/cancellation.
- `./scripts/check-channels.sh --changed`:
  **All checks passed**
- black (79), flake8, mypy with repository pre-commit arguments, and scoped pylint:
  **clean on changed files**
- `lark-oapi==1.5.3` dependency floor was verified in an isolated environment to already provide the CardKit element PATCH models/API used here; no dependency change is required.
- `pre-commit run --all-files` was attempted three times but could not complete within the environment because of hook setup/full-repository execution time. The available log shows black/flake8 passed and the mypy failure is in pre-existing `cli/shutdown_cmd.py`, not in changed files. CI is left to confirm the full repository gate.

## Scope

Only these Feishu files are changed:

- `src/qwenpaw/app/channels/feishu/channel.py`
- `src/qwenpaw/app/channels/feishu/constants.py`
- `tests/unit/channels/test_feishu.py`

No Telegram changes, generated files, dependency changes, or unrelated refactors are included.

## Residual Risk

The remaining risk is live CardKit visual behavior in a real Feishu client, especially collapse animation/rendering under true concurrent turns. The CardKit payload shape and lifecycle sequencing are covered by unit/contract tests.