### PR TITLE
ci: freeze default-branch merges during releases

### DIFF
--- a/.github/workflows/release-window-sentinel.yml
+++ b/.github/workflows/release-window-sentinel.yml
@@ -1,0 +1,92 @@
+# Release-window sentinel: keeps the "Release Window" status current on every
+# PR targeting the default branch.
+#
+# The branch ruleset lists "Release Window" among its required status checks,
+# so every mergeable PR must carry a GREEN "Release Window" status on its head
+# commit, and a RED one blocks the merge. Two producers maintain it:
+#
+#   - this sentinel, which stamps the PR head on every PR event (open /
+#     reopen / push / draft-to-ready / base-branch change via "edited"): green
+#     while no release is in flight, red while the "release-window-active"
+#     lock-marker label exists;
+#   - release-window-watchdog.yml, the sole unfreezer: it sweeps ALL open PRs
+#     back to green and deletes the lock marker once no release run remains
+#     in flight (see its header comment). release.yml's freeze-main creates
+#     the lock marker and stamps all open PRs red at release start.
+#
+# A commit with NO "Release Window" status at all cannot be merged either (a
+# required check that never reported blocks), so every failure mode of this
+# machinery fails closed — it can delay a merge, never allow one it should
+# block. Drafts are skipped: GitHub forbids merging them anyway, and the
+# ready_for_review trigger stamps them the moment they become mergeable.
+#
+# SECURITY: this workflow uses pull_request_target (so it gets a write token
+# even for fork PRs) but NEVER checks out or executes PR code — it only reads
+# event metadata (the head SHA) and posts a commit status. This is the safe
+# metadata-only pattern for this trigger.
+
+name: Release Window Sentinel
+
+on:
+  pull_request_target:
+    # "edited" covers a base-branch change (e.g. re-targeting onto the default
+    # branch), which otherwise leaves the PR unstamped until the next push.
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+
+permissions:
+  statuses: write
+  # Reading the "release-window-active" lock-marker label goes through the
+  # labels endpoint, which belongs to the issues permission scope. Today the
+  # GET works without it because the repository is public (GitHub allows
+  # unauthenticated reads of public resources) — but that would silently break
+  # if the repo ever went private: this job would stop seeing the label, take
+  # the else branch and stamp EVERY PR green during a release (fail-open).
+  # Declaring it explicitly removes that hidden dependency at zero cost.
+  issues: read
+
+jobs:
+  stamp:
+    runs-on: ubuntu-latest
+    # A hung `gh api` here would block the PR event indefinitely. The stamp is
+    # two requests; anything over 5 minutes is a hang, not slowness. Failing
+    # leaves the head commit unstamped, which a required check treats as
+    # "not reported" — blocked, i.e. fail-closed.
+    timeout-minutes: 5
+    steps:
+      - name: Stamp the Release Window status on this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "PR #$PR_NUMBER is a draft — cannot be merged; stamp deferred until ready_for_review."
+            exit 0
+          fi
+
+          default="$(gh api "repos/$REPO" --jq '.default_branch')"
+          if [ "$BASE_REF" != "$default" ]; then
+            echo "PR #$PR_NUMBER targets '$BASE_REF', not the default branch '$default' — nothing to guard."
+            exit 0
+          fi
+
+          if gh api "repos/$REPO/labels/release-window-active" >/dev/null 2>&1; then
+            state="failure"
+            desc="Release in progress — merges frozen"
+          else
+            state="success"
+            desc="No release in flight — merges allowed"
+          fi
+
+          gh api --method POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context="Release Window" \
+            -f description="$desc" \
+            -f target_url="$PR_URL" >/dev/null
+          echo "Stamped $state on PR #$PR_NUMBER ($HEAD_SHA)"

--- a/.github/workflows/release-window-watchdog.yml
+++ b/.github/workflows/release-window-watchdog.yml
@@ -1,0 +1,337 @@
+# Release-window watchdog: the SOLE unfreezer of the release merge freeze,
+# plus the one-time backfill tool.
+#
+# Architecture: release.yml's freeze-main job freezes merges into the default
+# branch while a release is in flight — it posts a red "Release Window" commit
+# status on every open non-draft PR and creates the "release-window-active"
+# lock-marker label, whose description records the release run id. Unfreezing
+# deliberately does NOT happen in release.yml; it happens ONLY here:
+#
+#   * scheduled mode (every 5 minutes): if the lock marker is present but no
+#     release run is queued/in-progress (checked twice, and the run id recorded
+#     in the label is verified to be completed), the release is over — delete
+#     the marker FIRST (so the sentinel stamps any concurrent new push green,
+#     closing the red-remnant race), then sweep every open non-draft PR back to
+#     green.
+#   * manual backfill mode (workflow_dispatch with backfill=true): stamp a
+#     green "Release Window" status on every open non-draft PR targeting the
+#     default branch. Run this ONCE right after "Release Window" is added to
+#     the branch ruleset's required status checks, so existing PRs are not left
+#     without the now-required stamp. New PRs are stamped by
+#     release-window-sentinel.yml; PRs whose head changes are re-stamped there
+#     too, so the backfill is a one-time migration. The backfill refuses to run
+#     while a freeze is active; if a leaked label cannot be removed by this
+#     watchdog, delete the label manually first, then backfill.
+#
+# Why the watchdog is the sole unfreezer:
+#   * concurrent releases (different tags) share ONE repository-level lock; a
+#     per-run unfreeze job in release.yml would let release A's ending unlock
+#     release B's still-active freeze. Here the freeze persists until no
+#     release run remains at all.
+#   * "Re-run failed jobs" does not re-run freeze-main (it already succeeded),
+#     so a per-run unfreeze would leave the re-run window unprotected. Here the
+#     re-run keeps its run status queued/in_progress, so the freeze persists
+#     until the re-run truly finishes.
+#   * A single unfreeze exit removes the "two unfreezers" race surface entirely.
+#
+# Known residual risks — ALL fail closed (they can only delay a merge, never
+# allow one during a release window):
+#   * GitHub cron may be delayed (typically <= 15 minutes; no upper bound is
+#     guaranteed under load), so the unfreeze may lag release completion by
+#     that much. Manual label deletion + backfill is the human fallback.
+#   * A seconds-scale TOCTOU remains between the final in-flight check and the
+#     label deletion (a brand-new release starting in exactly that window); it
+#     cannot be fully eliminated within GitHub Actions primitives.
+#   * If this job dies between deleting the label and finishing the sweep, the
+#     remaining red statuses persist until a manual backfill (the next patrol
+#     sees no label and exits).
+#
+# Cost model (GITHUB_TOKEN is capped at ~1,000 requests/hour/repo, shared by
+# every workflow in the repo): the scheduled path does exactly 1 request when
+# idle (read the lock-marker label). While a legitimate release is in flight it
+# spends a handful of checks and exits. The expensive full sweep only runs
+# after the release is confirmed over.
+#
+# Note on PRs opened mid-release: a required status check with no reported
+# status blocks merging on its own, so they need no red stamp to be blocked;
+# they get their red stamp from the sentinel anyway and their green stamp from
+# this watchdog at the end.
+
+name: Release Window Watchdog
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: >-
+          One-time migration: stamp a green "Release Window" status on every
+          open non-draft PR targeting the default branch. Run once after the
+          ruleset starts requiring "Release Window".
+        required: false
+        type: boolean
+        default: false
+
+# Never let two watchdog runs act at the same time (a scheduled run overlapping
+# a manual one could double-sweep or interleave label checks).
+concurrency:
+  group: release-window-watchdog
+  cancel-in-progress: false
+
+permissions:
+  statuses: write
+  actions: read
+  contents: read
+  # Deleting the lock-marker label requires the label (issues) scope — the same
+  # permission set under which release.yml creates/deletes labels successfully.
+  issues: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    # A hung patrol must not occupy the concurrency group above forever — that
+    # would stop every later patrol from healing a leaked freeze. Being killed
+    # mid-sweep is exactly the "runner killed mid-sweep" residual risk already
+    # documented in the header: by then the lock marker is gone, so remaining
+    # red statuses keep blocking merges (fail-closed) and a manual backfill
+    # heals them. Sweeping ~285 PRs at 0.25s intervals plus retries fits well
+    # inside 15 minutes.
+    timeout-minutes: 15
+    steps:
+      - name: Heal a leaked release freeze / backfill stamps
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BACKFILL: ${{ inputs.backfill }}
+          WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          api_post_status() {
+            # api_post_status <sha> <state> <description> <target_url>
+            # Retries on primary/secondary rate limits (HTTP 403/429) with
+            # exponential backoff; any other error fails immediately.
+            local sha="$1" state="$2" desc="$3" url="$4"
+            local attempt=1 delay=2 err
+            while true; do
+              err="$(gh api --method POST "repos/$REPO/statuses/$sha" \
+                -f state="$state" \
+                -f context="Release Window" \
+                -f description="$desc" \
+                -f target_url="$url" 2>&1 >/dev/null)" && return 0
+              case "$err" in
+                *"HTTP 403"*|*"HTTP 429"*|*"rate limit"*|*"abuse"*) rate_limited=1 ;;
+                *) rate_limited=0 ;;
+              esac
+              if [ "$rate_limited" = "1" ]; then
+                if [ "$attempt" -ge 4 ]; then
+                  echo "::error::Giving up on status for $sha after $attempt attempts: $err"
+                  return 1
+                fi
+                echo "Rate-limited writing status for $sha; retry $attempt in ${delay}s."
+                sleep "$delay"
+                delay=$((delay * 2))
+                attempt=$((attempt + 1))
+              else
+                echo "::error::Failed writing status for $sha: $err"
+                return 1
+              fi
+            done
+          }
+
+          fetch_pr_list() {
+            # fetch_pr_list <base-branch>
+            # Prints "<pr> <head-sha>" per line for every open NON-DRAFT PR
+            # targeting <base-branch>; prints nothing when there are none.
+            #
+            # This MUST be a command substitution at the call site, never a
+            # process substitution (`< <(...)`) feeding the loop directly: a
+            # process substitution runs in its own process whose exit status is
+            # invisible to `set -e` and `pipefail`, so a failed list fetch would
+            # run the loop zero times and this job would still print "all open
+            # PRs re-stamped green" — reporting peace while having done nothing.
+            # Here the failure propagates, the run goes red, and the next patrol
+            # retries (or an operator sees the red run and intervenes).
+            #
+            # Retries ANY failure (not just rate limits) with exponential
+            # backoff and gives up after 4 attempts. Listing is fatal here, so
+            # even a transient 404 deserves a retry — observed for real during
+            # review: the first `--paginate` call returned HTTP 404 and the same
+            # command then succeeded three times in a row.
+            local base="$1" attempt=1 delay=2 rc out
+            while true; do
+              rc=0
+              out="$(gh api --paginate "repos/$REPO/pulls?state=open&base=$base&per_page=100" \
+                --jq '.[] | select(.draft != true) | "\(.number) \(.head.sha)"' 2>/dev/null)" || rc=$?
+              if [ "$rc" -eq 0 ]; then
+                # Emit nothing for an empty result: a stray blank line would
+                # give the caller's `while read` one iteration with empty pr/sha.
+                if [ -n "$out" ]; then
+                  printf '%s\n' "$out"
+                fi
+                return 0
+              fi
+              if [ "$attempt" -ge 4 ]; then
+                echo "::error::Giving up listing open PRs after $attempt attempts (gh api exit $rc on pulls?state=open&base=$base)." >&2
+                return 1
+              fi
+              echo "Listing open PRs failed (gh api exit $rc); retry $attempt in ${delay}s." >&2
+              sleep "$delay"
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          default="$(gh api "repos/$REPO" --jq '.default_branch')"
+
+          # ── Mode 1: one-time backfill (manual dispatch only) ───────────────
+          if [ "${BACKFILL:-false}" = "true" ]; then
+            # Guard: backfill stamps GREEN. Refuse while a freeze is active,
+            # or a manual backfill could paint red (frozen) PRs green and
+            # punch a hole through an in-flight release window.
+            if gh api "repos/$REPO/labels/release-window-active" >/dev/null 2>&1; then
+              echo "::error::Backfill refused: a release freeze is active (release-window-active label present). Wait for the release to finish."
+              exit 1
+            fi
+            echo "Backfill mode: stamping green 'Release Window' on every open non-draft PR."
+            # Command substitution, NOT process substitution — see fetch_pr_list.
+            pr_list="$(fetch_pr_list "$default")"
+            stamped=0
+            failures=0
+            if [ -n "$pr_list" ]; then
+              while read -r pr sha; do
+                current="$(gh api "repos/$REPO/commits/$sha/status" \
+                  --jq '.statuses | map(select(.context == "Release Window")) | (first.state // "absent")' </dev/null)"
+                if [ "$current" = "success" ]; then
+                  echo "PR #$pr ($sha): already green"
+                  continue
+                fi
+                if api_post_status "$sha" "success" "No release in flight — merges allowed" "$WATCHDOG_URL"; then
+                  echo "PR #$pr ($sha): $current -> green"
+                  stamped=$((stamped + 1))
+                else
+                  failures=$((failures + 1))
+                fi
+                sleep 0.25
+              done <<< "$pr_list"
+            else
+              echo "No open non-draft PRs target '$default' — nothing to backfill."
+            fi
+            if [ "$failures" -gt 0 ]; then
+              echo "::error::$failures PR(s) could not be stamped; re-run the backfill to heal them."
+              exit 1
+            fi
+            echo "Backfill done: $stamped PR(s) stamped green."
+            exit 0
+          fi
+
+          # ── Mode 2: scheduled reconcile — the sole unfreezer ───────────────
+          # 1. Is the lock-marker label even present? If not, nothing is frozen
+          #    and we exit (1 request while idle).
+          if ! label_json="$(gh api "repos/$REPO/labels/release-window-active" 2>/dev/null)"; then
+            echo "No release-window-active label — nothing frozen. Exiting."
+            exit 0
+          fi
+          echo "Lock marker present; checking whether a release is still in flight."
+
+          # Locate the release workflow by path (robust against the file being
+          # renamed; a stale hard-coded name would silently disable us). If it
+          # cannot be found, refuse to unfreeze — fail closed.
+          wf_ids="$(gh api --paginate "repos/$REPO/actions/workflows" \
+            --jq '.workflows[] | select(.path | endswith("/release.yml")) | .id | tostring')"
+          wf_id="$(printf '%s\n' "$wf_ids" | awk 'NR==1')"
+          if [ -z "$wf_id" ]; then
+            echo "::error::Cannot locate the release workflow — refusing to unfreeze (fail closed)."
+            exit 1
+          fi
+
+          release_in_flight() {
+            # Server-side status filters: immune to pagination ordering and to
+            # re-runs (a re-run keeps its run id and created_at, so a
+            # created-desc listing could bury it; status filtering cannot).
+            local n
+            n="$(gh api "repos/$REPO/actions/workflows/$wf_id/runs?status=in_progress&per_page=1" --jq '.total_count')"
+            [ "$n" -gt 0 ] && return 0
+            n="$(gh api "repos/$REPO/actions/workflows/$wf_id/runs?status=queued&per_page=1" --jq '.total_count')"
+            [ "$n" -gt 0 ] && return 0
+            return 1
+          }
+
+          # 2. First in-flight check: a legitimate release keeps its freeze.
+          if release_in_flight; then
+            echo "Release run in flight — freeze is legitimate. Exiting."
+            exit 0
+          fi
+
+          # 3. Re-read the label: if it vanished, or now records a different
+          #    release run, a new freeze took over between our checks — back off.
+          label_json="$(gh api "repos/$REPO/labels/release-window-active" 2>/dev/null)" || {
+            echo "Lock marker disappeared while checking — nothing to do. Exiting."
+            exit 0
+          }
+          label_desc="$(printf '%s' "$label_json" | jq -r '.description // ""')"
+          recorded_run="$(printf '%s' "$label_desc" | grep -oE 'run [0-9]+' | grep -oE '[0-9]+' | awk 'NR==1' || true)"
+          if [ -n "$recorded_run" ]; then
+            run_status="$(gh api "repos/$REPO/actions/runs/$recorded_run" --jq '.status' 2>/dev/null || echo unknown)"
+            if [ "$run_status" != "completed" ]; then
+              echo "Recorded release run $recorded_run is '$run_status' — a release is starting or in flight; not unfreezing."
+              exit 0
+            fi
+          fi
+
+          # 4. Second in-flight check right before mutating state — compresses
+          #    the "watchdog vs brand-new release" TOCTOU window to seconds.
+          if release_in_flight; then
+            echo "Release run appeared during checks — aborting unfreeze. Exiting."
+            exit 0
+          fi
+
+          echo "Release over (no run queued/in-progress; recorded run completed). Unfreezing."
+
+          # 5. Delete the lock marker FIRST: from this instant the sentinel
+          #    stamps every new push green, which closes the race where a
+          #    late red stamp outlives the sweep. Errors are NOT swallowed:
+          #    404 means already gone (continue), anything else aborts and
+          #    the next patrol retries.
+          if err="$(gh api --method DELETE "repos/$REPO/labels/release-window-active" 2>&1 >/dev/null)"; then
+            echo "Lock marker removed."
+          elif [[ "$err" == *"HTTP 404"* ]]; then
+            echo "Lock marker already gone."
+          else
+            echo "::error::Could not delete the lock marker — will retry next patrol: $err"
+            exit 1
+          fi
+
+          # 6. Now fetch the PR list and sweep everything back to green. Any
+          #    sha pushed after step 5 is stamped green by the sentinel;
+          #    sweeping its predecessor sha here is harmless.
+          #
+          # Command substitution, NOT process substitution — see fetch_pr_list.
+          # The label is already gone at this point, so a failed fetch leaves
+          # the red statuses behind (fail-closed: PRs stay blocked, never
+          # wrongly merged). It must NOT be allowed to pass silently as
+          # "everything re-stamped green" — that is what would leave the
+          # remnant undiscovered until someone gets stuck.
+          pr_list="$(fetch_pr_list "$default")"
+          swept=0
+          failures=0
+          if [ -n "$pr_list" ]; then
+            while read -r pr sha; do
+              if api_post_status "$sha" "success" "Release window closed — merges allowed" "$WATCHDOG_URL"; then
+                echo "Unfroze PR #$pr ($sha)"
+                swept=$((swept + 1))
+              else
+                failures=$((failures + 1))
+              fi
+              sleep 0.25
+            done <<< "$pr_list"
+          else
+            echo "PR list is empty: no open non-draft PRs target '$default' — nothing to sweep."
+          fi
+
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::$failures PR(s) could not be re-stamped green; the label is already gone, so run the manual backfill to heal them."
+            exit 1
+          fi
+          echo "Release window closed; $swept open PR(s) re-stamped green."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,19 @@
 #   4. If anything fails, nothing is published and the draft is left untouched
 #      (zero external trace; just fix and re-run).
 #
+# Merge freeze: from the moment this workflow starts until it ends (success,
+# failure, cancellation or a re-run of failed jobs), a red "Release Window"
+# commit status is posted on every open PR targeting the default branch.
+# With "Release Window" listed among the required status checks of the branch
+# ruleset, no PR can be merged into the default branch while a release is in
+# flight. UNFREEZING deliberately does NOT happen in this workflow:
+# release-window-watchdog.yml is the sole unfreezer — it waits until NO
+# release run is queued/in-progress (which also covers concurrent releases
+# with different tags, and "Re-run failed jobs" windows that never re-run
+# freeze-main), then deletes the lock marker and re-stamps every PR green.
+# The label description records this run's id so the watchdog can verify the
+# recorded run completed before unlocking.
+#
 # dry_run=true stubs the three production-external publishes (PyPI / Docker /
 # OSS) so fork CI can exercise the gating + draft flip without touching prod.
 # Draft-asset upload, the draft→published flip and the duty issue still run for
@@ -37,14 +50,178 @@ on:
 permissions:
   contents: write
   issues: write
+  # Needed by the freeze-main job below, which posts commit statuses
+  # ("Release Window") on the head commit of every open PR targeting the
+  # default branch while a release is in flight.
+  statuses: write
 
 concurrency:
   group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # ── Merge freeze: block PR merges into the default branch while releasing ──
+  # Posts a red "Release Window" commit status on the head commit of every
+  # open non-draft PR targeting the default branch, and creates the
+  # "release-window-active" label as a lock marker. When a repository ruleset
+  # lists "Release Window" among its required status checks, no PR can be
+  # merged: existing PRs carry the red status, and PRs opened later carry no
+  # status at all, which a required check treats as "not reported" (blocked).
+  # Unfreezing is the sole responsibility of release-window-watchdog.yml,
+  # which waits until no release run remains in flight (see header comment).
+  # Commit statuses are repository-local, so this also runs on dry_run
+  # (forks only affect forks).
+  freeze-main:
+    runs-on: ubuntu-latest
+    # GitHub-hosted jobs default to a 6-hour timeout. If `gh api` hangs instead
+    # of failing (half-dead network, stalled TLS), this job would sit there with
+    # the lock marker raised and every PR stamped red — freezing the default
+    # branch for 6 hours, and the watchdog would correctly refuse to unlock
+    # (the recorded release run is still "in progress"). Timing out turns that
+    # into a job failure, which skips resolve and closes the release: the
+    # fail-closed property is unchanged, the blast radius is not.
+    # Freezing ~285 PRs takes well under a minute in practice.
+    timeout-minutes: 10
+    steps:
+      - name: Freeze merges into the default branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          default="$(gh api "repos/$REPO" --jq '.default_branch')"
+          echo "Freezing merges into '$default' for release run $RUN_URL"
+
+          api_post_status() {
+            # api_post_status <sha> <state> <description> <target_url>
+            # A failed red stamp here fails the whole release, so retry on
+            # primary/secondary rate limits (HTTP 403/429) with exponential
+            # backoff; any other error fails immediately.
+            local sha="$1" state="$2" desc="$3" url="$4"
+            local attempt=1 delay=2 err
+            while true; do
+              err="$(gh api --method POST "repos/$REPO/statuses/$sha" \
+                -f state="$state" \
+                -f context="Release Window" \
+                -f description="$desc" \
+                -f target_url="$url" 2>&1 >/dev/null)" && return 0
+              case "$err" in
+                *"HTTP 403"*|*"HTTP 429"*|*"rate limit"*|*"abuse"*) rate_limited=1 ;;
+                *) rate_limited=0 ;;
+              esac
+              if [ "$rate_limited" = "1" ]; then
+                if [ "$attempt" -ge 4 ]; then
+                  echo "::error::Giving up on status for $sha after $attempt attempts: $err"
+                  return 1
+                fi
+                echo "Rate-limited writing status for $sha; retry $attempt in ${delay}s."
+                sleep "$delay"
+                delay=$((delay * 2))
+                attempt=$((attempt + 1))
+              else
+                echo "::error::Failed writing status for $sha: $err"
+                return 1
+              fi
+            done
+          }
+
+          fetch_pr_list() {
+            # fetch_pr_list <base-branch>
+            # Prints "<pr> <head-sha>" per line for every open NON-DRAFT PR
+            # targeting <base-branch>; prints nothing when there are none.
+            #
+            # This MUST be a command substitution at the call site, never a
+            # process substitution (`< <(...)`) feeding the loop directly: a
+            # process substitution runs in its own process whose exit status
+            # is invisible to `set -e` and `pipefail`, so a failed list fetch
+            # would run the loop zero times, leave failures=0, and let this job
+            # report SUCCESS while not a single PR got frozen — a silent hole
+            # in the release window (fail-open). Command substitution propagates
+            # the failure, so the job dies and resolve is blocked (fail-closed).
+            #
+            # Retries ANY failure, not just rate limits — deliberately wider
+            # than api_post_status below. Listing is fatal by design, so even a
+            # transient 404 or a stalled TLS handshake deserves a retry: a
+            # single blip must not abort a whole release. Observed for real
+            # during review — the first `--paginate` call returned HTTP 404 and
+            # the same command then succeeded three times in a row.
+            local base="$1" attempt=1 delay=2 rc out
+            while true; do
+              rc=0
+              out="$(gh api --paginate "repos/$REPO/pulls?state=open&base=$base&per_page=100" \
+                --jq '.[] | select(.draft != true) | "\(.number) \(.head.sha)"' 2>/dev/null)" || rc=$?
+              if [ "$rc" -eq 0 ]; then
+                # Emit nothing for an empty result: a stray blank line would
+                # give the caller's `while read` one iteration with empty pr/sha.
+                if [ -n "$out" ]; then
+                  printf '%s\n' "$out"
+                fi
+                return 0
+              fi
+              if [ "$attempt" -ge 4 ]; then
+                echo "::error::Giving up listing open PRs after $attempt attempts (gh api exit $rc on pulls?state=open&base=$base). Freezing nothing is not an option — aborting." >&2
+                return 1
+              fi
+              echo "Listing open PRs failed (gh api exit $rc); retry $attempt in ${delay}s." >&2
+              sleep "$delay"
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          # Lock marker: lets the sentinel and the watchdog tell "frozen" from
+          # "not frozen" with a single cheap request. Idempotent. The
+          # description records THIS run's id so the watchdog can verify the
+          # recorded run completed before unlocking (guards against a new
+          # release starting during watchdog cleanup).
+          label_desc="Release in flight — merges into the default branch are frozen (run ${{ github.run_id }})"
+          if gh api "repos/$REPO/labels/release-window-active" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/$REPO/labels/release-window-active" \
+              -f description="$label_desc" >/dev/null
+          else
+            gh api --method POST "repos/$REPO/labels" \
+              -f name="release-window-active" \
+              -f color="B60205" \
+              -f description="$label_desc" >/dev/null
+          fi
+          echo "Lock marker present."
+
+          # Page through ALL open non-draft PRs targeting the default branch
+          # (never a fixed limit: a PR missed by the freeze would silently keep
+          # a merge hole open for the whole release window). Drafts cannot be
+          # merged by GitHub in the first place.
+          #
+          # Command substitution, NOT process substitution — see fetch_pr_list.
+          # If listing fails, this job fails and the release is blocked.
+          pr_list="$(fetch_pr_list "$default")"
+          frozen=0
+          failures=0
+          if [ -n "$pr_list" ]; then
+            while read -r pr sha; do
+              if api_post_status "$sha" "failure" "Release in progress — merges frozen" "$RUN_URL"; then
+                echo "Froze PR #$pr ($sha)"
+                frozen=$((frozen + 1))
+              else
+                failures=$((failures + 1))
+              fi
+              sleep 0.25
+            done <<< "$pr_list"
+          else
+            echo "No open non-draft PRs target '$default' — nothing to freeze."
+          fi
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::$failures PR(s) could not be frozen — aborting the release (fail closed)."
+            exit 1
+          fi
+          echo "Freeze applied: $frozen PR(s) stamped red."
+
   # ── Resolve the draft, pin the commit, fail fast on missing secrets ─────────
+  # Fail-closed: resolve waits on freeze-main. If the merge freeze cannot be
+  # applied, the release must not proceed — releasing without the freeze would
+  # silently re-open exactly the window this workflow exists to close.
   resolve:
+    needs: [freeze-main]
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.pick.outputs.tag }}
@@ -575,3 +752,14 @@ jobs:
       ref: ${{ needs.resolve.outputs.sha }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
+
+  # ── Merge unfreeze is NOT done here ─────────────────────────────────────────
+  # release-window-watchdog.yml is the sole unfreezer: it deletes the lock
+  # marker and re-stamps every open PR green only once NO release run is
+  # queued/in-progress anywhere in the repo. This removes the race surface of
+  # having two unfreezers, and correctly covers concurrent releases (different
+  # tags) and "Re-run failed jobs" windows (freeze-main is not re-run there,
+  # but the re-run keeps the run queued/in_progress). The label's description
+  # records this run's id, which the watchdog verifies completed. Residual
+  # cost: merges are re-opened minutes after release completion rather than
+  # seconds — an accepted trade-off at the release-end boundary.


### PR DESCRIPTION
> **Submitted by**: 秦琼·CIOps@QPQAT

## Why

During the `v2.2.0-beta.4` release on Aug 31 (09:42–13:01 CST), PR #7267 was merged into `main` at 10:32 — while the release was still running.

The release pipeline is already SHA-pinned, so the artifacts themselves were correct (verified: all 8 workflow files identical between the pinned SHA and the drifted `main`, and re-runs check out the pinned commit). But **the default branch keeps accepting merges throughout the release window**, and that is a process gap on its own:

- the baseline moves while a release is in flight;
- if a release needs a re-run or manual intervention, code merged during the window introduces unexpected state;
- release window and developer merges running concurrently complicates incident triage (during the 403 investigation of that very release, "a PR was merged mid-release" was seriously suspected as the cause — later disproved, but the suspicion itself cost investigation time).

This PR closes that gap: **while a release is in flight, no PR can be merged into the default branch; the freeze lifts automatically when the release completes, fails, or is cancelled.**

## Design: fully automatic, never relying on a human remembering to unlock

A human-driven "lock before release / unlock after" is strictly worse — forgetting to unlock freezes `main` indefinitely. So this design has exactly one safety property that everything else follows from:

> **A required status check that has never reported a state blocks the merge.** Therefore every failure mode in this mechanism results in *over*-blocking (delayed merge), never in *under*-blocking (a merge slipping through).

Mechanism = commit status `Release Window` + required check in the branch ruleset + three status producers. **There is exactly one unlock path** (the watchdog).

### 1. `release.yml`: a new `freeze-main` job (locks only, never unlocks)

- Raises the lock marker label `release-window-active`, whose **description records this release's run id** — the watchdog uses it to verify "has the release recorded on the lock actually finished?";
- Walks every non-draft open PR targeting the default branch (**paginated in full, no hard cap**) and stamps a **red** `Release Window` status on each head commit;
- **Fails closed**: `resolve` depends on `freeze-main`, so *if the branch cannot be frozen, the release does not proceed*. Any failure to stamp red (including 4 retries against rate limiting) fails the release;
- Order is **label first, then stamp red** — so a PR opened in between is caught by the sentinel immediately; there is no gap.

### 2. New sentinel: `release-window-sentinel.yml`

- Triggers: `pull_request_target` (opened / reopened / synchronize / ready_for_review / **edited**). `edited` matters because it covers "PR re-pointed at the default branch" — without it such a PR would have no status at all and stay blocked until its next push;
- **Security**: reads event metadata only (the head SHA) and **never checks out or executes PR code** — the standard metadata-only pattern against `pull_request_target` injection;
- Stamps on every PR event: green normally, red while the lock marker exists;
- Drafts are skipped (GitHub will not merge a draft anyway); `ready_for_review` re-stamps the moment a draft is promoted.

The sentinel exists because `administration: write` is **not a valid value** in a workflow `permissions:` block (GitHub rejects it outright) — rules cannot be added/removed dynamically, so the required check must be permanently present, which in turn means something must keep stamping green during the long stretches between releases. Without it, every new PR would be blocked forever by a check that has never reported.

### 3. New watchdog: `release-window-watchdog.yml` — **the only unfreezer**

- **Patrols every 5 minutes**; idle cost is **1 API request** (does the lock marker exist?);
- Unlocks when "the marker is still there but no release is in flight";
- **Unlock order**: double-check nothing is running → verify the run recorded on the lock has completed → **delete the label first** → then re-stamp every PR green. This mirrors `freeze-main` exactly: the instant the label is gone the sentinel stamps green for all new pushes, so nobody can be left red during the sweep;
- **Permissions and error handling**: `issues: write` (required to delete a label), and it **does not swallow errors** — a 404 is treated as "already deleted" and processing continues, while any other error fails this patrol loudly (leaving a trace) and retries next round;
- **In-flight detection uses server-side status filters** (`status=in_progress` / `status=queued`, reading `total_count`) rather than paging by creation time — a re-run of failed jobs does not change the run's creation timestamp, so a creation-time scan can be shadowed by newer records and wrongly conclude "nothing is running";
- **Concurrency group** so two patrols can never interleave;
- **One-shot backfill mode** (manual dispatch): stamps green on the existing open PRs the first time the ruleset requires `Release Window`. Backfill refuses to run while a release is in flight (it would wipe out the reds), and reports per-item failure counts, exiting non-zero on any failure.

### Why unlocking has only one exit (the watchdog)

The first iteration unlocked at the end of the release, with the watchdog as a fallback. Two independent design reviews found two real holes in that:

1. **A re-run window with no protection at all.** After a failed release, the end-of-release unlock had already lifted the lock. When a maintainer clicks "Re-run failed jobs", `freeze-main` does *not* run again (it already succeeded) — so the release genuinely continues while `main` is unlocked. That directly violates "until the release completes, is cancelled, or fails".
2. **Red statuses leaked by an unlock race.** Unlocking swept PRs green *first* and deleted the label *last*. Anyone pushing during those minutes got a red stamp from the sentinel (label still present) against a SHA that was not in the sweep list — leaving a red status nobody ever clears, permanently blocking that PR.

With the watchdog as the sole unfreezer: release fails → lock stays → re-run puts the run back into "in flight" → watchdog stays out of the way → unlock only after the re-run truly finishes. Both holes close at once, with ~50 fewer lines and two fewer race surfaces.

**Cost**: after a normal release the unlock waits for the next patrol (typically 5–15 minutes). The protection being asked for is *during* the release; releasing a few minutes later does not weaken it.

## Verification (all measured, none inferred)

Every claim below comes from an actual run on a fork, not from reading the code.

| What was verified | How | Result |
|---|---|---|
| Commit statuses can be written to fork-PR head commits | probe | ✅ |
| `if: always()` still runs after a manual cancel | probe: start a 600s job → cancel → observe | ✅ |
| Label create/delete permissions | probe (`gh label delete` hangs on its interactive confirm in CI — switched to API DELETE) | ✅ |
| Permission declarations are legal | measured: `administration` is rejected as invalid; `statuses: write` / `issues: write` / `issues: read` are natively supported | ✅ |
| End-to-end: freeze takes effect, and the failure path still cleans up | full release pipeline on a fork with `dry_run` (run 33629082182) | ✅ |
| Watchdog self-heals a leaked lock (end to end) | simulated leaked lock + 2 red PRs → manual watchdog dispatch (run 33712928688) | ✅ label deleted, both PRs green, full log chain |
| Failure keeps the lock → scheduled patrol unlocks automatically | draft with a mismatched version so `resolve` fails instantly → run 33714090947: `freeze-main` success / `resolve` failure / 13 jobs skipped, **lock retained by design** → the 16:19 scheduled patrol (run 33732719107) unlocked on its own | ✅ log contains the `recorded run completed` predicate |
| **Fault injection on the PR-listing path** | temporary branch replacing the real request inside `fetch_pr_list` with `false` → `dry_run` release on the fork (run **33743647302**) | ✅ **`freeze-main` failure, `resolve` skipped, all 13 downstream jobs skipped — the release was blocked.** Log: `Lock marker present.` → `Listing open PRs failed (gh api exit 1); retry 1 in 2s / 2 in 4s / 3 in 8s` → `##[error]Giving up listing open PRs after 4 attempts ... Freezing nothing is not an option — aborting.` |
| Watchdog cleanup after the injection | lock left by the above → watchdog on the fixed code (run **33743823017**) | ✅ success; `Lock marker present` → `Release over (no run queued/in-progress; recorded run completed)` → `Lock marker removed` → `Unfroze PR #53/#49` → `Release window closed; 2 open PR(s) re-stamped green.` |
| Failure matrix with a stubbed `gh` (every failure combination) | freeze-main: ok=0 / listing fails=1 / empty list=0 / status write fails=1; watchdog sweep: ok=0 / listing fails=1 / empty list=0 / status write fails=1; backfill: ok=0 / listing fails=1 / refused while frozen=1; sentinel: lock present→red / no lock→green / draft→skip / non-default base→skip | ✅ all match "fail closed" |
| Re-verified after adding `timeout-minutes` | `dry_run` on the fork (run **33750414308**) | ✅ `freeze-main` **success in 7 seconds**; watchdog cleanup run **33750641252** success; zero residue (label 404, both PRs green, 0 draft releases) |
| Full pre-commit at the repo-pinned versions | — | ✅ incl. GitHub Actions workflow lint |

Test residue was cleaned up completely: the fault-injection branch is deleted (local and remote), draft releases deleted, lock marker gone (404), the two test PRs restored to green.

### One hole worth calling out, because it was nearly shipped

The second review round rejected an earlier revision for a **fail-open regression I had introduced myself** while fixing an unrelated counting bug: the red-stamping loop had been rewritten to use process substitution (`< <(gh api ...)`), whose exit status is invisible to `set -e` / `pipefail`. If listing open PRs failed (a transient 404, a rate limit), the loop simply ran zero times, the failure counter stayed 0, and `freeze-main` **reported success — the release went ahead with zero PRs frozen**. Worse, because the lock label *was* raised, the watchdog later unlocked normally, leaving **no residue at all**: the log is indistinguishable from "this repo genuinely had no open PRs".

This is not hypothetical. While reviewing, a read-only `gh api --paginate` query against this repository returned **HTTP 404 on its first attempt and then succeeded three times in a row**. The same blip landing on `freeze-main` would have silently voided the entire protection.

The fix extracts a single `fetch_pr_list()` helper used by all three call sites: command substitution (so a non-zero exit discards the captured output entirely — a partial page can never be mistaken for a complete list), an explicit empty-list guard, and retries on **any** failure with 2s/4s/8s backoff before giving up and failing the job. The retry is deliberately wider than the status writer's (which retries only rate limits) for exactly the 404 case above.

## Known residual risks (all fail closed — they delay merges, never leak one)

| Risk | Effect | Fallback |
|---|---|---|
| GitHub scheduled runs can be delayed (typically ≤15 min, no upper bound at peak) | unlock lags the end of the release | admin deletes the label manually + runs one backfill |
| Seconds-wide window between the final in-flight check and deleting the label | if a new release starts in that exact instant, its lock could be torn off | narrowed from minutes to seconds by the double in-flight check plus verifying the recorded run has completed; cannot be eliminated within GitHub Actions — documented as-is |
| Runner killed after the label is deleted but mid-sweep | remaining red statuses stay (the next patrol sees no label and exits, by design) | run one backfill |
| Listing keeps failing (e.g. a prolonged GitHub-side outage) | the release itself fails | **intentional**: better to fail the release than to "succeed" with `main` unfrozen. The 4 retries absorb transient blips |

## Deployment (one-time, after merge)

The code alone does nothing until the required check exists — please note step 1 needs an admin.

1. **Admin** (ruleset permission holder) adds `Release Window` to the required status checks of ruleset **13309478** (currently: `Pre-commit`, `Test Summary`, `Frontend Summary`, `console format check`, `website format check`);
2. Dispatch the watchdog once with `backfill=true` to stamp green on the ~286 existing non-draft open PRs (without this they would be blocked forever by a check that never reported);
3. **Open a throwaway PR to confirm the check actually gates** — verify `Release Window` appears in the required list and a green one allows merging. This guards against the ruleset being configured in evaluate-only mode, or a bypass list silently disabling it;
4. Done. From then on every release freezes automatically and the watchdog unlocks automatically, with no human in the loop.

## Rate-limit budget

`GITHUB_TOKEN` is limited to 1000 requests/hour/repository, shared by all workflows in the repo.

- One freeze: ≈ (number of open PRs) requests, spent once at release start (~286 today). Writes are spaced 0.25s apart, with exponential backoff up to 4 retries on HTTP 403/429;
- One unlock: ≈ (number of open PRs) requests, spent by the watchdog after the release ends;
- Sentinel: 1–2 requests per PR event, event-driven;
- Watchdog: 1 request per 5 minutes when idle (≈12/hour); ≈4 per patrol while a release is in flight (label lookup + locate workflow + two status-filtered queries). Negligible.

## Files

All additions; no existing logic is modified or removed.

| File | Change |
|---|---|
| `.github/workflows/release.yml` | +`freeze-main` job (`timeout-minutes: 10`), +`statuses: write` / `issues: write` permissions (+188 lines) |
| `.github/workflows/release-window-sentinel.yml` | new (92 lines, `timeout-minutes: 5`, `statuses: write` + `issues: read`) |
| `.github/workflows/release-window-watchdog.yml` | new (337 lines, `timeout-minutes: 15`) |

617 added lines, single commit.

All three jobs declare `timeout-minutes` because GitHub-hosted jobs default to a **6-hour** timeout: if `gh api` *hangs* rather than fails (half-dead network, stalled TLS), `freeze-main` would sit there with the marker raised and every PR red — `main` frozen for six hours, and the watchdog would correctly refuse to unlock (the recorded release run is still "in progress"). Timing out turns that into a job failure, which skips `resolve` and closes the release: same fail-closed property, far smaller blast radius. Freezing ~286 PRs takes well under a minute in practice (measured: 7 seconds).

## Review history

This went through two independent internal design review rounds (reviewer did not touch the code — read-only review plus building their own harnesses to test it). The second round **rejected** an intermediate revision and is what caught the fail-open regression described above; the third pass approved it after verifying the fix by extracting the helper verbatim and running six scenarios against a stubbed `gh` — including "pagination fails halfway through", confirming a partial list can never be used as if complete — plus independently re-fetching the fault-injection logs and recomputing the backoff intervals from the timestamps (2s/4s/8s, exact match).

Nine issues were found and fixed across the two rounds: three from self-review, six from the first review round (including the watchdog lacking delete permission *and* swallowing the 403 into a "label deleted" success — a permanently stuck lock reported as healthy), and three more from the re-review (the fail-open regression above, the same pattern in two watchdog loops, and the sentinel relying on the repository being public for its label read, now an explicit `issues: read`).
