### PR TITLE
fix(agents): handle PDF blocks for text-only models

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -32,6 +32,7 @@ from agentscope.tool import Toolkit
 from .context.base import ContextManager
 from .skill_system import get_workspace_skills_dir
 from .utils.image_freezing import freeze_local_images_async
+from .utils.message_request_normalizer import _is_media_block
 from ..modes.coding import CodingModeMixin
 from ..utils.io_utils import run_sync_io
 from ..constant import (
@@ -498,9 +499,6 @@ class QwenPawAgent(CodingModeMixin, Agent):
     # is to make a previously-rejected request retryable, so leaving
     # residue would defeat the point.
     # ------------------------------------------------------------------
-
-    _MEDIA_BLOCK_TYPES = {"image", "audio", "video", "file"}
-    _MEDIA_MIME_PREFIXES = ("image/", "audio/", "video/")
 
     def _get_model_key(self) -> str | None:
         """Return the capability-cache key for the active model."""
@@ -1144,17 +1142,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
         )
 
     def _is_media_block(self, block: Any) -> bool:
-        """Return True if *block* carries image/audio/video data."""
-        if isinstance(block, dict):
-            return block.get("type") in self._MEDIA_BLOCK_TYPES
-        btype = getattr(block, "type", None)
-        if btype in self._MEDIA_BLOCK_TYPES:
-            return True
-        if btype == "data":
-            source = getattr(block, "source", None)
-            mt = getattr(source, "media_type", "") or ""
-            return mt.startswith(self._MEDIA_MIME_PREFIXES)
-        return False
+        """Return True if *block* carries model media/document data."""
+        return _is_media_block(block)
 
     # ------------------------------------------------------------------
     # Tool call enhancement: hint injection + hook registration

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -26,6 +26,7 @@ from .tool_message_utils import _sanitize_tool_messages
 # user-facing history; this one prepares retryable requests.
 _MEDIA_BLOCK_TYPES = {"image", "audio", "video", "file"}
 _MEDIA_MIME_PREFIXES = ("image/", "audio/", "video/")
+_DOCUMENT_MIME_TYPES = frozenset({"application/pdf"})
 
 # Fields that are provider-specific and should not leak across families.
 # Gemini: extra_content carries thought_signature.
@@ -122,17 +123,29 @@ def _clone_messages(msgs: list[Msg]) -> list[Msg]:
 
 
 def _is_media_block(block: Any) -> bool:
-    """Check if a block is a media block (dict or Pydantic DataBlock)."""
-    if isinstance(block, dict):
-        return block.get("type") in _MEDIA_BLOCK_TYPES
-    btype = getattr(block, "type", None)
+    """Check if a block carries media or a supported document payload."""
+    btype = (
+        block.get("type")
+        if isinstance(block, dict)
+        else getattr(block, "type", None)
+    )
     if btype in _MEDIA_BLOCK_TYPES:
         return True
     # 2.0 DataBlock: type="data", media type in source.media_type
     if btype == "data":
-        source = getattr(block, "source", None)
-        mt = getattr(source, "media_type", "") or ""
-        return mt.startswith(_MEDIA_MIME_PREFIXES)
+        source = (
+            block.get("source")
+            if isinstance(block, dict)
+            else getattr(block, "source", None)
+        )
+        mt = (
+            source.get("media_type", "")
+            if isinstance(source, dict)
+            else getattr(source, "media_type", "")
+        ) or ""
+        return (
+            mt.startswith(_MEDIA_MIME_PREFIXES) or mt in _DOCUMENT_MIME_TYPES
+        )
     return False
 
 

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -19,6 +19,7 @@ from qwenpaw.agents.utils.message_request_normalizer import (
     _clean_provider_specific_fields,
     _clone_msg,
     _clone_messages,
+    _is_media_block,
     _strip_media_blocks_in_place,
     normalize_messages_for_model_request,
 )
@@ -34,7 +35,7 @@ def _data_block(media_type: str, url: str = "file:///tmp/test") -> DataBlock:
     return DataBlock(source=URLSource(url=url, media_type=media_type))
 
 
-def _is_media_block(block) -> bool:
+def _is_data_block(block) -> bool:
     return getattr(block, "type", None) == "data"
 
 
@@ -211,6 +212,28 @@ def test_strip_media_blocks_preserves_non_media_content(text_message):
     assert msgs[0].content == text_message.content
 
 
+@pytest.mark.parametrize(
+    "block",
+    [
+        _data_block("application/pdf", "file:///tmp/report.pdf"),
+        {
+            "type": "data",
+            "source": {
+                "type": "url",
+                "url": "file:///tmp/report.pdf",
+                "media_type": "application/pdf",
+            },
+        },
+    ],
+)
+def test_is_media_block_recognizes_pdf_data_blocks(block):
+    assert _is_media_block(block) is True
+
+
+def test_is_media_block_preserves_plain_text_data_block():
+    assert _is_media_block(_data_block("text/plain")) is False
+
+
 def test_strip_media_blocks_handles_empty_content():
     msg = Msg(name="user", role="user", content=[])
     msgs = [msg]
@@ -256,6 +279,72 @@ def test_normalize_without_multimodal_support_strips_media(image_message):
     assert msgs[0].content[0].type == "data"
     assert normalized[0].content[0].type == "text"
     assert normalized[0].content[0].text == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_normalize_without_multimodal_support_strips_pdf():
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[_data_block("application/pdf", "file:///tmp/report.pdf")],
+    )
+
+    normalized = normalize_messages_for_model_request(
+        [msg],
+        supports_multimodal=False,
+    )
+
+    assert _is_data_block(msg.content[0])
+    assert len(normalized[0].content) == 1
+    assert normalized[0].content[0].type == "text"
+    assert normalized[0].content[0].text == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_normalize_keeps_user_pdf_for_multimodal_model():
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[_data_block("application/pdf", "file:///tmp/report.pdf")],
+    )
+
+    normalized = normalize_messages_for_model_request(
+        [msg],
+        supports_multimodal=True,
+    )
+
+    assert _is_data_block(normalized[0].content[0])
+
+
+def test_normalize_keeps_pdf_returned_by_tool_for_multimodal_model():
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ToolCallBlock(
+                type="tool_call",
+                id="call_read",
+                name="read_document",
+                input='{"path":"/tmp/report.pdf"}',
+            ),
+            ToolResultBlock(
+                type="tool_result",
+                id="call_read",
+                name="read_document",
+                output=[
+                    _data_block(
+                        "application/pdf",
+                        "file:///tmp/report.pdf",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    normalized = normalize_messages_for_model_request(
+        [msg],
+        supports_multimodal=True,
+    )
+
+    assert _is_data_block(normalized[0].content[1].output[0])
 
 
 def test_normalize_preserves_original_messages(mixed_content_message):


### PR DESCRIPTION
## Description

Treat `application/pdf` DataBlocks as media during request-time normalization so text-only models do not receive unsupported OpenAI file blocks from persisted history.

The media-block predicate now handles both Pydantic and dict-shaped DataBlocks and is shared by request normalization and the ReAct fallback path, preventing the two implementations from drifting.

**Security Considerations:** No security-sensitive behavior changes. Stored conversation history is not mutated; stripping only affects request-time copies for models explicitly marked as text-only.

Fixes: #7617
Fixes: #7597

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

```bash
PYTHONPATH=src conda run -n qwenpaw python -m pytest -q \
  tests/unit/agents/test_message_request_normalizer.py \
  tests/unit/agents/test_model_factory_message_normalization.py
```

Coverage includes Pydantic and dict PDF DataBlocks, text-only stripping, preservation for multimodal models, nested tool results, existing image/audio/video behavior, and `text/plain` preservation.

## Evidence

```text
........................................................................ [ 91%]
.......                                                                  [100%]
79 passed in 1.73s
```

Changed-file pre-commit run:

```text
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

`git diff --check` also passes.

## Additional Notes

This intentionally preserves the existing PDF file-block behavior for multimodal models. Providers that support images but reject document/file blocks require a separate document-capability signal and are outside this narrowly scoped fix.
