### PR TITLE
perf(scroll): avoid repeated history integrity scans (Aone)

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -94,6 +94,7 @@ class HistoryStore:
         # Flipped True by ``close()`` so callers can tell an intentional
         # teardown race from a real disk outage (see ``closed``).
         self._closed = False
+        self._checked_identity: tuple[int, int] | None = None
         probe_key, run_integrity_probe = self._claim_integrity_probe(
             self._path,
         )
@@ -108,16 +109,25 @@ class HistoryStore:
                 # bad file and recreate fresh, degrading "broken memory" to
                 # "lost history". The probe claim stays held across recovery
                 # so a concurrent opener cannot race the quarantine.
+                # Cache hits own the same claim as first opens. Invalidate
+                # the old result before recovery and always check the new DB.
+                with self._integrity_probe_condition:
+                    self._integrity_probe_checked.pop(probe_key, None)
                 self._quarantine(exc)
-                self._open_and_init(
-                    run_integrity_probe=run_integrity_probe,
-                )
+                self._open_and_init(run_integrity_probe=True)
         except BaseException:
-            if run_integrity_probe:
-                self._finish_integrity_probe(probe_key, succeeded=False)
+            # Release SQLite resources before waking another constructor.
+            try:
+                self._conn.close()
+            except (AttributeError, sqlite3.Error):
+                pass
+            self._finish_integrity_probe(probe_key, succeeded=False)
             raise
-        if run_integrity_probe:
-            self._finish_integrity_probe(probe_key, succeeded=True)
+        self._finish_integrity_probe(
+            probe_key,
+            succeeded=True,
+            checked_identity=self._checked_identity,
+        )
 
     @staticmethod
     def _file_identity(path: Path) -> tuple[int, int] | None:
@@ -133,7 +143,7 @@ class HistoryStore:
         cls,
         path: Path,
     ) -> tuple[tuple[int, Path], bool]:
-        """Claim the process's one integrity probe for the current DB file.
+        """Serialize construction/recovery and decide whether to probe.
 
         The path is the coordination key so a corrupt first open can
         quarantine and recreate the file without another constructor racing
@@ -146,6 +156,9 @@ class HistoryStore:
             while key in cls._integrity_probe_inflight:
                 condition.wait()
 
+            # Even a cache hit can encounter corruption during schema init.
+            # Hold ownership until construction (including recovery) finishes.
+            cls._integrity_probe_inflight.add(key)
             identity = cls._file_identity(key[1])
             if (
                 identity is not None
@@ -153,7 +166,6 @@ class HistoryStore:
             ):
                 return key, False
 
-            cls._integrity_probe_inflight.add(key)
             return key, True
 
     @classmethod
@@ -162,14 +174,19 @@ class HistoryStore:
         key: tuple[int, Path],
         *,
         succeeded: bool,
+        checked_identity: tuple[int, int] | None = None,
     ) -> None:
         """Publish a probe result and wake constructors waiting on it."""
         condition = cls._integrity_probe_condition
         with condition:
-            if succeeded:
-                identity = cls._file_identity(key[1])
-                if identity is not None:
-                    cls._integrity_probe_checked[key] = identity
+            if not succeeded:
+                cls._integrity_probe_checked.pop(key, None)
+            elif checked_identity is not None:
+                # Never associate a result with a replacement we did not scan.
+                if cls._file_identity(key[1]) == checked_identity:
+                    cls._integrity_probe_checked[key] = checked_identity
+                else:
+                    cls._integrity_probe_checked.pop(key, None)
             cls._integrity_probe_inflight.discard(key)
             condition.notify_all()
 
@@ -185,16 +202,23 @@ class HistoryStore:
         # check_same_thread=False: used from both loop and worker threads;
         # ``self._lock`` provides the serialization SQLite would get from
         # same-thread affinity.
+        self._checked_identity = None
+        identity_before_open = self._file_identity(self._path)
         self._conn = sqlite3.connect(
             str(self._path),
             check_same_thread=False,
         )
+        identity_after_open = self._file_identity(self._path)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
         # Probe for corruption that only surfaces on read.
         if run_integrity_probe:
             self._run_integrity_check()
+            # A missing file may have just been created by sqlite3.connect.
+            # Otherwise require the same identity across connection opening.
+            if identity_before_open in (None, identity_after_open):
+                self._checked_identity = identity_after_open
         self._init_schema()
 
     def _quarantine(self, exc: Exception) -> None:

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import sys
 import threading
@@ -67,6 +68,15 @@ class HistoryStore:
     # per process when it's missing, so a long-lived server doesn't log-spam.
     _fts_unavailable_warned = False
 
+    # ``quick_check`` scans the whole database. Agents are built per request,
+    # so running it in every constructor makes request cost grow with the
+    # entire history file. Keep independent connections, but coordinate the
+    # probe process-wide: the first opener checks, concurrent openers wait,
+    # and later openers skip it while the same file remains at this path.
+    _integrity_probe_condition = threading.Condition()
+    _integrity_probe_inflight: set[tuple[int, Path]] = set()
+    _integrity_probe_checked: dict[tuple[int, Path], tuple[int, int]] = {}
+
     def __init__(self, db_path: str | Path) -> None:
         self._path = Path(db_path).expanduser()
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -84,16 +94,94 @@ class HistoryStore:
         # Flipped True by ``close()`` so callers can tell an intentional
         # teardown race from a real disk outage (see ``closed``).
         self._closed = False
+        probe_key, run_integrity_probe = self._claim_integrity_probe(
+            self._path,
+        )
         try:
-            self._open_and_init()
-        except sqlite3.DatabaseError as exc:
-            # A corrupt / unreadable DB (truncated file, stale WAL trio, bad
-            # page) would crash every task at startup. Quarantine the bad file
-            # and recreate fresh, degrading "broken memory" to "lost history".
-            self._quarantine(exc)
-            self._open_and_init()
+            try:
+                self._open_and_init(
+                    run_integrity_probe=run_integrity_probe,
+                )
+            except sqlite3.DatabaseError as exc:
+                # A corrupt / unreadable DB (truncated file, stale WAL trio,
+                # bad page) would crash every task at startup. Quarantine the
+                # bad file and recreate fresh, degrading "broken memory" to
+                # "lost history". The probe claim stays held across recovery
+                # so a concurrent opener cannot race the quarantine.
+                self._quarantine(exc)
+                self._open_and_init(
+                    run_integrity_probe=run_integrity_probe,
+                )
+        except BaseException:
+            if run_integrity_probe:
+                self._finish_integrity_probe(probe_key, succeeded=False)
+            raise
+        if run_integrity_probe:
+            self._finish_integrity_probe(probe_key, succeeded=True)
 
-    def _open_and_init(self) -> None:
+    @staticmethod
+    def _file_identity(path: Path) -> tuple[int, int] | None:
+        """Return the stable identity of the current file at ``path``."""
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        return stat.st_dev, stat.st_ino
+
+    @classmethod
+    def _claim_integrity_probe(
+        cls,
+        path: Path,
+    ) -> tuple[tuple[int, Path], bool]:
+        """Claim the process's one integrity probe for the current DB file.
+
+        The path is the coordination key so a corrupt first open can
+        quarantine and recreate the file without another constructor racing
+        that recovery. The cached file identity makes replacing the DB at the
+        same path trigger a new probe.
+        """
+        key = os.getpid(), path.resolve(strict=False)
+        condition = cls._integrity_probe_condition
+        with condition:
+            while key in cls._integrity_probe_inflight:
+                condition.wait()
+
+            identity = cls._file_identity(key[1])
+            if (
+                identity is not None
+                and cls._integrity_probe_checked.get(key) == identity
+            ):
+                return key, False
+
+            cls._integrity_probe_inflight.add(key)
+            return key, True
+
+    @classmethod
+    def _finish_integrity_probe(
+        cls,
+        key: tuple[int, Path],
+        *,
+        succeeded: bool,
+    ) -> None:
+        """Publish a probe result and wake constructors waiting on it."""
+        condition = cls._integrity_probe_condition
+        with condition:
+            if succeeded:
+                identity = cls._file_identity(key[1])
+                if identity is not None:
+                    cls._integrity_probe_checked[key] = identity
+            cls._integrity_probe_inflight.discard(key)
+            condition.notify_all()
+
+    def _run_integrity_check(self) -> None:
+        """Raise when SQLite reports corruption in the history database."""
+        row = self._conn.execute("PRAGMA quick_check").fetchone()
+        if not row or row[0] != "ok":
+            raise sqlite3.DatabaseError(
+                f"quick_check failed: {row[0] if row else None}",
+            )
+
+    def _open_and_init(self, *, run_integrity_probe: bool = True) -> None:
         # check_same_thread=False: used from both loop and worker threads;
         # ``self._lock`` provides the serialization SQLite would get from
         # same-thread affinity.
@@ -105,11 +193,8 @@ class HistoryStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
         # Probe for corruption that only surfaces on read.
-        row = self._conn.execute("PRAGMA quick_check").fetchone()
-        if not row or row[0] != "ok":
-            raise sqlite3.DatabaseError(
-                f"quick_check failed: {row[0] if row else None}",
-            )
+        if run_integrity_probe:
+            self._run_integrity_check()
         self._init_schema()
 
     def _quarantine(self, exc: Exception) -> None:

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -9,6 +9,7 @@ durability flag, and corruption quarantine.
 
 import asyncio
 import logging
+import os
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -617,3 +618,135 @@ def test_corrupt_db_is_quarantined_and_recreated(tmp_path: Path):
         assert store.count("s") == 1
     finally:
         store.close()
+
+
+@pytest.mark.parametrize("replace_during", ["check", "schema"])
+def test_replacement_during_open_is_not_cached(
+    tmp_path,
+    monkeypatch,
+    replace_during,
+):
+    path = tmp_path / "history.db"
+    replacement = tmp_path / "replacement.db"
+    HistoryStore(replacement).close()
+    calls = 0
+    original_check = HistoryStore._run_integrity_check
+    original_schema = HistoryStore._init_schema
+
+    def check(store):
+        nonlocal calls
+        calls += 1
+        original_check(store)
+        if calls == 1 and replace_during == "check":
+            replacement.replace(path)
+
+    def schema(store):
+        original_schema(store)
+        if calls == 1 and replace_during == "schema":
+            replacement.replace(path)
+
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", check)
+    monkeypatch.setattr(HistoryStore, "_init_schema", schema)
+    HistoryStore(path).close()
+    HistoryStore(path).close()
+    HistoryStore(path).close()
+    assert calls == 2
+
+
+def test_cache_hit_recovery_blocks_concurrent_open_and_checks_new_file(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "history.db"
+    HistoryStore(path).close()  # Warm the cache.
+    original_schema = HistoryStore._init_schema
+    original_quarantine = HistoryStore._quarantine
+    original_check = HistoryStore._run_integrity_check
+    condition = HistoryStore._integrity_probe_condition
+    original_wait = condition.wait
+    recovery_started = threading.Event()
+    release_recovery = threading.Event()
+    contender_waiting = threading.Event()
+    fail_schema = True
+    checks = 0
+
+    def schema(store):
+        nonlocal fail_schema
+        original_schema(store)
+        if fail_schema:
+            fail_schema = False
+            raise sqlite3.DatabaseError("synthetic corruption on cache hit")
+
+    def quarantine(store, exc):
+        recovery_started.set()
+        assert release_recovery.wait(timeout=5)
+        original_quarantine(store, exc)
+
+    def wait(timeout=None):
+        contender_waiting.set()
+        return original_wait(timeout)
+
+    def check(store):
+        nonlocal checks
+        checks += 1
+        original_check(store)
+
+    def open_store():
+        store = HistoryStore(path)
+        quarantined = store.quarantined_to
+        store.close()
+        return quarantined
+
+    monkeypatch.setattr(HistoryStore, "_init_schema", schema)
+    monkeypatch.setattr(HistoryStore, "_quarantine", quarantine)
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", check)
+    monkeypatch.setattr(condition, "wait", wait)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        recovering = pool.submit(open_store)
+        try:
+            assert recovery_started.wait(timeout=5)
+            contender = pool.submit(open_store)
+            assert contender_waiting.wait(timeout=5)
+            assert not contender.done()
+        finally:
+            release_recovery.set()
+        assert recovering.result(timeout=10) is not None
+        assert contender.result(timeout=10) is None
+    HistoryStore(path).close()
+    assert checks == 1  # Recreated file checked once, then cached.
+
+
+def test_failed_cache_hit_recovery_releases_claim_and_invalidates_cache(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "history.db"
+    HistoryStore(path).close()
+    original_schema = HistoryStore._init_schema
+    original_check = HistoryStore._run_integrity_check
+    fail_schema = True
+    checks = 0
+
+    def schema(store):
+        nonlocal fail_schema
+        original_schema(store)
+        if fail_schema:
+            fail_schema = False
+            raise sqlite3.DatabaseError("synthetic cache-hit corruption")
+
+    def check(store):
+        nonlocal checks
+        checks += 1
+        if checks == 1:
+            raise sqlite3.DatabaseError("synthetic recovery check failure")
+        original_check(store)
+
+    monkeypatch.setattr(HistoryStore, "_init_schema", schema)
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", check)
+    with pytest.raises(sqlite3.DatabaseError, match="recovery check failure"):
+        HistoryStore(path)
+    key = (os.getpid(), path.resolve())
+    assert key not in HistoryStore._integrity_probe_checked
+    assert key not in HistoryStore._integrity_probe_inflight
+    HistoryStore(path).close()
+    assert checks == 2

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -10,6 +10,8 @@ durability flag, and corruption quarantine.
 import asyncio
 import logging
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -82,6 +84,122 @@ def test_created_at_index_migrates_existing_populated_store(
         assert migrated.count("legacy") == 5000
     finally:
         migrated.close()
+
+
+def test_integrity_check_runs_once_per_process_for_same_file(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "history.db"
+    calls = 0
+    original = HistoryStore._run_integrity_check
+
+    def tracked(store):
+        nonlocal calls
+        calls += 1
+        return original(store)
+
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", tracked)
+
+    first = HistoryStore(db_path)
+    first.close()
+    second = HistoryStore(db_path)
+    second.close()
+
+    assert calls == 1
+
+
+def test_integrity_check_is_single_flight_for_concurrent_openers(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "history.db"
+    calls = 0
+    calls_lock = threading.Lock()
+    barrier = threading.Barrier(8)
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    original = HistoryStore._run_integrity_check
+
+    def tracked(store):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        probe_started.set()
+        assert release_probe.wait(timeout=5)
+        return original(store)
+
+    def open_store():
+        barrier.wait(timeout=5)
+        history = HistoryStore(db_path)
+        history.close()
+
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", tracked)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(open_store) for _ in range(8)]
+        assert probe_started.wait(timeout=5)
+        release_probe.set()
+        for future in futures:
+            future.result(timeout=10)
+
+    assert calls == 1
+
+
+def test_integrity_check_repeats_when_database_file_is_replaced(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "history.db"
+    replacement_path = tmp_path / "replacement.db"
+    calls = 0
+    original = HistoryStore._run_integrity_check
+
+    def tracked(store):
+        nonlocal calls
+        calls += 1
+        return original(store)
+
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", tracked)
+    first = HistoryStore(db_path)
+    first.close()
+
+    replacement = sqlite3.connect(replacement_path)
+    replacement.execute("CREATE TABLE replacement_marker (value INTEGER)")
+    replacement.close()
+    replacement_path.replace(db_path)
+
+    second = HistoryStore(db_path)
+    second.close()
+
+    assert calls == 2
+
+
+def test_failed_integrity_check_is_retried_and_not_cached(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "history.db"
+    calls = 0
+    original = HistoryStore._run_integrity_check
+
+    def fail_once(store):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise sqlite3.DatabaseError("synthetic corruption")
+        return original(store)
+
+    monkeypatch.setattr(HistoryStore, "_run_integrity_check", fail_once)
+    recovered = HistoryStore(db_path)
+    try:
+        assert recovered.quarantined_to is not None
+        assert calls == 2
+    finally:
+        recovered.close()
+
+    reopened = HistoryStore(db_path)
+    reopened.close()
+    assert calls == 2
 
 
 def test_append_is_idempotent_on_session_dedup_key(store: HistoryStore):


### PR DESCRIPTION
## Summary

This PR prevents Scroll from running `PRAGMA quick_check` every time an agent is built.

It now:

- Runs the integrity check once per process for each `history.db`.
- Prevents concurrent agent builds from checking the same database simultaneously.
- Checks again if the database file is replaced or recreated.
- Does not cache failed checks.
- Preserves the existing corruption quarantine and recovery behavior.
- Keeps database connections request-scoped.

## Problem

QwenPaw builds a new agent for each request. Each build creates a new `HistoryStore`, which previously ran `PRAGMA quick_check`.

Because `quick_check` scans the database, its cost grows with the size of `history.db`. Large databases therefore caused unnecessary disk I/O and request latency. Concurrent cron jobs could trigger multiple full scans simultaneously.

## Implementation

Integrity checks are coordinated using:

- Process ID
- Canonical database path
- Database file identity (`st_dev` and `st_ino`)
- A condition variable for concurrent opens

The integrity-check claim remains held while a corrupted database is quarantined and recreated, preventing concurrent recovery races.

## Integrity trade-off

The database is still checked:

- On its first open in each process
- After the file is replaced or recreated
- After a failed check during recovery

It is no longer proactively scanned on every request. Normal SQLite operations can still report runtime database errors, and a process restart performs a new complete check.

## Testing

Added tests covering:

- Repeated opens of the same database
- Concurrent first opens
- Database replacement
- Failed checks and quarantine recovery

Validation results:

- 478 tests passed
- Black passed
- Flake8 passed
- Pylint passed
- Mypy passed