### PR TITLE
[DO NOT MERGE]: Gemini returns 400 "Requests ending with a model turn are not supported" after background tool completion

### DIFF
--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -13,8 +13,8 @@ def make_offload_hint_msg(entry: Any) -> Any:
 
     The hint flattens the finalized response content blocks (TextBlock,
     ImageBlock, etc.) directly into the message so that provider formatters
-    treat it as an ordinary assistant message — no ToolResultBlock means no
-    orphan ``role=tool`` wire message and no tool-call pairing issues.
+    treat it as ordinary runtime input — no ToolResultBlock means no orphan
+    ``role=tool`` wire message and no tool-call pairing issues.
     """
     end = entry.end_state or "unknown"
     notification = TextBlock(
@@ -31,6 +31,6 @@ def make_offload_hint_msg(entry: Any) -> Any:
     result_blocks = list(entry.final_response.content or [])
     return Msg(
         name="system",
-        role="assistant",
+        role="user",
         content=[notification] + result_blocks,
     )

--- a/tests/unit/tool_calls/test_coordinator_completion.py
+++ b/tests/unit/tool_calls/test_coordinator_completion.py
@@ -367,7 +367,7 @@ async def test_background_completion_emits_hint():
     )
 
     assert events[-1].metadata["offloaded"] is True
-    assert hint.role == "assistant"
+    assert hint.role == "user"
     text_block = next(
         block
         for block in hint.content
@@ -913,6 +913,11 @@ async def test_background_cancel_force_cancels_non_cooperative_tool():
     await asyncio.wait_for(entry.background_task, timeout=2)
     assert entry.force_cancelled is True
     assert entry.ctx.cancel_reason == CancelReason.USER
+    hint = await asyncio.wait_for(
+        _wait_for_hint(coordinator, "session-bg-cancel"),
+        timeout=2,
+    )
+    assert hint.role == "user"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixed the Gemini background-tool completion failure.

The root cause was confirmed: completed and interrupted offloaded tool notifications were appended as `assistant` messages, leaving Gemini with a trailing model turn. I changed these runtime-generated notifications to `role="user"` while preserving the flattened result blocks and existing `name="system"` metadata.

Regression coverage now verifies the role for both successful completion and interrupted background execution.

Checks passed:

- `35 passed` in `tests/unit/tool_calls`
- Pre-commit checks, including mypy, Black, Flake8, and pylint
- `git diff --check`

A live Gemini gateway call was not run because it would require external network access and credentials.

Closes #7625