### PR TITLE
fix(mcp): let the legacy handshake arbitrate a 401 discover probe

### DIFF
--- a/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
+++ b/src/qwenpaw/drivers/handlers/mcp_streamable_http.py
@@ -48,6 +48,7 @@ _JSONRPC_UNSUPPORTED_PROTOCOL_VERSION = -32022
 _MCP_SESSION_ID_HEADER = "mcp-session-id"
 
 _LIST_TOOLS_MAX_PAGES = 50
+_OAUTH_BODY_SNIPPET_LIMIT = 200
 _IEEE754_SAFE_INT_MIN = -(2**53 - 1)
 _IEEE754_SAFE_INT_MAX = 2**53 - 1
 
@@ -76,6 +77,14 @@ _MISSING = object()
 
 class _LegacyProtocolError(Exception):
     """Handshake-era peer; triggers AutoClient fallback."""
+
+
+class _OAuthRequiredError(RuntimeError):
+    """Peer answered HTTP 401.
+
+    Subclasses ``RuntimeError`` so callers keep their existing contract,
+    while ``_negotiate`` can reclassify the handshake probe alone.
+    """
 
 
 class _JsonRpcError(Exception):
@@ -449,6 +458,39 @@ def _discover_rpc_error(exc: _JsonRpcError) -> RuntimeError:
     )
 
 
+def _oauth_required_message(
+    *,
+    name: str,
+    method: str,
+    body: bytes,
+    www_authenticate: str | None,
+) -> str:
+    """Build a 401 message that keeps the peer's own diagnostics visible.
+
+    A 401 is not always a credential failure: gateways in front of
+    handshake-era servers may wrap "unknown method" in a Bearer challenge.
+    Echoing the body lets that case be diagnosed without a packet capture.
+    """
+    challenge = (
+        f"www-authenticate={www_authenticate}"
+        if www_authenticate
+        else "no www-authenticate header"
+    )
+    parts = [
+        f"MCP client '{name}' requires OAuth authorization: HTTP 401 "
+        f"for '{method}' ({challenge}). Authorize via the UI.",
+    ]
+    text = body.decode("utf-8", errors="replace").strip()
+    if text:
+        parts.append(f"Peer body: {text[:_OAUTH_BODY_SNIPPET_LIMIT]}")
+    parts.append(
+        "If this peer is a legacy server that does not implement MCP "
+        f"{_MODERN_PROTOCOL_VERSION}, the 401 may be its gateway reporting "
+        "an unsupported method rather than a real credential failure.",
+    )
+    return " ".join(parts)
+
+
 class _HttpClientBase:
     """Shared constructor fields for Streamable-HTTP clients."""
 
@@ -707,6 +749,15 @@ class HttpStatelessClient(_HttpClientBase):
             ):
                 raise _LegacyProtocolError(str(exc)) from exc
             raise _discover_rpc_error(exc) from exc
+        except _OAuthRequiredError as exc:
+            # A gateway may wrap "unknown method" in a Bearer challenge
+            # instead of 400/404/405, so a 401 here is not proof that
+            # credentials are missing. Let the legacy handshake arbitrate:
+            # a peer that truly requires OAuth answers 401 there too, and
+            # HttpStatefulClient surfaces the OAuth error itself.
+            raise _LegacyProtocolError(
+                f"discover probe got HTTP 401: {exc}",
+            ) from exc
         except httpx.HTTPStatusError as exc:
             # Bare 400/404/405 ⇒ one legacy fallback.
             if _is_legacy_protocol_evidence(
@@ -778,11 +829,16 @@ class HttpStatelessClient(_HttpClientBase):
             response_headers = dict(response.headers)
             raw_body = b""
             if status == 401:
-                await response.aread()
-                raise RuntimeError(
-                    f"MCP client '{self.name}' requires OAuth "
-                    "authorization (HTTP 401). Please authorize "
-                    "via the UI.",
+                raw_body = await response.aread()
+                raise _OAuthRequiredError(
+                    _oauth_required_message(
+                        name=self.name,
+                        method=method,
+                        body=raw_body,
+                        www_authenticate=response.headers.get(
+                            "www-authenticate",
+                        ),
+                    ),
                 )
             if "text/event-stream" in ctype:
                 data = await self._read_sse_rpc_response(
@@ -902,9 +958,11 @@ class HttpAutoClient(_HttpClientBase):
             follow_redirects=follow_redirects,
             **shared,
         )
+        fallback_reason = ""
         try:
             await modern.connect(timeout=timeout)
         except _LegacyProtocolError as exc:
+            fallback_reason = str(exc)
             logger.info(
                 f"MCP client '{self.name}' falling back to legacy: {exc}",
             )
@@ -928,8 +986,15 @@ class HttpAutoClient(_HttpClientBase):
         legacy = HttpStatefulClient(**shared)
         try:
             await legacy.connect(timeout=remaining)
-        except BaseException:
+        except BaseException as exc:
             await legacy.close(ignore_errors=True)
+            if fallback_reason:
+                # Keep the modern probe's verdict reachable: the legacy
+                # error alone can hide that the peer first answered 401.
+                logger.warning(
+                    f"MCP client '{self.name}' legacy fallback failed "
+                    f"({exc}); modern probe reported: {fallback_reason}",
+                )
             raise
         self._impl = legacy
         self.is_stateful = True

--- a/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
+++ b/tests/unit/drivers/handlers/test_mcp_dual_protocol.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any, Callable
 
 import httpx
@@ -30,10 +31,12 @@ from qwenpaw.drivers.handlers.mcp_streamable_http import (
     _PROTOCOL_VERSION_META_KEY,
     _JsonRpcError,
     _LegacyProtocolError,
+    _OAuthRequiredError,
     _build_mcp_param_headers,
     _collect_tool_header_bindings,
     _is_https_upgrade,
     _normalize_call_tool_result,
+    _oauth_required_message,
     _same_origin,
     _supported_versions_from_payload,
 )
@@ -95,6 +98,48 @@ def _sse(*events: Any, status: int = 200) -> httpx.Response:
         status,
         content="".join(parts).encode(),
         headers={"content-type": "text/event-stream"},
+    )
+
+
+_GATEWAY_401_BODY = json.dumps(
+    {
+        "error": {
+            "code": 401,
+            "message": "MCP Failure",
+            "data": json.dumps(
+                {
+                    "error": {
+                        "code": -32601,
+                        "message": "Method not found",
+                        "data": "Method server/discover not found",
+                    },
+                },
+            ),
+        },
+    },
+)
+
+_GATEWAY_401_CHALLENGE = (
+    'Bearer resource_metadata="https://gw.test/.well-known/'
+    'oauth-protected-resource", error="invalid_token", '
+    'error_description="Access token is missing or invalid"'
+)
+
+
+def _gateway_401(_rid: Any) -> httpx.Response:
+    """A gateway that wraps "unknown method" in an OAuth-style 401.
+
+    Mirrors the pkulaw shape: no ``jsonrpc`` envelope, no ``id``, and the
+    real ``-32601`` double-encoded inside ``data`` as a string. Fallback
+    must not depend on parsing any of it.
+    """
+    return httpx.Response(
+        401,
+        text=_GATEWAY_401_BODY,
+        headers={
+            "content-type": "application/json",
+            "WWW-Authenticate": _GATEWAY_401_CHALLENGE,
+        },
     )
 
 
@@ -242,6 +287,10 @@ def test_normalize_call_tool_result_snake_case_aliases():
         lambda r: _ok(r, {"supportedVersions": ["2025-11-25"]}),
         lambda r: _err(r, -32601, "Method not found: server/discover"),
         lambda r: _err(r, -32022, "bad", {"supported": ["2025-11-25"]}),
+        # A 401 on the discover probe is not proof credentials are missing;
+        # the legacy handshake arbitrates.
+        lambda r: httpx.Response(401, text="u"),
+        _gateway_401,
     ],
 )
 async def test_auto_falls_back_once(monkeypatch, make):
@@ -270,8 +319,14 @@ async def test_auto_falls_back_once(monkeypatch, make):
 @pytest.mark.parametrize(
     ("make", "exc_type", "match"),
     [
-        (lambda r: httpx.Response(401, text="u"), RuntimeError, "OAuth"),
         (_transport_error(httpx.ReadTimeout), httpx.ReadTimeout, None),
+        # Only 401 joins 400/404/405 as fallback evidence; other 4xx stay
+        # hard failures so a real authorization problem is not masked.
+        (
+            lambda r: httpx.Response(403, text="forbidden"),
+            httpx.HTTPStatusError,
+            None,
+        ),
         (
             lambda r: _err(r, -32020, "header mismatch", status=400),
             RuntimeError,
@@ -310,6 +365,88 @@ async def test_auto_does_not_fallback(monkeypatch, make, exc_type, match):
         await c.connect()
     assert not connected
     assert c._impl is None
+
+
+async def test_auto_still_reports_oauth_when_legacy_also_denies(monkeypatch):
+    """Fallback must not swallow a genuine OAuth requirement."""
+
+    class Fake(HttpStatefulClient):
+        async def connect(self, timeout=30.0):
+            del timeout
+            raise RuntimeError(
+                "MCP client 'auto' requires OAuth authorization "
+                "(HTTP 401). Please authorize via the UI before connecting.",
+            )
+
+        async def close(self, ignore_errors=True):
+            del ignore_errors
+
+    monkeypatch.setattr(mod, "HttpStatefulClient", Fake)
+    c = _cli(HttpAutoClient, "auto", lambda r: _gateway_401(_rid(r)))
+    with pytest.raises(RuntimeError, match="OAuth"):
+        await c.connect()
+    assert c._impl is None
+    assert not c.is_connected
+
+
+async def test_auto_logs_modern_reason_when_legacy_fails(monkeypatch, caplog):
+    """The 401 verdict stays reachable when the legacy attempt fails too."""
+
+    class Fake(HttpStatefulClient):
+        async def connect(self, timeout=30.0):
+            del timeout
+            raise RuntimeError("legacy boom")
+
+        async def close(self, ignore_errors=True):
+            del ignore_errors
+
+    monkeypatch.setattr(mod, "HttpStatefulClient", Fake)
+    c = _cli(HttpAutoClient, "auto", lambda r: _gateway_401(_rid(r)))
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="legacy boom"):
+            await c.connect()
+    assert "HTTP 401" in caplog.text
+
+
+async def test_stateless_401_after_connect_stays_oauth_error():
+    """Only the discover probe is reclassified; tools/list is not."""
+
+    def handler(req):
+        body = json.loads(req.content)
+        if body["method"] == "server/discover":
+            return _disc(body["id"])
+        return _gateway_401(body["id"])
+
+    c = _cli(HttpStatelessClient, "sl", handler)
+    await c.connect()
+    try:
+        with pytest.raises(_OAuthRequiredError, match="OAuth"):
+            await c.list_tools()
+    finally:
+        await c.close()
+
+
+def test_oauth_message_keeps_peer_diagnostics():
+    msg = _oauth_required_message(
+        name="pkulaw",
+        method="server/discover",
+        body=_GATEWAY_401_BODY.encode(),
+        www_authenticate=_GATEWAY_401_CHALLENGE,
+    )
+    assert "-32601" in msg
+    assert "invalid_token" in msg
+    assert "legacy server" in msg
+
+
+def test_oauth_message_notes_missing_challenge():
+    msg = _oauth_required_message(
+        name="x",
+        method="tools/list",
+        body=b"",
+        www_authenticate=None,
+    )
+    assert "no www-authenticate header" in msg
+    assert "Peer body" not in msg
 
 
 async def test_auto_timeout_skips_legacy_fallback(monkeypatch):


### PR DESCRIPTION
## Description

Some MCP endpoints only support old protocol, regress on 2.2.0 from working to `MCP client 'X' requires OAuth authorization (HTTP 401). Please authorize via the UI.` — while the same static `Authorization: Bearer` token handshakes fine on every legacy protocol version.

**Root cause.** `HttpAutoClient` probes the modern protocol with `server/discover` before falling back once to the handshake-era `initialize` flow. The pkulaw gateway does not implement `server/discover`, but instead of the conventional 400/404/405 it answers **HTTP 401 + `WWW-Authenticate: Bearer`** with the real JSON-RPC method-not-found wrapped in the body. `HttpStatelessClient._rpc` mapped *any* 401 to a bare `RuntimeError` **before the body was parsed** (`await response.aread()` read it, then discarded it). `_negotiate` only catches `_JsonRpcError` and `httpx.HTTPStatusError`, so that `RuntimeError` propagated straight through; `_connect_locked` only falls back on `_LegacyProtocolError`, so the legacy handshake was never attempted. `_is_legacy_protocol_evidence` recognises `{400, 404, 405}` — 401 was not in the set.

**Fix.**: **let the second handshake arbitrate**. A 401 on the `server/discover` probe is now reclassified as legacy evidence, so `initialize` runs and answers the question empirically: if it succeeds, credentials were never the problem (pkulaw); if it also 401s, `HttpStatefulClient._is_401_error` sets `_oauth_required` and `connect()` raises essentially the same OAuth error as before. The client never has to decide whether a given gateway's 401 is sincere.



**Related Issue:** https://github.com/agentscope-ai/QwenPaw/issues/7620

**Security Considerations.** No credential, token, header or config handling is modified. The fallback re-sends the *same* headers to the *same* URL; `_AsyncClient` still refuses cross-origin redirects, so the extra attempt cannot leak credentials to another origin. A peer that genuinely requires OAuth still fails closed — verified end-to-end below. **One new exposure to review:** the 401 message now echoes up to 200 characters of the peer's response body, and that message reaches the log. A server that reflected the `Authorization` header into its own error body would get it logged. Judged acceptable because the snippet is the only way `-32601 Method not found` becomes visible at all, but a reviewer who disagrees should say so — redaction or dropping the snippet are both one-line changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes — ran it **scoped to the two changed files** instead (`pre-commit run --files …`); every hook passes, output in Evidence
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks — no hook modified anything
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — rationale lives in the `_OAuthRequiredError` docstring, the `_oauth_required_message` docstring and the `_negotiate` handler comment; no user-facing docs affected
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable — no channel code touched.

## Testing

**Not verified against the real pkulaw service** — no credentials for it here. Everything below is either unit-level or end-to-end against a local HTTP server built to reproduce the reported response shape byte-for-byte. A reviewer with pkulaw access should confirm the 10 endpoints connect before this ships.

- **One pre-existing test case had to move, and that is the point of the PR.** `test_auto_does_not_fallback` asserted `(401, body "u") → RuntimeError matching "OAuth"` — exactly the behaviour being changed. It now lives in `test_auto_falls_back_once`. This was the *only* existing assertion that failed; nothing else in the suite encodes the old contract.
- **New `_gateway_401` fixture** reproduces the reported shape: no `jsonrpc` key, no `id`, outer `error.code == 401`, `-32601` double-encoded as a *string* inside `data`, plus the `WWW-Authenticate: Bearer resource_metadata=…, error="invalid_token"` challenge. Asserting fallback against this fixture is what proves the fix does not depend on parsing any layer of the body.
- **Negative direction covered explicitly**: `test_auto_still_reports_oauth_when_legacy_also_denies` (a peer that denies both handshakes still raises the OAuth error, with `_impl is None` and `is_connected` false) and the new 403 case (other 4xx stay hard failures).
- **Scope guard**: `test_stateless_401_after_connect_stays_oauth_error` connects successfully, then 401s `tools/list` — must still raise `_OAuthRequiredError`, not fall back.
- **Diagnostics**: two tests pin that the message carries the `-32601` body snippet and the challenge when present, and degrades to `no www-authenticate header` with no `Peer body:` section when absent.
- Full unit suite: **10433 passed, 21 skipped** (5m04s). Targeted file: **62 passed** (was 55).

## Evidence

End-to-end against a real local `ThreadingHTTPServer` and the **real** `HttpStatefulClient` (no mocks). Throwaway harness, deliberately not committed.

pkulaw-shaped gateway — 401 on `server/discover`, normal handshake-era `initialize` otherwise:

```text
INFO  mcp_streamable_http.py:966 | MCP client 'pkulaw-e2e' falling back to legacy:
      discover probe got HTTP 401: … (www-authenticate=Bearer resource_metadata=…,
      error="invalid_token", …). Peer body: {"error": {"code": 401, "message":
      "MCP Failure", "data": "{\"error\": {\"code\": -32601, …}}"}} …
INFO  mcp_stateful_client.py:250 | MCP client connected: pkulaw-e2e

CONNECTED  is_stateful=True  tools=['law_search']
--- server hits ---
    ('POST', 'server/discover',          'Bearer static-token-abc')
    ('POST', 'initialize',               'Bearer static-token-abc')
    ('POST', 'notifications/initialized','Bearer static-token-abc')
    ('GET',  '/mcp')
    ('POST', 'tools/list',               'Bearer static-token-abc')
```

Genuine OAuth server — every request answers 401. Must still fail, and must fail loudly:

```text
INFO    mcp_streamable_http.py:966 | MCP client 'real-oauth-e2e' falling back to legacy: discover probe got HTTP 401: …
INFO    mcp_stateful_client.py:290 | MCP client 'real-oauth-e2e': server requires OAuth (HTTP 401). Authorize via the UI to connect.
WARNING mcp_streamable_http.py:994 | MCP client 'real-oauth-e2e' legacy fallback failed (…requires OAuth authorization (HTTP 401)…); modern probe reported: discover probe got HTTP 401: …

RAISED RuntimeError: MCP client 'real-oauth-e2e' requires OAuth authorization (HTTP 401). Please authorize via the UI before connecting.
state: is_connected=False impl=None
--- server hits ---   (exactly one extra round-trip)
    ('POST', b'{"jsonrpc":"2.0","id":1,"method":"server/discover","params":')
    ('POST', b'{"method":"initialize","params":{"protocolVersion":"2025-11-')
```

Regression suites:

```bash
$ pytest tests/unit/drivers/handlers/test_mcp_dual_protocol.py -q
62 passed in 0.26s

$ pytest tests/unit -q
10433 passed, 21 skipped, 63 warnings in 304.60s (0:05:04)
```

Scoped pre-commit run:

```bash
$ pre-commit run --files src/qwenpaw/drivers/handlers/mcp_streamable_http.py \
    tests/unit/drivers/handlers/test_mcp_dual_protocol.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

- **Two defects found while validating this fix, deliberately NOT addressed here.** Both are independent of the 401 path and each deserves its own issue:
  1. `app/routers/mcp_oauth.py` — `_fetch_json` accepts only HTTP 200, so OAuth discovery dead-ends for any gateway whose `oauth-protected-resource` endpoint itself requires credentials (pkulaw's does). This is what makes the old error message unactionable rather than merely wrong; fixing it would help real OAuth users of such gateways.
  2. `HttpAutoClient` does not observe its impl's lifecycle. `is_connected` is cleared only in its own `close()`, so when the underlying `HttpStatefulClient` session drops or enters a reconnect window, `_require_impl()` still passes and delegates to a dead impl — surfacing `MCP client 'X' is not connected. Call connect() first.` with no reconnect or retry. Observed live against a pkulaw endpoint during validation. Larger change than this PR should carry.
- **Cost of the fix:** a server that genuinely requires OAuth now pays exactly one extra round-trip at connect (measured above: 2 requests, not 1). The 401 path in `_run_lifecycle` returns early without incrementing `_consecutive_failures`, so the circuit breaker is not polluted. `HttpStatefulClient._setup_transport` passes no auth provider, so the extra attempt triggers no OAuth metadata discovery of its own.
- **Reconcile with the original reporter before merging.** Their patch is on fork branch `fix/mcp-401-legacy-fallback` (commit `0ab45fcc`) and takes the body-matching approach this PR argues against. This PR reaches the same user-visible outcome without parsing the body, so their reported behaviour is fixed either way — but they should see this reasoning, and their verbatim raw 401 body (with `content-type`) is still worth obtaining to confirm the `_gateway_401` fixture matches reality.
- **Behavioural change is intentionally visible in one test name.** If a reviewer sees `test_auto_does_not_fallback` lose a case and `test_auto_falls_back_once` gain two, that is the contract change, not test churn.
