### PR TITLE
fix(console): correct BiDi rendering for mixed RTL/LTR text (#2120)

### DIFF
--- a/console/src/pages/Chat/BidiSenderInput.test.tsx
+++ b/console/src/pages/Chat/BidiSenderInput.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import BidiSenderInput from "./BidiSenderInput";
+
+vi.mock("antd", async () => {
+  const React = await import("react");
+  return {
+    Input: {
+      TextArea: React.forwardRef(function MockTextArea(
+        props: Record<string, unknown>,
+        ref: React.Ref<HTMLTextAreaElement>,
+      ) {
+        return React.createElement("textarea", { ...props, ref });
+      }),
+    },
+  };
+});
+
+describe("BidiSenderInput", () => {
+  it("sets dir=auto so mixed RTL/LTR input follows the Unicode BiDi algorithm", () => {
+    render(<BidiSenderInput value="مرحبا Hello 123" onChange={vi.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("dir", "auto");
+  });
+});

--- a/console/src/pages/Chat/BidiSenderInput.tsx
+++ b/console/src/pages/Chat/BidiSenderInput.tsx
@@ -1,0 +1,17 @@
+import { Input } from "antd";
+import { forwardRef, type ComponentProps } from "react";
+
+type TextAreaProps = ComponentProps<typeof Input.TextArea>;
+
+/**
+ * Thin Sender TextArea wrapper that opts into Unicode BiDi auto-detection.
+ * The vendor Sender defaults to LTR; `dir="auto"` lets the browser pick
+ * direction from the first strong character (e.g. Arabic vs English).
+ */
+const BidiSenderInput = forwardRef<unknown, TextAreaProps>(
+  function BidiSenderInput(props, ref) {
+    return <Input.TextArea {...props} ref={ref} dir="auto" />;
+  },
+);
+
+export default BidiSenderInput;

--- a/console/src/pages/Chat/BidiSenderInput.tsx
+++ b/console/src/pages/Chat/BidiSenderInput.tsx
@@ -1,14 +1,19 @@
 import { Input } from "antd";
-import { forwardRef, type ComponentProps } from "react";
+import {
+  forwardRef,
+  type ComponentProps,
+  type ComponentRef,
+} from "react";
 
 type TextAreaProps = ComponentProps<typeof Input.TextArea>;
+type TextAreaRef = ComponentRef<typeof Input.TextArea>;
 
 /**
  * Thin Sender TextArea wrapper that opts into Unicode BiDi auto-detection.
  * The vendor Sender defaults to LTR; `dir="auto"` lets the browser pick
  * direction from the first strong character (e.g. Arabic vs English).
  */
-const BidiSenderInput = forwardRef<unknown, TextAreaProps>(
+const BidiSenderInput = forwardRef<TextAreaRef, TextAreaProps>(
   function BidiSenderInput(props, ref) {
     return <Input.TextArea {...props} ref={ref} dir="auto" />;
   },

--- a/console/src/pages/Chat/HostBubbles.module.less
+++ b/console/src/pages/Chat/HostBubbles.module.less
@@ -1,3 +1,8 @@
+/* Fix #2120: let mixed RTL/LTR runs follow the Unicode plaintext algorithm. */
+.bidiContent {
+  unicode-bidi: plaintext;
+}
+
 .collapsedSteps {
   width: calc(100% + 8px);
   margin-left: -8px;

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -86,11 +86,13 @@ function DeferredMarkdown({
   const deferredContent = useDeferredValue(content);
 
   return (
-    <Markdown
-      components={renderableCodeComponents}
-      content={deferredContent}
-      cursor={cursor}
-    />
+    <div dir="auto" className={styles.bidiContent}>
+      <Markdown
+        components={renderableCodeComponents}
+        content={deferredContent}
+        cursor={cursor}
+      />
+    </div>
   );
 }
 
@@ -123,7 +125,11 @@ const HostMessage = React.memo(function HostMessage({
               />
             );
           case AgentScopeRuntimeContentType.REFUSAL:
-            return <Markdown key={index} content={item.refusal} raw />;
+            return (
+              <div key={index} dir="auto" className={styles.bidiContent}>
+                <Markdown content={item.refusal} raw />
+              </div>
+            );
           case AgentScopeRuntimeContentType.IMAGE:
             return (
               <Images

--- a/console/src/pages/Chat/RichFileReferenceInput.module.less
+++ b/console/src/pages/Chat/RichFileReferenceInput.module.less
@@ -6,6 +6,7 @@
   max-height: 128px;
   overflow: auto;
   color: inherit;
+  unicode-bidi: plaintext;
 }
 
 .richEditor {
@@ -18,6 +19,8 @@
   overflow-wrap: anywhere;
   line-height: 1.65;
   cursor: text;
+  /* Fix #2120: mixed Arabic/English (etc.) inside one line */
+  unicode-bidi: plaintext;
 }
 
 .paragraph {
@@ -73,6 +76,8 @@
   border: 1px solid var(--app-info-border);
   border-radius: 7px;
   cursor: pointer;
+  direction: ltr;
+  unicode-bidi: isolate;
 
   svg {
     flex: 0 0 auto;
@@ -100,6 +105,8 @@
   font-family: var(--ant-font-family-code);
   background: var(--app-info-bg);
   border-color: var(--app-info-border);
+  direction: ltr;
+  unicode-bidi: isolate;
 }
 
 .codePopover {
@@ -124,6 +131,8 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     background: var(--app-fill-faint);
+    direction: ltr;
+    unicode-bidi: isolate;
   }
 }
 

--- a/console/src/pages/Chat/RichFileReferenceInput.test.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.test.tsx
@@ -43,8 +43,22 @@ describe("RichFileReferenceInput", () => {
 
     const editor = screen.getByRole("textbox");
     expect(editor).toHaveAttribute("contenteditable", "true");
+    expect(editor.closest("[dir='auto']")).not.toBeNull();
     expect(editor).not.toHaveTextContent("/work/app.ts");
     expect(container.querySelector("textarea")).toHaveValue(raw);
+  });
+
+  it("keeps mixed Arabic and English text under plaintext BiDi", async () => {
+    const mixed = "مرحبا Hello 123";
+    render(
+      <RichFileReferenceInputProvider onOpenReference={vi.fn()}>
+        <RichFileReferenceInput value={mixed} onChange={vi.fn()} />
+      </RichFileReferenceInputProvider>,
+    );
+
+    const editor = await screen.findByRole("textbox");
+    expect(editor.closest("[dir='auto']")).toHaveAttribute("dir", "auto");
+    expect(editor).toHaveTextContent(mixed);
   });
 
   it("clears the visible editor when the sender value is cleared", async () => {

--- a/console/src/pages/Chat/RichFileReferenceInput.tsx
+++ b/console/src/pages/Chat/RichFileReferenceInput.tsx
@@ -660,6 +660,7 @@ const RichFileReferenceInput = forwardRef<unknown, TextAreaProps>(
       <div
         className={`${styles.richInputRoot} ${className ?? ""}`}
         style={style}
+        dir="auto"
         data-disabled={disabled || undefined}
       >
         <LexicalComposer

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -620,6 +620,27 @@
 }
 /* End #6583 */
 
+/* Fix #2120: BiDi for mixed RTL/LTR in chat input and rendered messages.
+ * dir="auto" is set on the sender TextArea (BidiSenderInput) and on host
+ * message wrappers; unicode-bidi: plaintext lets inline opposite-direction
+ * runs reorder correctly. Keep code/pre always LTR-isolated. */
+.chatMessagesArea :global {
+  .qwenpaw-sender textarea,
+  [class*="sender-input"] textarea,
+  [class*="bubble"] [class*="markdown"] {
+    unicode-bidi: plaintext;
+  }
+
+  [class*="bubble"] [class*="markdown"] pre,
+  [class*="bubble"] [class*="markdown"] code,
+  [class*="bubble"] .qwenpaw-code-block,
+  [class*="bubble"] [class*="code-block"] {
+    direction: ltr;
+    unicode-bidi: isolate;
+  }
+}
+/* End #2120 */
+
 /* ---- Rate-limit guidance banner ---- */
 .rateLimitBanner {
   display: flex;

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -82,6 +82,26 @@ describe("Chat attachment preview styles", () => {
   });
 });
 
+describe("Chat BiDi text styles (#2120)", () => {
+  it("applies plaintext BiDi to chat input and message markdown", () => {
+    const marker = "Fix #2120";
+    const markerIndex = stylesSource.indexOf(marker);
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("/* End #2120 */", markerIndex),
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toContain(".qwenpaw-sender textarea");
+    expect(rule).toContain('[class*="bubble"] [class*="markdown"]');
+    expect(rule).toMatch(/unicode-bidi:\s*plaintext/);
+    expect(rule).toContain('[class*="bubble"] [class*="markdown"] pre');
+    expect(rule).toContain('[class*="bubble"] [class*="markdown"] code');
+    expect(rule).toMatch(/direction:\s*ltr/);
+    expect(rule).toMatch(/unicode-bidi:\s*isolate/);
+  });
+});
+
 describe("Chat mobile layout styles", () => {
   it("releases the vendor chat minimum width on narrow viewports", () => {
     const mobileStart = stylesSource.indexOf(

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -131,6 +131,7 @@ import {
 } from "../../stores/filesSurfaceStore";
 import { useCodingTabsStore } from "../../stores/codingTabsStore";
 import { RichFileReferenceInputProvider } from "./RichFileReferenceInput";
+import BidiSenderInput from "./BidiSenderInput";
 import type { ParsedFileReference } from "./fileReferenceFormatting";
 import { scrollReverseMessageList } from "./messageScroll";
 import { LONG_CHAT_USER_MESSAGE_ANCHORS } from "./longChatPerformance";
@@ -3169,6 +3170,9 @@ export default function ChatPage() {
       },
       sender: {
         ...(i18nConfig as any)?.sender,
+        components: {
+          input: BidiSenderInput,
+        },
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
         beforeUI: showSenderBeforeUI ? (


### PR DESCRIPTION
## Description

Fixes mixed RTL/LTR (BiDi) rendering in the Console chat input and rendered message bubbles. Without this, Arabic (and other RTL) text mixed with English, numbers, or code visually reorders incorrectly.

Adds `dir="auto"` on the sender textarea / input container and message content wrappers, applies `unicode-bidi: plaintext` for inline mixed-direction runs, and keeps code/preformatted/file-path fragments as `direction: ltr; unicode-bidi: isolate`.

**Related Issue:** Fixes #2120

**Security Considerations:** N/A — presentation-only CSS/DOM attributes in Console chat UI.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit` locally on the changed files and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`vitest` for Console; `pytest` N/A for this change) and they pass
- [x] Documentation updated (if needed) — not needed
- [x] Ready for review

## Testing

1. Open Console chat.
2. Type a mixed sentence such as `مرحبا Hello 123` into the chat input — English/numbers should stay LTR inside the RTL sentence.
3. Send the message — the rendered bubble should keep the same ordering.
4. Confirm fenced code / inline code / file-path chips stay LTR in RTL messages.

## Evidence

Console-only change. Local verification after the TextAreaRef typing fix:

```text
cd console && npx tsc -b --noEmit
# exit 0 (no type errors)

cd console && npm run test:run -- \
  src/pages/Chat/index.module.test.ts \
  src/pages/Chat/BidiSenderInput.test.tsx \
  src/pages/Chat/RichFileReferenceInput.test.tsx \
  src/pages/Chat/HostBubbles.test.ts
# Test Files  4 passed (4)
# Tests       18 passed (18)

pre-commit run --files \
  console/src/pages/Chat/BidiSenderInput.tsx \
  console/src/pages/Chat/BidiSenderInput.test.tsx \
  console/src/pages/Chat/HostBubbles.module.less \
  console/src/pages/Chat/HostBubbles.tsx \
  console/src/pages/Chat/RichFileReferenceInput.module.less \
  console/src/pages/Chat/RichFileReferenceInput.test.tsx \
  console/src/pages/Chat/RichFileReferenceInput.tsx \
  console/src/pages/Chat/index.module.less \
  console/src/pages/Chat/index.module.test.ts \
  console/src/pages/Chat/index.tsx
# detect private key ... Passed
# trim trailing whitespace ... Passed
# exit 0

npx prettier --check <changed Chat files>
# All matched files use Prettier code style!

pytest
# N/A — no Python/backend changes in this PR
```

## Additional Notes

There is an older open PR (#2142) that attempted a broader layout.css-only BiDi tweak. This PR scopes the fix to Chat sender/message containers (plus LTR isolation for code), matching how other Console chat CSS fixes are done in index.module.less.

Follow-up commit types `BidiSenderInput` with `ComponentRef<typeof Input.TextArea>` so `tsc -b --noEmit` / production build succeeds.