### PR TITLE
fix(skill): update clawhub url

### DIFF
--- a/console/src/pages/Agent/Skills/components/index.ts
+++ b/console/src/pages/Agent/Skills/components/index.ts
@@ -66,8 +66,14 @@ export const skillMarkets: SkillMarket[] = [
     homepage: "https://clawhub.ai",
     urlPrefix: "https://clawhub.ai/",
     examples: [
-      { label: "word-docx", url: "https://clawhub.ai/ivangdavila/word-docx" },
-      { label: "excel-xlsx", url: "https://clawhub.ai/ivangdavila/excel-xlsx" },
+      {
+        label: "word-docx",
+        url: "https://clawhub.ai/ivangdavila/skills/word-docx",
+      },
+      {
+        label: "excel-xlsx",
+        url: "https://clawhub.ai/ivangdavila/skills/excel-xlsx",
+      },
     ],
   },
   {

--- a/src/qwenpaw/agents/skill_system/hub.py
+++ b/src/qwenpaw/agents/skill_system/hub.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Skills hub client and install helpers."""
+
 from __future__ import annotations
 
 import asyncio
@@ -17,7 +18,7 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Literal
-from urllib.parse import quote, urlparse, unquote
+from urllib.parse import quote, urljoin, urlparse, unquote
 
 import frontmatter
 import httpx
@@ -569,6 +570,18 @@ async def _http_fetch(
         except httpx.HTTPStatusError as e:
             last_error = e
             status = e.response.status_code
+            if status == 409:
+                try:
+                    conflict = e.response.json()
+                except ValueError:
+                    conflict = None
+                if (
+                    isinstance(conflict, dict)
+                    and conflict.get("code") == "AMBIGUOUS_SKILL_SLUG"
+                ):
+                    raise SkillsError(
+                        message=e.response.text,
+                    ) from e
             if status == 403 and "api.github.com" in host:
                 body_text = ""
                 try:
@@ -1971,6 +1984,7 @@ async def _hydrate_clawhub_payload(
     *,
     slug: str,
     requested_version: str,
+    owner: str = "",
 ) -> Any:
     """Convert ClawHub metadata responses into a bundle with file contents."""
     if _bundle_has_content(data):
@@ -1999,7 +2013,10 @@ async def _hydrate_clawhub_payload(
             base,
             _hub_version_path().format(slug=skill_slug, version=version_hint),
         )
-        version_data = await _http_json_get(version_url)
+        version_data = await _http_json_get(
+            version_url,
+            params={"owner": owner} if owner else None,
+        )
         version_obj = (
             version_data.get("version")
             if isinstance(version_data, dict)
@@ -2026,6 +2043,8 @@ async def _hydrate_clawhub_payload(
         if not isinstance(path, str) or not path:
             continue
         params = {"path": path}
+        if owner:
+            params["owner"] = owner
         if version_str:
             params["version"] = version_str
         try:
@@ -2051,6 +2070,7 @@ async def _hydrate_clawhub_payload(
 async def _fetch_bundle_from_clawhub_slug(
     slug: str,
     version: str,
+    owner: str = "",
 ) -> tuple[Any, str]:
     if not slug:
         raise ConfigurationException(
@@ -2065,6 +2085,10 @@ async def _fetch_bundle_from_clawhub_slug(
     data: Any | None = None
     source_url = ""
     for candidate in candidates:
+        if owner:
+            candidate = str(
+                httpx.URL(candidate).copy_merge_params({"owner": owner}),
+            )
         try:
             data = await _http_json_get(candidate)
             source_url = candidate
@@ -2079,6 +2103,7 @@ async def _fetch_bundle_from_clawhub_slug(
         data,
         slug=slug,
         requested_version=version,
+        owner=owner,
     )
     return hydrated, source_url
 
@@ -2094,7 +2119,19 @@ async def _fetch_bundle_from_clawhub_url(
             config_key="skills_hub.bundle_url",
             message="Invalid ClawHub URL format",
         )
-    return await _fetch_bundle_from_clawhub_slug(slug, requested_version)
+    # Accept both /owner/skills/slug and legacy /owner/slug pages.
+    # /slug and /skills/slug remain valid for globally unique slugs.
+    parts = [unquote(p) for p in urlparse(bundle_url).path.split("/") if p]
+    owner = ""
+    if (len(parts) == 2 and parts[0] != "skills") or (
+        len(parts) == 3 and parts[1] == "skills"
+    ):
+        owner = parts[0]
+    return await _fetch_bundle_from_clawhub_slug(
+        slug,
+        requested_version,
+        owner=owner,
+    )
 
 
 # ---------- Public search API ----------------------------------------------
@@ -2138,7 +2175,15 @@ async def search_hub_skills(
                     item.get("description") or item.get("summary") or "",
                 ),
                 version=str(item.get("version") or ""),
-                source_url=str(item.get("url") or ""),
+                source_url=urljoin(
+                    base,
+                    str(item.get("canonicalUrl") or item.get("url") or "")
+                    or (
+                        f"/{owner_handle}/skills/{slug}"
+                        if owner_handle
+                        else f"/{slug}"
+                    ),
+                ),
                 author=owner_display or owner_handle,
                 icon_url=owner_image,
             ),

--- a/src/qwenpaw/market/providers/clawhub.py
+++ b/src/qwenpaw/market/providers/clawhub.py
@@ -4,12 +4,13 @@
 Two upstream endpoints via hub's shared async client:
 
     GET /api/v1/search?q=&limit=          keyword search (no stats)
-    GET /api/v1/skills?limit=&cursor=&sort=  browse listing (carries
-        stats: downloads / stars / installs)
+    GET /api/v1/trending?kind=skills&limit=&cursor=  owner-qualified browse
 
 """
 
 from __future__ import annotations
+
+from urllib.parse import unquote, urljoin, urlparse
 
 from ...agents.skill_system.hub import http_json_get, search_hub_skills
 from ..schema import MarketResult
@@ -17,8 +18,8 @@ from .base import MARKET_SEARCH_TIMEOUT_S
 
 
 _HOMEPAGE = "https://clawhub.ai"
-_BROWSE_PATH = "/api/v1/skills"
-_BROWSE_SORT = "recommended"
+_BROWSE_PATH = "/api/v1/trending"
+_BROWSE_LIMIT = 100
 
 # The per-request ceiling we send to the keyword /search endpoint.
 _OVERFETCH_LIMIT = 500
@@ -64,7 +65,7 @@ class ClawHubProvider:
             all_results.append(
                 MarketResult(
                     source=self.key,
-                    slug=slug,
+                    slug=_skill_reference(source_url) or slug,
                     name=item.name or slug,
                     description=item.description or None,
                     source_url=source_url,
@@ -86,13 +87,17 @@ class ClawHubProvider:
         target_page = max(1, int(page))
         if target_page > _MAX_PAGE_WALK:
             return [], False, None
+        page_size = max(1, int(limit))
+        start = (target_page - 1) * page_size
+        end = start + page_size
         cursor: str | None = None
-        page_items: list[dict[str, object]] = []
-        next_cursor: str | None = None
-        for current_page in range(1, target_page + 1):
+        results: dict[str, MarketResult] = {}
+        # Replay upstream cursors for the numbered market page. Filter before
+        # slicing: Trending mixes ClawHub and skills.sh in the same snapshot.
+        for _ in range(_MAX_PAGE_WALK):
             params: dict[str, str | int] = {
-                "limit": max(1, int(limit)),
-                "sort": _BROWSE_SORT,
+                "limit": _BROWSE_LIMIT,
+                "kind": "skills",
             }
             if cursor:
                 params["cursor"] = cursor
@@ -102,60 +107,71 @@ class ClawHubProvider:
                 timeout=MARKET_SEARCH_TIMEOUT_S,
             )
             items = body.get("items") if isinstance(body, dict) else None
-            page_items = (
-                [i for i in items if isinstance(i, dict)]
-                if isinstance(items, list)
-                else []
-            )
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, dict):
+                        converted = _browse_to_result(item)
+                        if converted is not None:
+                            results.setdefault(converted.slug, converted)
             raw_cursor = (
                 body.get("nextCursor") if isinstance(body, dict) else None
             )
-            next_cursor = raw_cursor if isinstance(raw_cursor, str) else None
-            if current_page == target_page:
+            cursor = raw_cursor if isinstance(raw_cursor, str) else None
+            if len(results) > end or not cursor:
                 break
-            if not next_cursor:
-                page_items = []
-                break
-            cursor = next_cursor
-        results: list[MarketResult] = []
-        for item in page_items:
-            converted = _browse_to_result(item)
-            if converted is not None:
-                results.append(converted)
-        # /skills has no total count; has_more rides on the cursor.
-        return results, bool(next_cursor), None
+        else:
+            raise RuntimeError("ClawHub Trending pagination limit exceeded")
+        # The upstream total includes skills.sh and is not our filtered total.
+        return list(results.values())[start:end], len(results) > end, None
 
 
 def _browse_to_result(item: dict[str, object]) -> MarketResult | None:
-    slug = _str(item.get("slug"))
-    if not slug:
+    if item.get("source") != "clawhub":
+        return None
+    source_url = urljoin(_HOMEPAGE, _str(item.get("canonicalUrl")))
+    reference = _skill_reference(source_url)
+    if not reference:
         return None
     stats: dict[str, str | int] = {}
-    raw_stats = item.get("stats")
-    if isinstance(raw_stats, dict):
-        for stat_key in ("downloads", "stars", "installs"):
-            value = raw_stats.get(stat_key)
+    metrics = item.get("metrics")
+    if isinstance(metrics, dict):
+        # Trending downloads cover the last 24 hours; installs are lifetime.
+        for stat_key, metric_key in (
+            ("downloads", "trending24hDownloads"),
+            ("installs", "lifetimeInstalls"),
+        ):
+            value = metrics.get(metric_key)
             if isinstance(value, int) and not isinstance(value, bool):
                 stats[stat_key] = value
-    version = ""
-    tags = item.get("tags")
-    if isinstance(tags, dict):
-        version = _str(tags.get("latest"))
+    publisher = item.get("publisher")
+    publisher = publisher if isinstance(publisher, dict) else {}
     return MarketResult(
         source="clawhub",
-        slug=slug,
-        name=_str(item.get("displayName")) or slug,
-        description=_str(item.get("summary"))
-        or _str(item.get("description"))
-        or None,
-        source_url=f"{_HOMEPAGE}/{slug}",
-        version=version or None,
-        # /skills carries no owner or logo, so both stay null; the search
-        # path supplies the owner avatar when a query is present.
-        author=None,
-        icon_url=None,
+        slug=reference,
+        name=_str(item.get("displayName")) or _str(item.get("slug")),
+        description=_str(item.get("summary")) or None,
+        source_url=source_url,
+        # Trending carries no version; the installer resolves latest by owner.
+        version=None,
+        author=_str(publisher.get("displayName"))
+        or _str(publisher.get("handle"))
+        or reference.split("/", 1)[0],
+        icon_url=_str(publisher.get("image")) or None,
         stats=stats or None,
     )
+
+
+def _skill_reference(source_url: str) -> str:
+    """Use owner/slug as the market identity without changing display names."""
+    parsed = urlparse(source_url)
+    if parsed.hostname not in {"clawhub.ai", "www.clawhub.ai"}:
+        return ""
+    parts = [unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) == 3 and parts[1] == "skills":
+        return f"{parts[0]}/{parts[2]}"
+    if len(parts) == 2 and parts[0] != "skills":
+        return "/".join(parts)
+    return ""
 
 
 def _str(value: object) -> str:

--- a/tests/unit/agents/skill_system/test_hub.py
+++ b/tests/unit/agents/skill_system/test_hub.py
@@ -7,6 +7,7 @@ cache, HTTP fetch primitives (retry/backoff/limits), bundle tree
 normalization, provider URL parsers, zip→bundle converters, provider
 routing and the install pipeline — with all network I/O mocked.
 """
+
 # pylint: disable=wrong-import-position,protected-access,redefined-outer-name,too-many-public-methods,unused-argument,unused-import,unused-variable,use-implicit-booleaness-not-comparison  # noqa: E501
 from __future__ import annotations
 
@@ -570,6 +571,27 @@ class TestHttpFetch:
         client = _FakeClient([_FakeResponse(404, b"nope")])
         with pytest.raises(httpx.HTTPStatusError):
             self._fetch(client)
+
+    def test_ambiguous_slug_is_not_retried(self):
+        conflict = {
+            "code": "AMBIGUOUS_SKILL_SLUG",
+            "message": "Specify an owner",
+            "matches": [{"url": "https://clawhub.ai/alice/skills/shared"}],
+        }
+        client = _FakeClient(
+            [_FakeResponse(409, json.dumps(conflict).encode())],
+        )
+        with pytest.raises(SkillsError, match="alice/skills/shared"):
+            self._fetch(client)
+        assert client.calls == 1
+
+    @pytest.mark.parametrize("body", [b"conflict", b"{}", b"[]"])
+    def test_other_conflicts_remain_retryable(self, body, no_sleep):
+        client = _FakeClient(
+            [_FakeResponse(409, body), _FakeResponse(200, b"ok")],
+        )
+        assert self._fetch(client) == b"ok"
+        assert client.calls == 2
 
     def test_github_403_rate_limit(self):
         client = _FakeClient(
@@ -2241,6 +2263,62 @@ class TestHydrateClawhubPayload:
 
 
 class TestFetchBundleClawhub:
+    @pytest.mark.parametrize(
+        "path,owner",
+        [
+            ("/alice/skills/shared", "alice"),
+            ("/bob/shared", "bob"),
+            ("/alice/skills/shared/", "alice"),
+            ("/shared", ""),
+            ("/skills/shared", ""),
+        ],
+    )
+    def test_owner_preserved_through_all_requests(
+        self,
+        monkeypatch,
+        path,
+        owner,
+    ):
+        requests = []
+
+        async def get_json(url, params=None):
+            request_url = httpx.URL(url).copy_merge_params(params or {})
+            requests.append(request_url.path)
+            assert request_url.params.get("owner", "") == owner
+            if request_url.path.endswith("/versions/1.0"):
+                return {
+                    "version": {
+                        "version": "1.0",
+                        "files": [{"path": "SKILL.md"}],
+                    },
+                }
+            return {
+                "skill": {"slug": "shared"},
+                "latestVersion": {"version": "1.0"},
+            }
+
+        async def get_text(url, params=None):
+            requests.append(httpx.URL(url).path)
+            assert params["path"] == "SKILL.md"
+            assert params["version"] == "1.0"
+            assert params.get("owner", "") == owner
+            return f"content from {owner}"
+
+        monkeypatch.setattr(hub, "_http_json_get", get_json)
+        monkeypatch.setattr(hub, "_http_text_get", get_text)
+        bundle, _ = _run(
+            hub._fetch_bundle_from_clawhub_url(
+                "https://clawhub.ai" + path,
+                "",
+            ),
+        )
+        assert bundle["files"]["SKILL.md"] == f"content from {owner}"
+        assert requests == [
+            "/api/v1/skills/shared",
+            "/api/v1/skills/shared/versions/1.0",
+            "/api/v1/skills/shared/file",
+        ]
+
     def test_slug_required(self):
         with pytest.raises(ConfigurationException, match="slug is required"):
             _run(hub._fetch_bundle_from_clawhub_slug("", ""))
@@ -2286,6 +2364,37 @@ class TestFetchBundleClawhub:
 
 
 class TestSearchHubSkills:
+    @pytest.mark.parametrize(
+        "metadata,expected",
+        [
+            (
+                {"canonicalUrl": "/alice/skills/shared"},
+                "https://clawhub.ai/alice/skills/shared",
+            ),
+            (
+                {"canonicalUrl": "https://clawhub.ai/bob/skills/shared"},
+                "https://clawhub.ai/bob/skills/shared",
+            ),
+            (
+                {"owner": {"handle": "bob", "displayName": "Bob Smith"}},
+                "https://clawhub.ai/bob/skills/shared",
+            ),
+            ({}, "https://clawhub.ai/shared"),
+        ],
+    )
+    def test_install_url_preserves_identity(
+        self,
+        monkeypatch,
+        metadata,
+        expected,
+    ):
+        async def search(*args, **kwargs):
+            return {"results": [{"slug": "shared", **metadata}]}
+
+        monkeypatch.setattr(hub, "_http_json_get", search)
+        result = _run(hub.search_hub_skills("shared"))[0]
+        assert result.source_url == expected
+
     def test_results_mapping(self, monkeypatch):
         async def _json(url, params=None, timeout=None):
             assert params == {"q": "pdf", "limit": 2}
@@ -2312,6 +2421,7 @@ class TestSearchHubSkills:
         results = _run(hub.search_hub_skills("pdf", limit=2))
         assert len(results) == 2
         assert results[0].slug == "pdf-tool"
+        assert results[0].source_url == "http://x"
         assert results[0].author == "Display"
         assert results[0].icon_url == "http://img"
         assert results[1].slug == "no-slug-but-name"
@@ -2325,6 +2435,9 @@ class TestSearchHubSkills:
         monkeypatch.setattr(hub, "_http_json_get", _json)
         results = _run(hub.search_hub_skills("x"))
         assert results[0].author == "fallback-handle"
+        assert results[0].source_url == (
+            "https://clawhub.ai/fallback-handle/skills/s"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix the download for clawhub skill via url.

**Related Issue:** Fixes #7634.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

