### PR TITLE
fix(memory): prepare Auto-Dream for ReMe 0.4.1.12

### DIFF
--- a/src/qwenpaw/agents/memory/reme_config.py
+++ b/src/qwenpaw/agents/memory/reme_config.py
@@ -420,9 +420,8 @@ def _base_config() -> dict[str, Any]:
                 "backend": "base",
                 "description": (
                     "Auto-dream: scan today's day-index and daily notes, "
-                    "globally extract merged units/topics, integrate digest "
-                    "units, write interests.yaml, and persist the dream "
-                    "catalog."
+                    "globally extract merged units, integrate digest units, "
+                    "and persist the dream catalog."
                 ),
                 "parameters": {
                     "type": "object",
@@ -431,27 +430,16 @@ def _base_config() -> dict[str, Any]:
                         "hint": {"type": "string", "default": ""},
                         "scan_days": {"type": "integer", "default": 2},
                         "max_units": {"type": "integer", "default": 5},
-                        "topic_count": {"type": "integer", "default": 3},
-                        "topic_diversity_days": {
-                            "type": "integer",
-                            "default": 7,
-                        },
                     },
                 },
                 "steps": [
                     {
                         "backend": "dream_extract_step",
                         "file_catalog": "dream",
-                        "topic_session_id": "interests",
                         "scan_days": 2,
                         "max_units": 5,
                     },
                     {"backend": "dream_integrate_step"},
-                    {
-                        "backend": "dream_topics_step",
-                        "topic_count": 3,
-                        "topic_diversity_days": 7,
-                    },
                     {"backend": "dream_finish_step", "file_catalog": "dream"},
                 ],
             },

--- a/tests/unit/agents/memory/test_reme_config.py
+++ b/tests/unit/agents/memory/test_reme_config.py
@@ -42,6 +42,25 @@ def test_reme_file_processing_is_limited_to_10_mb() -> None:
     )
 
 
+def test_auto_dream_only_consolidates_durable_memory() -> None:
+    cfg = _config_for_embedding(EmbeddingModelConfig())
+
+    auto_dream = cfg["jobs"]["auto_dream"]
+    assert auto_dream["steps"] == [
+        {
+            "backend": "dream_extract_step",
+            "file_catalog": "dream",
+            "scan_days": 2,
+            "max_units": 5,
+        },
+        {"backend": "dream_integrate_step"},
+        {"backend": "dream_finish_step", "file_catalog": "dream"},
+    ]
+    properties = auto_dream["parameters"]["properties"]
+    assert "topic_count" not in properties
+    assert "topic_diversity_days" not in properties
+
+
 def test_reindex_job_exposes_explicit_scopes() -> None:
     cfg = _config_for_embedding(EmbeddingModelConfig())
 

--- a/website/public/docs/memory-evolving-and-proactive.en.md
+++ b/website/public/docs/memory-evolving-and-proactive.en.md
@@ -4,12 +4,12 @@
 
 QwenPaw has two related but currently **independent** paths:
 
-| Path             | Input                                      | Output                                            |
-| ---------------- | ------------------------------------------ | ------------------------------------------------- |
-| Memory evolution | Daily memory under `memory/`               | Durable knowledge in `digest/` + `interests.yaml` |
-| `/proactive`     | Recent chat sessions + optional screenshot | One message prefixed with `[PROACTIVE]`           |
+| Path             | Input                                      | Output                                  |
+| ---------------- | ------------------------------------------ | --------------------------------------- |
+| Memory evolution | Daily memory under `memory/`               | Durable knowledge in `digest/`          |
+| `/proactive`     | Recent chat sessions + optional screenshot | One message prefixed with `[PROACTIVE]` |
 
-`/proactive` does **not** read `digest/` or `interests.yaml` today. See “Current boundary” at the end of this page.
+`/proactive` does **not** read `digest/` today. See “Current boundary” at the end of this page.
 
 <p align="center">
   <img src="https://img.alicdn.com/imgextra/i3/O1CN01mG5Uot1GQdX33v4h4_!!6000000000617-55-tps-1200-640.svg" alt="QwenPaw long-term memory from capture and consolidation to retrieval and discovery" />
@@ -85,25 +85,9 @@ Auto-Dream does not re-read all of `memory/` every day:
 
 That is why long-term memory can be corrected indefinitely without losing history: conclusions are mutable, the record of the moment is not.
 
-### Interest topics, produced along the way
+### Auto-Dream and proactive mode remain separate
 
-While consolidating durable nodes, Auto-Dream also picks a small set of non-repetitive interest topics from recent evidence — up to three by default — and writes them to `memory/<date>/interests.yaml`:
-
-```yaml
-- title: Verify the emergency rollback path
-  reason: The hotfix exception was added, but the follow-up checks are not yet documented.
-  evidence:
-    - Emergency staging bypass discussed in the hotfix retrospective.
-  keywords: [hotfix, rollback, release]
-  paths:
-    - memory/2026-08-20/hotfix-retrospective.md
-```
-
-Each topic carries a reason, evidence, keywords, and relevant paths — so it does not just claim “you may care about X,” it can also explain why. Generation also checks the topics produced over the last seven days to avoid suggesting the same thing every day. ReMe exposes a low-level `proactive` job that reads this file for other integrations; a missing file returns a normal skipped result rather than an error.
-
-<p align="center">
-  <img src="https://img.alicdn.com/imgextra/i1/O1CN01ddkg0rN9DXK49o5c_!!6000000001181-0-tps-2048-796.jpg" alt="Auto-Dream integration results and interest-topic summary" />
-</p>
+Auto-Dream only consolidates daily memory into durable `digest/` nodes. It no longer generates `interests.yaml`. QwenPaw's `/proactive` mode continues to derive possible next steps from recent sessions and optional screen context; it does not depend on Auto-Dream output.
 
 ---
 

--- a/website/public/docs/memory-evolving-and-proactive.zh.md
+++ b/website/public/docs/memory-evolving-and-proactive.zh.md
@@ -4,12 +4,12 @@
 
 QwenPaw 里有两条相关但目前**各自独立**的链路：
 
-| 链路         | 数据来源                    | 产出                                  |
-| ------------ | --------------------------- | ------------------------------------- |
-| 记忆自进化   | `memory/` 每日记忆          | `digest/` 长期知识 + `interests.yaml` |
-| `/proactive` | 近期聊天会话 + 可选桌面截图 | 一条以 `[PROACTIVE]` 开头的主动消息   |
+| 链路         | 数据来源                    | 产出                                |
+| ------------ | --------------------------- | ----------------------------------- |
+| 记忆自进化   | `memory/` 每日记忆          | `digest/` 长期知识                  |
+| `/proactive` | 近期聊天会话 + 可选桌面截图 | 一条以 `[PROACTIVE]` 开头的主动消息 |
 
-`/proactive` 目前**不读取** `digest/` 和 `interests.yaml`。这一点在文末「当前边界」中会再说明。
+`/proactive` 目前**不读取** `digest/`。这一点在文末「当前边界」中会再说明。
 
 <p align="center">
   <img src="https://img.alicdn.com/imgextra/i3/O1CN01mG5Uot1GQdX33v4h4_!!6000000000617-55-tps-1200-640.svg" alt="QwenPaw 长期记忆从捕获、整理到检索与发现的全景" />
@@ -85,25 +85,9 @@ Auto-Dream 不会每天从头重读整个 `memory/`：
 
 这也是为什么长期记忆可以一直修正而不丢历史：结论可变，现场不可变。
 
-### 顺手产出的兴趣主题
+### Auto-Dream 与主动交互仍是独立链路
 
-整合长期节点时，Auto-Dream 还会从近期证据里挑出少量、互不重复的兴趣主题，默认最多 3 个，写入 `memory/<date>/interests.yaml`：
-
-```yaml
-- title: 验证紧急回滚流程
-  reason: 已增加 hotfix 例外，但尚未记录事后补做的检查。
-  evidence:
-    - hotfix 复盘中讨论了跳过 staging 的情况。
-  keywords: [hotfix, rollback, release]
-  paths:
-    - memory/2026-08-20/hotfix-retrospective.md
-```
-
-每个主题都带上原因、证据、关键词和相关路径——也就是说，它不只说“你可能关心 X”，还能说清“我为什么这么认为”。生成时会参考近 7 天已经出过的主题做去重，避免天天推荐同一件事。ReMe 提供一个底层 `proactive` job 读取该文件，供其他集成消费；文件不存在时返回 skipped，不会报错。
-
-<p align="center">
-  <img src="https://img.alicdn.com/imgextra/i1/O1CN01ddkg0rN9DXK49o5c_!!6000000001181-0-tps-2048-796.jpg" alt="Auto-Dream 的整合结果与兴趣主题摘要" />
-</p>
+Auto-Dream 只负责将每日记忆整合为 `digest/` 中的长期节点，不再生成 `interests.yaml`。QwenPaw 的 `/proactive` mode 仍然根据近期会话和可选的屏幕上下文推断可能的下一步，不依赖 Auto-Dream 的产出。
 
 ---
 

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -269,7 +269,7 @@ Each durable node also uses contextual Wikilinks in `## Sources` to point back t
   <img src="https://img.alicdn.com/imgextra/i1/O1CN01ddkg0rN9DXK49o5c_!!6000000001181-0-tps-2048-796.jpg" alt="Auto-Dream run summary delivered to Inbox" />
 </p>
 
-Auto-Dream also writes `interests.yaml`. This is separate from QwenPaw's current `/proactive` mode; `/proactive` does not currently read that file.
+Auto-Dream only consolidates daily memory into durable `digest/` nodes. QwenPaw's current `/proactive` mode is a separate workflow driven by recent sessions and optional screen context.
 
 ### 5. Memory Search Recalls the Right Evidence
 

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -244,7 +244,7 @@ Auto-Link 是 Auto-Dream 构建文档图谱的关键。它不是等整理结束�
   <img src="https://img.alicdn.com/imgextra/i1/O1CN01ddkg0rN9DXK49o5c_!!6000000001181-0-tps-2048-796.jpg" alt="Auto-Dream 完成后推送到 Inbox 的任务摘要" />
 </p>
 
-Auto-Dream 还会生成 `interests.yaml`。它与 QwenPaw 当前的 `/proactive` mode 是独立能力；当前 `/proactive` 不读取该文件。
+Auto-Dream 只负责将每日记忆整合为 `digest/` 中的长期节点。QwenPaw 当前的 `/proactive` mode 是一条独立链路，依据近期会话和可选的屏幕上下文工作。
 
 ### 5. Memory Search 在需要时找回正确的记忆
 


### PR DESCRIPTION
## Summary

- remove the deprecated Auto-Dream topic extraction step and arguments deleted by agentscope-ai/ReMe#488
- keep QwenPaw proactive mode independent; do not enable the new ReMe proactive refresh pipeline
- update English and Chinese memory docs to reflect that Auto-Dream now only consolidates durable digest nodes
- add a regression test for the embedded Auto-Dream job contract

## Versioning

`reme-ai==0.4.1.12` is not published yet, so this PR intentionally keeps the existing `0.4.1.11` dependency and lockfile. The reduced Auto-Dream chain works with 0.4.1.11 and validates against the ReMe PR #488 source. The dependency pin and lockfile can be updated after 0.4.1.12 is available on PyPI.

## Validation

- `uv run pytest tests/unit/agents/memory/test_reme_config.py tests/unit/agents/memory/test_reme_inbox_notifications.py tests/unit/agents/test_command_handler.py -q` (57 passed)
- focused `pre-commit` checks for all changed files
- Prettier check for the four changed documentation files
- ReMe PR #488 registry check for all configured Auto-Dream steps
- ReMe PR #488 `ApplicationConfig.model_validate` check for the embedded QwenPaw config