### PR TITLE
feat(skills): expose versions and validate declared dependencies

### DIFF
--- a/console/src/api/types/skill.ts
+++ b/console/src/api/types/skill.ts
@@ -8,6 +8,7 @@ export type SkillSyncStatus =
 export interface SkillSpec {
   name: string;
   description?: string;
+  version_text?: string;
   source: string;
   enabled?: boolean;
   channels?: string[];
@@ -21,11 +22,19 @@ export interface SkillDetail extends SkillSpec {
   content: string;
   config?: Record<string, unknown>;
   installed_from?: string;
+  requirements?: SkillRequirements;
+}
+
+export interface SkillRequirements {
+  require_bins: string[];
+  require_envs: string[];
+  require_mcps: string[];
 }
 
 export interface PoolSkillSpec {
   name: string;
   description?: string;
+  version_text?: string;
   source: string;
   external?: boolean;
   external_path?: string;
@@ -41,6 +50,7 @@ export interface PoolSkillDetail extends PoolSkillSpec {
   content: string;
   config?: Record<string, unknown>;
   installed_from?: string;
+  requirements?: SkillRequirements;
   builtin_language?: string;
   available_builtin_languages?: string[];
   auto_sync_targets?: string[] | null;

--- a/console/src/components/SkillConfigEditor.module.less
+++ b/console/src/components/SkillConfigEditor.module.less
@@ -1,0 +1,6 @@
+.editor {
+  textarea::placeholder {
+    color: var(--ant-color-text-placeholder, #a3a3a3);
+    opacity: 1;
+  }
+}

--- a/console/src/components/SkillConfigEditor.tsx
+++ b/console/src/components/SkillConfigEditor.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@agentscope-ai/design";
+import { useTranslation } from "react-i18next";
+import type { SkillRequirements } from "../api/types/skill";
+import styles from "./SkillConfigEditor.module.less";
+
+interface SkillConfigEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  requirements?: SkillRequirements;
+}
+
+export function SkillConfigEditor({
+  value,
+  onChange,
+  requirements,
+}: SkillConfigEditorProps) {
+  const { t } = useTranslation();
+  const envs = requirements?.require_envs;
+  const placeholder = envs?.length
+    ? JSON.stringify(
+        Object.fromEntries(envs.map((name) => [name, "..."])),
+        null,
+        2,
+      )
+    : "";
+
+  return (
+    <div className={styles.editor}>
+      <Input.TextArea
+        aria-label={t("skills.config")}
+        rows={4}
+        value={value.trim() === "{}" ? "" : value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/console/src/pages/Agent/Skills/components/SkillCard.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillCard.tsx
@@ -231,6 +231,13 @@ export const SkillCard = React.memo(function SkillCard({
         </Tooltip>
       </div>
 
+      {skill.version_text && (
+        <div className={styles.metaInfoRow}>
+          <span className={styles.metaInfoLabel}>{t("skillPool.version")}</span>
+          <span className={styles.metaInfoValue}>{skill.version_text}</span>
+        </div>
+      )}
+
       {/* Channels row */}
       <div className={styles.metaInfoRow}>
         <span className={styles.metaInfoLabel}>{t("skills.channels")}</span>

--- a/console/src/pages/Agent/Skills/components/SkillDrawer.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillDrawer.tsx
@@ -13,6 +13,7 @@ import { ThunderboltOutlined, StopOutlined } from "@ant-design/icons";
 import type { FormInstance } from "antd";
 import type { SkillDetail } from "../../../../api/types";
 import { MarkdownCopy } from "../../../../components/MarkdownCopy/MarkdownCopy";
+import { SkillConfigEditor } from "../../../../components/SkillConfigEditor";
 import { api } from "../../../../api";
 import { deriveInstalledFromLabel } from "../../../../utils/skill";
 
@@ -376,14 +377,13 @@ export function SkillDrawer({
             validateStatus={configError ? "error" : undefined}
             help={configError || undefined}
           >
-            <Input.TextArea
-              rows={4}
+            <SkillConfigEditor
               value={configText}
-              onChange={(e) => {
-                setConfigText(e.target.value);
+              onChange={(value) => {
+                setConfigText(value);
                 setConfigError("");
               }}
-              placeholder={t("skills.configPlaceholder")}
+              requirements={editing ? editingSkill?.requirements : undefined}
             />
           </Form.Item>
 

--- a/console/src/pages/Agent/Skills/components/SkillListItem.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillListItem.tsx
@@ -63,6 +63,11 @@ export function SkillListItem({
             <span className={styles.typeBadge}>
               {isBuiltin ? t("skills.builtin") : t("skills.custom")}
             </span>
+            {skill.version_text && (
+              <span className={styles.typeBadge}>
+                {t("skillPool.version")}: {skill.version_text}
+              </span>
+            )}
             {skill.preload && (
               <span className={styles.preloadListTag}>
                 {t("skills.preload")}

--- a/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
@@ -149,6 +149,13 @@ export function PoolSkillCard({
         </Tooltip>
       </div>
 
+      {skill.version_text && (
+        <div className={styles.metaInfoRow}>
+          <span className={styles.metaInfoLabel}>{t("skillPool.version")}</span>
+          <span className={styles.metaInfoValue}>{skill.version_text}</span>
+        </div>
+      )}
+
       {/* Updated row */}
       {skill.last_updated && (
         <div className={styles.metaInfoRow}>

--- a/console/src/pages/Settings/SkillPool/components/PoolSkillDrawer.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillDrawer.tsx
@@ -20,6 +20,7 @@ import {
 import { getAgentDisplayName } from "../../../../utils/agentDisplayName";
 import { MAX_TAGS, MAX_TAG_LENGTH } from "../../../Agent/Skills/components";
 import { MarkdownCopy } from "../../../../components/MarkdownCopy/MarkdownCopy";
+import { SkillConfigEditor } from "../../../../components/SkillConfigEditor";
 import type { PoolMode } from "../useSkillPool";
 import styles from "../index.module.less";
 
@@ -301,13 +302,12 @@ export function PoolSkillDrawer({
             </Form.Item>
 
             <Form.Item label={t("skills.config")}>
-              <Input.TextArea
-                rows={4}
+              <SkillConfigEditor
                 value={configText}
-                onChange={(e) => {
-                  onConfigTextChange(e.target.value);
-                }}
-                placeholder={t("skills.configPlaceholder")}
+                onChange={onConfigTextChange}
+                requirements={
+                  mode === "edit" ? activeSkill?.requirements : undefined
+                }
               />
             </Form.Item>
           </Form>

--- a/console/src/pages/Settings/SkillPool/components/PoolSkillListItem.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillListItem.tsx
@@ -83,6 +83,11 @@ export function PoolSkillListItem({
             {isBuiltin && (
               <span className={styles.typeBadge}>{t("skillPool.builtin")}</span>
             )}
+            {skill.version_text && (
+              <span className={styles.typeBadge}>
+                {t("skillPool.version")}: {skill.version_text}
+              </span>
+            )}
             {automationLabel && (
               <span className={styles.automationTag}>{automationLabel}</span>
             )}

--- a/src/qwenpaw/agents/skill_system/models.py
+++ b/src/qwenpaw/agents/skill_system/models.py
@@ -68,6 +68,7 @@ class SkillRequirements(BaseModel):
 
     require_bins: list[str] = Field(default_factory=list)
     require_envs: list[str] = Field(default_factory=list)
+    require_mcps: list[str] = Field(default_factory=list)
 
 
 __all__ = [

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -25,6 +25,7 @@ from ...drivers.errors import DriverCardError
 from ...drivers.storage import card_paths_for_name, load_card
 from ...exceptions import SkillsError
 from ...utils.file_snapshot_cache import FileSignature
+from ...utils.shell_normalization import shell_execution_path
 from ..utils.file_handling import (
     read_text_file_with_encoding_fallback,
     single_line_log_value,
@@ -1231,8 +1232,9 @@ def check_skill_dependencies(
         if not env.get(_skill_env_key(env_name)):
             missing.append(f"Environment variable not set: {env_name}")
 
+    search_path = shell_execution_path(env.get("PATH"))
     for binary in requirements.require_bins:
-        if shutil.which(binary, path=env.get("PATH")) is None:
+        if shutil.which(binary, path=search_path) is None:
             missing.append(f"CLI binary not found on PATH: {binary}")
 
     if workspace_dir is not None:

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -1215,6 +1215,11 @@ def list_workspaces() -> list[dict[str, str]]:
     return workspaces
 
 
+def _skill_env_key(key: str) -> str:
+    """Preserve platform env-key semantics in dependency-check snapshots."""
+    return key.upper() if os.name == "nt" else key
+
+
 def check_skill_dependencies(
     requirements: SkillRequirements,
     env: Mapping[str, str],
@@ -1223,7 +1228,7 @@ def check_skill_dependencies(
     """Return unmet prerequisites without logging or starting processes."""
     missing = []
     for env_name in requirements.require_envs:
-        if not env.get(env_name):
+        if not env.get(_skill_env_key(env_name)):
             missing.append(f"Environment variable not set: {env_name}")
 
     for binary in requirements.require_bins:
@@ -1277,7 +1282,10 @@ def resolve_effective_skills(
             post = load_skill_frontmatter_from_dir(skill_dir)
             requirements, errors = parse_skill_requirements(post)
             if not errors:
-                env = dict(os.environ)
+                env = {
+                    _skill_env_key(key): value
+                    for key, value in os.environ.items()
+                }
                 config = entry.get("config") or {}
                 if isinstance(config, dict) and config:
                     overrides = _build_skill_config_env_overrides(
@@ -1287,7 +1295,7 @@ def resolve_effective_skills(
                     )
                     for key, value in overrides.items():
                         # Runtime also preserves existing empty values.
-                        env.setdefault(key, value)
+                        env.setdefault(_skill_env_key(key), value)
                 errors = check_skill_dependencies(
                     requirements,
                     env,

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -15,18 +15,24 @@ import tempfile
 import threading
 import weakref
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ...drivers.errors import DriverCardError
+from ...drivers.storage import card_paths_for_name, load_card
 from ...exceptions import SkillsError
 from ...utils.file_snapshot_cache import FileSignature
-from ..utils.file_handling import read_text_file_with_encoding_fallback
+from ..utils.file_handling import (
+    read_text_file_with_encoding_fallback,
+    single_line_log_value,
+)
 from .models import (
     BuiltinSkillIdentity,
     BuiltinSkillVariant,
+    SkillRequirements,
 )
 from .store import (
     build_skill_metadata,
@@ -44,9 +50,11 @@ from .store import (
     is_ignored_skill_entry,
     is_pool_builtin_entry,
     is_primary_pool_skill_dir,
+    load_skill_frontmatter_from_dir,
     mutate_json,
     mutate_pool_manifest,
     normalize_skill_manifest_entry,
+    parse_skill_requirements,
     read_frontmatter_safe_from_path,
     read_pool_skill_automation,
     read_skill_manifest,
@@ -320,7 +328,6 @@ def _build_skill_config_env_overrides(
     Config keys that match a declared ``require_envs`` entry are
     injected as environment variables.  Keys not in ``require_envs``
     are silently skipped (still available via the full JSON var).
-    Missing required keys are logged as warnings.
     """
     overrides: dict[str, str] = {}
 
@@ -337,15 +344,6 @@ def _build_skill_config_env_overrides(
         if value in (None, ""):
             continue
         overrides[key] = _stringify_skill_env_value(value)
-
-    for env_name in normalized_required_envs:
-        if env_name not in overrides:
-            logger.warning(
-                "Skill '%s' requires env '%s' but config does "
-                "not provide it",
-                skill_name,
-                env_name,
-            )
 
     overrides[_skill_config_env_var_name(skill_name)] = json.dumps(
         config,
@@ -1217,21 +1215,96 @@ def list_workspaces() -> list[dict[str, str]]:
     return workspaces
 
 
+def check_skill_dependencies(
+    requirements: SkillRequirements,
+    env: Mapping[str, str],
+    workspace_dir: Path | None,
+) -> list[str]:
+    """Return unmet prerequisites without logging or starting processes."""
+    missing = []
+    for env_name in requirements.require_envs:
+        if not env.get(env_name):
+            missing.append(f"Environment variable not set: {env_name}")
+
+    for binary in requirements.require_bins:
+        if shutil.which(binary, path=env.get("PATH")) is None:
+            missing.append(f"CLI binary not found on PATH: {binary}")
+
+    if workspace_dir is not None:
+        for name in requirements.require_mcps:
+            try:
+                paths = card_paths_for_name(workspace_dir / "drivers", name)
+                if not paths:
+                    missing.append(f"MCP server not configured: {name}")
+                    continue
+                card = load_card(paths[0])
+                if card.name != name or card.protocol != "mcp":
+                    missing.append(
+                        f"MCP server configuration is invalid: {name}",
+                    )
+                elif not card.enabled:
+                    missing.append(f"MCP server is disabled: {name}")
+            except (DriverCardError, UnicodeError):
+                missing.append(
+                    f"MCP server configuration is invalid: {name}",
+                )
+    return missing
+
+
 def resolve_effective_skills(
     workspace_dir: Path,
     channel_name: str,
 ) -> list[str]:
-    """Resolve enabled workspace skills for one channel."""
+    """Resolve enabled skills whose declared prerequisites are satisfied.
+
+    Unavailable skills keep their enabled state and are reconsidered on
+    the next resolution.
+    """
     manifest = read_skill_manifest(workspace_dir)
+    skills_dir = get_workspace_skills_dir(workspace_dir)
     resolved = []
     for skill_name, entry in sorted(manifest.get("skills", {}).items()):
         if not entry.get("enabled", False):
             continue
         channels = entry.get("channels") or ["all"]
-        if "all" in channels or channel_name in channels:
-            skill_dir = get_workspace_skills_dir(workspace_dir) / skill_name
-            if skill_dir.exists():
-                resolved.append(skill_name)
+        if "all" not in channels and channel_name not in channels:
+            continue
+        skill_dir = skills_dir / skill_name
+        if not skill_dir.exists():
+            continue
+        try:
+            # The manifest retains valid fields but not declaration errors.
+            post = load_skill_frontmatter_from_dir(skill_dir)
+            requirements, errors = parse_skill_requirements(post)
+            if not errors:
+                env = dict(os.environ)
+                config = entry.get("config") or {}
+                if isinstance(config, dict) and config:
+                    overrides = _build_skill_config_env_overrides(
+                        skill_name,
+                        config,
+                        requirements.require_envs,
+                    )
+                    for key, value in overrides.items():
+                        # Runtime also preserves existing empty values.
+                        env.setdefault(key, value)
+                errors = check_skill_dependencies(
+                    requirements,
+                    env,
+                    workspace_dir,
+                )
+        except Exception as exc:
+            # Isolate inspection failures at the single-skill boundary.
+            errors = [str(exc)]
+        if errors:
+            logger.error(
+                "Skipping skill '%s' in workspace %s: %s",
+                single_line_log_value(skill_name),
+                single_line_log_value(workspace_dir),
+                single_line_log_value("; ".join(errors)),
+            )
+            continue
+        resolved.append(skill_name)
     return resolved
 
 

--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -269,64 +269,47 @@ def _read_bounded_frontmatter_bytes(skill_md: Path) -> bytes | None:
     return raw_frontmatter
 
 
-def read_skill_frontmatter_from_dir(
-    skill_dir: Path,
-    skill_name: str = "",
-) -> dict[str, Any]:
-    """Read only the YAML header of ``SKILL.md`` with encoding fallback."""
-    if not skill_name:
-        skill_name = skill_dir.name
+def load_skill_frontmatter_from_dir(skill_dir: Path) -> dict[str, Any]:
+    """Read the bounded YAML header, preserving read and parse failures."""
     skill_md = skill_dir / "SKILL.md"
-    fallback = {"name": skill_name, "description": ""}
-
-    try:
-        raw_frontmatter = _read_bounded_frontmatter_bytes(skill_md)
-    except OSError as exc:
-        logger.warning(
-            "Failed to read SKILL frontmatter for '%s' at %s: %s. "
-            "Using fallback values.",
-            single_line_log_value(skill_name),
-            single_line_log_value(skill_md),
-            single_line_log_value(exc),
-        )
-        return fallback
-
+    raw_frontmatter = _read_bounded_frontmatter_bytes(skill_md)
     if raw_frontmatter is None:
-        return fallback
+        raise SkillsError(
+            "SKILL.md is missing a bounded YAML frontmatter header",
+        )
 
-    metadata: dict[str, Any] | None = None
-    parse_error: Exception | None = None
     for encoding in _FRONTMATTER_ENCODINGS:
         try:
             text = raw_frontmatter.decode(encoding)
             post = frontmatter.loads(text)
-            metadata = dict(post.metadata)
-            break
+            return dict(post.metadata)
         except UnicodeDecodeError:
             continue
         except (LookupError, yaml.YAMLError, TypeError, ValueError) as exc:
-            parse_error = exc
-            break
+            raise SkillsError(
+                f"SKILL.md frontmatter is invalid: {exc}",
+            ) from exc
+    raise SkillsError("Failed to decode SKILL.md frontmatter")
 
-    if metadata is not None:
-        return metadata
 
-    if parse_error is not None:
+def read_skill_frontmatter_from_dir(
+    skill_dir: Path,
+    skill_name: str = "",
+) -> dict[str, Any]:
+    """Read the YAML header with fallback values for metadata display."""
+    if not skill_name:
+        skill_name = skill_dir.name
+    try:
+        return load_skill_frontmatter_from_dir(skill_dir)
+    except (OSError, SkillsError) as exc:
         logger.warning(
-            "Failed to parse SKILL frontmatter for '%s' at %s: %s. "
+            "Failed to read SKILL frontmatter for '%s' at %s: %s. "
             "Using fallback values.",
             single_line_log_value(skill_name),
-            single_line_log_value(skill_md),
-            single_line_log_value(parse_error),
+            single_line_log_value(skill_dir / "SKILL.md"),
+            single_line_log_value(exc),
         )
-    else:
-        logger.warning(
-            "Failed to decode SKILL frontmatter for '%s' at %s. "
-            "Using fallback values.",
-            single_line_log_value(skill_name),
-            single_line_log_value(skill_md),
-        )
-    return fallback
+        return {"name": skill_name, "description": ""}
 
 
 def get_skill_mtime(skill_dir: Path) -> str:
@@ -880,8 +863,10 @@ def _resolve_skill_name(skill_dir: Path) -> str:
     return skill_dir.name
 
 
-def _extract_requirements(post: dict[str, Any]) -> SkillRequirements:
-    """Extract requirements from a parsed frontmatter dict."""
+def parse_skill_requirements(
+    post: dict[str, Any],
+) -> tuple[SkillRequirements, list[str]]:
+    """Return valid requirement fields and all declaration errors."""
     metadata = post.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
@@ -899,27 +884,37 @@ def _extract_requirements(post: dict[str, Any]) -> SkillRequirements:
             post.get("requires", {}),
         )
 
-    try:
-        if isinstance(requires, list):
-            return SkillRequirements(
-                require_bins=list(requires),
-                require_envs=[],
+    if isinstance(requires, list):
+        requires = {"bins": requires}
+
+    if not isinstance(requires, dict):
+        return SkillRequirements(), [
+            "requires must be a mapping or a list of binaries",
+        ]
+
+    normalized = {}
+    errors = []
+    for key in ("bins", "env", "mcp"):
+        values = requires.get(key, [])
+        if not isinstance(values, list) or any(
+            not isinstance(value, str) or not value.strip() for value in values
+        ):
+            errors.append(
+                f"requires.{key} must be a list of non-empty strings",
             )
-
-        if not isinstance(requires, dict):
-            return SkillRequirements()
-
-        return SkillRequirements(
-            require_bins=list(requires.get("bins", [])),
-            require_envs=list(requires.get("env", [])),
+            values = []
+        normalized[key] = list(
+            dict.fromkeys(value.strip() for value in values),
         )
-    except Exception as e:
-        logger.warning(
-            "Failed to parse skill requirements: %s. "
-            "Falling back to empty requirements.",
-            e,
-        )
-        return SkillRequirements()
+
+    return (
+        SkillRequirements(
+            require_bins=normalized["bins"],
+            require_envs=normalized["env"],
+            require_mcps=normalized["mcp"],
+        ),
+        errors,
+    )
 
 
 def build_skill_metadata(
@@ -953,7 +948,13 @@ def _build_skill_metadata_from_post(
     source: str,
     protected: bool = False,
 ) -> dict[str, Any]:
-    requirements = _extract_requirements(post)
+    requirements, errors = parse_skill_requirements(post)
+    for error in errors:
+        logger.warning(
+            "Ignoring invalid requirements in skill '%s': %s",
+            single_line_log_value(skill_name),
+            error,
+        )
     return {
         "name": skill_name,
         "description": str(post.get("description", "") or ""),

--- a/src/qwenpaw/agents/skills/mailbox-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/mailbox-en/SKILL.md
@@ -2,11 +2,11 @@
 name: mailbox
 description: "Use this skill whenever the user needs ANY mailbox/email operation — checking, reading, searching, sending, replying, forwarding, organizing or deleting email, managing threads, connecting a personal mailbox, or registering a new mailbox. This skill is the single entry point for email tasks and orchestrates qwenpawmail-mcp for nine supported personal-mail domains."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "📧"
     requires:
-      mcp: ["qwenpawmail-mcp"]
+      mcp: ["qwenpawmail"]
 ---
 
 # Mailbox Operations (qwenpawmail-mcp)

--- a/src/qwenpaw/agents/skills/mailbox-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/mailbox-zh/SKILL.md
@@ -2,11 +2,11 @@
 name: mailbox
 description: "当用户需要任何邮箱/邮件操作时使用此技能——包括查看、阅读、搜索、发送、回复、转发、整理或删除邮件，管理会话线程，绑定个人邮箱或注册新邮箱。此技能是邮件任务的统一且唯一入口，通过 qwenpawmail-mcp 编排操作，当前支持 9 个个人邮箱域名。"
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "📧"
     requires:
-      mcp: ["qwenpawmail-mcp"]
+      mcp: ["qwenpawmail"]
 ---
 
 # 邮箱操作 (qwenpawmail-mcp)

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -31,7 +31,10 @@ from ...runtime.tool_registry import tool_descriptor
 from ...sandbox import ExecutionResult
 from ...sandbox.config import SandboxConfig
 from ...utils.io_utils import run_sync_io
-from ...utils.shell_normalization import normalize_posix_line_continuations
+from ...utils.shell_normalization import (
+    normalize_posix_line_continuations,
+    shell_execution_path,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -1340,12 +1343,7 @@ async def execute_shell_command(
 
     # Ensure the venv Python is on PATH for subprocesses
     env = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    existing_path = env.get("PATH", "")
-    if existing_path:
-        env["PATH"] = python_bin_dir + os.pathsep + existing_path
-    else:
-        env["PATH"] = python_bin_dir
+    env["PATH"] = shell_execution_path(env.get("PATH"))
 
     if sandbox_config is not None and not isinstance(
         sandbox_config,

--- a/src/qwenpaw/app/routers/skills.py
+++ b/src/qwenpaw/app/routers/skills.py
@@ -46,6 +46,7 @@ from ...agents.skill_system.registry import (
     reconcile_workspace_manifest,
     update_single_builtin,
 )
+from ...agents.skill_system.models import SkillRequirements
 from ...agents.skill_system.store import (
     build_skill_metadata,
     default_workspace_manifest,
@@ -249,6 +250,7 @@ class SkillSpec(BaseModel):
 
     name: str
     description: str = ""
+    version_text: str = ""
     source: str
     emoji: str = ""
     enabled: bool = False
@@ -264,6 +266,7 @@ class SkillDetail(SkillSpec):
     content: str
     config: dict[str, Any] = Field(default_factory=dict)
     installed_from: str = ""
+    requirements: SkillRequirements = Field(default_factory=SkillRequirements)
 
 
 class PoolSkillSpec(BaseModel):
@@ -271,6 +274,7 @@ class PoolSkillSpec(BaseModel):
 
     name: str
     description: str = ""
+    version_text: str = ""
     source: str
     emoji: str = ""
     external: bool = False
@@ -288,6 +292,7 @@ class PoolSkillDetail(PoolSkillSpec):
     content: str
     config: dict[str, Any] = Field(default_factory=dict)
     installed_from: str = ""
+    requirements: SkillRequirements = Field(default_factory=SkillRequirements)
     builtin_language: str = ""
     available_builtin_languages: list[str] = Field(default_factory=list)
     auto_sync_targets: list[str] | None = None
@@ -737,6 +742,7 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
                 SkillSpec(
                     name=skill_name,
                     description=str(metadata.get("description", "") or ""),
+                    version_text=metadata["version_text"],
                     source=source,
                     emoji=str(metadata.get("emoji", "") or ""),
                     enabled=entry.get("enabled", False),
@@ -784,6 +790,7 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
                 PoolSkillSpec(
                     name=skill_name,
                     description=str(metadata.get("description", "") or ""),
+                    version_text=metadata["version_text"],
                     source=source,
                     emoji=str(metadata.get("emoji", "") or ""),
                     external=is_external,
@@ -834,6 +841,8 @@ def _build_workspace_skill_detail(
     return SkillDetail(
         name=skill_name,
         description=str(metadata.get("description", "") or ""),
+        version_text=metadata["version_text"],
+        requirements=SkillRequirements(**metadata["requirements"]),
         source=source,
         emoji=str(metadata.get("emoji", "") or ""),
         enabled=bool(entry.get("enabled", False)),
@@ -875,6 +884,8 @@ def _build_pool_skill_detail(skill_name: str) -> PoolSkillDetail | None:
     return PoolSkillDetail(
         name=skill_name,
         description=str(metadata.get("description", "") or ""),
+        version_text=metadata["version_text"],
+        requirements=SkillRequirements(**metadata["requirements"]),
         source=source,
         emoji=str(metadata.get("emoji", "") or ""),
         external=is_external,

--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -40,7 +40,7 @@ from ..agents.skill_system.hub import (
 from ..agents.utils.file_handling import read_text_file_with_encoding_fallback
 from ..config import load_config
 from ..envs import load_envs
-from ..envs.store import _PROTECTED_BOOTSTRAP_KEYS
+from ..envs.registry import is_bootstrap_protected_env_key
 from ..exceptions import SkillsError
 from ..security.skill_scanner import SkillScanError, scan_skill_directory
 from .http import client, resolve_base_url
@@ -188,7 +188,7 @@ def _get_skill_test_env(
     configured_envs = {
         name: value
         for name, value in load_envs().items()
-        if name not in _PROTECTED_BOOTSTRAP_KEYS
+        if not is_bootstrap_protected_env_key(name)
     }
     env = {**configured_envs, **env}
     if (

--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 
 import click
+import frontmatter
+import httpx
 
 from ..agents.skill_system import (
     SkillConflictError,
@@ -19,7 +22,16 @@ from ..agents.skill_system import (
     reconcile_workspace_manifest,
     resolve_pool_skill_dir,
 )
-from ..agents.skill_system.store import validate_skill_content
+from ..agents.skill_system.models import SkillRequirements
+from ..agents.skill_system.registry import (
+    _build_skill_config_env_overrides,
+    check_skill_dependencies,
+)
+from ..agents.skill_system.store import (
+    normalize_skill_manifest_entry,
+    parse_skill_requirements,
+    validate_skill_content,
+)
 from ..agents.skill_system.hub import (
     aclose_hub_client,
     import_pool_skill_from_hub,
@@ -27,8 +39,11 @@ from ..agents.skill_system.hub import (
 )
 from ..agents.utils.file_handling import read_text_file_with_encoding_fallback
 from ..config import load_config
+from ..envs import load_envs
+from ..envs.store import _PROTECTED_BOOTSTRAP_KEYS
 from ..exceptions import SkillsError
 from ..security.skill_scanner import SkillScanError, scan_skill_directory
+from .http import client, resolve_base_url
 from .utils import prompt_checkbox, prompt_confirm
 
 
@@ -101,8 +116,8 @@ def _print_skill_changes(
         )
 
 
-def _validate_skill_frontmatter(skill_dir: Path) -> None:
-    """Validate required skill metadata."""
+def _validate_skill_frontmatter(skill_dir: Path) -> SkillRequirements:
+    """Validate skill metadata and the supported dependency declarations."""
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.is_file():
         raise click.ClickException(f"Missing SKILL.md: {skill_md}")
@@ -110,12 +125,21 @@ def _validate_skill_frontmatter(skill_dir: Path) -> None:
     content = read_text_file_with_encoding_fallback(skill_md)
     try:
         validate_skill_content(content)
+        requirements, errors = parse_skill_requirements(
+            dict(frontmatter.loads(content).metadata),
+        )
     except SkillsError as exc:
         raise click.ClickException(str(exc))
     except Exception as exc:
         raise click.ClickException(
             f"SKILL.md frontmatter is invalid: {exc}",
         ) from exc
+
+    if errors:
+        raise click.ClickException(
+            "SKILL.md frontmatter is invalid:\n  - " + "\n  - ".join(errors),
+        )
+    return requirements
 
 
 def _resolve_scope(
@@ -154,13 +178,122 @@ def _resolve_skill_test_dir(
     return get_workspace_skills_dir(working_dir) / skill
 
 
-def _run_skill_test(skill_dir: Path) -> str:
+def _get_skill_test_env(
+    skill_dir: Path,
+    require_envs: list[str],
+    workspace_dir: Path | None,
+) -> dict[str, str]:
+    """Resolve local skill env without mutating the process environment."""
+    env = dict(os.environ)
+    configured_envs = {
+        name: value
+        for name, value in load_envs().items()
+        if name not in _PROTECTED_BOOTSTRAP_KEYS
+    }
+    env = {**configured_envs, **env}
+    if (
+        not require_envs
+        or workspace_dir is None
+        or skill_dir.resolve()
+        != (get_workspace_skills_dir(workspace_dir) / skill_dir.name).resolve()
+    ):
+        return env
+
+    entries = read_skill_manifest(workspace_dir).get("skills", {})
+    entry = normalize_skill_manifest_entry(entries.get(skill_dir.name))
+    skill_config = entry.get("config") or {}
+    if isinstance(skill_config, dict) and skill_config:
+        overrides = _build_skill_config_env_overrides(
+            skill_dir.name,
+            skill_config,
+            require_envs,
+        )
+        for key, value in overrides.items():
+            # Runtime injection also preserves existing values, even empty.
+            env.setdefault(key, value)
+    return env
+
+
+def _validate_skill_dependencies(
+    skill_dir: Path,
+    requirements: SkillRequirements,
+    workspace_dir: Path | None,
+) -> None:
+    """Check local prerequisites without executing binaries or MCP calls."""
+    env = _get_skill_test_env(
+        skill_dir,
+        requirements.require_envs,
+        workspace_dir,
+    )
+    missing = check_skill_dependencies(requirements, env, workspace_dir)
+
+    if requirements.require_mcps and workspace_dir is not None:
+        click.echo(
+            "MCP checks cover configuration only, "
+            "not connectivity or tool access.",
+        )
+
+    if missing:
+        raise click.ClickException(
+            "Declared dependencies are not satisfied:\n  - "
+            + "\n  - ".join(missing),
+        )
+
+
+def _warn_skill_command_conflict(
+    skill_name: str,
+    agent_id: str,
+    base_url: str,
+) -> None:
+    """Inspect the live registry, with a built-in-only check when offline."""
+    try:
+        with client(base_url) as http:
+            response = http.get(
+                "/workspace/commands/available",
+                headers={"X-Agent-Id": agent_id},
+                timeout=2.0,
+            )
+            response.raise_for_status()
+            commands = {
+                item["name"].lower(): item["category"]
+                for item in response.json()["commands"]
+            }
+            if not commands:
+                raise ValueError("Live command registry is empty")
+    except (httpx.HTTPError, ValueError, KeyError, TypeError):
+        from ..runtime.builtin_commands import collect_builtin_command_specs
+
+        commands = {
+            name.lower(): spec.category
+            for spec in collect_builtin_command_specs()
+            for name in (spec.name, *spec.aliases)
+        }
+        click.echo(
+            "Warning: live command registry unavailable; checked built-in "
+            "commands only. Plugin and other runtime commands "
+            "were not checked.",
+        )
+
+    category = commands.get(skill_name.lower())
+    if category is not None:
+        click.echo(
+            f"Warning: /{skill_name} is shadowed by an existing "
+            f"{category or 'registered'} command in agent '{agent_id}'; "
+            "the command takes precedence over this skill.",
+        )
+
+
+def _run_skill_test(
+    skill_dir: Path,
+    *,
+    workspace_dir: Path | None = None,
+) -> str:
     """Run local skill validation and security scanning."""
     if not skill_dir.is_dir():
         raise click.ClickException(f"Skill directory not found: {skill_dir}")
 
     skill_name = skill_dir.name
-    _validate_skill_frontmatter(skill_dir)
+    requirements = _validate_skill_frontmatter(skill_dir)
     try:
         result = scan_skill_directory(
             skill_dir,
@@ -175,6 +308,7 @@ def _run_skill_test(skill_dir: Path) -> str:
             "Security scan found "
             f"{len(result.findings)} issue(s) in skill '{skill_name}'.",
         )
+    _validate_skill_dependencies(skill_dir, requirements, workspace_dir)
     return skill_name
 
 
@@ -833,14 +967,27 @@ def uninstall_cmd(
 @click.option(
     "--agent-id",
     default=None,
-    help="Target agent ID (defaults to 'default').",
+    help="Target agent for dependency and command checks "
+    "(default for skill names).",
 )
 @click.option(
     "--pool",
     is_flag=True,
     help="Resolve the skill name from the shared pool.",
 )
-def test_cmd(skill: str, agent_id: str | None, pool: bool) -> None:
+@click.option(
+    "--base-url",
+    default=None,
+    help="Override API URL for command checks.",
+)
+@click.pass_context
+def test_cmd(
+    ctx: click.Context,
+    skill: str,
+    agent_id: str | None,
+    pool: bool,
+    base_url: str | None,
+) -> None:
     """Validate a workspace skill, pool skill, or local skill directory."""
     scope = _resolve_scope(agent_id, pool)
     skill_dir = _resolve_skill_test_dir(
@@ -848,6 +995,31 @@ def test_cmd(skill: str, agent_id: str | None, pool: bool) -> None:
         scope,
         pool=scope is None,
     )
-    skill_name = _run_skill_test(skill_dir)
+    # Local paths are not implicitly associated with the default agent.
+    target_agent = (
+        scope
+        if scope is not None
+        and (agent_id or not Path(skill).expanduser().exists())
+        else None
+    )
+    workspace_dir = (
+        _get_agent_workspace(target_agent) if target_agent else None
+    )
+    click.echo(
+        "Binary and environment checks use this CLI host "
+        "and local configuration.",
+    )
+    skill_name = _run_skill_test(skill_dir, workspace_dir=workspace_dir)
+    if target_agent:
+        _warn_skill_command_conflict(
+            skill_name,
+            target_agent,
+            resolve_base_url(ctx, base_url),
+        )
+    else:
+        click.echo(
+            "MCP configuration and command conflict checks skipped: "
+            "no target agent selected. Use --agent-id to check a workspace.",
+        )
     click.echo(f"Skill test passed: {skill_name}")
     click.echo(f"Path: {skill_dir}")

--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -25,6 +25,7 @@ from ..agents.skill_system import (
 from ..agents.skill_system.models import SkillRequirements
 from ..agents.skill_system.registry import (
     _build_skill_config_env_overrides,
+    _skill_env_key,
     check_skill_dependencies,
 )
 from ..agents.skill_system.store import (
@@ -184,9 +185,9 @@ def _get_skill_test_env(
     workspace_dir: Path | None,
 ) -> dict[str, str]:
     """Resolve local skill env without mutating the process environment."""
-    env = dict(os.environ)
+    env = {_skill_env_key(key): value for key, value in os.environ.items()}
     configured_envs = {
-        name: value
+        _skill_env_key(name): value
         for name, value in load_envs().items()
         if not is_bootstrap_protected_env_key(name)
     }
@@ -210,7 +211,7 @@ def _get_skill_test_env(
         )
         for key, value in overrides.items():
             # Runtime injection also preserves existing values, even empty.
-            env.setdefault(key, value)
+            env.setdefault(_skill_env_key(key), value)
     return env
 
 

--- a/src/qwenpaw/runtime/commands/control/skills_handler.py
+++ b/src/qwenpaw/runtime/commands/control/skills_handler.py
@@ -1,21 +1,16 @@
 # -*- coding: utf-8 -*-
 """Handler for /skills command.
 
-Lists enabled skills for the current channel in a compact format.
+Lists available skills for the current channel in a compact format.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import frontmatter as fm
-
 from ....agents.skill_system import (
-    get_workspace_skills_dir,
     reconcile_workspace_manifest,
-)
-from ....agents.utils.file_handling import (
-    read_text_file_with_encoding_fallback,
+    resolve_effective_skills,
 )
 
 from .base import BaseControlCommandHandler, ControlContext
@@ -25,7 +20,7 @@ class SkillsCommandHandler(BaseControlCommandHandler):
     """Handler for /skills command.
 
     Usage:
-        /skills    # List enabled skills for this channel
+        /skills    # List available skills for this channel
     """
 
     command_name = "/skills"
@@ -56,41 +51,21 @@ class SkillsCommandHandler(BaseControlCommandHandler):
 
         channel_id = context.channel.channel
         manifest = reconcile_workspace_manifest(workspace_dir)
-        skills_dir = get_workspace_skills_dir(workspace_dir)
-
         lines = []
-        found = False
-        for folder_name, entry in sorted(
-            manifest.get("skills", {}).items(),
-        ):
-            if not entry.get("enabled", False):
-                continue
-            channels = entry.get("channels") or ["all"]
-            if "all" not in channels and channel_id not in channels:
-                continue
-            skill_dir = skills_dir / folder_name
-            if not skill_dir.exists():
-                continue
-            found = True
-
-            # Read frontmatter for display name.
-            skill_md = skill_dir / "SKILL.md"
+        for folder_name in resolve_effective_skills(workspace_dir, channel_id):
+            entry = manifest.get("skills", {}).get(folder_name, {})
             description = (
                 entry.get("metadata", {}).get("description")
                 or "No description."
             )
-            if skill_md.exists():
-                raw = read_text_file_with_encoding_fallback(skill_md)
-                post = fm.loads(raw)
-                description = post.get("description") or description
 
             lines.append(
                 f"**{folder_name}**: "
                 f"{self._truncate_description(description)}",
             )
 
-        if not found:
-            return "No skills are currently enabled for this channel."
+        if not lines:
+            return "No skills are currently available for this channel."
         lines.append(
             "\n---\n"
             "*Use `/<skill_name>` for details, "

--- a/src/qwenpaw/utils/shell_normalization.py
+++ b/src/qwenpaw/utils/shell_normalization.py
@@ -2,6 +2,20 @@
 """Normalization shared by shell security checks and execution."""
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
+
+
+def shell_execution_path(inherited_path: str | None) -> str:
+    """Prepend the running Python's bin directory for shell commands."""
+    python_bin = str(Path(sys.executable).parent)
+    return (
+        python_bin + os.pathsep + inherited_path
+        if inherited_path
+        else python_bin
+    )
+
 
 def normalize_posix_line_continuations(command: str) -> str:
     r"""Remove POSIX ``\\`` + newline continuations from *command*.

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -349,9 +349,15 @@ def test_isolated_workspace_creates_overlay(tmp_path):
 
     skills_dir = tmp_path / "ext_skills"
     (skills_dir / "alpha").mkdir(parents=True)
-    (skills_dir / "alpha" / "SKILL.md").write_text("# alpha\n")
+    (skills_dir / "alpha" / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Test alpha skill\n---\n# alpha\n",
+        encoding="utf-8",
+    )
     (skills_dir / "beta").mkdir(parents=True)
-    (skills_dir / "beta" / "SKILL.md").write_text("# beta\n")
+    (skills_dir / "beta" / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: Test beta skill\n---\n# beta\n",
+        encoding="utf-8",
+    )
     (skills_dir / "not-a-skill").mkdir(parents=True)
 
     base_ws = tmp_path / "real_workspace"

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -688,7 +688,7 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 | `qwenpaw skills info SKILL_NAME`       | One exact skill name                                        | `--agent-id ID` (default `default`) or `--pool`                                                                                                                                                                                 |
 | `qwenpaw skills install BUNDLE_URL`    | A skill URL from a supported source                         | `--pool` imports to the Pool; `--agent-id ID` installs into that workspace; they are mutually exclusive; for compatibility, omitting both still targets the Pool; `--enable/--no-enable` is workspace-only (enabled by default) |
 | `qwenpaw skills uninstall SKILL_NAME`  | One exact skill name                                        | `--pool` removes it from the Pool; `--agent-id ID` removes it from that workspace; they are mutually exclusive; for compatibility, omitting both still targets the Pool                                                         |
-| `qwenpaw skills test SKILL`            | A local skill directory or exact name in the selected scope | `--agent-id ID` (default `default`) or `--pool`                                                                                                                                                                                 |
+| `qwenpaw skills test SKILL`            | A local skill directory or exact name in the selected scope | `--agent-id ID` (default `default` for names) or `--pool`; `--base-url URL` for command checks                                                                                                                                  |
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill --pool  # Import into the local skill pool
@@ -705,6 +705,15 @@ qwenpaw skills disable pdf --agent-id abc123      # Disable without uninstalling
 qwenpaw skills info [skill_name]               # See default agent's skill details
 qwenpaw skills info [skill_name] --pool        # See details in the Pool
 qwenpaw skills info [skill_name] --agent-id abc123 # See specific agent's skill details
+
+# Validate an installed skill
+qwenpaw skills test my_skill --agent-id abc123
+
+# Check a local directory without selecting an agent
+qwenpaw skills test ./my_skill
+
+# Also check target MCP configuration and command names
+qwenpaw skills test ./my_skill --agent-id abc123
 ```
 
 In the `skills config` checkbox, type a contiguous substring to narrow the

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -671,7 +671,7 @@ qwenpaw chats delete <chat_id>
 | `qwenpaw skills info SKILL_NAME`       | 一个精确的技能名                     | `--agent-id ID`（默认 `default`）或 `--pool`                                                                                                                     |
 | `qwenpaw skills install BUNDLE_URL`    | 支持来源的技能 URL                   | `--pool` 导入 Pool；`--agent-id ID` 直接安装到该 workspace；二者互斥；为兼容旧用法，两者都不传时仍导入 Pool；`--enable/--no-enable` 仅支持 workspace（默认启用） |
 | `qwenpaw skills uninstall SKILL_NAME`  | 一个精确的技能名                     | `--pool` 从 Pool 删除；`--agent-id ID` 从该 workspace 删除；二者互斥；为兼容旧用法，两者都不传时仍操作 Pool                                                      |
-| `qwenpaw skills test SKILL`            | 本地技能目录，或作用域内的精确技能名 | `--agent-id ID`（默认 `default`）或 `--pool`                                                                                                                     |
+| `qwenpaw skills test SKILL`            | 本地技能目录，或作用域内的精确技能名 | `--agent-id ID`（按名称查找时默认 `default`）或 `--pool`；命令检查可用 `--base-url URL` 指定服务                                                                 |
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill --pool  # 导入到本地技能池
@@ -688,6 +688,15 @@ qwenpaw skills disable pdf --agent-id abc123      # 禁用但不卸载
 qwenpaw skills info [skill_name]               # 看默认智能体的技能详情
 qwenpaw skills info [skill_name] --pool        # 看 Pool 中的技能详情
 qwenpaw skills info [skill_name] --agent-id abc123 # 看特定智能体的技能详情
+
+# 检查已安装的技能
+qwenpaw skills test my_skill --agent-id abc123
+
+# 检查本地目录，不默认绑定智能体
+qwenpaw skills test ./my_skill
+
+# 同时检查目标 MCP 配置和命令名称
+qwenpaw skills test ./my_skill --agent-id abc123
 ```
 
 `skills config` 的复选框中可直接输入连续文本，即时缩小候选范围，无需用 ↑/↓

--- a/website/public/docs/skills.en.md
+++ b/website/public/docs/skills.en.md
@@ -319,10 +319,8 @@ content before relying on it.
 
 Create a directory under `$QWENPAW_WORKING_DIR/workspaces/{agent_id}/skills/`, add a
 `SKILL.md`, and make sure it includes YAML front matter with `name` and
-`description`. If the skill depends on external binaries or environment
-variables, declare them in `metadata.requires`; QwenPaw exposes them as
-`require_bins` and `require_envs` metadata, but does not disable the skill
-automatically.
+`description`. Declare CLI binaries, environment variables, and MCP server
+names in `metadata.requires` (or `metadata.qwenpaw.requires`).
 
 #### Example SKILL.md
 
@@ -331,9 +329,11 @@ automatically.
 name: my_skill
 description: My custom capability
 metadata:
+  version: "1.0"
   requires:
     bins: [ffmpeg]
     env: [MY_SKILL_API_KEY]
+    mcp: [my-mcp-server]
 ---
 
 # Usage
@@ -342,6 +342,56 @@ This skill is used for…
 ```
 
 `name` and `description` are **required**. `metadata` is optional.
+
+The optional version is displayed in workspace and Pool cards and lists.
+QwenPaw reads `version`, `metadata.version`, or
+`metadata.builtin_skill_version`, in that order. It preserves the declared
+text without enforcing SemVer or automatically updating it. Authors maintain
+the field in `SKILL.md`; skills without it show no version label.
+
+`requires` declares mandatory prerequisites. In the example above, `my_skill`
+needs the `ffmpeg` executable, the `MY_SKILL_API_KEY` environment variable,
+and an enabled MCP server registered as `my-mcp-server` in the target workspace.
+Use the registered MCP name, not its package or executable name.
+
+The YAML lists declare names, not values: `env: [MY_SKILL_API_KEY]` is valid;
+`env: MY_SKILL_API_KEY` is not a valid dependency declaration. To provide the
+value, open the installed skill's configuration in the Console and enter a
+JSON object:
+
+```json
+{
+  "MY_SKILL_API_KEY": "replace-with-your-api-key"
+}
+```
+
+Dependency fields must be lists of non-empty names. Unknown dependency types
+are ignored; skill-to-skill dependencies and version constraints are not
+resolved. At load time, an enabled skill with a malformed supported declaration
+or an unmet dependency is skipped with an ERROR log; other skills and the agent
+continue running. The enabled setting and valid metadata fields are preserved.
+After fixing the declaration or dependency, the skill becomes available on the
+next load without enabling it again. Skills without declared dependencies load
+normally.
+
+Environment checks include this skill's workspace config using the same
+precedence as runtime injection: existing process values, including empty
+strings, are not overwritten. Binary checks use the effective PATH. MCP checks
+only verify a valid, enabled MCP configuration in the target workspace, not
+connectivity or tool permissions. Skipped skills are also omitted from
+`/skills`, preload, and explicit skill invocation.
+
+For a skill installed in the default workspace, validate it with:
+
+```bash
+qwenpaw skills test my_skill --agent-id default
+```
+
+Replace `default` with the target agent ID when needed. A missing API key,
+missing `ffmpeg`, or missing/disabled MCP configuration causes a nonzero exit
+code. For example, a missing key produces
+`Environment variable not set: MY_SKILL_API_KEY`. See [CLI](./cli) for checking
+local directories and Pool skills.
 
 Manually placed skills are detected on the next manifest reconcile and added
 to `skill.json` as **disabled**. Enable them in the Console or CLI.
@@ -596,7 +646,10 @@ When a skill runs, the effective config follows this priority (highest wins):
    `config` is copied as the initial workspace config. Subsequent workspace
    edits take precedence.
 
-For `requires` metadata, the parser checks keys in order: `metadata.openclaw.requires` → `metadata.qwenpaw.requires` → `metadata.requires`. The first one found is used.
+For `requires` metadata, the parser checks keys in order:
+`metadata.openclaw.requires` → `metadata.qwenpaw.requires` →
+`metadata.clawdbot.requires` → `metadata.requires` → `requires`.
+The first one found is used.
 
 ---
 

--- a/website/public/docs/skills.zh.md
+++ b/website/public/docs/skills.zh.md
@@ -277,9 +277,7 @@ QwenPaw 帮你写这些文件。
 确认文件确实写进了正确的工作区目录，并检查 skill 内容质量后再使用。
 
 在 `$QWENPAW_WORKING_DIR/workspaces/{agent_id}/skills/` 下新建目录，并放入 `SKILL.md`。
-`SKILL.md` 必须包含带 `name` 和 `description` 的 YAML front matter。若 Skill
-依赖外部二进制或环境变量，可在 `metadata.requires` 中声明；QwenPaw 会将其透出为
-`require_bins` 和 `require_envs` 元数据，但不会因此自动禁用 Skill。
+`SKILL.md` 必须包含带 `name` 和 `description` 的 YAML front matter。若 Skill 依赖命令行程序、环境变量或 MCP 服务，可在 `metadata.requires`（或 `metadata.qwenpaw.requires`）中声明。
 
 #### SKILL.md 示例
 
@@ -288,9 +286,11 @@ QwenPaw 帮你写这些文件。
 name: my_skill
 description: 我的自定义能力说明
 metadata:
+  version: "1.0"
   requires:
     bins: [ffmpeg]
     env: [MY_SKILL_API_KEY]
+    mcp: [my-mcp-server]
 ---
 
 # 使用说明
@@ -299,6 +299,32 @@ metadata:
 ```
 
 `name` 和 `description` 为**必填**字段，`metadata` 为可选。
+
+版本可选，会显示在工作区和技能池的卡片及列表中。QwenPaw 依次读取 `version`、`metadata.version`、`metadata.builtin_skill_version`，保留声明文本，不强制 SemVer，也不会自动修改版本。作者在 `SKILL.md` 中手动维护；未声明时不显示版本标签。
+
+`requires` 声明的是硬性前提。上面的 `my_skill` 需要 `ffmpeg` 可执行程序、`MY_SKILL_API_KEY` 环境变量，以及目标工作区中已启用、注册名为 `my-mcp-server` 的 MCP 服务。MCP 名称应填写注册名，而不是软件包名或可执行程序名。
+
+YAML 列表只声明名称，不填写实际值：`env: [MY_SKILL_API_KEY]` 合法，`env: MY_SKILL_API_KEY` 不符合依赖声明格式。要提供实际值，在控制台打开已安装 Skill 的配置，填写 JSON 对象：
+
+```json
+{
+  "MY_SKILL_API_KEY": "replace-with-your-api-key"
+}
+```
+
+依赖字段必须是非空名称组成的列表。未知依赖类型会被忽略，不解析技能间依赖或版本约束。
+
+加载时，若已启用 Skill 的受支持依赖字段格式错误，或依赖不满足，会记录 ERROR 日志并跳过该 Skill；其他 Skill 和 agent 继续运行。启用状态及其他有效元数据字段保持不变。修复声明或补齐依赖后，下次加载即可恢复，无需重新启用。没有声明依赖的 Skill 正常加载。
+
+环境变量检查会考虑该 Skill 的工作区 config，并遵循实际注入的优先级：已有进程环境变量（包括空字符串）不会被覆盖。命令行程序按有效 PATH 检查。MCP 只检查目标工作区的 MCP 配置有效且已启用，不检查连接或工具权限。被跳过的 Skill 也不会出现在 `/skills` 列表中，不能通过 preload 或显式 skill 命令加载。
+
+如果 Skill 安装在默认工作区，可执行：
+
+```bash
+qwenpaw skills test my_skill --agent-id default
+```
+
+检查其他工作区时，将 `default` 替换为目标 agent ID。缺少 API Key、找不到 `ffmpeg`，或 MCP 未配置/未启用时，命令返回非零退出码。例如，缺少密钥时会提示 `Environment variable not set: MY_SKILL_API_KEY`。本地目录和技能池的检查方式见 [CLI](./cli)。
 
 手动放置的 Skill 会在下次清单调和时被检测到，并以**禁用**状态写入 `skill.json`。
 在控制台或 CLI 中启用即可。
@@ -523,7 +549,7 @@ Skill 运行时，生效配置按以下优先级（高优先覆盖低优先）�
 3. **池配置：** 从池下载技能到工作区时，池的 `config` 会作为初始工作区配
    置复制过来，之后工作区的编辑优先。
 
-对于 `requires` 元数据，解析器按顺序检查：`metadata.openclaw.requires` → `metadata.qwenpaw.requires` → `metadata.requires`，取第一个找到的。
+对于 `requires` 元数据，解析器按顺序检查：`metadata.openclaw.requires` → `metadata.qwenpaw.requires` → `metadata.clawdbot.requires` → `metadata.requires` → `requires`，取第一个找到的。
 
 ---
 


### PR DESCRIPTION
## Description

This PR: 
- Expose optional, author-maintained skill versions in workspace/Pool APIs and Console cards/lists.
- Add MCP requirements and field-level validation for env/bin/MCP declarations.
- Check prerequisites during loading; log and skip unavailable skills without disabling them or blocking
others. Recheck on subsequent resolution.
- Extend `skills test` with dependency checks and exact command-name shadow warnings, preserving `/`
dispatch behavior.
- Add env-only JSON config placeholders without changing detail layout.
- Fix mailbox MCP declarations, bump their version to 1.3, and update EN/ZH docs.

Related to #7557.

### Update:
- Fix stale skill test.
- Update shell PATH.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review