### PR TITLE
fix(tool-calls): emit offload completion hints as user messages

### DIFF
--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -12,9 +12,9 @@ def make_offload_hint_msg(entry: Any) -> Any:
     """Construct a hint Msg for a completed offloaded tool call.
 
     The hint flattens the finalized response content blocks (TextBlock,
-    ImageBlock, etc.) directly into the message so that provider formatters
-    treat it as an ordinary assistant message — no ToolResultBlock means no
-    orphan ``role=tool`` wire message and no tool-call pairing issues.
+    ImageBlock, etc.) directly into an input message so provider formatters
+    do not emit an orphan ``role=tool`` message and the next model call does
+    not end with an assistant/model turn.
     """
     end = entry.end_state or "unknown"
     notification = TextBlock(
@@ -31,6 +31,6 @@ def make_offload_hint_msg(entry: Any) -> Any:
     result_blocks = list(entry.final_response.content or [])
     return Msg(
         name="system",
-        role="assistant",
+        role="user",
         content=[notification] + result_blocks,
     )

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -367,7 +367,7 @@ async def test_background_completion_emits_hint():
     )
 
     assert events[-1].metadata["offloaded"] is True
-    assert hint.role == "assistant"
+    assert hint.role == "user"
     text_block = next(
         block
         for block in hint.content


### PR DESCRIPTION
## Description

Fix Gemini failures that occur after a background/offloaded tool call completes or is interrupted.

QwenPaw currently creates the background tool completion notification in `make_offload_hint_msg()` with:

```python
role="assistant"
```

The hint is then appended directly to the conversation context before the next model invocation.

For Gemini-compatible providers, this can make the request end with an assistant/model turn, causing Gemini to reject the request with:

```text
400 INVALID_ARGUMENT: Requests ending with a model turn are not supported.
```

This PR changes the offload completion notification from an assistant message to a user/input message:

```diff
 return Msg(
     name="system",
-    role="assistant",
+    role="user",
     content=[notification] + result_blocks,
 )
```

The notification is generated by the QwenPaw runtime rather than by the model, so treating it as an input turn also better reflects its semantics.

The existing coordinator regression test is updated accordingly to expect the offload completion hint to use `role="user"`.

**Related Issue:** Fixes #7625

**Security Considerations:** None. This change only adjusts the conversation role used for internally generated background tool completion notifications.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Refactoring

## Component(s) Affected

* [x] Core / Backend (app, agents, config, providers, utils, local_models)
* [ ] Console (frontend web UI)
* [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
* [ ] Skills
* [ ] CLI
* [ ] Documentation (website)
* [x] Tests
* [ ] CI/CD
* [ ] Scripts / Deploy

## Checklist

* [ ] I ran `pre-commit run --all-files` locally and it passes
* [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
* [ ] I ran tests locally (`pytest` or as relevant) and they pass
* [ ] Documentation updated (if needed)
* [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This change is in the core tool-call offload logic and does not modify any channel implementation.

## Testing

The existing regression test in:

```text
tests/unit/tool_calls/test_coordinator_completion.py
```

has been updated so that `test_background_completion_emits_hint` now verifies:

```python
assert hint.role == "user"
```

instead of:

```python
assert hint.role == "assistant"
```

Recommended focused test:

```bash
pytest tests/unit/tool_calls/test_coordinator_completion.py -q
```

Recommended full project checks:

```bash
pre-commit run --all-files
pytest
```

## Evidence

The issue was reproduced on QwenPaw 2.2.0 with a Gemini model.

The captured QwenPaw error dump contained:

```text
openai.BadRequestError: Error code: 400 - {
  'error': {
    'code': 400,
    'message': 'Requests ending with a model turn are not supported.',
    'status': 'INVALID_ARGUMENT'
  }
}
```

Inspection of `agent_state.state.context` showed that the final context message immediately before the failed Gemini request was the runtime-generated offload completion notification:

```text
role="assistant"
name="system"

<system-notification>
Background tool call `execute_shell_command` (...)
completed with state=interrupted. Result below.
</system-notification>
```

The notification was traced directly to:

```text
src/qwenpaw/tool_calls/_hint.py
```

where `make_offload_hint_msg()` used:

```python
return Msg(
    name="system",
    role="assistant",
    content=[notification] + result_blocks,
)
```

The same one-line role change was also applied to the affected QwenPaw 2.2.0 deployment as a local workaround:

```diff
-role="assistant",
+role="user",
```

and the modified module passed Python syntax validation:

```bash
python -m py_compile \
  /app/venv/lib/python3.11/site-packages/qwenpaw/tool_calls/_hint.py
```

Output:

```text
# completed successfully with no syntax errors
```

The PR also updates the existing unit regression test to enforce the new `user` role behavior.

## Additional Notes

This is separate from the earlier `ToolResultBlock` / orphan `role=tool` issue.

QwenPaw 2.2.0 already flattens the finalized background tool response blocks so that no orphan `ToolResultBlock` is emitted. The remaining issue is specifically that the resulting runtime notification is still represented as an assistant message.

Changing the runtime-generated offload completion hint to an input/user turn prevents the conversation from ending with a model turn before the next Gemini inference.
