### PR TITLE
feat(console): restore session direct path input alongside picker

### DIFF
--- a/console/src/features/project-directory/SessionProjectDirectory.test.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.test.tsx
@@ -11,6 +11,10 @@ const {
   mockUseIsMobile,
   mockListProjects,
   mockSetSessionDirectory,
+  mockClearProjectDirs,
+  mockGetChatDirectory,
+  mockGetProjectDirs,
+  mockSetProjectDirs,
 } = vi.hoisted(() => ({
   mockBrowseDirs: vi.fn(),
   mockCreateDirectory: vi.fn(),
@@ -18,6 +22,10 @@ const {
   mockUseIsMobile: vi.fn(() => false),
   mockListProjects: vi.fn(),
   mockSetSessionDirectory: vi.fn(),
+  mockClearProjectDirs: vi.fn(),
+  mockGetChatDirectory: vi.fn(),
+  mockGetProjectDirs: vi.fn(),
+  mockSetProjectDirs: vi.fn(),
 }));
 
 vi.mock("../../api/modules/projectDirectory", () => ({
@@ -32,10 +40,10 @@ vi.mock("../../api/modules/projectDirectory", () => ({
 
 vi.mock("../../api/modules/chatProjectDirectory", () => ({
   chatProjectDirectoryApi: {
-    clearProjectDirs: vi.fn(),
-    get: vi.fn(),
-    getProjectDirs: vi.fn(),
-    setProjectDirs: vi.fn(),
+    clearProjectDirs: mockClearProjectDirs,
+    get: mockGetChatDirectory,
+    getProjectDirs: mockGetProjectDirs,
+    setProjectDirs: mockSetProjectDirs,
   },
 }));
 
@@ -45,7 +53,8 @@ vi.mock("../../hooks/useIsMobile", () => ({
 
 // The single-path picker these tests drive (path field, clear button,
 // recent-project selection, Apply) lives on AGENT scope. Session scope
-// binds an ordered list of directories instead, so it has no path field.
+// binds an ordered list of directories; its own direct path input shares the
+// queued path with the picker (see the session scope suite below).
 const scope = { kind: "agent" as const, agentId: "default" };
 
 const projects = [
@@ -383,5 +392,224 @@ describe("SessionProjectDirectory", () => {
     await waitFor(() => {
       expect(mockSetSessionDirectory).toHaveBeenCalledWith("/projects/runtime");
     });
+  });
+});
+
+describe("SessionProjectDirectory session scope direct path input (#7588)", () => {
+  const sessionScope = {
+    kind: "session" as const,
+    agentId: "default",
+    sessionId: "sess-1",
+    chatId: "chat-1",
+  };
+  const boundDirs = [
+    {
+      path: "/projects/alpha",
+      label: null,
+      exists: true,
+      nested_with: null,
+      is_workspace: false,
+    },
+    {
+      path: "/projects/beta",
+      label: null,
+      exists: true,
+      nested_with: null,
+      is_workspace: false,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseIsMobile.mockReturnValue(false);
+    mockListProjects.mockResolvedValue([]);
+    mockBrowseDirs.mockResolvedValue({
+      current: "/projects",
+      parent: "/",
+      dirs: [{ name: "custom", path: "/projects/custom" }],
+    });
+    mockGetProjectDirs.mockResolvedValue({
+      project_dirs: boundDirs,
+      source: "session",
+      agent_project_dir: null,
+    });
+    mockSetProjectDirs.mockImplementation(
+      async (_chatId: string, entries: { path: string }[]) => ({
+        project_dirs: entries.map((entry) => ({
+          path: entry.path,
+          label: null,
+          exists: true,
+          nested_with: null,
+          is_workspace: false,
+        })),
+        source: "session",
+        agent_project_dir: null,
+      }),
+    );
+  });
+
+  const openSessionPanel = async (user: ReturnType<typeof userEvent.setup>) =>
+    user.click(
+      await screen.findByRole("button", {
+        name: "projectDirectory.sessionTitle",
+      }),
+    );
+
+  const getPathInput = async () =>
+    screen.findByPlaceholderText("projectDirectory.pathPlaceholder");
+
+  it("shows a direct path input on session scope", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+
+    expect(await getPathInput()).toBeInTheDocument();
+  });
+
+  it("pastes a POSIX path + Enter switches the primary, keeping other dirs", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "/home/user/deep/project{Enter}");
+
+    await waitFor(() => {
+      expect(mockSetProjectDirs).toHaveBeenCalledWith("chat-1", [
+        { path: "/home/user/deep/project", label: null },
+        { path: "/projects/alpha", label: null },
+        { path: "/projects/beta", label: null },
+      ]);
+    });
+    // The always-live trigger already advertises the new primary.
+    expect(
+      screen.getByRole("button", { name: "projectDirectory.sessionTitle" }),
+    ).toHaveTextContent("project");
+    // A successful switch closes the panel (its overlay keeps a frozen copy
+    // while closed), so reopen it to read the live state: the committed
+    // primary is listed first and the input is cleared.
+    await openSessionPanel(user);
+    expect(
+      screen.getAllByText("/home/user/deep/project").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(await getPathInput()).toHaveValue("");
+  });
+
+  it("trims surrounding whitespace before switching", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "  /projects/typed  {Enter}");
+
+    await waitFor(() => {
+      expect(mockSetProjectDirs).toHaveBeenCalledWith("chat-1", [
+        { path: "/projects/typed", label: null },
+        { path: "/projects/alpha", label: null },
+        { path: "/projects/beta", label: null },
+      ]);
+    });
+  });
+
+  it("passes Windows absolute paths through without canonicalization", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(
+      await getPathInput(),
+      "C:\\Users\\test\\deep\\project{Enter}",
+    );
+
+    await waitFor(() => {
+      expect(mockSetProjectDirs).toHaveBeenCalledWith("chat-1", [
+        { path: "C:\\Users\\test\\deep\\project", label: null },
+        { path: "/projects/alpha", label: null },
+        { path: "/projects/beta", label: null },
+      ]);
+    });
+  });
+
+  it("fills the direct input when a browsed directory is picked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.click(await screen.findByRole("button", { name: /custom/ }));
+
+    expect(await getPathInput()).toHaveValue("/projects/custom");
+    expect(mockSetProjectDirs).not.toHaveBeenCalled();
+  });
+
+  it("makes an already-bound typed path the primary", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "/projects/beta{Enter}");
+
+    await waitFor(() => {
+      expect(mockSetProjectDirs).toHaveBeenCalledWith("chat-1", [
+        { path: "/projects/beta", label: null },
+        { path: "/projects/alpha", label: null },
+      ]);
+    });
+  });
+
+  it("shows a backend error without polluting the bound list", async () => {
+    const user = userEvent.setup();
+    mockSetProjectDirs.mockRejectedValueOnce(
+      new Error("Not a directory: /nope"),
+    );
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "/nope{Enter}");
+
+    await waitFor(() => {
+      expect(mockSetProjectDirs).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      await screen.findByText("Not a directory: /nope"),
+    ).toBeInTheDocument();
+    // Previously bound directories are still rendered.
+    expect(screen.getByText("/projects/alpha")).toBeInTheDocument();
+    expect(screen.getByText("/projects/beta")).toBeInTheDocument();
+  });
+
+  it("does nothing destructive on Enter with the current primary", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "/projects/alpha{Enter}");
+
+    // No request: the primary is already bound first.
+    expect(mockSetProjectDirs).not.toHaveBeenCalled();
+    // The queue is dismissed without dropping any binding.
+    expect(await getPathInput()).toHaveValue("");
+  });
+
+  it("does not switch on blur", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    await user.type(await getPathInput(), "/projects/typed");
+    await user.tab();
+
+    expect(mockSetProjectDirs).not.toHaveBeenCalled();
+  });
+
+  it("does not switch on Enter with an empty input", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionProjectDirectory scope={sessionScope} />);
+
+    await openSessionPanel(user);
+    const input = await getPathInput();
+    input.focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockSetProjectDirs).not.toHaveBeenCalled();
   });
 });

--- a/console/src/features/project-directory/SessionProjectDirectory.tsx
+++ b/console/src/features/project-directory/SessionProjectDirectory.tsx
@@ -370,7 +370,7 @@ export default function SessionProjectDirectory({
   const isBound = (path: string) =>
     dirs.some((entry) => exactSamePath(entry.path, path));
 
-  /** Queue a single-clicked folder as the next one to bind. */
+  /** Queue a single-clicked folder or a typed path as the next one to bind. */
   const selectPending = (path: string) => {
     setListError(null);
     setPendingPath(path);
@@ -465,21 +465,20 @@ export default function SessionProjectDirectory({
     });
   };
 
-  /** Commit the edited list. Index 0 becomes the server's primary. */
-  const saveSessionList = async () => {
-    if (isNoopSave) {
-      // Just dismiss: no request, no unsaved-changes warning, and no tab
-      // teardown for a directory set that is already bound.
-      setPendingPath("");
-      setListError(null);
-      setOpen(false);
-      return;
-    }
+  /** Commit the given list. Index 0 becomes the server's primary.
+   *
+   *  The typed path and the graphical picker share this commit: both send the
+   *  whole ordered list to `PUT /chats/{id}/project-dirs`, where the server
+   *  normalises every entry and rejects non-directories — the text input is
+   *  only another way to name a directory, never a wider permission. */
+  const commitSessionList = async (entries: ProjectDirEntry[]) => {
     if (beforeChange && !(await beforeChange())) return;
-    const payload: ProjectDirPayloadEntry[] = bindableDirs.map((entry) => ({
-      path: entry.path,
-      label: entry.label,
-    }));
+    const payload: ProjectDirPayloadEntry[] = entries
+      .filter((entry) => entry.path.trim())
+      .map((entry) => ({
+        path: entry.path.trim(),
+        label: entry.label,
+      }));
     if (payload.length === 0) return;
     if (!chatId) {
       setPendingProjectDirectory(
@@ -513,6 +512,57 @@ export default function SessionProjectDirectory({
     } finally {
       setSaving(false);
     }
+  };
+
+  /** Commit the edited list. Index 0 becomes the server's primary. */
+  const saveSessionList = async () => {
+    if (isNoopSave) {
+      // Just dismiss: no request, no unsaved-changes warning, and no tab
+      // teardown for a directory set that is already bound.
+      setPendingPath("");
+      setListError(null);
+      setOpen(false);
+      return;
+    }
+    await commitSessionList(bindableDirs);
+  };
+
+  /** Switch the primary to the queued path, from a paste + Enter.
+   *
+   *  Restores the v2.1 "paste a path, press Enter, the directory switches"
+   *  flow on top of the multi-directory list: the typed directory moves to
+   *  (or is added at) the front and the list is committed at once, so every
+   *  other bound directory is kept — switching the primary never drops one.
+   *  An already-primary path just dismisses the queue; a full list keeps the
+   *  pending row's cap hint instead of sending a request the server refuses. */
+  const submitPendingAsPrimary = () => {
+    const path = pendingPath.trim();
+    if (!path || saving) return;
+    const index = dirs.findIndex((entry) => exactSamePath(entry.path, path));
+    if (index === 0) {
+      setPendingPath("");
+      setListError(null);
+      return;
+    }
+    if (index > 0) {
+      const next = [
+        dirs[index] as ProjectDirEntry,
+        ...dirs.filter((_, i) => i !== index),
+      ];
+      void commitSessionList(next);
+      return;
+    }
+    if (dirs.length >= MAX_PROJECT_DIRS) return;
+    const entry: ProjectDirEntry = {
+      path,
+      label: null,
+      exists: true,
+      nested_with: null,
+      // A typed path is a project directory the same way a browser pick is.
+      // Only the server can say otherwise, and it will on the next load.
+      is_workspace: false,
+    };
+    void commitSessionList([entry, ...dirs]);
   };
 
   const save = async () => {
@@ -633,7 +683,9 @@ export default function SessionProjectDirectory({
       </div>
 
       {/* Agent scope keeps the single-path field; session scope shows the
-          bound list here instead — it *is* the session's directory set. */}
+          bound list here instead — it *is* the session's directory set. The
+          path field above it is shared: typing or picking fills the same
+          queued path, Enter switches the primary, Add appends instead. */}
       {isAgentScope ? (
         selectedRecentProject ? (
           <div className={styles.pathChip}>
@@ -666,6 +718,15 @@ export default function SessionProjectDirectory({
         )
       ) : (
         <div className={styles.boundDirs}>
+          <Input
+            className={styles.pathInput}
+            prefix={<Folder size={15} />}
+            value={pendingPath}
+            onChange={(event) => selectPending(event.target.value)}
+            placeholder={t("projectDirectory.pathPlaceholder")}
+            onPressEnter={() => submitPendingAsPrimary()}
+            allowClear
+          />
           {dirs.length > 0 || pendingPath ? (
             <ul className={styles.boundList} ref={listRef}>
               {dirs.map((entry, index) => (
@@ -729,7 +790,9 @@ export default function SessionProjectDirectory({
                     </em>
                   ) : dirs.length >= MAX_PROJECT_DIRS ? (
                     <em className={styles.boundTag}>
-                      {t("projectDirectory.tooMany", { max: MAX_PROJECT_DIRS })}
+                      {t("projectDirectory.tooMany", {
+                        max: MAX_PROJECT_DIRS,
+                      })}
                     </em>
                   ) : (
                     <Button


### PR DESCRIPTION
Fixes #7588.

## What Problem This Solves

QwenPaw v2.1 allowed users to paste a working-directory path and press Enter to switch directly. During the session-scoped multi-directory refactor in #6976, the session single-path field was replaced by the bound-directory list, but the direct input capability was not migrated.

For deeply nested directories this leaves users dependent on the graphical picker even when they already have the exact path from a terminal, IDE, or file manager.

## What Changes

- Restore a direct path input above the session bound-directory list.
- Keep the graphical picker unchanged.
- Typing or picking a directory feeds the same pending-path state.
- Pressing Enter on a new path makes it the primary directory while preserving existing bound directories.
- Pressing Enter on an already-bound non-primary path promotes it to primary without duplicating it.
- Both picker Apply and direct-path Enter commit through the existing `PUT /chats/{id}/project-dirs` backend path.
- Server-side directory validation and the existing 10-directory cap remain authoritative.
- Invalid paths do not corrupt the currently bound directory state.

## Evidence

The regression was traced to #6976 (`dd0c65ee`), where the session single-path field was replaced by the multi-directory bound list. The PR's stated scope was multi-directory binding; it did not introduce a security/product decision forbidding typed paths. Agent scope retained its direct input, and the current backend continues to validate submitted paths with the same existing-directory checks.

Regression tests verify:
- new typed path becomes primary and preserves existing bindings;
- existing bound path can be promoted without duplication;
- current-primary Enter is a no-op;
- picker and input share pending state;
- invalid backend responses preserve the bound list;
- blur does not submit.

## Testing

- `SessionProjectDirectory.test.tsx`: 20 passed
- project-directory focused suite: 34 passed (3 files)
- files-workspace regression suite: 96 passed (14 files, joint run with project-directory)
- `tsc -b --noEmit`: passed
- eslint: passed
- prettier: passed
- `git diff --check`: passed

The full Vite production build did not complete within the sandbox's 300-second execution window; no build error was observed before timeout. Focused type-check/lint/test gates above passed.

## Scope

Only the session project-directory Console component and its regression tests are changed. No backend API, security boundary, dependency, channel, or unrelated Console behavior changes are included.

## Residual Risk

A live browser/backend visual interaction check was not performed in the sandbox. The request payload, primary-directory ordering, error behavior, and picker/input interaction are covered by automated tests.
