### PR TITLE
fix(shell): detach child stdin from interactive console

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -654,6 +654,7 @@ def _execute_subprocess_sync(
         proc = subprocess.Popen(  # pylint: disable=consider-using-with
             wrapped,
             shell=False,
+            stdin=subprocess.DEVNULL,
             stdout=stdout_file,
             stderr=stderr_file,
             text=False,
@@ -1138,6 +1139,7 @@ async def _execute_posix_host(
             shell_executable or "/bin/sh",
             "-c",
             cmd,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=outputs.stdout_file,
             stderr=outputs.stderr_file,
             bufsize=0,

--- a/src/qwenpaw/sandbox/bubblewrap_sandbox.py
+++ b/src/qwenpaw/sandbox/bubblewrap_sandbox.py
@@ -214,6 +214,7 @@ class BubblewrapSandbox(LocalSandbox):
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *full_cmd,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,

--- a/src/qwenpaw/sandbox/linux_sandbox.py
+++ b/src/qwenpaw/sandbox/linux_sandbox.py
@@ -746,6 +746,7 @@ class LinuxSandbox:
                 self._process = await asyncio.create_subprocess_exec(
                     python,
                     script_path,
+                    stdin=asyncio.subprocess.DEVNULL,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=cwd_resolved,

--- a/src/qwenpaw/sandbox/local_sandbox.py
+++ b/src/qwenpaw/sandbox/local_sandbox.py
@@ -213,6 +213,7 @@ class NoneSandbox(LocalSandbox):
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *_shell_argv(shell, cmd),
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,

--- a/src/qwenpaw/sandbox/macos_sandbox.py
+++ b/src/qwenpaw/sandbox/macos_sandbox.py
@@ -293,6 +293,7 @@ class MacOSSandbox(LocalSandbox):
                 shell,
                 "-c",
                 cmd,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -703,6 +703,7 @@ async def test_execute_posix_host_captures_regular_file_output(tmp_path):
     proc.wait.assert_awaited_once()
     assert create_process.call_args.args == ("/bin/sh", "-c", "echo hello")
     kwargs = create_process.call_args.kwargs
+    assert kwargs["stdin"] is asyncio.subprocess.DEVNULL
     assert kwargs["stdout"] != asyncio.subprocess.PIPE
     assert kwargs["stderr"] != asyncio.subprocess.PIPE
     assert kwargs["cwd"] == str(tmp_path)
@@ -2097,7 +2098,7 @@ def test_execute_subprocess_sync_reaps_after_fallback_kill(tmp_path):
         patch(
             "qwenpaw.agents.tools.shell.subprocess.Popen",
             return_value=proc,
-        ),
+        ) as popen_mock,
         patch(
             "qwenpaw.agents.tools.shell._create_job_object_win32",
             return_value=None,
@@ -2118,6 +2119,7 @@ def test_execute_subprocess_sync_reaps_after_fallback_kill(tmp_path):
         )
 
     assert code == -1
+    assert popen_mock.call_args.kwargs["stdin"] is subprocess.DEVNULL
     kill_tree.assert_called_once_with(4321)
     proc.kill.assert_called_once_with()
     # The final reap is bounded so a child stuck in kernel I/O costs a

--- a/tests/unit/sandbox/test_bubblewrap_sandbox.py
+++ b/tests/unit/sandbox/test_bubblewrap_sandbox.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -37,6 +38,34 @@ class TestBuildBwrapArgs:
         defaults.update(kwargs)
         config = SandboxConfig(**defaults)
         return BubblewrapSandbox(config)
+
+    def test_execute_redirects_stdin_to_devnull(self):
+        """Bubblewrap commands must not inherit the parent console stdin."""
+        sandbox = self._make_sandbox()
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+
+        with (
+            patch.object(sandbox, "_find_bwrap", return_value="bwrap"),
+            patch.object(
+                sandbox,
+                "_build_bwrap_args",
+                return_value=["--", "/bin/sh", "-c", "echo ok"],
+            ),
+            patch(
+                "qwenpaw.sandbox.bubblewrap_sandbox."
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=proc),
+            ) as create_process,
+        ):
+            result = asyncio.run(sandbox.execute("echo ok"))
+
+        assert result.exit_code == 0
+        assert (
+            create_process.call_args.kwargs["stdin"]
+            is asyncio.subprocess.DEVNULL
+        )
 
     def test_allow_read_all_generates_ro_bind_root(self):
         sb = self._make_sandbox(allow_read_all=True)

--- a/tests/unit/sandbox/test_config.py
+++ b/tests/unit/sandbox/test_config.py
@@ -51,7 +51,6 @@ class TestSandboxConfigDefaults:
         assert mount.writable is True
         assert mount.executable is False
 
-
     def test_port_rule_defaults(self):
         rule = PortRule(port=8080)
         assert rule.port == 8080
@@ -81,10 +80,7 @@ class TestMacOSSandboxExecution:
             result = asyncio.run(sandbox.execute("echo ok"))
 
         assert result.exit_code == 0
-        assert (
-            create_process.call_args.kwargs["stdin"]
-            is asyncio.subprocess.DEVNULL
-        )
+        assert create_process.call_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
 
 
 # ============================================================================
@@ -183,10 +179,7 @@ class TestSeatbeltProfile:
         assert "/tmp/untrusted" in after_deny
 
     def test_platform_hints_seatbelt_extra_rules(self):
-        extra = (
-            "(allow iokit-open "
-            '(iokit-user-client-class "AGXDeviceUserClient"))'
-        )
+        extra = "(allow iokit-open " '(iokit-user-client-class "AGXDeviceUserClient"))'
         sandbox = self._make_sandbox(
             platform_hints={"seatbelt_extra_rules": extra},
         )

--- a/tests/unit/sandbox/test_config.py
+++ b/tests/unit/sandbox/test_config.py
@@ -80,7 +80,10 @@ class TestMacOSSandboxExecution:
             result = asyncio.run(sandbox.execute("echo ok"))
 
         assert result.exit_code == 0
-        assert create_process.call_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
+        assert (
+            create_process.call_args.kwargs["stdin"]
+            is asyncio.subprocess.DEVNULL
+        )
 
 
 # ============================================================================
@@ -179,7 +182,10 @@ class TestSeatbeltProfile:
         assert "/tmp/untrusted" in after_deny
 
     def test_platform_hints_seatbelt_extra_rules(self):
-        extra = "(allow iokit-open " '(iokit-user-client-class "AGXDeviceUserClient"))'
+        extra = (
+            "(allow iokit-open "
+            '(iokit-user-client-class "AGXDeviceUserClient"))'
+        )
         sandbox = self._make_sandbox(
             platform_hints={"seatbelt_extra_rules": extra},
         )

--- a/tests/unit/sandbox/test_config.py
+++ b/tests/unit/sandbox/test_config.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from qwenpaw.sandbox import (
     MountSpec,
@@ -50,11 +51,40 @@ class TestSandboxConfigDefaults:
         assert mount.writable is True
         assert mount.executable is False
 
+
     def test_port_rule_defaults(self):
         rule = PortRule(port=8080)
         assert rule.port == 8080
         assert rule.direction == "connect"
         assert rule.allow is True
+
+
+class TestMacOSSandboxExecution:
+    """Test macOS sandbox process configuration."""
+
+    def test_execute_redirects_stdin_to_devnull(self):
+        """Seatbelt commands must not inherit the parent console stdin."""
+        sandbox = MacOSSandbox(
+            SandboxConfig(
+                mode=SandboxMode.SEATBELT,
+                workspace_dir="/tmp/ws",
+            ),
+        )
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+
+        with patch(
+            "qwenpaw.sandbox.macos_sandbox.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ) as create_process:
+            result = asyncio.run(sandbox.execute("echo ok"))
+
+        assert result.exit_code == 0
+        assert (
+            create_process.call_args.kwargs["stdin"]
+            is asyncio.subprocess.DEVNULL
+        )
 
 
 # ============================================================================

--- a/tests/unit/sandbox/test_linux_sandbox.py
+++ b/tests/unit/sandbox/test_linux_sandbox.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock, mock_open, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 
@@ -225,6 +226,43 @@ class TestDetectPlatformMode:
 # ============================================================================
 # LinuxSandbox._generate_sandbox_script — rule compilation
 # ============================================================================
+
+
+class TestLinuxSandboxExecution:
+    """Test Landlock sandbox process configuration."""
+
+    def test_execute_redirects_stdin_to_devnull(self, tmp_path):
+        """Landlock commands must not inherit the parent console stdin."""
+        from qwenpaw.sandbox.linux_sandbox import LinuxSandbox
+
+        sandbox = LinuxSandbox(
+            SandboxConfig(
+                mode=SandboxMode.LANDLOCK,
+                workspace_dir=str(tmp_path),
+            ),
+        )
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+
+        with (
+            patch(
+                "qwenpaw.sandbox.linux_sandbox._generate_sandbox_script",
+                return_value="print('sandbox')",
+            ),
+            patch(
+                "qwenpaw.sandbox.linux_sandbox."
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=proc),
+            ) as create_process,
+        ):
+            result = asyncio.run(sandbox.execute("echo ok"))
+
+        assert result.exit_code == 0
+        assert (
+            create_process.call_args.kwargs["stdin"]
+            is asyncio.subprocess.DEVNULL
+        )
 
 
 class TestLinuxSandboxRuleCompilation:

--- a/tests/unit/sandbox/test_unenforced_config.py
+++ b/tests/unit/sandbox/test_unenforced_config.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -352,6 +353,25 @@ class TestNoneSandboxReporting:
         result = asyncio.run(sandbox.execute("echo $0"))
         assert result.exit_code == 0
         assert "/bin/sh" in result.stdout
+
+    def test_execute_redirects_stdin_to_devnull(self, tmp_path):
+        """NoneSandbox must not inherit the parent console stdin."""
+        sandbox = NoneSandbox(_config(workspace_dir=str(tmp_path)))
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+
+        with patch(
+            "qwenpaw.sandbox.local_sandbox.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ) as create_process:
+            result = asyncio.run(sandbox.execute("echo ok"))
+
+        assert result.exit_code == 0
+        assert (
+            create_process.call_args.kwargs["stdin"]
+            is asyncio.subprocess.DEVNULL
+        )
 
 
 class TestBubblewrapReporting:


### PR DESCRIPTION
## Summary

Prevent shell tool child processes from inheriting the interactive console
stdin.

On Windows, a shell command that reads stdin could consume the QwenPaw
console input and block the command pipeline. Since the child is created with
`CREATE_NEW_PROCESS_GROUP`, Ctrl+C could also fail to terminate the stuck
process group.

Close:#7554

## Changes

- Redirect Windows host shell stdin to `subprocess.DEVNULL`.
- Redirect POSIX host shell stdin to `asyncio.subprocess.DEVNULL`.
- Apply the same protection to shell-executing sandbox backends:
  - `NoneSandbox`
  - bubblewrap
  - Linux sandbox
  - macOS sandbox
- Add unit-test assertions for Windows and POSIX stdin configuration.

Existing process-group, Job Object, timeout, cancellation, and process-tree
cleanup behavior is unchanged.

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `sys.stdin.read()` returned EOF immediately and produced:
  ```text
  READY
  STDIN_EOF_OK
- A long-running child command was cancelled and timed out correctly.
- Ctrl+C in the QwenPaw host console shut down the service cleanly without
  requiring the console window or process tree to be killed manually.
- The focused regression suite passed: 2 passed.
- The related shell and sandbox suite passed: 206 passed, 36 skipped.
<img width="970" height="671" alt="{17730B44-48F9-457D-BF06-D0A88A97E547}" src="https://github.com/user-attachments/assets/8c11814f-6b3f-4eee-93f5-bc3281750c38" />

