### PR TITLE
fix(console): prevent chat submissions from bypassing the queue

### DIFF
--- a/console/src/api/modules/chat.test.ts
+++ b/console/src/api/modules/chat.test.ts
@@ -215,6 +215,29 @@ describe("chatApi CRUD", () => {
     );
   });
 
+  it("getChatStatus uses the lightweight status endpoint", async () => {
+    await chatApi.getChatStatus("chat/1");
+    expect(request).toHaveBeenCalledWith(
+      "/chats/chat%2F1/status",
+      expect.objectContaining({ signal: undefined, headers: undefined }),
+    );
+  });
+
+  it("getChatStatus forwards agent identity and AbortSignal", async () => {
+    const controller = new AbortController();
+    await chatApi.getChatStatus("chat-1", {
+      signal: controller.signal,
+      agentId: "agent-2",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "/chats/chat-1/status",
+      expect.objectContaining({
+        signal: controller.signal,
+        headers: { "X-Agent-Id": "agent-2" },
+      }),
+    );
+  });
+
   it("updateChat sends PUT to the correct path", async () => {
     await chatApi.updateChat("chat-1", { name: "New Name" });
     expect(request).toHaveBeenCalledWith(

--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -18,6 +18,10 @@ export interface ChatUploadResponse {
   stored_name?: string;
 }
 
+export interface ChatStatusResponse {
+  status: "idle" | "running";
+}
+
 const FILES_PREVIEW = "/files/preview";
 
 export const chatApi = {
@@ -97,6 +101,21 @@ export const chatApi = {
       `/chats/${encodeURIComponent(chatId)}${query ? `?${query}` : ""}`,
       {
         signal: options?.signal,
+      },
+    );
+  },
+
+  getChatStatus: (
+    chatId: string,
+    options?: { signal?: AbortSignal; agentId?: string },
+  ) => {
+    return request<ChatStatusResponse>(
+      `/chats/${encodeURIComponent(chatId)}/status`,
+      {
+        signal: options?.signal,
+        headers: options?.agentId
+          ? { "X-Agent-Id": options.agentId }
+          : undefined,
       },
     );
   },

--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -5,9 +5,12 @@
  * Strategy: render ChatPage with comprehensive mocks, exercise callbacks.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { forwardRef, useImperativeHandle } from "react";
 import { screen, waitFor, act } from "@testing-library/react";
 import { renderWithProviders } from "@/test/common_setup";
+import { useMessageQueueStore } from "@/stores/messageQueueStore";
 import ChatPage from "./index";
+import { stopBackgroundQueue } from "./backgroundQueueRegistry";
 import { chatExtensions } from "@/plugins/registry/chatExtensions";
 
 // ---------------------------------------------------------------------------
@@ -18,6 +21,8 @@ const {
   mockGetActiveModels,
   mockUploadFile,
   mockFilePreviewUrl,
+  mockGetChatStatus,
+  mockRuntimeSubmit,
   mockGetApiUrl,
   mockSelectedAgent,
   mockSetSelectedAgent,
@@ -30,6 +35,8 @@ const {
   mockGetActiveModels: vi.fn(),
   mockUploadFile: vi.fn(),
   mockFilePreviewUrl: vi.fn((f: string) => `/preview/${f}`),
+  mockGetChatStatus: vi.fn(),
+  mockRuntimeSubmit: vi.fn(),
   mockGetApiUrl: vi.fn((p: string) => `http://localhost:3000${p}`),
   mockSelectedAgent: vi.fn(() => "default"),
   mockSetSelectedAgent: vi.fn(),
@@ -71,8 +78,12 @@ vi.mock("./components/ChatSessionInitializer", () => ({
 }));
 
 vi.mock("@agentscope-ai/chat", () => ({
-  AgentScopeRuntimeWebUI: vi.fn((props: any) => {
+  AgentScopeRuntimeWebUI: forwardRef((props: any, ref) => {
     capturedOptions = props.options;
+    useImperativeHandle(ref, () => ({
+      input: { submit: mockRuntimeSubmit },
+      messages: { removeAllMessages: vi.fn() },
+    }));
     return (
       <div data-testid="chat-ui">
         {props.options?.theme?.rightHeader}
@@ -105,6 +116,7 @@ vi.mock("@/api/modules/chat", () => ({
   chatApi: {
     uploadFile: mockUploadFile,
     filePreviewUrl: mockFilePreviewUrl,
+    getChatStatus: mockGetChatStatus,
     stopChat: vi.fn(() => Promise.resolve()),
   },
 }));
@@ -276,56 +288,21 @@ vi.mock("@/hooks/useAgentRunningConfigApprovalLevel", () => ({
   useAgentRunningConfigApprovalLevel: vi.fn(() => "standard"),
 }));
 
-vi.mock("@/stores/messageQueueStore", () => ({
-  useMessageQueueStore: Object.assign(
-    vi.fn((selector?: any) => {
-      const state = {
-        queues: {},
-        getQueue: vi.fn(() => []),
-        getRunState: vi.fn(() => "idle"),
-        setItemStatus: vi.fn(),
-        setCurrentSendingId: vi.fn(),
-        currentSendingId: null,
-        remove: vi.fn(),
-        loadFromStorage: vi.fn(),
-        consumeMigratedTo: vi.fn(() => undefined),
-        enqueue: vi.fn(),
-        edit: vi.fn(),
-        reorder: vi.fn(),
-        clear: vi.fn(),
-        setRunState: vi.fn(),
-        migrateQueue: vi.fn(),
-      };
-      return selector ? selector(state) : state;
-    }),
-    {
-      getState: vi.fn(() => ({
-        queues: {},
-        getQueue: vi.fn(() => []),
-        getRunState: vi.fn(() => "idle"),
-        setItemStatus: vi.fn(),
-        setCurrentSendingId: vi.fn(),
-        currentSendingId: null,
-        remove: vi.fn(),
-        loadFromStorage: vi.fn(),
-        consumeMigratedTo: vi.fn(() => undefined),
-        enqueue: vi.fn(),
-        edit: vi.fn(),
-        reorder: vi.fn(),
-        clear: vi.fn(),
-        setRunState: vi.fn(),
-        migrateQueue: vi.fn(),
-      })),
-    },
-  ),
-  MAX_QUEUE_SIZE: 100,
-  STORAGE_PREFIX: "chat.queue.",
-  withSendLock: vi.fn(async (_key: string, fn: () => any) => fn()),
-  holdOwnershipLock: vi.fn((_key: string, cb: () => void, _signal: any) => {
-    cb();
-    return Promise.resolve();
-  }),
-}));
+vi.mock("@/stores/messageQueueStore", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/stores/messageQueueStore")
+  >();
+  return {
+    ...actual,
+    withSendLock: vi.fn(async (_key: string, fn: () => unknown) => fn()),
+    holdOwnershipLock: vi.fn(
+      (_key: string, cb: () => void, _signal: AbortSignal) => {
+        cb();
+        return Promise.resolve();
+      },
+    ),
+  };
+});
 
 vi.mock("@/utils/agentBackend", () => ({
   requiresQwenPawModel: mockRequiresQwenPawModel,
@@ -507,9 +484,20 @@ vi.mock("./utils", async () => {
 // ---------------------------------------------------------------------------
 describe("ChatPage coverage", () => {
   beforeEach(() => {
+    stopBackgroundQueue();
     chatExtensions.__resetForTests();
     capturedOptions = null;
     mockCopyText.mockClear();
+    mockGetChatStatus.mockReset();
+    mockGetChatStatus.mockResolvedValue({ status: "idle" });
+    mockRuntimeSubmit.mockReset();
+    localStorage.clear();
+    useMessageQueueStore.setState({
+      queues: {},
+      runStates: {},
+      currentSendingId: null,
+      lastMigratedTo: null,
+    });
     mockBeginLoopModeSubmission.mockReset();
     mockBeginLoopModeSubmission.mockImplementation((text: string) => text);
     mockRequiresQwenPawModel.mockReset();
@@ -548,6 +536,7 @@ describe("ChatPage coverage", () => {
   });
 
   afterEach(() => {
+    stopBackgroundQueue();
     chatExtensions.__resetForTests();
     vi.clearAllMocks();
   });
@@ -1104,6 +1093,176 @@ describe("ChatPage coverage", () => {
 
     expect(result).toEqual({ proceed: true, query: "do the task" });
     expect(mockBeginLoopModeSubmission).not.toHaveBeenCalled();
+  });
+
+  it("queues an attachment submission while the backend chat is running", async () => {
+    const chatId = "11111111-1111-4111-8111-111111111111";
+    mockGetChatStatus.mockResolvedValue({ status: "running" });
+    renderWithProviders(<ChatPage />, {
+      initialEntries: [`/chat/${chatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const beforeSubmit = capturedOptions?.sender?.beforeSubmit;
+    const result = await beforeSubmit({
+      query: "inspect this file",
+      fileList: [
+        {
+          uid: "file-1",
+          name: "evidence.txt",
+          type: "text/plain",
+          size: 42,
+          response: { url: "/files/evidence.txt" },
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
+    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId);
+    expect(useMessageQueueStore.getState().getQueue(chatId)).toEqual([
+      expect.objectContaining({
+        text: "inspect this file",
+        attachments: [
+          {
+            url: "/files/evidence.txt",
+            name: "evidence.txt",
+            type: "text/plain",
+            size: 42,
+          },
+        ],
+        backendSessionId: "test-session",
+        userId: "test-user",
+        channel: "console",
+      }),
+    ]);
+    act(() => useMessageQueueStore.getState().clear(chatId));
+  });
+
+  it("allows a submission when the backend chat is idle", async () => {
+    const chatId = "22222222-2222-4222-8222-222222222222";
+    mockGetChatStatus.mockResolvedValue({ status: "idle" });
+    renderWithProviders(<ChatPage />, {
+      initialEntries: [`/chat/${chatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const beforeSubmit = capturedOptions?.sender?.beforeSubmit;
+    const result = await beforeSubmit({ query: "next turn" });
+
+    expect(result).toEqual({ proceed: true, query: "next turn" });
+    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId);
+    expect(useMessageQueueStore.getState().getQueue(chatId)).toEqual([]);
+  });
+
+  it("issue 7559: persists the follow-up while backend cleanup is running and sends it once idle", async () => {
+    const chatId = "75590000-0000-4000-8000-000000000001";
+    const storageKey = `qwenpaw:message-queue:${chatId}`;
+    let statusChecks = 0;
+
+    mockGetChatStatus.mockImplementation(async () => {
+      statusChecks += 1;
+      return { status: statusChecks < 3 ? "running" : "idle" };
+    });
+    global.fetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/console/chat") && init?.method === "POST") {
+          return { ok: true, status: 200, body: null } as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        } as Response;
+      },
+    );
+    mockRuntimeSubmit.mockImplementation(
+      (data: { query: string; fileList?: unknown[] }) =>
+        capturedOptions.api.fetch({
+          input: [
+            {
+              role: "user",
+              content: data.query,
+              session: { session_id: "test-session" },
+            },
+          ],
+        }),
+    );
+
+    renderWithProviders(<ChatPage />, {
+      initialEntries: [`/chat/${chatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    // This is the exact race from #7559: the SDK input is already enabled,
+    // while TaskTracker still reports the previous run as active.
+    let result: unknown;
+    await act(async () => {
+      result = await capturedOptions.sender.beforeSubmit({
+        query: "follow-up during cleanup",
+        fileList: [
+          {
+            uid: "race-file",
+            name: "race.txt",
+            type: "text/plain",
+            response: { url: "/files/race.txt" },
+          },
+        ],
+      });
+    });
+
+    expect(result).toBe(false);
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(
+          ([url, init]) =>
+            String(url).endsWith("/console/chat") && init?.method === "POST",
+        ),
+    ).toHaveLength(0);
+    expect(
+      JSON.parse(localStorage.getItem(storageKey) || "null"),
+    ).toMatchObject({
+      items: [
+        {
+          text: "follow-up during cleanup",
+          backendSessionId: "test-session",
+          attachments: [{ url: "/files/race.txt", name: "race.txt" }],
+        },
+      ],
+    });
+
+    // The production Zustand store notifies ChatPage. The drain first sees
+    // running, polls again, then submits only after the backend becomes idle.
+
+    await waitFor(
+      () => {
+        const posts = vi
+          .mocked(fetch)
+          .mock.calls.filter(
+            ([url, init]) =>
+              String(url).endsWith("/console/chat") && init?.method === "POST",
+          );
+        expect(posts).toHaveLength(1);
+      },
+      { timeout: 4_000 },
+    );
+
+    const post = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith("/console/chat") && init?.method === "POST",
+      );
+    const body = JSON.parse(String(post?.[1]?.body));
+    expect(statusChecks).toBeGreaterThanOrEqual(3);
+    expect(body).toMatchObject({
+      session_id: "test-session",
+      user_id: "test-user",
+      channel: "console",
+    });
+    expect(mockRuntimeSubmit).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(storageKey)).toBeNull();
   });
 
   // ── sender attachments trigger renders ─────────────────────────────────

--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -10,6 +10,7 @@ import { screen, waitFor, act } from "@testing-library/react";
 import { renderWithProviders } from "@/test/common_setup";
 import { useMessageQueueStore } from "@/stores/messageQueueStore";
 import ChatPage from "./index";
+import sessionApi from "./sessionApi";
 import { stopBackgroundQueue } from "./backgroundQueueRegistry";
 import { chatExtensions } from "@/plugins/registry/chatExtensions";
 
@@ -491,6 +492,11 @@ describe("ChatPage coverage", () => {
     mockGetChatStatus.mockReset();
     mockGetChatStatus.mockResolvedValue({ status: "idle" });
     mockRuntimeSubmit.mockReset();
+    vi.mocked(sessionApi.getSessionIdentity).mockReturnValue({
+      sessionId: "test-session",
+      userId: "test-user",
+      channel: "console",
+    });
     localStorage.clear();
     useMessageQueueStore.setState({
       queues: {},
@@ -1118,7 +1124,9 @@ describe("ChatPage coverage", () => {
     });
 
     expect(result).toBe(false);
-    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId);
+    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId, {
+      agentId: "default",
+    });
     expect(useMessageQueueStore.getState().getQueue(chatId)).toEqual([
       expect.objectContaining({
         text: "inspect this file",
@@ -1150,8 +1158,90 @@ describe("ChatPage coverage", () => {
     const result = await beforeSubmit({ query: "next turn" });
 
     expect(result).toEqual({ proceed: true, query: "next turn" });
-    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId);
+    expect(mockGetChatStatus).toHaveBeenCalledWith(chatId, {
+      agentId: "default",
+    });
     expect(useMessageQueueStore.getState().getQueue(chatId)).toEqual([]);
+  });
+
+  it("serializes rapid admissions so a stale idle result cannot start two direct sends", async () => {
+    const chatId = "33322222-2222-4222-8222-222222222222";
+    let resolveStatus: (value: { status: "idle" }) => void = () => {};
+    mockGetChatStatus.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStatus = resolve;
+        }),
+    );
+    renderWithProviders(<ChatPage />, {
+      initialEntries: [`/chat/${chatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const beforeSubmit = capturedOptions?.sender?.beforeSubmit;
+    const first = beforeSubmit({ query: "first" });
+    await waitFor(() => expect(mockGetChatStatus).toHaveBeenCalledTimes(1));
+    const second = beforeSubmit({ query: "second" });
+
+    resolveStatus({ status: "idle" });
+    let results: unknown[] = [];
+    await act(async () => {
+      results = await Promise.all([first, second]);
+    });
+
+    expect(results[0]).toEqual({ proceed: true, query: "first" });
+    expect(results[1]).toBe(false);
+    expect(mockGetChatStatus).toHaveBeenCalledTimes(1);
+    expect(useMessageQueueStore.getState().getQueue(chatId)).toEqual([
+      expect.objectContaining({ text: "second" }),
+    ]);
+    act(() => useMessageQueueStore.getState().clear(chatId));
+  });
+
+  it("uses the admission-time session identity when direct send starts later", async () => {
+    const chatId = "33322222-2222-4222-8222-222222222223";
+    vi.mocked(sessionApi.getSessionIdentity).mockReturnValue({
+      sessionId: "source-session",
+      userId: "source-user",
+      channel: "console",
+    });
+    mockGetChatStatus.mockResolvedValue({ status: "idle" });
+    renderWithProviders(<ChatPage />, {
+      initialEntries: [`/chat/${chatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const result = await capturedOptions.sender.beforeSubmit({
+      query: "stay in source",
+    });
+    expect(result).toEqual({ proceed: true, query: "stay in source" });
+
+    vi.mocked(sessionApi.getSessionIdentity).mockReturnValue({
+      sessionId: "target-session",
+      userId: "target-user",
+      channel: "console",
+    });
+    await capturedOptions.api.fetch({
+      input: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "stay in source" }],
+        },
+      ],
+    });
+
+    const post = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith("/console/chat") && init?.method === "POST",
+      );
+    expect(JSON.parse(String(post?.[1]?.body))).toMatchObject({
+      session_id: "source-session",
+      user_id: "source-user",
+      channel: "console",
+    });
+    expect(post?.[1]?.headers).toMatchObject({ "X-Agent-Id": "default" });
   });
 
   it("issue 7559: persists the follow-up while backend cleanup is running and sends it once idle", async () => {

--- a/console/src/pages/Chat/ChatPage.coverage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.coverage.test.tsx
@@ -6,7 +6,8 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { forwardRef, useImperativeHandle } from "react";
-import { screen, waitFor, act } from "@testing-library/react";
+import { screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 import { renderWithProviders } from "@/test/common_setup";
 import { useMessageQueueStore } from "@/stores/messageQueueStore";
 import ChatPage from "./index";
@@ -1196,6 +1197,46 @@ describe("ChatPage coverage", () => {
       expect.objectContaining({ text: "second" }),
     ]);
     act(() => useMessageQueueStore.getState().clear(chatId));
+  });
+
+  it("releases an unconsumed direct-send slot when switching sessions", async () => {
+    const sourceChatId = "33322222-2222-4222-8222-222222222224";
+    const targetChatId = "33322222-2222-4222-8222-222222222225";
+
+    function ChatHarness() {
+      const navigate = useNavigate();
+      return (
+        <>
+          <button onClick={() => navigate(`/chat/${targetChatId}`)}>
+            Switch session
+          </button>
+          <ChatPage />
+        </>
+      );
+    }
+
+    renderWithProviders(<ChatHarness />, {
+      initialEntries: [`/chat/${sourceChatId}`],
+    });
+    await screen.findByTestId("chat-ui");
+
+    const first = await capturedOptions.sender.beforeSubmit({
+      query: "abandoned direct send",
+    });
+    expect(first).toEqual({ proceed: true, query: "abandoned direct send" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch session" }));
+
+    let second: unknown;
+    await act(async () => {
+      second = await capturedOptions.sender.beforeSubmit({
+        query: "send after switch",
+      });
+    });
+
+    expect(second).toEqual({ proceed: true, query: "send after switch" });
+    expect(mockGetChatStatus).toHaveBeenCalledTimes(2);
+    expect(useMessageQueueStore.getState().getQueue(targetChatId)).toEqual([]);
   });
 
   it("uses the admission-time session identity when direct send starts later", async () => {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2081,6 +2081,7 @@ export default function ChatPage() {
       }
       foregroundQueueWaitAbortRef.current?.abort();
       foregroundQueueWaitAbortRef.current = null;
+      pendingDirectSubmissionRef.current = null;
       // Only the owner tab may continue sending in the background; non-owner
       // tabs leave the queue alone for the owner (or next owner) to handle.
       if (!isOwnerRef.current) return;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -248,19 +248,11 @@ async function waitForChatIdle(
   if (!chatIdForStatus) return true;
   while (!signal.aborted) {
     try {
-      // Use direct fetch with the correct agent ID header to avoid
-      // cross-agent status misreads when the user has switched agents.
-      const headers = buildAuthHeaders();
-      if (agentId) {
-        headers["X-Agent-Id"] = agentId;
-      }
-      const res = await fetch(
-        getApiUrl(`/chats/${encodeURIComponent(chatIdForStatus)}`),
-        { headers, signal },
-      );
-      if (!res.ok) return true; // 404 / error → treat as idle
-      const chat = await res.json();
-      if (chat?.status !== "running") return true;
+      const chat = await chatApi.getChatStatus(chatIdForStatus, {
+        signal,
+        agentId,
+      });
+      if (chat.status !== "running") return true;
     } catch {
       // If aborted, return false (not idle) so the caller breaks cleanly.
       if (signal.aborted) return false;
@@ -1308,6 +1300,7 @@ export default function ChatPage() {
   const messageQueueRef = useRef(messageQueue);
   messageQueueRef.current = messageQueue;
   const autoSendTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const foregroundQueueWaitAbortRef = useRef<AbortController | null>(null);
   const prevQueueLenRef = useRef(messageQueue.length);
 
   const sessionApprovalLevelRef = useRef<ToolExecutionLevel | null>(null);
@@ -1469,7 +1462,8 @@ export default function ChatPage() {
 
   const scheduleNextSend = useCallback(() => {
     if (autoSendTimerRef.current) clearTimeout(autoSendTimerRef.current);
-    autoSendTimerRef.current = setTimeout(() => {
+    foregroundQueueWaitAbortRef.current?.abort();
+    autoSendTimerRef.current = setTimeout(async () => {
       autoSendTimerRef.current = null;
       if (chatLoadingRef.current) return;
       // Only the owner tab is allowed to actually send.
@@ -1480,15 +1474,49 @@ export default function ChatPage() {
       const q = messageQueueRef.current;
       if (q.length === 0) return;
       const next = q[0];
+
+      // SDK loading becomes false on the Completed SSE, slightly before the
+      // backend releases the TaskTracker run. Wait for the authoritative chat
+      // status before draining the local queue, just like the background
+      // sender does.
+      const ctrl = new AbortController();
+      foregroundQueueWaitAbortRef.current = ctrl;
+      const chatIdForStatus =
+        sessionApi.getRealIdForSession(queueSessionId) || queueSessionId;
+      const idle = await waitForChatIdle(chatIdForStatus, ctrl.signal);
+      if (foregroundQueueWaitAbortRef.current === ctrl) {
+        foregroundQueueWaitAbortRef.current = null;
+      }
+      if (
+        !idle ||
+        ctrl.signal.aborted ||
+        queueSessionIdRef.current !== queueSessionId ||
+        chatLoadingRef.current ||
+        !isOwnerRef.current
+      ) {
+        return;
+      }
+
       // Acquire the per-session send lock so concurrent tabs don't both fire
       // the same item. If another tab holds the lock, drop this attempt; the
       // cross-tab broadcast will refresh our queue and the next loading→idle
       // transition will retry.
       void withSendLock(queueSessionId, () => {
         // Re-check: another tab may have already removed this item via
-        // broadcast, or a session switch may have happened.
+        // broadcast, a session switch may have happened, or the user may
+        // have paused the queue while the backend-idle poll was in flight.
         const fresh = useMessageQueueStore.getState().getQueue(queueSessionId);
-        if (fresh.length === 0 || fresh[0].id !== next.id) return;
+        const freshRunState = useMessageQueueStore
+          .getState()
+          .getRunState(queueSessionId);
+        if (
+          freshRunState === "paused" ||
+          freshRunState === "error" ||
+          fresh.length === 0 ||
+          fresh[0].id !== next.id
+        ) {
+          return;
+        }
         useMessageQueueStore.getState().setCurrentSendingId(next.id);
         useMessageQueueStore.getState().remove(queueSessionId, next.id);
         // Force-set window.currentSessionId from the queue item's snapshot
@@ -1520,6 +1548,8 @@ export default function ChatPage() {
       clearTimeout(autoSendTimerRef.current);
       autoSendTimerRef.current = null;
     }
+    foregroundQueueWaitAbortRef.current?.abort();
+    foregroundQueueWaitAbortRef.current = null;
     prevChatLoadingRef.current = false;
     // Keep prevQueueLenRef at current value to prevent auto-send effect from
     // seeing a false 0→N transition on stale messageQueue in the same render.
@@ -1895,6 +1925,74 @@ export default function ChatPage() {
   useChatInputDraft(isChatActive, selectedAgent);
   // ── Message Queue ───────────────────────────────────────────────────────
 
+  const enqueueSubmittedInput = useCallback(
+    (inputData: IAgentScopeRuntimeWebUIInputData): boolean => {
+      const currentQ = useMessageQueueStore.getState().getQueue(queueSessionId);
+      if (currentQ.length >= MAX_QUEUE_SIZE) {
+        message.warning(t("chat.queue.queueFull", { max: MAX_QUEUE_SIZE }));
+        return false;
+      }
+
+      const identity = sessionApi.getSessionIdentity();
+      const attachments = inputData.fileList
+        ?.map((file) => {
+          const response = file.response as { url?: string } | undefined;
+          const url = response?.url || file.url || file.thumbUrl;
+          if (!url) return null;
+          return {
+            url,
+            name: file.name,
+            type: file.type,
+            size: file.size,
+          };
+        })
+        .filter((file): file is NonNullable<typeof file> => file !== null);
+
+      const queueText = usesQwenPawBackend
+        ? prepareLoopModeMessage(inputData.query.trim())
+        : inputData.query.trim();
+      useMessageQueueStore.getState().enqueue(queueSessionId, {
+        text: queueText,
+        attachments: attachments?.length ? attachments : undefined,
+        backendSessionId: identity.sessionId || undefined,
+        userId: identity.userId,
+        channel: identity.channel,
+      });
+      pendingFileListRef.current = [];
+      localStorage.removeItem(getDraftStorageKey(selectedAgent));
+      draftSuppressed = true;
+      return true;
+    },
+    [message, queueSessionId, selectedAgent, t, usesQwenPawBackend],
+  );
+
+  const shouldEnqueueSubmission = useCallback(async (): Promise<boolean> => {
+    if (!isOwnerRef.current) return true;
+
+    const queueBusy =
+      chatLoadingRef.current ||
+      messageQueueRef.current.length > 0 ||
+      autoSendTimerRef.current !== null ||
+      useMessageQueueStore.getState().currentSendingId !== null;
+    if (queueBusy) return true;
+    if (!usesQwenPawBackend) return false;
+
+    // The SDK clears its loading flag as soon as it receives a Completed SSE,
+    // before the backend finishes response-cycle cleanup and releases the
+    // TaskTracker run. Use the backend chat status as the admission authority
+    // so submissions in that gap are queued instead of receiving HTTP 409.
+    const backendChatId = resolveBackendChatId(chatIdRef.current);
+    if (!backendChatId) return false;
+    try {
+      const chat = await chatApi.getChatStatus(backendChatId);
+      return chat.status === "running";
+    } catch {
+      // Preserve availability on a transient status-check failure. The
+      // backend's 409 remains the final cross-client concurrency guard.
+      return false;
+    }
+  }, [usesQwenPawBackend]);
+
   // Stop background sender for THIS session when ChatPage mounts (foreground
   // takes over); start background senders for all OTHER sessions with pending
   // items. On unmount (or session switch), start bg sender for THIS session.
@@ -1908,6 +2006,8 @@ export default function ChatPage() {
         clearTimeout(autoSendTimerRef.current);
         autoSendTimerRef.current = null;
       }
+      foregroundQueueWaitAbortRef.current?.abort();
+      foregroundQueueWaitAbortRef.current = null;
       // Only the owner tab may continue sending in the background; non-owner
       // tabs leave the queue alone for the owner (or next owner) to handle.
       if (!isOwnerRef.current) return;
@@ -2012,6 +2112,7 @@ export default function ChatPage() {
                 size: f.size,
               }))
             : undefined,
+        backendSessionId: enqueueIdentity.sessionId || undefined,
         userId: enqueueIdentity.userId,
         channel: enqueueIdentity.channel,
       });
@@ -2060,18 +2161,21 @@ export default function ChatPage() {
           chatApi.stopChat(resolvedId).catch(() => {});
         }
       }
-      useMessageQueueStore.getState().remove(queueSessionId, item.id);
-      setTimeout(() => {
-        void withSendLock(queueSessionId, () => {
-          useMessageQueueStore.getState().setCurrentSendingId(item.id);
-          chatRef.current?.input.submit({
-            query: beginLoopModeSubmission(item.text),
-            fileList: buildFileList(item),
-          });
-        });
-      }, 600);
+      const store = useMessageQueueStore.getState();
+      const queue = store.getQueue(queueSessionId);
+      const target = queue.find((candidate) => candidate.id === item.id);
+      if (!target) return;
+      // Keep the item durable while the interrupted backend run winds down,
+      // move it to the head, then reuse the normal idle-gated drain path.
+      store.reorder(queueSessionId, [
+        target,
+        ...queue.filter((candidate) => candidate.id !== item.id),
+      ]);
+      store.setItemStatus(queueSessionId, item.id, "pending");
+      store.setRunState(queueSessionId, "running");
+      scheduleNextSend();
     },
-    [queueSessionId, buildFileList],
+    [queueSessionId, scheduleNextSend],
   );
 
   const handleQueueClear = useCallback(() => {
@@ -2082,24 +2186,11 @@ export default function ChatPage() {
     const current = useMessageQueueStore.getState().getRunState(queueSessionId);
     if (current === "paused") {
       useMessageQueueStore.getState().setRunState(queueSessionId, "running");
-      // Try to resume sending immediately
-      if (!chatLoadingRef.current && isOwnerRef.current) {
-        void withSendLock(queueSessionId, () => {
-          const q = useMessageQueueStore.getState().getQueue(queueSessionId);
-          if (q.length === 0) return;
-          const head = q[0];
-          useMessageQueueStore.getState().setCurrentSendingId(head.id);
-          useMessageQueueStore.getState().remove(queueSessionId, head.id);
-          chatRef.current?.input.submit({
-            query: beginLoopModeSubmission(head.text),
-            fileList: buildFileList(head),
-          });
-        });
-      }
+      scheduleNextSend();
     } else {
       useMessageQueueStore.getState().setRunState(queueSessionId, "paused");
     }
-  }, [queueSessionId, buildFileList]);
+  }, [queueSessionId, scheduleNextSend]);
 
   const handleQueueRetry = useCallback(
     (id: string) => {
@@ -2107,43 +2198,17 @@ export default function ChatPage() {
         .getState()
         .setItemStatus(queueSessionId, id, "pending");
       useMessageQueueStore.getState().setRunState(queueSessionId, "running");
-      // Trigger send if idle
-      if (!chatLoadingRef.current && isOwnerRef.current) {
-        void withSendLock(queueSessionId, () => {
-          const q = useMessageQueueStore.getState().getQueue(queueSessionId);
-          const target = q.find((it) => it.id === id);
-          if (!target) return;
-          useMessageQueueStore.getState().setCurrentSendingId(id);
-          useMessageQueueStore.getState().remove(queueSessionId, id);
-          chatRef.current?.input.submit({
-            query: beginLoopModeSubmission(target.text),
-            fileList: buildFileList(target),
-          });
-        });
-      }
+      scheduleNextSend();
     },
-    [queueSessionId, buildFileList],
+    [queueSessionId, scheduleNextSend],
   );
 
   const handleQueueSkip = useCallback(
     (id: string) => {
       useMessageQueueStore.getState().remove(queueSessionId, id);
-      // After skip, try to continue sending
-      if (!chatLoadingRef.current && isOwnerRef.current) {
-        void withSendLock(queueSessionId, () => {
-          const q = useMessageQueueStore.getState().getQueue(queueSessionId);
-          if (q.length === 0) return;
-          const next = q[0];
-          useMessageQueueStore.getState().setCurrentSendingId(next.id);
-          useMessageQueueStore.getState().remove(queueSessionId, next.id);
-          chatRef.current?.input.submit({
-            query: beginLoopModeSubmission(next.text),
-            fileList: buildFileList(next),
-          });
-        });
-      }
+      scheduleNextSend();
     },
-    [queueSessionId, buildFileList],
+    [queueSessionId, scheduleNextSend],
   );
   // ── End Message Queue ───────────────────────────────────────────────────
 
@@ -2866,45 +2931,16 @@ export default function ChatPage() {
       inputData: IAgentScopeRuntimeWebUIInputData,
     ): Promise<boolean | IAgentScopeRuntimeWebUISenderBeforeSubmitResult> => {
       if (isComposingRef.current) return false;
-      // Single-tab ownership: non-owner tabs are queue-only. Re-route every
-      // submit (Enter / send button / programmatic) to the shared queue and
-      // abort the actual SDK send. The owner tab will pick the item up via
-      // cross-tab broadcast and send it.
-      if (!isOwnerRef.current) {
+      // Sender submit paths share the same admission check. This covers Enter,
+      // the send button, and attachment submissions.
+      if (await shouldEnqueueSubmission()) {
         const val = inputData.query.trim();
         if (!val) return false;
-        const currentQ = useMessageQueueStore
-          .getState()
-          .getQueue(queueSessionId);
-        if (currentQ.length >= MAX_QUEUE_SIZE) {
-          message.warning(t("chat.queue.queueFull", { max: MAX_QUEUE_SIZE }));
-          return false;
-        }
-        const queueText = usesQwenPawBackend
-          ? prepareLoopModeMessage(val)
-          : val;
-        const enqueueIdentity = sessionApi.getSessionIdentity();
-        useMessageQueueStore.getState().enqueue(queueSessionId, {
-          text: queueText,
-          attachments:
-            pendingFileListRef.current.length > 0
-              ? pendingFileListRef.current.map((f) => ({
-                  url: f.url,
-                  name: f.name,
-                  type: f.type,
-                  size: f.size,
-                }))
-              : undefined,
-          userId: enqueueIdentity.userId,
-          channel: enqueueIdentity.channel,
-        });
-        pendingFileListRef.current = [];
+        if (!enqueueSubmittedInput(inputData)) return false;
         const textarea = getActiveSenderTextarea();
         if (textarea) setTextareaValue(textarea, "");
         // Clear sender attachment preview (deferred to next tick)
         clearSenderAttachments();
-        localStorage.removeItem(getDraftStorageKey(selectedAgent));
-        draftSuppressed = true;
         return false;
       }
       localStorage.removeItem(getDraftStorageKey(selectedAgent));
@@ -3578,6 +3614,8 @@ export default function ChatPage() {
     filesWorkspaceOpen,
     toggleFilesWorkspace,
     isOwner,
+    enqueueSubmittedInput,
+    shouldEnqueueSubmission,
     bgTaskCount,
     bgBackendSessionId,
     queueSessionId,

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -158,6 +158,18 @@ interface ApprovalMessageData {
   sourceType: string;
 }
 
+interface SubmissionSnapshot {
+  queueSessionId: string;
+  backendChatId?: string;
+  agentId: string;
+  identity: {
+    sessionId: string;
+    userId: string;
+    channel: string;
+  };
+  usesQwenPawBackend: boolean;
+}
+
 function resolveBackendChatId(chatId?: string | null): string | undefined {
   if (!chatId) return undefined;
   const resolved = sessionApi.getRealIdForSession(chatId);
@@ -1301,6 +1313,8 @@ export default function ChatPage() {
   messageQueueRef.current = messageQueue;
   const autoSendTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const foregroundQueueWaitAbortRef = useRef<AbortController | null>(null);
+  const submissionAdmissionTailRef = useRef<Promise<void>>(Promise.resolve());
+  const pendingDirectSubmissionRef = useRef<SubmissionSnapshot | null>(null);
   const prevQueueLenRef = useRef(messageQueue.length);
 
   const sessionApprovalLevelRef = useRef<ToolExecutionLevel | null>(null);
@@ -1466,6 +1480,9 @@ export default function ChatPage() {
     autoSendTimerRef.current = setTimeout(async () => {
       autoSendTimerRef.current = null;
       if (chatLoadingRef.current) return;
+      // A direct submission has passed admission but has not reached
+      // customFetch yet. Let it start before draining later queued messages.
+      if (pendingDirectSubmissionRef.current) return;
       // Only the owner tab is allowed to actually send.
       if (!isOwnerRef.current) return;
       // Respect pause/error state — read fresh from store
@@ -1510,6 +1527,7 @@ export default function ChatPage() {
           .getState()
           .getRunState(queueSessionId);
         if (
+          pendingDirectSubmissionRef.current ||
           freshRunState === "paused" ||
           freshRunState === "error" ||
           fresh.length === 0 ||
@@ -1925,15 +1943,30 @@ export default function ChatPage() {
   useChatInputDraft(isChatActive, selectedAgent);
   // ── Message Queue ───────────────────────────────────────────────────────
 
+  const captureSubmissionSnapshot = useCallback(
+    (): SubmissionSnapshot => ({
+      queueSessionId,
+      backendChatId: resolveBackendChatId(chatIdRef.current),
+      agentId: selectedAgent,
+      identity: sessionApi.getSessionIdentity(),
+      usesQwenPawBackend,
+    }),
+    [queueSessionId, selectedAgent, usesQwenPawBackend],
+  );
+
   const enqueueSubmittedInput = useCallback(
-    (inputData: IAgentScopeRuntimeWebUIInputData): boolean => {
-      const currentQ = useMessageQueueStore.getState().getQueue(queueSessionId);
+    (
+      inputData: IAgentScopeRuntimeWebUIInputData,
+      snapshot: SubmissionSnapshot,
+    ): boolean => {
+      const currentQ = useMessageQueueStore
+        .getState()
+        .getQueue(snapshot.queueSessionId);
       if (currentQ.length >= MAX_QUEUE_SIZE) {
         message.warning(t("chat.queue.queueFull", { max: MAX_QUEUE_SIZE }));
         return false;
       }
 
-      const identity = sessionApi.getSessionIdentity();
       const attachments = inputData.fileList
         ?.map((file) => {
           const response = file.response as { url?: string } | undefined;
@@ -1948,50 +1981,90 @@ export default function ChatPage() {
         })
         .filter((file): file is NonNullable<typeof file> => file !== null);
 
-      const queueText = usesQwenPawBackend
+      const queueText = snapshot.usesQwenPawBackend
         ? prepareLoopModeMessage(inputData.query.trim())
         : inputData.query.trim();
-      useMessageQueueStore.getState().enqueue(queueSessionId, {
+      useMessageQueueStore.getState().enqueue(snapshot.queueSessionId, {
         text: queueText,
         attachments: attachments?.length ? attachments : undefined,
-        backendSessionId: identity.sessionId || undefined,
-        userId: identity.userId,
-        channel: identity.channel,
+        agentId: snapshot.agentId,
+        backendSessionId: snapshot.identity.sessionId || undefined,
+        userId: snapshot.identity.userId,
+        channel: snapshot.identity.channel,
       });
-      pendingFileListRef.current = [];
-      localStorage.removeItem(getDraftStorageKey(selectedAgent));
-      draftSuppressed = true;
+      const snapshotIsCurrent =
+        selectedAgentRef.current === snapshot.agentId &&
+        queueSessionIdRef.current === snapshot.queueSessionId;
+      if (snapshotIsCurrent) {
+        pendingFileListRef.current = [];
+        draftSuppressed = true;
+      }
+      localStorage.removeItem(getDraftStorageKey(snapshot.agentId));
+
+      // If navigation completed while admission was pending, the old page's
+      // cleanup ran before this item existed and could not start its sender.
+      if (
+        !snapshotIsCurrent &&
+        snapshot.identity.sessionId &&
+        snapshot.backendChatId &&
+        !hasBackgroundQueue(snapshot.queueSessionId)
+      ) {
+        void startBackgroundQueue(
+          snapshot.queueSessionId,
+          snapshot.identity.sessionId,
+          snapshot.backendChatId,
+        );
+      }
       return true;
     },
-    [message, queueSessionId, selectedAgent, t, usesQwenPawBackend],
+    [message, t],
   );
 
-  const shouldEnqueueSubmission = useCallback(async (): Promise<boolean> => {
-    if (!isOwnerRef.current) return true;
+  const shouldEnqueueSubmission = useCallback(
+    async (snapshot: SubmissionSnapshot): Promise<boolean> => {
+      if (
+        pendingDirectSubmissionRef.current ||
+        selectedAgentRef.current !== snapshot.agentId ||
+        queueSessionIdRef.current !== snapshot.queueSessionId
+      ) {
+        return true;
+      }
+      if (!isOwnerRef.current) return true;
 
-    const queueBusy =
-      chatLoadingRef.current ||
-      messageQueueRef.current.length > 0 ||
-      autoSendTimerRef.current !== null ||
-      useMessageQueueStore.getState().currentSendingId !== null;
-    if (queueBusy) return true;
-    if (!usesQwenPawBackend) return false;
+      const store = useMessageQueueStore.getState();
+      const queueBusy =
+        chatLoadingRef.current ||
+        store.getQueue(snapshot.queueSessionId).length > 0 ||
+        autoSendTimerRef.current !== null ||
+        store.currentSendingId !== null;
+      if (queueBusy) return true;
+      if (!snapshot.usesQwenPawBackend) return false;
 
-    // The SDK clears its loading flag as soon as it receives a Completed SSE,
-    // before the backend finishes response-cycle cleanup and releases the
-    // TaskTracker run. Use the backend chat status as the admission authority
-    // so submissions in that gap are queued instead of receiving HTTP 409.
-    const backendChatId = resolveBackendChatId(chatIdRef.current);
-    if (!backendChatId) return false;
-    try {
-      const chat = await chatApi.getChatStatus(backendChatId);
-      return chat.status === "running";
-    } catch {
-      // Preserve availability on a transient status-check failure. The
-      // backend's 409 remains the final cross-client concurrency guard.
-      return false;
-    }
-  }, [usesQwenPawBackend]);
+      // The SDK clears its loading flag as soon as it receives a Completed SSE,
+      // before the backend finishes response-cycle cleanup and releases the
+      // TaskTracker run. Use the backend chat status as the admission authority
+      // so submissions in that gap are queued instead of receiving HTTP 409.
+      if (!snapshot.backendChatId) return false;
+      try {
+        const chat = await chatApi.getChatStatus(snapshot.backendChatId, {
+          agentId: snapshot.agentId,
+        });
+        return (
+          chat.status === "running" ||
+          selectedAgentRef.current !== snapshot.agentId ||
+          queueSessionIdRef.current !== snapshot.queueSessionId
+        );
+      } catch {
+        // Preserve availability on a transient status-check failure. The
+        // backend's 409 remains the final cross-client concurrency guard.
+        return (
+          selectedAgentRef.current !== snapshot.agentId ||
+          queueSessionIdRef.current !== snapshot.queueSessionId
+        );
+      }
+    },
+    [],
+  );
 
   // Stop background sender for THIS session when ChatPage mounts (foreground
   // takes over); start background senders for all OTHER sessions with pending
@@ -2591,18 +2664,24 @@ export default function ChatPage() {
       biz_params?: Record<string, unknown>;
       signal?: AbortSignal;
     }): Promise<Response> => {
+      const directSubmission = pendingDirectSubmissionRef.current;
+      pendingDirectSubmissionRef.current = null;
+      const requestAgentId = directSubmission?.agentId ?? selectedAgent;
+      const requestUsesQwenPawBackend =
+        directSubmission?.usesQwenPawBackend ?? usesQwenPawBackend;
       pendingFallbackEventsRef.current = [];
       pendingFallbackEventKeysRef.current.clear();
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         ...buildAuthHeaders(),
       };
+      headers["X-Agent-Id"] = requestAgentId;
 
-      if (usesQwenPawBackend) {
+      if (requestUsesQwenPawBackend) {
         try {
           const activeModels = await providerApi.getActiveModels({
             scope: "effective",
-            agent_id: selectedAgent,
+            agent_id: requestAgentId,
           });
           if (
             !activeModels?.active_llm?.provider_id ||
@@ -2623,7 +2702,7 @@ export default function ChatPage() {
       if (submittedValue !== null) {
         clearSubmittedSenderInput(submittedValue);
         pendingSenderClearRef.current = null;
-        localStorage.removeItem(getDraftStorageKey(selectedAgent));
+        localStorage.removeItem(getDraftStorageKey(requestAgentId));
       }
 
       const { input = [], biz_params } = data;
@@ -2649,11 +2728,12 @@ export default function ChatPage() {
           ? [rewrittenLastMsg]
           : [];
 
-      const identity = sessionApi.getSessionIdentity();
+      const identity =
+        directSubmission?.identity ?? sessionApi.getSessionIdentity();
       const usageTurn = useTurnUsageStore
         .getState()
         .beginTurn(
-          selectedAgent,
+          requestAgentId,
           identity.sessionId || session?.session_id || "",
         );
       let requestBody: Record<string, unknown> = {
@@ -2671,7 +2751,7 @@ export default function ChatPage() {
         const next = entry.item.transform({
           payload: requestBody,
           sessionId: String(requestBody.session_id || ""),
-          selectedAgent,
+          selectedAgent: requestAgentId,
         });
         if (next && typeof next === "object") {
           requestBody = next;
@@ -2695,19 +2775,20 @@ export default function ChatPage() {
           break;
         }
       }
-      if (usesQwenPawBackend) {
+      if (requestUsesQwenPawBackend) {
         applyApprovalLevelToRequestBody(
           requestBody,
           sessionApprovalLevelRef.current,
           runningConfigApprovalLevel,
         );
         projectSessionId =
+          directSubmission?.queueSessionId ??
           sessionApi.lastActiveChatId ??
           chatIdRef.current ??
           String(requestBody.session_id || "new");
         const pendingRequest = withPendingProjectDirectory(
           requestBody,
-          selectedAgent,
+          requestAgentId,
           projectSessionId,
         );
         requestBody = pendingRequest.requestBody;
@@ -2725,6 +2806,7 @@ export default function ChatPage() {
       }
 
       const backendChatId =
+        directSubmission?.backendChatId ??
         sessionApi.getRealIdForSession(String(requestBody.session_id || "")) ??
         chatIdRef.current ??
         String(requestBody.session_id || "");
@@ -2769,11 +2851,13 @@ export default function ChatPage() {
       }
 
       const localIdToResolve = sessionApi.lastActiveChatId ?? chatIdRef.current;
-      if (response.ok && localIdToResolve) {
+      const submissionIdToResolve =
+        directSubmission?.queueSessionId ?? localIdToResolve;
+      if (response.ok && submissionIdToResolve) {
         if (appliedProjectDir && projectSessionId) {
-          setPendingProjectDirectory(selectedAgent, projectSessionId, null);
+          setPendingProjectDirectory(requestAgentId, projectSessionId, null);
         }
-        sessionApi.triggerResolve(localIdToResolve);
+        sessionApi.triggerResolve(submissionIdToResolve);
       }
 
       return wrapChatResponseUsageStream(response, chatRef, usageTurn);
@@ -2931,29 +3015,60 @@ export default function ChatPage() {
       inputData: IAgentScopeRuntimeWebUIInputData,
     ): Promise<boolean | IAgentScopeRuntimeWebUISenderBeforeSubmitResult> => {
       if (isComposingRef.current) return false;
-      // Sender submit paths share the same admission check. This covers Enter,
-      // the send button, and attachment submissions.
-      if (await shouldEnqueueSubmission()) {
-        const val = inputData.query.trim();
-        if (!val) return false;
-        if (!enqueueSubmittedInput(inputData)) return false;
+      const val = inputData.query.trim();
+      if (!val) return false;
+      const snapshot = captureSubmissionSnapshot();
+
+      // Serialize the async status decision. Without this gate, two rapid
+      // submissions can both observe stale "idle" responses and both POST.
+      const previousAdmission = submissionAdmissionTailRef.current;
+      let releaseAdmission = () => {};
+      submissionAdmissionTailRef.current = new Promise<void>((resolve) => {
+        releaseAdmission = resolve;
+      });
+      await previousAdmission;
+
+      let enqueue = false;
+      try {
+        enqueue = await shouldEnqueueSubmission(snapshot);
+        if (enqueue) {
+          if (!enqueueSubmittedInput(inputData, snapshot)) return false;
+        } else {
+          // Reserve the direct-send slot before releasing the admission gate.
+          // Later submissions will queue until customFetch consumes it.
+          pendingDirectSubmissionRef.current = snapshot;
+        }
+      } finally {
+        releaseAdmission();
+      }
+
+      if (enqueue) {
+        const snapshotIsCurrent =
+          selectedAgentRef.current === snapshot.agentId &&
+          queueSessionIdRef.current === snapshot.queueSessionId;
+        if (!snapshotIsCurrent) return false;
         const textarea = getActiveSenderTextarea();
         if (textarea) setTextareaValue(textarea, "");
         // Clear sender attachment preview (deferred to next tick)
         clearSenderAttachments();
         return false;
       }
-      localStorage.removeItem(getDraftStorageKey(selectedAgent));
-      draftSuppressed = true;
-      // Clear pending attachments when sending directly (not through queue)
-      pendingFileListRef.current = [];
+      const snapshotIsCurrent =
+        selectedAgentRef.current === snapshot.agentId &&
+        queueSessionIdRef.current === snapshot.queueSessionId;
+      localStorage.removeItem(getDraftStorageKey(snapshot.agentId));
+      if (snapshotIsCurrent) {
+        draftSuppressed = true;
+        // Clear pending attachments when sending directly (not through queue)
+        pendingFileListRef.current = [];
+      }
 
-      const prepared = usesQwenPawBackend
+      const prepared = snapshot.usesQwenPawBackend
         ? beginLoopModeSubmission(inputData.query)
         : inputData.query;
       pendingSenderClearRef.current = prepared;
 
-      const textarea = getActiveSenderTextarea();
+      const textarea = snapshotIsCurrent ? getActiveSenderTextarea() : null;
       if (textarea) {
         if (prepared !== textarea.value) {
           setTextareaValue(textarea, prepared);
@@ -3614,6 +3729,7 @@ export default function ChatPage() {
     filesWorkspaceOpen,
     toggleFilesWorkspace,
     isOwner,
+    captureSubmissionSnapshot,
     enqueueSubmittedInput,
     shouldEnqueueSubmission,
     bgTaskCount,

--- a/console/src/stores/messageQueueStore.test.ts
+++ b/console/src/stores/messageQueueStore.test.ts
@@ -181,6 +181,22 @@ describe("messageQueueStore", () => {
       .currentSessionId;
   });
 
+  it("enqueue prefers the caller's authoritative backendSessionId", () => {
+    (window as unknown as { currentSessionId?: string }).currentSessionId =
+      "stale-window-session";
+
+    useMessageQueueStore.getState().enqueue(SESSION_ID, {
+      text: "hi",
+      backendSessionId: "authoritative-session",
+    });
+
+    const item = useMessageQueueStore.getState().getQueue(SESSION_ID)[0];
+    expect(item.backendSessionId).toBe("authoritative-session");
+
+    delete (window as unknown as { currentSessionId?: string })
+      .currentSessionId;
+  });
+
   it("enqueue leaves agentId/backendSessionId undefined when none are set", () => {
     useMessageQueueStore.getState().enqueue(SESSION_ID, { text: "hi" });
 

--- a/console/src/stores/messageQueueStore.test.ts
+++ b/console/src/stores/messageQueueStore.test.ts
@@ -168,6 +168,21 @@ describe("messageQueueStore", () => {
     expect(item.agentId).toBe("agent-x");
   });
 
+  it("enqueue prefers the caller's admission-time agentId", () => {
+    sessionStorage.setItem(
+      "qwenpaw-agent-storage",
+      JSON.stringify({ state: { selectedAgent: "new-agent" } }),
+    );
+
+    useMessageQueueStore.getState().enqueue(SESSION_ID, {
+      text: "hi",
+      agentId: "source-agent",
+    });
+
+    const item = useMessageQueueStore.getState().getQueue(SESSION_ID)[0];
+    expect(item.agentId).toBe("source-agent");
+  });
+
   it("enqueue captures backendSessionId from window.currentSessionId when set", () => {
     (window as unknown as { currentSessionId?: string }).currentSessionId =
       "backend-42";

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -64,6 +64,8 @@ export interface QueueItemInput {
   images?: QueueImage[];
   mentions?: QueueMention[];
   quote?: QueueQuote;
+  /** Agent identity captured by the caller before any async admission check. */
+  agentId?: string;
   /** Authoritative backend session_id captured by the caller. */
   backendSessionId?: string;
   userId?: string;
@@ -355,14 +357,16 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
     }
     // Capture the current selected agent at enqueue time so that
     // background sending uses the correct X-Agent-Id even after switch.
-    let agentId: string | undefined;
+    let agentId = input.agentId;
     try {
-      const agentStorage =
-        sessionStorage.getItem("qwenpaw-agent-storage") ||
-        localStorage.getItem("qwenpaw-agent-storage");
-      if (agentStorage) {
-        const parsed = JSON.parse(agentStorage);
-        agentId = parsed?.state?.selectedAgent || undefined;
+      if (!agentId) {
+        const agentStorage =
+          sessionStorage.getItem("qwenpaw-agent-storage") ||
+          localStorage.getItem("qwenpaw-agent-storage");
+        if (agentStorage) {
+          const parsed = JSON.parse(agentStorage);
+          agentId = parsed?.state?.selectedAgent || undefined;
+        }
       }
     } catch {
       // ignore

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -64,6 +64,8 @@ export interface QueueItemInput {
   images?: QueueImage[];
   mentions?: QueueMention[];
   quote?: QueueQuote;
+  /** Authoritative backend session_id captured by the caller. */
+  backendSessionId?: string;
   userId?: string;
   channel?: string;
 }
@@ -368,6 +370,7 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
     // Capture backend session_id so background sender targets the correct
     // session even if the session list is cleared after agent switch.
     const backendSessionId =
+      input.backendSessionId ||
       (window as unknown as { currentSessionId?: string }).currentSessionId ||
       undefined;
     const item: QueueItem = {

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 from uuid import uuid4
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -92,6 +92,12 @@ class ProjectDirectoryUpdate(BaseModel):
     """Controlled Session project directory update."""
 
     project_dir: str
+
+
+class ChatStatusResponse(BaseModel):
+    """Lightweight TaskTracker status for one chat."""
+
+    status: Literal["idle", "running"]
 
 
 class ProjectDirEntryPayload(BaseModel):
@@ -694,6 +700,16 @@ async def clear_chat_project_dirs(
 
 
 # ----- Existing CRUD endpoints -----
+
+
+@router.get("/{chat_id}/status", response_model=ChatStatusResponse)
+async def get_chat_status(
+    chat_id: str,
+    workspace=Depends(get_workspace),
+) -> ChatStatusResponse:
+    """Return agent-scoped run status without reading chat persistence."""
+    status = await workspace.task_tracker.get_status(chat_id)
+    return ChatStatusResponse(status=status)
 
 
 @router.get("/{chat_id}", response_model=ChatHistory)

--- a/tests/unit/app/chats/test_api.py
+++ b/tests/unit/app/chats/test_api.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
-from qwenpaw.app.chats.api import get_chat, list_chats
+from qwenpaw.app.chats.api import get_chat, get_chat_status, list_chats
 from qwenpaw.app.chats.models import ChatSpec
 
 
@@ -69,3 +69,30 @@ async def test_get_chat_hides_app_owned_dialogue_when_caller_opts_out():
         )
 
     assert raised.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_chat_status_uses_tracker_without_loading_chat_persistence():
+    tracker = SimpleNamespace(get_status=AsyncMock(return_value="running"))
+    workspace = SimpleNamespace(task_tracker=tracker)
+
+    result = await get_chat_status(
+        chat_id="chat-1",
+        workspace=workspace,
+    )
+
+    assert result.status == "running"
+    tracker.get_status.assert_awaited_once_with("chat-1")
+
+
+@pytest.mark.asyncio
+async def test_get_chat_status_treats_unknown_run_key_as_idle():
+    tracker = SimpleNamespace(get_status=AsyncMock(return_value="idle"))
+
+    result = await get_chat_status(
+        chat_id="missing",
+        workspace=SimpleNamespace(task_tracker=tracker),
+    )
+
+    assert result.status == "idle"
+    tracker.get_status.assert_awaited_once_with("missing")


### PR DESCRIPTION
## Summary

- add a lightweight chat run-status endpoint backed directly by TaskTracker
- route sender submissions, including attachments, into the existing localStorage queue while the chat is still running
- serialize async admission decisions so stale or reordered status responses cannot start concurrent POSTs
- snapshot chat, agent, and backend session identity before the status request and preserve it through queueing/direct send
- make the foreground queue wait for authoritative backend idle status before sending the next item
- keep HTTP 409 as the final server-side concurrency guard

## Root cause

The chat SDK clears its loading state when it receives the Completed SSE event, but TaskTracker releases the active run only after the remaining response-cycle cleanup finishes. A follow-up submitted during that gap bypassed the local queue and reached the backend while the same chat was still marked running.

The status preflight is asynchronous, so it also needs an admission gate and an immutable submission identity. Without those, reordered status responses can start two POSTs and a chat/agent switch during the request can retarget the pending message.

## Validation

- related Vitest suites: 163 passed
- related pytest suites: 8 passed
- `npx tsc -b --noEmit`: passed
- targeted Prettier and changed-files pre-commit checks: passed
- real Chrome against `http://localhost:5173`: second message persisted in localStorage, POST delayed until backend idle, both POSTs returned 200, persisted role order was user A → assistant A → user B → assistant B, no 409
- deterministic reordered-status browser probe: POST order FIRST → SECOND, maximum concurrent POST count 1
- deterministic session-switch browser probe: message retained the source backend session ID

Fixes #7559