### PR TITLE
fix(console): unify language selector options

### DIFF
--- a/console/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
+++ b/console/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
@@ -22,7 +22,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/api/modules/language", () => ({
-  languageApi: { updateLanguage: mockUpdateLanguage },
+  settingsApi: { updateLanguage: mockUpdateLanguage },
 }));
 
 vi.mock("@agentscope-ai/design", () => ({
@@ -80,7 +80,7 @@ describe("LanguageSwitcher", () => {
     expect(localStorage.getItem("language")).toBe("ja");
   });
 
-  it("calls languageApi.updateLanguage after switching language", async () => {
+  it("calls settingsApi.updateLanguage after switching language", async () => {
     const user = userEvent.setup();
     renderWithProviders(<LanguageSwitcher />);
     await user.click(screen.getByText("English"));

--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -1,31 +1,10 @@
 import { Dropdown } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
 import { Button, type MenuProps } from "antd";
-import { languageApi } from "../../api/modules/language";
+import { settingsApi } from "../../api/modules/language";
+import { LANGUAGE_LIST } from "../../constants/languageList";
 import styles from "./index.module.less";
-import {
-  SparkChinese02Line,
-  SparkEnglish02Line,
-  SparkJapanLine,
-  SparkRusLine,
-  SparkPtLine,
-} from "@agentscope-ai/icons";
-
-interface LanguageConfig {
-  key: string;
-  label: string;
-  icon: React.ReactElement;
-}
-
-export const LANGUAGE_LIST: LanguageConfig[] = [
-  { key: "en", label: "English", icon: <SparkEnglish02Line /> },
-  { key: "zh", label: "简体中文", icon: <SparkChinese02Line /> },
-  { key: "ja", label: "日本語", icon: <SparkJapanLine /> },
-  { key: "ru", label: "Русский", icon: <SparkRusLine /> },
-  { key: "pt-BR", label: "Português (Brasil)", icon: <SparkPtLine /> },
-  { key: "id", label: "Bahasa Indonesia", icon: <SparkEnglish02Line /> },
-  { key: "vi", label: "Tiếng Việt", icon: <SparkEnglish02Line /> },
-];
+export { LANGUAGE_LIST };
 
 const KNOWN_LANG_KEYS = new Set(LANGUAGE_LIST.map((lang) => lang.key));
 
@@ -49,7 +28,7 @@ export default function LanguageSwitcher({
     if (!persistRemotely) {
       return;
     }
-    languageApi
+    settingsApi
       .updateLanguage(lang)
       .catch((err) =>
         console.error("Failed to save language preference:", err),

--- a/console/src/constants/languageList.tsx
+++ b/console/src/constants/languageList.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from "react";
+import {
+  SparkChinese02Line,
+  SparkEnglish02Line,
+  SparkJapanLine,
+  SparkRusLine,
+  SparkPtLine,
+} from "@agentscope-ai/icons";
+
+export interface LanguageConfig {
+  key: string;
+  label: string;
+  icon: ReactElement;
+}
+
+export const LANGUAGE_LIST: LanguageConfig[] = [
+  { key: "en", label: "English", icon: <SparkEnglish02Line /> },
+  { key: "zh", label: "简体中文", icon: <SparkChinese02Line /> },
+  { key: "ja", label: "日本語", icon: <SparkJapanLine /> },
+  { key: "ru", label: "Русский", icon: <SparkRusLine /> },
+  { key: "pt-BR", label: "Português (Brasil)", icon: <SparkPtLine /> },
+  { key: "id", label: "Bahasa Indonesia", icon: <SparkEnglish02Line /> },
+  { key: "vi", label: "Tiếng Việt", icon: <SparkEnglish02Line /> },
+];

--- a/console/src/layouts/SidebarSettingsPanel.tsx
+++ b/console/src/layouts/SidebarSettingsPanel.tsx
@@ -6,15 +6,11 @@ import { Select } from "antd";
 import {
   SparkSunLine,
   SparkMoonLine,
-  SparkChinese02Line,
-  SparkEnglish02Line,
-  SparkJapanLine,
-  SparkRusLine,
-  SparkPtLine,
   SparkFullscreenLine,
   SparkExitFullscreenLine,
 } from "@agentscope-ai/icons";
-import { languageApi } from "../api/modules/language";
+import { settingsApi } from "../api/modules/language";
+import { LANGUAGE_LIST } from "../constants/languageList";
 import { useTheme, type ThemeMode } from "../contexts/ThemeContext";
 import { useSidebarModeStore } from "../stores/sidebarModeStore";
 import { isTauriRuntime } from "../tauri/backendRuntime";
@@ -31,14 +27,7 @@ type CloseBehavior = "ask" | CloseAction;
 
 // ── Language config ────────────────────────────────────────────────────────
 
-const LANGS = [
-  { key: "en", label: "English", icon: <SparkEnglish02Line size={14} /> },
-  { key: "zh", label: "简体中文", icon: <SparkChinese02Line size={14} /> },
-  { key: "ja", label: "日本語", icon: <SparkJapanLine size={14} /> },
-  { key: "ru", label: "Русский", icon: <SparkRusLine size={14} /> },
-  { key: "pt-BR", label: "Português", icon: <SparkPtLine size={14} /> },
-];
-const KNOWN_KEYS = new Set(LANGS.map((l) => l.key));
+const KNOWN_KEYS = new Set(LANGUAGE_LIST.map((lang) => lang.key));
 
 // ── Component ─────────────────────────────────────────────────────────────
 
@@ -63,7 +52,7 @@ export default function SidebarSettingsPanel({
   const changeLanguage = (lang: string) => {
     i18n.changeLanguage(lang);
     localStorage.setItem("language", lang);
-    languageApi.updateLanguage(lang).catch(() => {});
+    settingsApi.updateLanguage(lang).catch(() => {});
   };
 
   const changeCloseBehavior = (value: CloseBehavior) => {
@@ -105,7 +94,7 @@ export default function SidebarSettingsPanel({
           {t("sidebar.settings.language", "Language")}
         </span>
         <div className={styles.options}>
-          {LANGS.map(({ key, label, icon }) => (
+          {LANGUAGE_LIST.map(({ key, label, icon }) => (
             <button
               key={key}
               title={label}
@@ -114,7 +103,7 @@ export default function SidebarSettingsPanel({
               }`}
               onClick={() => changeLanguage(key)}
             >
-              {icon}
+              {React.cloneElement(icon, { size: 14 })}
             </button>
           ))}
         </div>


### PR DESCRIPTION
Fixed the inconsistency between the top language dropdown menu and the language options in the sidebar settings within the Console.
The sidebar settings previously offered only five languages, omitting Bahasa Indonesia (id) and Tiếng Việt (vi). The language configuration has now been extracted into a shared module for reuse by both entry points, ensuring consistent language options. Additionally, relevant components were migrated from the deprecated `languageApi` to `settingsApi`, and test mocks were updated.

Fixes #7006

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
