### PR TITLE
fix(hub): authenticate CLI requests to the current local runtime

### DIFF
--- a/src/qwenpaw/agents/memory/proactive/proactive_responder.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_responder.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional, List, Dict
 
-import aiohttp
+import httpx
 
 from agentscope.agent import Agent, InjectionConfig, ReActConfig
 from agentscope.message import Msg, TextBlock
@@ -16,6 +16,8 @@ from agentscope.state import AgentState
 from agentscope.tool import FunctionTool, Toolkit
 
 from ....config.config import load_agent_config
+from ....utils.runtime_api import async_api_client
+from ...tools.agent_management import resolve_agent_api_base_url
 from ...tools import (
     browser,
     execute_shell_command,
@@ -294,8 +296,6 @@ async def send_proactive_message_via_http(
 ) -> Optional[Msg]:
     """Send a proactive message by directly calling the QwenPaw API."""
 
-    from ...tools.agent_management import resolve_agent_api_base_url
-
     session_id = f"proactive_mode:{active_agent_id}"
 
     request_payload = {
@@ -317,7 +317,6 @@ async def send_proactive_message_via_http(
     }
 
     headers = {"X-Agent-Id": active_agent_id}
-    timeout_config = aiohttp.ClientTimeout(total=timeout_seconds)
 
     base_url = resolve_agent_api_base_url()
     clean_base = base_url.rstrip("/")
@@ -326,30 +325,29 @@ async def send_proactive_message_via_http(
     )
 
     try:
-        async with aiohttp.ClientSession() as session:
-            url = f"{api_base_url.rstrip('/')}/console/chat"
-            async with session.post(
-                url,
+        async with (
+            asyncio.timeout(timeout_seconds),
+            async_api_client(api_base_url, timeout=timeout_seconds) as session,
+        ):
+            async with session.stream(
+                "POST",
+                "/console/chat",
                 json=request_payload,
                 headers=headers,
-                timeout=timeout_config,
             ) as resp:
                 resp.raise_for_status()
                 last_data = None
-                async for line_bytes in resp.content:
-                    line = line_bytes.decode("utf-8").strip()
+                async for line in resp.aiter_lines():
+                    line = line.strip()
                     if line.startswith("data: "):
-                        try:
-                            last_data = line[6:]
-                        except Exception:
-                            continue
+                        last_data = line[6:]
 
                 if last_data:
                     logger.info("Proactive message sent successfully via HTTP")
                 else:
                     logger.warning("No valid SSE data received from agent")
 
-    except asyncio.TimeoutError:
+    except (asyncio.TimeoutError, httpx.TimeoutException):
         logger.error(
             "Timeout (%ds) calling QwenPaw API for proactive message",
             timeout_seconds,

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -22,6 +22,11 @@ from ...constant import (
 )
 from ...runtime.tool_registry import tool_descriptor
 from ...utils.http import trust_env_for_url
+from ...utils.runtime_api import (
+    add_runtime_token,
+    add_runtime_token_async,
+    read_runtime_api,
+)
 from ...utils.timeout import (
     parse_positive_timeout_seconds as _parse_positive_timeout_seconds,
 )
@@ -40,13 +45,14 @@ def resolve_agent_api_base_url(base_url: Optional[str] = None) -> str:
 
     Priority:
     1. Explicit ``base_url`` argument
-    2. Last recorded API host/port from config
-    3. Built-in localhost fallback
+    2. Hub-managed runtime endpoint
+    3. Last recorded API host/port from config
+    4. Built-in localhost fallback
     """
     if base_url:
         return base_url.rstrip("/")
 
-    last_api = read_last_api()
+    last_api = read_runtime_api() or read_last_api()
     if last_api:
         host, port = last_api
         return f"http://{host}:{port}"
@@ -90,6 +96,7 @@ def create_agent_api_client(
         base_url=normalized,
         timeout=default_timeout,
         trust_env=trust_env_for_url(normalized),
+        event_hooks={"request": [add_runtime_token]},
     )
 
 
@@ -344,6 +351,7 @@ async def collect_final_agent_chat_response_async(
         base_url=normalized,
         timeout=httpx.Timeout(timeout),
         trust_env=trust_env_for_url(normalized),
+        event_hooks={"request": [add_runtime_token_async]},
     ) as client:
         async with client.stream(
             "POST",
@@ -377,6 +385,7 @@ async def stop_agent_chat_async(
         base_url=normalized,
         timeout=httpx.Timeout(timeout),
         trust_env=trust_env_for_url(normalized),
+        event_hooks={"request": [add_runtime_token_async]},
     ) as client:
         response = await client.post(
             "/console/chat/stop",
@@ -1504,6 +1513,7 @@ async def _call_fork_api(
         async with httpx.AsyncClient(
             timeout=30.0,
             trust_env=trust_env_for_url(url),
+            event_hooks={"request": [add_runtime_token_async]},
         ) as client:
             resp = await client.post(url, json=payload)
             resp.raise_for_status()

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -21,10 +21,9 @@ from ...constant import (
     DEFAULT_STREAM_TASK_TIMEOUT_SECONDS,
 )
 from ...runtime.tool_registry import tool_descriptor
-from ...utils.http import trust_env_for_url
 from ...utils.runtime_api import (
-    add_runtime_token,
-    add_runtime_token_async,
+    api_client,
+    async_api_client,
     read_runtime_api,
 )
 from ...utils.timeout import (
@@ -92,11 +91,9 @@ def create_agent_api_client(
 ) -> httpx.Client:
     """Create an HTTP client targeting the local agent API."""
     normalized = _normalize_api_base_url(base_url)
-    return httpx.Client(
+    return api_client(
         base_url=normalized,
         timeout=default_timeout,
-        trust_env=trust_env_for_url(normalized),
-        event_hooks={"request": [add_runtime_token]},
     )
 
 
@@ -347,11 +344,9 @@ async def collect_final_agent_chat_response_async(
     """
     normalized = _normalize_api_base_url(base_url)
     response_data: Optional[Dict[str, Any]] = None
-    async with httpx.AsyncClient(
+    async with async_api_client(
         base_url=normalized,
         timeout=httpx.Timeout(timeout),
-        trust_env=trust_env_for_url(normalized),
-        event_hooks={"request": [add_runtime_token_async]},
     ) as client:
         async with client.stream(
             "POST",
@@ -381,11 +376,9 @@ async def stop_agent_chat_async(
     explicit Stop endpoint instead of only closing the collection stream.
     """
     normalized = _normalize_api_base_url(base_url)
-    async with httpx.AsyncClient(
+    async with async_api_client(
         base_url=normalized,
         timeout=httpx.Timeout(timeout),
-        trust_env=trust_env_for_url(normalized),
-        event_hooks={"request": [add_runtime_token_async]},
     ) as client:
         response = await client.post(
             "/console/chat/stop",
@@ -1510,10 +1503,9 @@ async def _call_fork_api(
         "channel": channel,
     }
     try:
-        async with httpx.AsyncClient(
+        async with async_api_client(
+            base_url=url,
             timeout=30.0,
-            trust_env=trust_env_for_url(url),
-            event_hooks={"request": [add_runtime_token_async]},
         ) as client:
             resp = await client.post(url, json=payload)
             resp.raise_for_status()

--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -27,7 +27,7 @@ from ..utils.console_static import (
     CONSOLE_STATIC_ENV,
     resolve_console_static_dir,
 )
-from ..utils.http import trust_env_for_url
+from ..utils.runtime_api import api_client
 from ..utils.system_info import summarize_python_environment
 from .doctor_checks import (
     active_llm_local_failure_hint,
@@ -86,8 +86,8 @@ def _same_python_executable(a: str, b: str) -> bool:
 
 
 def _http_get(url: str, **kwargs) -> httpx.Response:
-    kwargs.setdefault("trust_env", trust_env_for_url(url))
-    return httpx.get(url, **kwargs)
+    with api_client(url) as client:
+        return client.get(url, **kwargs)
 
 
 def _check_api_health(

--- a/src/qwenpaw/cli/http.py
+++ b/src/qwenpaw/cli/http.py
@@ -7,8 +7,7 @@ from typing import Any, Optional
 import click
 import httpx
 
-from ..utils.http import trust_env_for_url
-from ..utils.runtime_api import add_runtime_token
+from ..utils.runtime_api import api_client
 
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8088"
@@ -20,12 +19,7 @@ def client(base_url: str) -> httpx.Client:
     base = base_url.rstrip("/")
     if not base.endswith("/api"):
         base = f"{base}/api"
-    return httpx.Client(
-        base_url=base,
-        timeout=30.0,
-        trust_env=trust_env_for_url(base),
-        event_hooks={"request": [add_runtime_token]},
-    )
+    return api_client(base)
 
 
 def print_json(data: Any) -> None:

--- a/src/qwenpaw/cli/http.py
+++ b/src/qwenpaw/cli/http.py
@@ -8,6 +8,7 @@ import click
 import httpx
 
 from ..utils.http import trust_env_for_url
+from ..utils.runtime_api import add_runtime_token
 
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8088"
@@ -23,6 +24,7 @@ def client(base_url: str) -> httpx.Client:
         base_url=base,
         timeout=30.0,
         trust_env=trust_env_for_url(base),
+        event_hooks={"request": [add_runtime_token]},
     )
 
 

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -9,6 +9,7 @@ import time
 import click
 
 from ..utils.stdio import ensure_standard_streams
+from ..utils.runtime_api import read_runtime_api
 
 # On Windows, force UTF-8 for stdout/stderr so cron and other commands
 # can handle Chinese and other non-ASCII (Linux is UTF-8 by default).
@@ -196,7 +197,7 @@ def _looks_like_project_path(value: str) -> bool:
 def cli(ctx: click.Context, host: str | None, port: int | None) -> None:
     """QwenPaw CLI."""
     # default from last run if not provided
-    last = read_last_api()
+    last = read_runtime_api() or read_last_api()
     if host is None or port is None:
         if last:
             host = host or last[0]

--- a/src/qwenpaw/cli/plugin_commands.py
+++ b/src/qwenpaw/cli/plugin_commands.py
@@ -10,15 +10,18 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Optional
 
 import click
+import httpx
 
-from qwenpaw.plugins.validation import (
+from ..config import utils as config_utils
+from ..utils.runtime_api import api_client, read_runtime_api
+
+from ..plugins.validation import (
     validate_plugin_module as _validate_plugin_module,
 )
 
@@ -35,9 +38,7 @@ def _get_api_base() -> Optional[str]:
         Base URL string such as ``http://127.0.0.1:8088/api`` if the
         app is running, otherwise ``None``.
     """
-    from ..config.utils import read_last_api
-
-    api_info = read_last_api()
+    api_info = read_runtime_api() or config_utils.read_last_api()
     if api_info is None:
         return None
     host, port = api_info
@@ -47,7 +48,7 @@ def _get_api_base() -> Optional[str]:
 def _api_install_plugin(source: str, force: bool = False) -> bool:
     """Send a hot-install request to the running QwenPaw API.
 
-    Uses the localhost auth-bypass so no credentials are required.
+    Authenticates to the current managed runtime when required.
 
     Args:
         source: Local directory path or HTTP(S) URL of the plugin
@@ -60,25 +61,23 @@ def _api_install_plugin(source: str, force: bool = False) -> bool:
     if base is None:
         return False
 
-    url = f"{base}/plugins/install"
-    payload = json.dumps({"source": source, "force": force}).encode()
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        method="POST",
-        headers={"Content-Type": "application/json"},
-    )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            body = json.loads(resp.read())
+        with api_client(base, timeout=120) as client:
+            response = client.post(
+                "plugins/install",
+                json={"source": source, "force": force},
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+            body = response.json()
         name = body.get("name", source)
         click.echo(
             f"✅ Plugin '{name}' installed and loaded (hot reload).",
         )
         return True
-    except urllib.error.HTTPError as exc:
+    except httpx.HTTPStatusError as exc:
         try:
-            detail = json.loads(exc.read()).get("detail", str(exc))
+            detail = exc.response.json().get("detail", str(exc))
         except Exception:
             detail = str(exc)
         click.echo(f"❌ API install failed: {detail}", err=True)
@@ -118,27 +117,29 @@ def _api_upload_plugin(zip_path: Path, force: bool = False) -> bool:
     )
 
     force_param = "true" if force else "false"
-    url = f"{base}/plugins/upload?force={force_param}"
-    req = urllib.request.Request(
-        url,
-        data=body,
-        method="POST",
-        headers={
-            "Content-Type": f"multipart/form-data; boundary={boundary}",
-            "Content-Length": str(len(body)),
-        },
-    )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            result = json.loads(resp.read())
+        with api_client(base, timeout=120) as client:
+            response = client.post(
+                "plugins/upload",
+                params={"force": force_param},
+                content=body,
+                follow_redirects=True,
+                headers={
+                    "Content-Type": (
+                        "multipart/form-data; " f"boundary={boundary}"
+                    ),
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
         name = result.get("name", zip_path.name)
         click.echo(
             f"✅ Plugin '{name}' installed and loaded (hot reload).",
         )
         return True
-    except urllib.error.HTTPError as exc:
+    except httpx.HTTPStatusError as exc:
         try:
-            detail = json.loads(exc.read()).get("detail", str(exc))
+            detail = exc.response.json().get("detail", str(exc))
         except Exception:
             detail = str(exc)
         click.echo(f"❌ API upload failed: {detail}", err=True)
@@ -161,11 +162,11 @@ def _api_uninstall_plugin(plugin_id: str) -> bool:
     if base is None:
         return False
 
-    url = f"{base}/plugins/{plugin_id}"
-    req = urllib.request.Request(url, method="DELETE")
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            body = json.loads(resp.read())
+        with api_client(base) as client:
+            response = client.delete(f"plugins/{plugin_id}")
+            response.raise_for_status()
+            body = response.json()
         click.echo(
             body.get(
                 "message",
@@ -173,9 +174,9 @@ def _api_uninstall_plugin(plugin_id: str) -> bool:
             ),
         )
         return True
-    except urllib.error.HTTPError as exc:
+    except httpx.HTTPStatusError as exc:
         try:
-            detail = json.loads(exc.read()).get("detail", str(exc))
+            detail = exc.response.json().get("detail", str(exc))
         except Exception:
             detail = str(exc)
         click.echo(f"❌ API uninstall failed: {detail}", err=True)

--- a/src/qwenpaw/cli/update_cmd.py
+++ b/src/qwenpaw/cli/update_cmd.py
@@ -21,6 +21,7 @@ from packaging.version import InvalidVersion, Version
 from ..__version__ import __version__
 from ..constant import WORKING_DIR
 from ..config.utils import read_last_api
+from ..utils.runtime_api import api_client
 from .process_utils import (
     _base_url,
     _candidate_hosts,
@@ -211,14 +212,13 @@ def _detect_installation() -> InstallInfo:
 def _probe_service(base_url: str) -> RunningServiceInfo:
     """Probe a possible running QwenPaw HTTP service."""
     try:
-        resp = httpx.get(
-            f"{base_url.rstrip('/')}/api/version",
-            timeout=2.0,
-            headers={"Accept": "application/json"},
-            trust_env=False,
-        )
-        resp.raise_for_status()
-        payload = resp.json()
+        with api_client(base_url, timeout=2.0, trust_env=False) as client:
+            resp = client.get(
+                f"{base_url.rstrip('/')}/api/version",
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
     except (httpx.HTTPError, ValueError):
         return RunningServiceInfo(is_running=False)
 

--- a/src/qwenpaw/hub/local_provisioner.py
+++ b/src/qwenpaw/hub/local_provisioner.py
@@ -18,6 +18,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import IO
 
+from ..utils.http import probe_host_for_bind_host
 from .credentials import runtime_credential_name_allowed
 from .provisioner import RuntimeProvisioner, RuntimeProvisionerAvailability
 from .models import RuntimeRecord, RuntimeState
@@ -168,9 +169,13 @@ class LocalProcessRuntimeProvisioner(RuntimeProvisioner):
             "--port",
             str(port),
         ]
+        runtime_host = record.host
+        runtime_port = port
         tunnel: WindowsReverseTunnelBroker | None = None
         if self._isolator.name == "windows-appcontainer":
             internal_port = allocate_loopback_port()
+            runtime_host = "127.0.0.1"
+            runtime_port = internal_port
             tunnel = WindowsReverseTunnelBroker(record.host, port)
             tunnel.start()
             command = [
@@ -194,7 +199,10 @@ class LocalProcessRuntimeProvisioner(RuntimeProvisioner):
                 str(internal_port),
             ]
         launch_record = replace(record, port=port)
-        environment = self.runtime_environment(launch_record, credentials)
+        environment = self.runtime_environment(
+            replace(launch_record, host=runtime_host, port=runtime_port),
+            credentials,
+        )
         try:
             isolated = self._isolator.prepare(
                 launch_record,
@@ -396,6 +404,10 @@ class LocalProcessRuntimeProvisioner(RuntimeProvisioner):
         environment[
             "QWENPAW_KEYRING_ACCOUNT"
         ] = f"qwenpaw-hub-{record.runtime_id}"
+        host = probe_host_for_bind_host(record.host)
+        if ":" in host:
+            host = f"[{host}]"
+        environment["QWENPAW_RUNTIME_API_URL"] = f"http://{host}:{record.port}"
         environment["QWENPAW_RUNTIME_ID"] = record.runtime_id
         environment["QWENPAW_TENANT_ID"] = record.tenant_id
         runtime_token = credentials.get("QWENPAW_RUNTIME_INTERNAL_TOKEN")

--- a/src/qwenpaw/hub/process_isolation.py
+++ b/src/qwenpaw/hub/process_isolation.py
@@ -290,6 +290,10 @@ class MacOSSeatbeltIsolator(ProcessIsolator):
             "(allow ipc-posix-shm)",
             "(allow network-outbound)",
             '(deny network-outbound (remote ip "localhost:*"))',
+            (
+                "(allow network-outbound "
+                f'(remote ip "localhost:{record.port}"))'
+            ),
             ("(allow network-bind " f'(local ip "localhost:{record.port}"))'),
             (
                 "(allow network-inbound "
@@ -365,11 +369,55 @@ class MacOSSeatbeltIsolator(ProcessIsolator):
             raise ProcessIsolationError(
                 "Seatbelt isolation probe read a host file.",
             )
+        self._probe_loopback_allowed(
+            profile_path,
+            record,
+            environment,
+        )
         self._probe_loopback_denied(
             profile_path,
             record,
             environment,
         )
+
+    def _probe_loopback_allowed(
+        self,
+        profile_path: Path,
+        record: RuntimeRecord,
+        environment: Mapping[str, str],
+    ) -> None:
+        """Verify a listener and its client can share the runtime sandbox."""
+        probe = (
+            "import socket;"
+            "listener=socket.socket();"
+            f"listener.bind(('127.0.0.1',{record.port}));"
+            "listener.listen(1);"
+            "client=socket.socket();"
+            "client.settimeout(2);"
+            f"client.connect(('127.0.0.1',{record.port}))"
+        )
+        result = subprocess.run(
+            [
+                self._executable,
+                "-f",
+                str(profile_path),
+                sys.executable,
+                "-B",
+                "-c",
+                probe,
+            ],
+            env=dict(environment),
+            cwd=record.working_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise ProcessIsolationError(
+                "Seatbelt isolation cannot connect to its runtime port: "
+                f"{result.stderr.strip()}",
+            )
 
     def _probe_loopback_denied(
         self,

--- a/src/qwenpaw/utils/runtime_api.py
+++ b/src/qwenpaw/utils/runtime_api.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-import os
-
 import httpx
 
+from ..constant import EnvVarLoader
 from .http import is_loopback_host
 
 _TOKEN_ENV = "QWENPAW_RUNTIME_INTERNAL_TOKEN"
@@ -15,11 +14,10 @@ _TOKEN_HEADER = "X-QwenPaw-Runtime-Token"
 
 def _runtime_url() -> httpx.URL | None:
     """Read the endpoint supplied by Hub, never a user API override."""
-    if not os.environ.get("QWENPAW_RUNTIME_ID") or not os.environ.get(
-        _TOKEN_ENV,
-    ):
+    runtime_id = EnvVarLoader.get_str("QWENPAW_RUNTIME_ID")
+    if not runtime_id or not EnvVarLoader.get_str(_TOKEN_ENV):
         return None
-    value = os.environ.get("QWENPAW_RUNTIME_API_URL")
+    value = EnvVarLoader.get_str("QWENPAW_RUNTIME_API_URL")
     if not value:
         return None
     try:
@@ -55,7 +53,7 @@ def add_runtime_token(request: httpx.Request) -> None:
         and target.port == runtime.port
         and not target.userinfo
     ):
-        request.headers[_TOKEN_HEADER] = os.environ[_TOKEN_ENV]
+        request.headers[_TOKEN_HEADER] = EnvVarLoader.get_str(_TOKEN_ENV)
 
 
 async def add_runtime_token_async(request: httpx.Request) -> None:

--- a/src/qwenpaw/utils/runtime_api.py
+++ b/src/qwenpaw/utils/runtime_api.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import httpx
 
 from ..constant import EnvVarLoader
-from .http import is_loopback_host
+from .http import is_loopback_host, trust_env_for_url
 
 _TOKEN_ENV = "QWENPAW_RUNTIME_INTERNAL_TOKEN"
 _TOKEN_HEADER = "X-QwenPaw-Runtime-Token"
@@ -40,22 +42,74 @@ def read_runtime_api() -> tuple[str, int] | None:
     return host, url.port or 80
 
 
-def add_runtime_token(request: httpx.Request) -> None:
-    """Scope the boundary token to each request, including redirects."""
+def _same_origin(target: httpx.URL, runtime: httpx.URL) -> bool:
+    """Compare the transport endpoint without accepting URL credentials."""
+    return (
+        target.scheme == runtime.scheme
+        and target.host == runtime.host
+        and target.port == runtime.port
+        and not target.userinfo
+    )
+
+
+def _add_runtime_token(
+    request: httpx.Request,
+    *,
+    base_url: httpx.URL,
+) -> None:
+    """Authenticate only requests from a trusted, direct runtime client."""
     runtime = _runtime_url()
     if runtime is None:
         return
     target = request.url
     request.headers.pop(_TOKEN_HEADER, None)
-    if (
-        target.scheme == runtime.scheme
-        and target.host == runtime.host
-        and target.port == runtime.port
-        and not target.userinfo
-    ):
+    if _same_origin(base_url, runtime) and _same_origin(target, runtime):
         request.headers[_TOKEN_HEADER] = EnvVarLoader.get_str(_TOKEN_ENV)
 
 
-async def add_runtime_token_async(request: httpx.Request) -> None:
+async def _add_runtime_token_async(
+    request: httpx.Request,
+    *,
+    base_url: httpx.URL,
+) -> None:
     """Apply the same boundary policy to asynchronous HTTP clients."""
-    add_runtime_token(request)
+    _add_runtime_token(request, base_url=base_url)
+
+
+def api_client(
+    base_url: str,
+    *,
+    timeout: float = 30.0,
+) -> httpx.Client:
+    """Bind authentication to the client's endpoint and proxy policy."""
+    return httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        trust_env=trust_env_for_url(base_url),
+        event_hooks={
+            "request": [
+                partial(_add_runtime_token, base_url=httpx.URL(base_url)),
+            ],
+        },
+    )
+
+
+def async_api_client(
+    base_url: str,
+    *,
+    timeout: float | httpx.Timeout = 30.0,
+) -> httpx.AsyncClient:
+    """Create an async client with the same direct-runtime policy."""
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        trust_env=trust_env_for_url(base_url),
+        event_hooks={
+            "request": [
+                partial(
+                    _add_runtime_token_async,
+                    base_url=httpx.URL(base_url),
+                ),
+            ],
+        },
+    )

--- a/src/qwenpaw/utils/runtime_api.py
+++ b/src/qwenpaw/utils/runtime_api.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 from functools import partial
 
 import httpx
 
 from ..constant import EnvVarLoader
-from .http import is_loopback_host, trust_env_for_url
+from .http import trust_env_for_url
 
 _TOKEN_ENV = "QWENPAW_RUNTIME_INTERNAL_TOKEN"
 _TOKEN_HEADER = "X-QwenPaw-Runtime-Token"
@@ -24,9 +25,10 @@ def _runtime_url() -> httpx.URL | None:
         return None
     try:
         url = httpx.URL(value)
-    except httpx.InvalidURL:
+        address = ipaddress.ip_address(url.host)
+    except (httpx.InvalidURL, ValueError):
         return None
-    if url.scheme != "http" or not is_loopback_host(url.host):
+    if url.scheme != "http" or not address.is_loopback:
         return None
     if url.userinfo or url.path != "/" or url.query or url.fragment:
         return None
@@ -80,12 +82,13 @@ def api_client(
     base_url: str,
     *,
     timeout: float = 30.0,
+    trust_env: bool = True,
 ) -> httpx.Client:
-    """Bind authentication to the client's endpoint and proxy policy."""
+    """Bind auth to the endpoint; loopback always bypasses env proxies."""
     return httpx.Client(
         base_url=base_url,
         timeout=timeout,
-        trust_env=trust_env_for_url(base_url),
+        trust_env=trust_env and trust_env_for_url(base_url),
         event_hooks={
             "request": [
                 partial(_add_runtime_token, base_url=httpx.URL(base_url)),

--- a/src/qwenpaw/utils/runtime_api.py
+++ b/src/qwenpaw/utils/runtime_api.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Endpoint discovery and request authentication for Hub local runtimes."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from .http import is_loopback_host
+
+_TOKEN_ENV = "QWENPAW_RUNTIME_INTERNAL_TOKEN"
+_TOKEN_HEADER = "X-QwenPaw-Runtime-Token"
+
+
+def _runtime_url() -> httpx.URL | None:
+    """Read the endpoint supplied by Hub, never a user API override."""
+    if not os.environ.get("QWENPAW_RUNTIME_ID") or not os.environ.get(
+        _TOKEN_ENV,
+    ):
+        return None
+    value = os.environ.get("QWENPAW_RUNTIME_API_URL")
+    if not value:
+        return None
+    try:
+        url = httpx.URL(value)
+    except httpx.InvalidURL:
+        return None
+    if url.scheme != "http" or not is_loopback_host(url.host):
+        return None
+    if url.userinfo or url.path != "/" or url.query or url.fragment:
+        return None
+    return url
+
+
+def read_runtime_api() -> tuple[str, int] | None:
+    """Return the managed runtime address, or preserve standalone defaults."""
+    url = _runtime_url()
+    if url is None:
+        return None
+    host = f"[{url.host}]" if ":" in url.host else url.host
+    return host, url.port or 80
+
+
+def add_runtime_token(request: httpx.Request) -> None:
+    """Scope the boundary token to each request, including redirects."""
+    runtime = _runtime_url()
+    if runtime is None:
+        return
+    target = request.url
+    request.headers.pop(_TOKEN_HEADER, None)
+    if (
+        target.scheme == runtime.scheme
+        and target.host == runtime.host
+        and target.port == runtime.port
+        and not target.userinfo
+    ):
+        request.headers[_TOKEN_HEADER] = os.environ[_TOKEN_ENV]
+
+
+async def add_runtime_token_async(request: httpx.Request) -> None:
+    """Apply the same boundary policy to asynchronous HTTP clients."""
+    add_runtime_token(request)

--- a/tests/unit/cli/test_cli_doctor_proxy.py
+++ b/tests/unit/cli/test_cli_doctor_proxy.py
@@ -2,52 +2,40 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
-from typing import Any
+from functools import partial
+
+import httpx
+import pytest
 
 from qwenpaw.cli import doctor_cmd
 
 
-class _Response:
-    def __init__(
-        self,
-        status_code: int = 200,
-        json_data: dict[str, Any] | None = None,
-        text: str = "",
-        content_type: str = "application/json",
-    ) -> None:
-        self.status_code = status_code
-        self._json_data = json_data or {}
-        self.text = text
-        self.headers = {"content-type": content_type}
+@pytest.mark.parametrize(
+    "url,trust_env",
+    [
+        ("http://127.1.2.3:8088/api/version", False),
+        ("http://192.168.1.10:8088/api/version", True),
+    ],
+)
+def test_doctor_http_get_preserves_proxy_policy(
+    monkeypatch,
+    url,
+    trust_env,
+) -> None:
+    captured = {}
+    real_client = httpx.Client
 
-    def json(self) -> dict[str, Any]:
-        return self._json_data
-
-
-# Doctor uses direct GET probes, so verify they apply the same proxy policy.
-def test_doctor_http_get_bypasses_env_for_loopback(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    def _fake_get(_url: str, **kwargs):
+    def create_client(**kwargs):
         captured.update(kwargs)
-        return _Response()
+        return real_client(**kwargs)
 
-    monkeypatch.setattr(doctor_cmd.httpx, "get", _fake_get)
-
-    doctor_cmd._http_get("http://127.1.2.3:8088/api/version", timeout=2.0)
-
-    assert captured["trust_env"] is False
-
-
-def test_doctor_http_get_keeps_env_for_remote_url(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    def _fake_get(_url: str, **kwargs):
-        captured.update(kwargs)
-        return _Response()
-
-    monkeypatch.setattr(doctor_cmd.httpx, "get", _fake_get)
-
-    doctor_cmd._http_get("http://192.168.1.10:8088/api/version", timeout=2.0)
-
-    assert captured["trust_env"] is True
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(
+            create_client,
+            transport=httpx.MockTransport(lambda _: httpx.Response(200)),
+        ),
+    )
+    doctor_cmd._http_get(url, timeout=2.0)
+    assert captured["trust_env"] is trust_env

--- a/tests/unit/cli/test_cli_runtime_auth.py
+++ b/tests/unit/cli/test_cli_runtime_auth.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 """Regression coverage for CLI access to managed runtime APIs."""
 
+import asyncio
 from functools import partial
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
@@ -13,9 +14,12 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from qwenpaw.agents.tools import agent_management
+from qwenpaw.agents.memory.proactive.proactive_responder import (
+    send_proactive_message_via_http,
+)
 from qwenpaw.app.auth import RuntimeBoundaryMiddleware
 from qwenpaw.cli import http as cli_http
-from qwenpaw.cli import doctor_cmd, plugin_commands
+from qwenpaw.cli import doctor_cmd, plugin_commands, update_cmd
 from qwenpaw.utils.runtime_api import async_api_client
 from qwenpaw.cli.main import cli
 
@@ -223,6 +227,7 @@ async def test_async_agent_requests_scope_token(monkeypatch, target):
     "endpoint",
     [
         "http://example.com:9001",
+        "http://localhost:9001",
         "https://127.0.0.1:9001",
         "http://user:password@127.0.0.1:9001",
         "http://127.0.0.1:bad",
@@ -236,6 +241,20 @@ def test_invalid_runtime_endpoint_does_not_override_app(monkeypatch, endpoint):
     assert agent_management.resolve_agent_api_base_url() == (
         "http://127.0.0.1:9002"
     )
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    with cli_http.client(_RUNTIME_URL) as client:
+        client.get("/agents")
+    assert seen == [None]
 
 
 def test_ipv6_runtime_endpoint(monkeypatch):
@@ -305,7 +324,7 @@ async def test_external_client_cannot_send_token_through_proxy(
 
 
 @pytest.mark.parametrize("managed", [True, False])
-def test_doctor_and_plugin_operations_pass_boundary(
+def test_cli_api_operations_pass_boundary(
     monkeypatch,
     tmp_path,
     managed,
@@ -343,12 +362,57 @@ def test_doctor_and_plugin_operations_pass_boundary(
         )
         ok, _ = doctor_cmd._check_api_health(f"http://127.0.0.1:{port}", 2)
         assert ok
+        assert update_cmd._probe_service(f"http://127.0.0.1:{port}").is_running
         assert plugin_commands._api_install_plugin("fixture")
         assert plugin_commands._api_upload_plugin(archive)
         assert plugin_commands._api_uninstall_plugin("demo")
     assert seen == [
         ("GET", "healthz", port),
+        ("GET", "version", port),
         ("POST", "plugins/install", port),
         ("POST", "plugins/upload", port),
         ("DELETE", "plugins/demo", port),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slow_stream", [False, True])
+async def test_proactive_request_auth_stream_and_total_timeout(
+    monkeypatch,
+    caplog,
+    slow_stream,
+):
+    seen = []
+    closed = []
+
+    class Stream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"da"
+            if slow_stream:
+                await asyncio.sleep(2)
+            yield b'ta: {"done":true}\n\n'
+
+        async def aclose(self):
+            closed.append(True)
+
+    def respond(request):
+        seen.append(
+            (
+                request.url.port,
+                request.headers.get(_TOKEN_HEADER),
+                request.headers.get("X-Agent-Id"),
+            ),
+        )
+        return httpx.Response(200, stream=Stream())
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        partial(httpx.AsyncClient, transport=httpx.MockTransport(respond)),
+    )
+    with caplog.at_level("INFO"):
+        await send_proactive_message_via_http("agent-a", "message", 1)
+    assert seen == [(9001, "secret-a", "agent-a")]
+    assert closed == [True]
+    expected = "Timeout (1s)" if slow_stream else "sent successfully via HTTP"
+    assert expected in caplog.text

--- a/tests/unit/cli/test_cli_runtime_auth.py
+++ b/tests/unit/cli/test_cli_runtime_auth.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Regression coverage for CLI access to managed runtime APIs."""
+
+from functools import partial
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from qwenpaw.agents.tools import agent_management
+from qwenpaw.app.auth import RuntimeBoundaryMiddleware
+from qwenpaw.cli import http as cli_http
+from qwenpaw.cli.main import cli
+
+_RUNTIME_URL = "http://127.0.0.1:9001"
+_TOKEN_HEADER = "X-QwenPaw-Runtime-Token"
+
+
+@pytest.fixture(autouse=True)
+def managed_runtime(monkeypatch):
+    """Give each test an isolated managed runtime environment."""
+    monkeypatch.setenv("QWENPAW_RUNTIME_ID", "runtime-a")
+    monkeypatch.setenv("QWENPAW_RUNTIME_INTERNAL_TOKEN", "secret-a")
+    monkeypatch.setenv("QWENPAW_RUNTIME_API_URL", _RUNTIME_URL)
+    monkeypatch.setattr(
+        "qwenpaw.cli.main.read_last_api",
+        lambda: ("127.0.0.1", 9002),
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "read_last_api",
+        lambda: ("127.0.0.1", 9002),
+    )
+
+
+@pytest.mark.parametrize("managed", [True, False])
+def test_agents_list_passes_real_boundary(monkeypatch, managed):
+    """Exercise Click, the HTTP client, and the real boundary middleware."""
+    app = FastAPI()
+    app.add_middleware(RuntimeBoundaryMiddleware)
+    seen = []
+
+    @app.get("/api/agents")
+    async def agents(request: Request):
+        seen.append(request.url.port)
+        return {"agents": [{"id": f"runtime-{request.url.port}"}]}
+
+    if not managed:
+        monkeypatch.delenv("QWENPAW_RUNTIME_INTERNAL_TOKEN")
+        monkeypatch.delenv("QWENPAW_RUNTIME_ID")
+        monkeypatch.delenv("QWENPAW_RUNTIME_API_URL")
+    with TestClient(app) as boundary:
+        # Use the ASGI transport without replacing client request behavior.
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            partial(httpx.Client, transport=boundary._transport),
+        )
+        result = CliRunner().invoke(cli, ["agents", "list"])
+    expected_port = 9001 if managed else 9002
+    assert result.exit_code == 0, result.exception
+    assert f"runtime-{expected_port}" in result.output
+    assert seen == [expected_port]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [cli_http.client, agent_management.create_agent_api_client],
+)
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        (_RUNTIME_URL, "secret-a"),
+        (f"{_RUNTIME_URL}/api/", "secret-a"),
+        ("http://127.0.0.1:9002", None),
+        ("http://localhost:9001", None),
+        ("https://127.0.0.1:9001", None),
+        ("http://example.com:9001", None),
+        ("http://127.0.0.1.example.com:9001", None),
+    ],
+)
+def test_token_is_scoped_to_runtime_origin(
+    monkeypatch,
+    factory,
+    target,
+    expected,
+):
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    with factory(target) as client:
+        client.get("/agents")
+    assert seen == [expected]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [cli_http.client, agent_management.create_agent_api_client],
+)
+def test_token_does_not_follow_redirects_or_absolute_urls(
+    monkeypatch,
+    factory,
+):
+    seen = []
+    external = "http://127.0.0.1:9002/api/agents"
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        if request.url.port == 9001:
+            return httpx.Response(302, headers={"Location": external})
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    with factory(_RUNTIME_URL) as client:
+        client.get("/agents", follow_redirects=True)
+        client.get(external)
+    assert seen == ["secret-a", None, None]
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "QWENPAW_RUNTIME_ID",
+        "QWENPAW_RUNTIME_API_URL",
+        "QWENPAW_RUNTIME_INTERNAL_TOKEN",
+    ],
+)
+def test_incomplete_runtime_metadata_keeps_app_behavior(monkeypatch, missing):
+    monkeypatch.delenv(missing)
+    assert agent_management.resolve_agent_api_base_url() == (
+        "http://127.0.0.1:9002"
+    )
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    with cli_http.client(_RUNTIME_URL) as client:
+        client.get("/agents")
+    assert seen == [None]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--port", "9002", "agents", "list"],
+        ["agents", "list", "--base-url", "http://example.com"],
+    ],
+)
+def test_explicit_cli_endpoint_never_receives_token(monkeypatch, arguments):
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200, json={"agents": []})
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    result = CliRunner().invoke(cli, arguments)
+    assert result.exit_code == 0, result.exception
+    assert seen == [None]
+
+
+@pytest.mark.parametrize("target", [None, "http://127.0.0.1:9002"])
+@pytest.mark.asyncio
+async def test_async_agent_requests_scope_token(monkeypatch, target):
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        partial(httpx.AsyncClient, transport=httpx.MockTransport(respond)),
+    )
+    await agent_management.collect_final_agent_chat_response_async(
+        target,
+        {},
+        "agent-a",
+        1,
+    )
+    await agent_management.stop_agent_chat_async(target, "session", "agent-a")
+    await agent_management._call_fork_api(
+        "agent-a",
+        "session",
+        base_url=target,
+    )
+    expected = "secret-a" if target is None else None
+    assert seen == [expected] * 3
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://example.com:9001",
+        "https://127.0.0.1:9001",
+        "http://user:password@127.0.0.1:9001",
+        "http://127.0.0.1:bad",
+        "http://127.0.0.1:9001/other",
+        "http://127.0.0.1:9001/?q=x",
+        "http://127.0.0.1:9001/#fragment",
+    ],
+)
+def test_invalid_runtime_endpoint_does_not_override_app(monkeypatch, endpoint):
+    monkeypatch.setenv("QWENPAW_RUNTIME_API_URL", endpoint)
+    assert agent_management.resolve_agent_api_base_url() == (
+        "http://127.0.0.1:9002"
+    )
+
+
+def test_ipv6_runtime_endpoint(monkeypatch):
+    endpoint = "http://[::1]:9001"
+    monkeypatch.setenv("QWENPAW_RUNTIME_API_URL", endpoint)
+    assert agent_management.resolve_agent_api_base_url() == endpoint
+    seen = []
+
+    def respond(request):
+        seen.append(request.headers.get(_TOKEN_HEADER))
+        return httpx.Response(200, json={"agents": []})
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
+    result = CliRunner().invoke(cli, ["agents", "list"])
+    assert result.exit_code == 0, result.exception
+    assert seen == ["secret-a"]

--- a/tests/unit/cli/test_cli_runtime_auth.py
+++ b/tests/unit/cli/test_cli_runtime_auth.py
@@ -3,6 +3,8 @@
 """Regression coverage for CLI access to managed runtime APIs."""
 
 from functools import partial
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 import httpx
 import pytest
@@ -13,6 +15,8 @@ from fastapi.testclient import TestClient
 from qwenpaw.agents.tools import agent_management
 from qwenpaw.app.auth import RuntimeBoundaryMiddleware
 from qwenpaw.cli import http as cli_http
+from qwenpaw.cli import doctor_cmd, plugin_commands
+from qwenpaw.utils.runtime_api import async_api_client
 from qwenpaw.cli.main import cli
 
 _RUNTIME_URL = "http://127.0.0.1:9001"
@@ -252,3 +256,99 @@ def test_ipv6_runtime_endpoint(monkeypatch):
     result = CliRunner().invoke(cli, ["agents", "list"])
     assert result.exit_code == 0, result.exception
     assert seen == ["secret-a"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_external_client_cannot_send_token_through_proxy(
+    monkeypatch,
+    asynchronous,
+):
+    """Exercise actual proxy routing rather than a mock transport."""
+    seen = []
+
+    class Proxy(BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen.append((self.path, self.headers.get(_TOKEN_HEADER)))
+            if self.path.startswith("http://external.example"):
+                self.send_response(302)
+                self.send_header("Location", f"{_RUNTIME_URL}/api/agents")
+            else:
+                self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    with HTTPServer(("127.0.0.1", 0), Proxy) as proxy:
+        thread = Thread(target=proxy.serve_forever, daemon=True)
+        thread.start()
+        proxy_url = f"http://127.0.0.1:{proxy.server_port}"
+        for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"):
+            monkeypatch.setenv(name, proxy_url)
+        monkeypatch.setenv("NO_PROXY", "")
+        try:
+            if asynchronous:
+                async with async_api_client("http://external.example") as api:
+                    await api.get("/agents", follow_redirects=True)
+                    await api.get(f"{_RUNTIME_URL}/api/agents")
+            else:
+                with cli_http.client("http://external.example") as api:
+                    api.get("/agents", follow_redirects=True)
+                    api.get(f"{_RUNTIME_URL}/api/agents")
+        finally:
+            proxy.shutdown()
+            thread.join(timeout=5)
+    assert len(seen) == 3
+    assert seen[1][0] == f"{_RUNTIME_URL}/api/agents"
+    assert all(token is None for _, token in seen)
+
+
+@pytest.mark.parametrize("managed", [True, False])
+def test_doctor_and_plugin_operations_pass_boundary(
+    monkeypatch,
+    tmp_path,
+    managed,
+):
+    """Cover missing API entry points without performing plugin installs."""
+    app = FastAPI()
+    app.add_middleware(RuntimeBoundaryMiddleware)
+    seen = []
+
+    @app.api_route("/api/{path:path}", methods=["GET", "POST", "DELETE"])
+    async def endpoint(request: Request, path: str):
+        seen.append((request.method, path, request.url.port))
+        return {"status": "ok", "name": "demo"}
+
+    if not managed:
+        for name in (
+            "QWENPAW_RUNTIME_ID",
+            "QWENPAW_RUNTIME_API_URL",
+            "QWENPAW_RUNTIME_INTERNAL_TOKEN",
+        ):
+            monkeypatch.delenv(name)
+    monkeypatch.setattr(
+        plugin_commands.config_utils,
+        "read_last_api",
+        lambda: ("127.0.0.1", 9002),
+    )
+    archive = tmp_path / "plugin.zip"
+    archive.write_bytes(b"fixture zip")
+    port = 9001 if managed else 9002
+    with TestClient(app) as boundary:
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            partial(httpx.Client, transport=boundary._transport),
+        )
+        ok, _ = doctor_cmd._check_api_health(f"http://127.0.0.1:{port}", 2)
+        assert ok
+        assert plugin_commands._api_install_plugin("fixture")
+        assert plugin_commands._api_upload_plugin(archive)
+        assert plugin_commands._api_uninstall_plugin("demo")
+    assert seen == [
+        ("GET", "healthz", port),
+        ("POST", "plugins/install", port),
+        ("POST", "plugins/upload", port),
+        ("DELETE", "plugins/demo", port),
+    ]

--- a/tests/unit/cli/test_cli_runtime_auth.py
+++ b/tests/unit/cli/test_cli_runtime_auth.py
@@ -44,6 +44,25 @@ def managed_runtime(monkeypatch):
     )
 
 
+def _boundary_transport(boundary: TestClient) -> httpx.MockTransport:
+    """Exercise the real app through TestClient's public HTTP interface."""
+
+    def respond(request):
+        response = boundary.request(
+            request.method,
+            str(request.url),
+            headers=request.headers.multi_items(),
+            content=request.read(),
+        )
+        return httpx.Response(
+            response.status_code,
+            headers=response.headers.multi_items(),
+            content=response.content,
+        )
+
+    return httpx.MockTransport(respond)
+
+
 @pytest.mark.parametrize("managed", [True, False])
 def test_agents_list_passes_real_boundary(monkeypatch, managed):
     """Exercise Click, the HTTP client, and the real boundary middleware."""
@@ -61,11 +80,10 @@ def test_agents_list_passes_real_boundary(monkeypatch, managed):
         monkeypatch.delenv("QWENPAW_RUNTIME_ID")
         monkeypatch.delenv("QWENPAW_RUNTIME_API_URL")
     with TestClient(app) as boundary:
-        # Use the ASGI transport without replacing client request behavior.
         monkeypatch.setattr(
             httpx,
             "Client",
-            partial(httpx.Client, transport=boundary._transport),
+            partial(httpx.Client, transport=_boundary_transport(boundary)),
         )
         result = CliRunner().invoke(cli, ["agents", "list"])
     expected_port = 9001 if managed else 9002
@@ -358,7 +376,7 @@ def test_cli_api_operations_pass_boundary(
         monkeypatch.setattr(
             httpx,
             "Client",
-            partial(httpx.Client, transport=boundary._transport),
+            partial(httpx.Client, transport=_boundary_transport(boundary)),
         )
         ok, _ = doctor_cmd._check_api_health(f"http://127.0.0.1:{port}", 2)
         assert ok

--- a/tests/unit/cli/test_cli_update.py
+++ b/tests/unit/cli/test_cli_update.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 import json
 from pathlib import Path
+from functools import partial
 
 import httpx
 import pytest
@@ -237,39 +238,42 @@ def test_update_reports_up_to_date(monkeypatch) -> None:
     assert "QwenPaw is already up to date." in result.output
 
 
-def test_probe_service_ignores_proxy_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+@pytest.mark.parametrize(
+    "base_url",
+    ["http://127.0.0.1:8088", "http://example.com:8088"],
+)
+def test_probe_service_ignores_proxy_env(monkeypatch, base_url) -> None:
+    captured = {}
+    real_client = httpx.Client
 
-    class _Response:
-        def raise_for_status(self) -> None:
-            return None
-
-        def json(self) -> dict[str, str]:
-            return {"version": "1.2.3"}
-
-    def _fake_get(url: str, **kwargs):
-        captured["url"] = url
+    def create_client(**kwargs):
         captured.update(kwargs)
-        return _Response()
+        return real_client(
+            **kwargs,
+            transport=httpx.MockTransport(
+                lambda _: httpx.Response(200, json={"version": "1.2.3"}),
+            ),
+        )
 
-    monkeypatch.setattr("qwenpaw.cli.update_cmd.httpx.get", _fake_get)
-
-    result = _probe_service("http://127.0.0.1:8088")
+    monkeypatch.setattr(httpx, "Client", create_client)
+    result = _probe_service(base_url)
 
     assert result.is_running is True
-    assert result.base_url == "http://127.0.0.1:8088"
+    assert result.base_url == base_url
     assert result.version == "1.2.3"
     assert captured["trust_env"] is False
 
 
 def test_probe_service_returns_not_running_on_http_error(monkeypatch) -> None:
-    def _fake_get(_url: str, **_kwargs):
+    def respond(_request):
         raise httpx.HTTPError("bad gateway")
 
-    monkeypatch.setattr("qwenpaw.cli.update_cmd.httpx.get", _fake_get)
-
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(respond)),
+    )
     result = _probe_service("http://127.0.0.1:8088")
-
     assert result.is_running is False
 
 

--- a/tests/unit/cli/test_doctor_cmd.py
+++ b/tests/unit/cli/test_doctor_cmd.py
@@ -107,31 +107,6 @@ class TestSamePythonExecutable:
         assert dc._same_python_executable(str(a), str(a)) is True
 
 
-class TestHttpGet:
-    def test_sets_trust_env_default(self, monkeypatch):
-        seen = {}
-
-        def fake_get(url, **kw):
-            seen.update(kw)
-            return _Resp()
-
-        monkeypatch.setattr(dc.httpx, "get", fake_get)
-        monkeypatch.setattr(dc, "trust_env_for_url", lambda u: False)
-        dc._http_get("http://x/api")
-        assert seen["trust_env"] is False
-
-    def test_explicit_trust_env_not_overridden(self, monkeypatch):
-        seen = {}
-
-        def fake_get(url, **kw):
-            seen.update(kw)
-            return _Resp()
-
-        monkeypatch.setattr(dc.httpx, "get", fake_get)
-        dc._http_get("http://x/api", trust_env=True)
-        assert seen["trust_env"] is True
-
-
 class TestProviderIsConfigured:
     def test_local(self):
         p = SimpleNamespace(

--- a/tests/unit/cli/test_plugin_commands.py
+++ b/tests/unit/cli/test_plugin_commands.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for cli/plugin_commands.py.
 
-All network (urllib), subprocess (pip/uv), filesystem (plugins dir) and
+All network (HTTPX/urllib), subprocess (pip/uv), filesystem (plugins dir) and
 config-system collaborators are monkeypatched at their source modules, so
 every code path runs in-process against temporary directories. The Click
 commands are driven through ``CliRunner`` against the ``plugin`` group.
@@ -12,10 +12,11 @@ from __future__ import annotations
 import io
 import json
 import subprocess
-import urllib.error
 import zipfile
 from pathlib import Path
+from functools import partial
 
+import httpx
 import pytest
 from click.testing import CliRunner
 
@@ -28,34 +29,20 @@ import qwenpaw.config.utils as config_utils
 # ---------------------------------------------------------------------------
 
 
-class _FakeResp(io.BytesIO):
-    """urlopen() result supporting context-manager + read()."""
-
-    def __init__(self, payload: dict):
-        super().__init__(json.dumps(payload).encode())
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        self.close()
-        return False
+def _response(payload: dict) -> httpx.Response:
+    return httpx.Response(200, json=payload)
 
 
-def _http_error(payload: bytes | None = None) -> urllib.error.HTTPError:
-    body = (
-        payload
-        if payload is not None
-        else json.dumps(
-            {"detail": "boom"},
-        ).encode()
-    )
-    return urllib.error.HTTPError(
-        "http://x/api",
-        500,
-        "server error",
-        {},  # type: ignore[arg-type]
-        io.BytesIO(body),
+def _http_error(payload: bytes | None = None) -> httpx.Response:
+    body = payload if payload is not None else b'{"detail":"boom"}'
+    return httpx.Response(500, content=body)
+
+
+def _patch_transport(monkeypatch, handler):
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(handler)),
     )
 
 
@@ -128,15 +115,14 @@ class TestApiInstallPlugin:
         _patch_base(monkeypatch)
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
-            captured["url"] = req.full_url
-            captured["body"] = req.data
-            return _FakeResp({"name": "demo"})
+        def respond(req, timeout=None):
+            captured["url"] = str(req.url)
+            captured["body"] = req.content
+            return _response({"name": "demo"})
 
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            fake_urlopen,
+        _patch_transport(
+            monkeypatch,
+            respond,
         )
         assert pc._api_install_plugin("https://x/p.zip", force=True) is True
         assert captured["url"].endswith("/plugins/install")
@@ -147,24 +133,18 @@ class TestApiInstallPlugin:
 
     def test_http_error_with_json_detail(self, monkeypatch, capsys):
         _patch_base(monkeypatch)
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(
-                _http_error(),
-            ),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(),
         )
         assert pc._api_install_plugin("src") is False
         assert "boom" in capsys.readouterr().err
 
     def test_http_error_with_non_json_body(self, monkeypatch, capsys):
         _patch_base(monkeypatch)
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(
-                _http_error(b"not json"),
-            ),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(b"not json"),
         )
         assert pc._api_install_plugin("src") is False
         assert "API install failed" in capsys.readouterr().err
@@ -175,7 +155,7 @@ class TestApiInstallPlugin:
         def boom(req, timeout=None):
             raise OSError("net down")
 
-        monkeypatch.setattr(pc.urllib.request, "urlopen", boom)
+        _patch_transport(monkeypatch, boom)
         assert pc._api_install_plugin("src") is False
         assert "net down" in capsys.readouterr().err
 
@@ -193,13 +173,13 @@ class TestApiUploadPlugin:
         z.write_bytes(b"ZIPBYTES")
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
-            captured["url"] = req.full_url
-            captured["body"] = req.data
-            captured["ctype"] = req.get_header("Content-type")
-            return _FakeResp({"name": "p"})
+        def respond(req, timeout=None):
+            captured["url"] = str(req.url)
+            captured["body"] = req.content
+            captured["ctype"] = req.headers["Content-Type"]
+            return _response({"name": "p"})
 
-        monkeypatch.setattr(pc.urllib.request, "urlopen", fake_urlopen)
+        _patch_transport(monkeypatch, respond)
         assert pc._api_upload_plugin(z, force=True) is True
         assert "force=true" in captured["url"]
         assert b"ZIPBYTES" in captured["body"]
@@ -212,10 +192,9 @@ class TestApiUploadPlugin:
         _patch_base(monkeypatch)
         z = tmp_path / "p.zip"
         z.write_bytes(b"x")
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(_http_error()),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(),
         )
         assert pc._api_upload_plugin(z) is False
         assert "boom" in capsys.readouterr().err
@@ -228,7 +207,7 @@ class TestApiUploadPlugin:
         def boom(req, timeout=None):
             raise ConnectionError("down")
 
-        monkeypatch.setattr(pc.urllib.request, "urlopen", boom)
+        _patch_transport(monkeypatch, boom)
         assert pc._api_upload_plugin(z) is False
         assert "down" in capsys.readouterr().err
 
@@ -241,12 +220,9 @@ class TestApiUploadPlugin:
         _patch_base(monkeypatch)
         z = tmp_path / "p.zip"
         z.write_bytes(b"x")
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(
-                _http_error(b"garbage"),
-            ),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(b"garbage"),
         )
         assert pc._api_upload_plugin(z) is False
         assert "API upload failed" in capsys.readouterr().err
@@ -261,20 +237,19 @@ class TestApiUninstallPlugin:
         _patch_base(monkeypatch)
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
-            captured["method"] = req.get_method()
-            return _FakeResp({"message": "bye"})
+        def respond(req, timeout=None):
+            captured["method"] = req.method
+            return _response({"message": "bye"})
 
-        monkeypatch.setattr(pc.urllib.request, "urlopen", fake_urlopen)
+        _patch_transport(monkeypatch, respond)
         assert pc._api_uninstall_plugin("pid") is True
         assert captured["method"] == "DELETE"
 
     def test_http_error(self, monkeypatch, capsys):
         _patch_base(monkeypatch)
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(_http_error()),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(),
         )
         assert pc._api_uninstall_plugin("pid") is False
         assert "API uninstall failed" in capsys.readouterr().err
@@ -285,18 +260,15 @@ class TestApiUninstallPlugin:
         def boom(req, timeout=None):
             raise RuntimeError("x")
 
-        monkeypatch.setattr(pc.urllib.request, "urlopen", boom)
+        _patch_transport(monkeypatch, boom)
         assert pc._api_uninstall_plugin("pid") is False
         assert "API request failed" in capsys.readouterr().err
 
     def test_http_error_with_non_json_body(self, monkeypatch, capsys):
         _patch_base(monkeypatch)
-        monkeypatch.setattr(
-            pc.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(
-                _http_error(b"garbage"),
-            ),
+        _patch_transport(
+            monkeypatch,
+            lambda req, timeout=None: _http_error(b"garbage"),
         )
         assert pc._api_uninstall_plugin("pid") is False
         assert "API uninstall failed" in capsys.readouterr().err

--- a/tests/unit/hub/test_credentials.py
+++ b/tests/unit/hub/test_credentials.py
@@ -197,6 +197,7 @@ def test_local_runtime_filters_untrusted_control_environment(
         {
             "PYTHONPATH": "/",
             "QWENPAW_WORKING_DIR": "/other-tenant",
+            "QWENPAW_RUNTIME_API_URL": "http://other-tenant:9002",
             "QWENPAW_RUNTIME_INTERNAL_TOKEN": "boundary-token",
             "OPENAI_API_KEY": "tenant-key",
         },
@@ -205,6 +206,9 @@ def test_local_runtime_filters_untrusted_control_environment(
     assert environment.get("PYTHONPATH") != "/"
     assert environment["QWENPAW_WORKING_DIR"] == str(record.working_dir)
     assert environment["QWENPAW_RUNTIME_INTERNAL_TOKEN"] == "boundary-token"
+    assert environment["QWENPAW_RUNTIME_API_URL"] == (
+        f"http://{record.host}:{record.port}"
+    )
     assert environment["OPENAI_API_KEY"] == "tenant-key"
     assert "LANGFUSE_SECRET_KEY" not in environment
     assert environment.get("PATH") == os.environ.get("PATH")

--- a/tests/unit/hub/test_process_isolation.py
+++ b/tests/unit/hub/test_process_isolation.py
@@ -2,6 +2,8 @@
 """Tests for fail-closed Hub runtime process isolation."""
 
 import mimetypes
+import socket
+import textwrap
 import subprocess
 import sys
 import threading
@@ -11,7 +13,10 @@ from pathlib import Path
 
 import pytest
 
-from qwenpaw.hub.local_provisioner import LocalProcessRuntimeProvisioner
+from qwenpaw.hub.local_provisioner import (
+    LocalProcessRuntimeProvisioner,
+    allocate_loopback_port,
+)
 from qwenpaw.hub.models import RuntimeRecord, RuntimeState
 from qwenpaw.hub.process_isolation import (
     IsolatedLaunch,
@@ -540,3 +545,72 @@ def test_runtime_parent_thread_survives_request_worker(
     provisioner.close()
 
     assert not launcher_threads[0].is_alive()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Requires Seatbelt")
+def test_macos_sandbox_cli_can_reach_only_its_runtime(tmp_path):
+    """Run the actual CLI inside its server's native sandbox."""
+    record = _record(tmp_path, port=allocate_loopback_port())
+    environment = LocalProcessRuntimeProvisioner.runtime_environment(
+        record,
+        {"QWENPAW_RUNTIME_INTERNAL_TOKEN": "sandbox-test-token"},
+    )
+    environment["PYTHONPATH"] = str(
+        Path(__file__).resolve().parents[3] / "src",
+    )
+    # Keep the other port listening so failure cannot be ECONNREFUSED.
+    with socket.socket() as other:
+        other.bind(("127.0.0.1", 0))
+        other.listen(1)
+        script = textwrap.dedent(
+            f"""
+            import errno
+            import socket
+            import subprocess
+            import sys
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+            from threading import Thread
+
+            class Handler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    token = self.headers.get("X-QwenPaw-Runtime-Token")
+                    assert token == "sandbox-test-token"
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b'{{"agents":[{{"id":"sandbox-agent"}}]}}')
+
+                def log_message(self, *args):
+                    pass
+
+            with HTTPServer(("127.0.0.1", {record.port}), Handler) as server:
+                Thread(target=server.serve_forever, daemon=True).start()
+                with socket.socket() as client:
+                    client.settimeout(2)
+                    assert client.connect_ex(
+                        ("127.0.0.1", {other.getsockname()[1]})
+                    ) == errno.EPERM
+                result = subprocess.run(
+                    [sys.executable, "-m", "qwenpaw", "agents", "list"],
+                    capture_output=True, text=True, timeout=30,
+                )
+                assert result.returncode == 0, result.stderr
+                assert '"id": "sandbox-agent"' in result.stdout
+                print("sandbox CLI OK; other port denied")
+            """,
+        )
+        launch = MacOSSeatbeltIsolator().prepare(
+            record,
+            [sys.executable, "-c", script],
+            environment,
+        )
+        result = subprocess.run(
+            launch.command,
+            env=launch.environment,
+            cwd=record.working_dir,
+            capture_output=True,
+            text=True,
+            timeout=40,
+            check=False,
+        )
+    assert result.returncode == 0, result.stderr
+    assert "sandbox CLI OK; other port denied" in result.stdout

--- a/tests/unit/hub/test_process_isolation.py
+++ b/tests/unit/hub/test_process_isolation.py
@@ -38,6 +38,7 @@ class _RecordingIsolator(ProcessIsolator):
     ) -> IsolatedLaunch:
         del record
         self.called = True
+        self.environment = dict(environment)
         return IsolatedLaunch(
             ["isolation-wrapper", *command],
             dict(environment),
@@ -60,6 +61,7 @@ class _WindowsRecordingIsolator(_RecordingIsolator):
     ) -> IsolatedLaunch:
         del record
         self.called = True
+        self.environment = dict(environment)
         self.command = list(command)
         return IsolatedLaunch(list(command), dict(environment))
 
@@ -384,6 +386,9 @@ def test_provisioner_launches_through_injected_isolator(
 
     assert isolator.called is True
     assert started.state is RuntimeState.RUNNING
+    assert isolator.environment["QWENPAW_RUNTIME_API_URL"] == (
+        f"http://{started.host}:{started.port}"
+    )
     provisioner.close()
 
 
@@ -418,6 +423,10 @@ def test_windows_runtime_uses_outbound_reverse_tunnel(
         "qwenpaw",
     ]
     assert command[command.index("--host", separator) + 1] == "127.0.0.1"
+    internal_port = command[command.index("--target-port") + 1]
+    assert isolator.environment["QWENPAW_RUNTIME_API_URL"] == (
+        f"http://127.0.0.1:{internal_port}"
+    )
     assert started.port == 9001
     assert _TunnelBroker.instances[0].started is True
 

--- a/tests/unit/hub/test_process_isolation.py
+++ b/tests/unit/hub/test_process_isolation.py
@@ -568,7 +568,8 @@ def test_macos_sandbox_cli_can_reach_only_its_runtime(tmp_path):
             import socket
             import subprocess
             import sys
-            from http.server import BaseHTTPRequestHandler, HTTPServer
+            from http.server import BaseHTTPRequestHandler
+            from socketserver import TCPServer
             from threading import Thread
 
             class Handler(BaseHTTPRequestHandler):
@@ -582,19 +583,19 @@ def test_macos_sandbox_cli_can_reach_only_its_runtime(tmp_path):
                 def log_message(self, *args):
                     pass
 
-            with HTTPServer(("127.0.0.1", {record.port}), Handler) as server:
+            # TCPServer avoids HTTPServer's unrelated reverse-DNS lookup.
+            with TCPServer(("127.0.0.1", {record.port}), Handler) as server:
                 Thread(target=server.serve_forever, daemon=True).start()
                 with socket.socket() as client:
                     client.settimeout(2)
                     assert client.connect_ex(
                         ("127.0.0.1", {other.getsockname()[1]})
                     ) == errno.EPERM
-                result = subprocess.run(
+                print("sandbox ready; starting CLI", flush=True)
+                subprocess.run(
                     [sys.executable, "-m", "qwenpaw", "agents", "list"],
-                    capture_output=True, text=True, timeout=30,
+                    timeout=30, check=True,
                 )
-                assert result.returncode == 0, result.stderr
-                assert '"id": "sandbox-agent"' in result.stdout
                 print("sandbox CLI OK; other port denied")
             """,
         )
@@ -613,4 +614,5 @@ def test_macos_sandbox_cli_can_reach_only_its_runtime(tmp_path):
             check=False,
         )
     assert result.returncode == 0, result.stderr
+    assert '"id": "sandbox-agent"' in result.stdout
     assert "sandbox CLI OK; other port denied" in result.stdout


### PR DESCRIPTION
## Description

Built-in CLI commands such as `qwenpaw agents list` fail with HTTP 401 inside Hub local sandboxes because their HTTP clients omit the runtime boundary token. Hub now supplies the internal API endpoint through the runtime environment, and API-backed commands select it ahead of persisted defaults while respecting explicit endpoint overrides.

Shared synchronous/asynchronous HTTP clients bind authentication to their initial endpoint and direct connection policy. Only clients created for the managed HTTP loopback origin can attach the token, and every request is checked again. An external client cannot acquire the token by following a redirect or requesting the runtime's absolute URL. Doctor probes, update service detection, plugin hot-install/upload/uninstall, and proactive SSE requests now use these clients too. Proactive requests retain their total timeout, and update probes retain their direct connection policy. External plugin downloads and PyPI requests remain separate.

On macOS, the Seatbelt profile permits connections to the runtime's own port while retaining the deny rule for other loopback ports. Startup probes verify both directions of this boundary. Windows AppContainer runtimes receive their internal API port rather than the reverse-tunnel port. Without managed runtime metadata, standalone app endpoint selection remains unchanged and no runtime token is added. External API clients continue to honor environment proxies.

**Related Issue:** Fixes #7612

**Security Considerations:** Runtime metadata is read through `EnvVarLoader`. Runtime ID, internal API URL, and boundary token must all be present before automatic authentication is enabled. Managed endpoints accept only loopback IP literals, never hostnames such as `localhost`. The provisioner supplies the endpoint, not user credentials or `--base-url`. Authentication and proxy selection are constructed together; requests to other origins have the runtime token removed. Server-side authentication is unchanged.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] CLI
- [x] Tests

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (not needed for this fix)
- [ ] Ready for review

Pre-commit was run on the changed Python files rather than the entire repository. Development plans and review documents are not included in the commits.

## Testing

Existing CLI, agent, Hub, doctor, plugin, and update tests are reused. Review coverage adds actual proxy routing (sync/async), API operations through the runtime boundary (managed/standalone), a native macOS sandbox running the actual CLI while another listening port is denied, and proactive SSE authentication/total-timeout behavior. Invalid endpoint tests also assert that no token is attached.

## Evidence

The initial regression reproduced `HTTPStatusError` with `401 Unauthorized` for `/api/agents`. The new native Seatbelt self-connect probe also reproduced `EPERM` before the precise own-port allowance was added.

After the fixes, in the QwenPaw conda environment:

```text
conda run -n QwenPaw env PYTHONPATH=src python -m pytest tests/unit/cli/test_cli_runtime_auth.py tests/unit/cli/test_cli_http_proxy.py tests/unit/cli/test_cli_agents.py tests/unit/agents/tools/test_agent_management.py tests/unit/hub/test_credentials.py tests/unit/hub/test_process_isolation.py tests/unit/app/test_hub_runtime_boundary.py tests/unit/utils/test_http.py tests/unit/cli/test_cli_doctor_proxy.py tests/unit/cli/test_doctor_cmd.py tests/unit/cli/test_doctor_health.py tests/unit/cli/test_plugin_commands.py tests/unit/cli/test_cli_update.py tests/unit/agents/memory/proactive/test_proactive_context_propagation.py -q --disable-warnings
430 passed in 6.79s

# Run before committing the review fixes:
git diff --name-only -z | xargs -0 conda run -n QwenPaw pre-commit run --files
All applicable hooks passed, including mypy, black, flake8, and pylint.

git diff --check
Passed (no output).
```

The real HTTP proxy received no runtime token for external-to-runtime redirects or absolute runtime URLs, for either synchronous or asynchronous clients. Native Seatbelt validation successfully ran `python -m qwenpaw agents list` with the runtime token against a test API in the same sandbox; connecting to another active loopback port returned `EPERM`.

CI dependency validation: the original four boundary tests were reproduced failing with Starlette 1.6.0 / FastAPI 0.141.1 / httpx2 2.12.0 alongside httpx 0.28.1. They reused a private TestClient transport whose response stream belongs to httpx2. The tests now use TestClient's public request API and construct HTTPX responses through MockTransport. No production code or dependency pins changed.

With those CI dependency versions supplied through an isolated local package directory, the existing runtime-auth and process-isolation test files passed: **56 passed**. The native sandbox fixture also avoids HTTPServer's unrelated reverse-DNS lookup and preserves CLI output for timeout diagnosis; hosted-runner confirmation is pending.

## Additional Notes

Native Windows/Linux sandbox end-to-end validation and a full Hub provisioning end-to-end run were not performed. Windows launch command and environment wiring are covered using an injected isolator.


