### PR TITLE
fix(computer-use): add control action to restart the native helper

### DIFF
--- a/console/src-tauri/src/computer_use_runtime.rs
+++ b/console/src-tauri/src/computer_use_runtime.rs
@@ -1130,6 +1130,25 @@ fn serve_control_connection(
                     ControlResponse::error("runtime_unavailable")
                 }
             },
+            // TCC decisions are cached per process, so a helper started before
+            // the user granted Screen Recording or Accessibility never sees
+            // the grant. Replace it so the fresh helper picks the
+            // authorization up.
+            "restart" => {
+                if let Err(err) = stop_helper(app) {
+                    log::warn!("[computer-use] control restart stop failed: {err}");
+                }
+                match ensure(app).and_then(|_| {
+                    runtime_capability(app)
+                        .ok_or_else(|| "Computer Use helper did not expose a capability".to_string())
+                }) {
+                    Ok(capability) => ControlResponse::capability(capability),
+                    Err(err) => {
+                        log::warn!("[computer-use] control restart failed: {err}");
+                        ControlResponse::error("runtime_unavailable")
+                    }
+                }
+            },
             #[cfg(target_os = "macos")]
             "begin_focus" => match (request.helper_pid, request.lease_id.as_deref()) {
                 (Some(helper_pid), Some(lease_id)) if !lease_id.is_empty() => {

--- a/src/qwenpaw/app/computer_use/runtime.py
+++ b/src/qwenpaw/app/computer_use/runtime.py
@@ -114,6 +114,31 @@ class HostRuntimeProvider:
             return capability
 
     @classmethod
+    def restart_helper(cls) -> bool:
+        """Replace the live helper with a freshly started one.
+
+        macOS caches TCC decisions (Screen Recording, Accessibility) per
+        process. A helper that started before the user granted those
+        permissions keeps being denied even after the grant, so it must be
+        replaced before the authorization becomes visible to Computer Use.
+        """
+        with cls._lock:
+            control = _control_endpoint()
+            if control is None:
+                return False
+            response = _request_control(control, {"action": "restart"})
+            # Whatever the host managed to do, the old helper is gone now;
+            # neither the cached capability nor the environment bootstrap
+            # (which names the old helper's endpoint) may answer again.
+            cls._capability = None
+            cls._environment_spent = True
+            capability = _capability_from_response(response)
+            if capability is None:
+                return False
+            cls._capability = capability
+            return True
+
+    @classmethod
     def invalidate_capability(cls, capability: RuntimeCapability) -> None:
         """Forget a capability whose endpoint has gone away.
 
@@ -210,8 +235,9 @@ def _control_endpoint() -> _ControlEndpoint | None:
     return _ControlEndpoint(host, port, token)
 
 
-def _request_capability(control: _ControlEndpoint) -> RuntimeCapability | None:
-    response = _request_control(control, {"action": "acquire"})
+def _capability_from_response(
+    response: dict[str, object] | None,
+) -> RuntimeCapability | None:
     if response is None or response.get("ok") is not True:
         return None
     pipe_name = response.get("pipe_name")
@@ -221,6 +247,12 @@ def _request_capability(control: _ControlEndpoint) -> RuntimeCapability | None:
     if not pipe_name or not secret:
         return None
     return RuntimeCapability(pipe_name, secret, COMPUTER_USE_PROTOCOL_VERSION)
+
+
+def _request_capability(control: _ControlEndpoint) -> RuntimeCapability | None:
+    return _capability_from_response(
+        _request_control(control, {"action": "acquire"}),
+    )
 
 
 def _request_control(

--- a/tests/unit/plugins/computer_use/test_capability_recovery.py
+++ b/tests/unit/plugins/computer_use/test_capability_recovery.py
@@ -148,3 +148,69 @@ def test_no_host_and_no_environment_means_no_capability(
 ) -> None:
     monkeypatch.setattr(runtime_module, "_control_endpoint", lambda: None)
     assert HostRuntimeProvider.acquire_capability() is None
+
+
+def test_restart_helper_replaces_the_cached_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A helper replaced after a TCC grant hands out a new endpoint.
+
+    The old helper is dead, so the restarted one must answer with a fresh
+    capability and the cached one must never be returned again.
+    """
+    monkeypatch.setattr(runtime_module, "_control_endpoint", object)
+    responses = iter(
+        [
+            {"ok": True, "pipe_name": "pipe-old", "capability": "secret"},
+            {"ok": True, "pipe_name": "pipe-new", "capability": "secret"},
+        ],
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "_request_control",
+        lambda _control, _fields: next(responses),
+    )
+
+    first = HostRuntimeProvider.acquire_capability()
+    assert first is not None
+    assert first.names_same_endpoint(_capability("pipe-old"))
+
+    assert HostRuntimeProvider.restart_helper() is True
+
+    second = HostRuntimeProvider.get_capability()
+    assert second is not None
+    assert second.names_same_endpoint(_capability("pipe-new"))
+
+
+def test_restart_helper_failure_stops_answering_with_the_old_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed restart still retires the dead helper's capability.
+
+    The host may fail to bring a replacement up, but the old helper is gone
+    either way, so its endpoint must not be handed out again.
+    """
+    monkeypatch.setattr(runtime_module, "_control_endpoint", object)
+    responses = iter(
+        [
+            {"ok": True, "pipe_name": "pipe-old", "capability": "secret"},
+        ],
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "_request_control",
+        lambda _control, _fields: next(responses, None),
+    )
+
+    first = HostRuntimeProvider.acquire_capability()
+    assert first is not None
+
+    assert HostRuntimeProvider.restart_helper() is False
+    assert HostRuntimeProvider.get_capability() is None
+
+
+def test_restart_helper_without_a_control_endpoint_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_control_endpoint", lambda: None)
+    assert HostRuntimeProvider.restart_helper() is False


### PR DESCRIPTION
## Description

On macOS, TCC decisions (Screen Recording, Accessibility) are cached **per process**. A Computer Use helper that was started before the user granted those permissions keeps being denied even after the grant lands in System Settings — the running helper simply never sees it. Today the only way to make the authorization take effect is restarting the whole desktop app.

This PR adds a `restart` action to the computer-use control protocol:

- **Desktop host (`computer_use_runtime.rs`)**: on `restart`, stop the live helper and start a fresh one, answering with the new capability. Reuses the existing `stop_helper` / `ensure` / `runtime_capability` primitives; follows the same response shape as `acquire`.
- **Backend (`app/computer_use/runtime.py`)**: expose `HostRuntimeProvider.restart_helper()`. It retires the cached capability and the environment bootstrap (both name the old helper's endpoint) whether or not the replacement comes up, and caches the new capability when it does — so a failed restart degrades to the existing `acquire`-again recovery path instead of handing out a dead endpoint. The response parsing is extracted into `_capability_from_response()` and shared with `_request_capability()`.
- **Tests**: three new cases in `test_capability_recovery.py` covering the replace-success, failed-restart-stops-answering-with-the-old-endpoint, and no-control-endpoint paths.

The intended call site is any consumer that observes a permission-denied result from the helper: record that a TCC grant is pending, wait for the user to authorize, then call `restart_helper()` before the next operation instead of asking the user to relaunch the app.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and rerun checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this fix)
- [ ] Ready for review

## Testing

Reproducing the original problem on macOS:

1. Launch the desktop app with Computer Use available, but deny Screen Recording / Accessibility when prompted, so the helper starts without the grant.
2. Grant the permissions in System Settings → Privacy & Security.
3. Any further computer-use operation from the same session still fails as if unpermitted — the running helper cannot observe the new TCC decision; only a full app restart clears it.

With this change, calling `HostRuntimeProvider.restart_helper()` after the grant replaces the stale helper and returns a working capability.

Verified locally:

```
$ python -m pytest tests/unit/plugins/computer_use/test_capability_recovery.py -q
8 passed in 0.16s

$ cd console/src-tauri && cargo test --lib computer_use_runtime
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured

$ cargo check --lib
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 01s
```

## Evidence

- `tests/unit/plugins/computer_use/test_capability_recovery.py` gains three regression tests for the restart path (capability replaced, stale endpoint retired on failure, no-control-endpoint guard).
- Behavior on the Rust side mirrors the existing `acquire` branch (stop → `ensure` → `runtime_capability`), and the existing `computer_use_runtime` unit tests still pass after the new match arm.

## Security Considerations

The new control action is authenticated by the same control-token check as every other action and only restarts a helper process that this host already manages; no new listening surface or privilege is introduced.
