### PR TITLE
fix(release): retry and verify desktop artifact downloads

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -151,6 +151,25 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 $artifact.FullName).Hash.ToLowerInvariant()
           "$hash  $($artifact.Name)" | Set-Content -Encoding ascii "$($artifact.FullName).sha256"
 
+          $updaterSignatures = @(Get-ChildItem `
+            "dist/QwenPaw-Tauri-*-Windows-setup.exe.sig" `
+            -ErrorAction SilentlyContinue)
+          $updaterMetadata = @(Get-ChildItem `
+            "dist/tauri-windows-*-updater.json" `
+            -ErrorAction SilentlyContinue)
+          if ($updaterSignatures.Count -gt 1 `
+              -or $updaterMetadata.Count -gt 1 `
+              -or $updaterSignatures.Count -ne $updaterMetadata.Count) {
+            throw "Expected one Windows updater signature and metadata file, or neither"
+          }
+          if ($updaterSignatures.Count -eq 1) {
+            foreach ($updaterFile in @($updaterSignatures[0], $updaterMetadata[0])) {
+              $updaterHash = (Get-FileHash -Algorithm SHA256 $updaterFile.FullName).Hash.ToLowerInvariant()
+              "$updaterHash  $($updaterFile.Name)" |
+                Set-Content -Encoding ascii "$($updaterFile.FullName).sha256"
+            }
+          }
+
       - name: Upload desktop verify logs (Tauri Windows)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -187,7 +206,9 @@ jobs:
           name: tauri-updater-meta-windows
           path: |
             dist/QwenPaw-Tauri-*-Windows-setup.exe.sig
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sig.sha256
             dist/tauri-windows-x86_64-updater.json
+            dist/tauri-windows-x86_64-updater.json.sha256
 
   build-tauri-macos:
     runs-on: macos-15
@@ -285,16 +306,27 @@ jobs:
           )
 
           updater_archives=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz)
+          updater_signatures=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig)
+          updater_metadata=(dist/tauri-darwin-*-updater.json)
           if [ ${#updater_archives[@]} -gt 1 ]; then
             echo "::error::Expected at most one macOS updater archive, found ${#updater_archives[@]}"
             exit 1
           fi
+          if [ ${#updater_signatures[@]} -ne ${#updater_archives[@]} ] || \
+             [ ${#updater_metadata[@]} -ne ${#updater_archives[@]} ]; then
+            echo "::error::Expected one macOS updater archive, signature and metadata file, or none"
+            exit 1
+          fi
           if [ ${#updater_archives[@]} -eq 1 ]; then
-            updater_archive="${updater_archives[0]}"
-            (
-              cd "$(dirname "$updater_archive")"
-              shasum -a 256 "$(basename "$updater_archive")" > "$(basename "$updater_archive").sha256"
-            )
+            for updater_file in \
+              "${updater_archives[0]}" \
+              "${updater_signatures[0]}" \
+              "${updater_metadata[0]}"; do
+              (
+                cd "$(dirname "$updater_file")"
+                shasum -a 256 "$(basename "$updater_file")" > "$(basename "$updater_file").sha256"
+              )
+            done
           fi
 
       - name: Upload desktop verify logs (Tauri macOS)
@@ -335,4 +367,6 @@ jobs:
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sha256
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig.sha256
             dist/tauri-darwin-*-updater.json
+            dist/tauri-darwin-*-updater.json.sha256

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -284,6 +284,19 @@ jobs:
             shasum -a 256 "$(basename "$artifact")" > "$(basename "$artifact").sha256"
           )
 
+          updater_archives=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz)
+          if [ ${#updater_archives[@]} -gt 1 ]; then
+            echo "::error::Expected at most one macOS updater archive, found ${#updater_archives[@]}"
+            exit 1
+          fi
+          if [ ${#updater_archives[@]} -eq 1 ]; then
+            updater_archive="${updater_archives[0]}"
+            (
+              cd "$(dirname "$updater_archive")"
+              shasum -a 256 "$(basename "$updater_archive")" > "$(basename "$updater_archive").sha256"
+            )
+          fi
+
       - name: Upload desktop verify logs (Tauri macOS)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -320,5 +333,6 @@ jobs:
           name: tauri-updater-meta-macos
           path: |
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sha256
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
             dist/tauri-darwin-*-updater.json

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -140,6 +140,17 @@ jobs:
             Stop-Process -Force -ErrorAction SilentlyContinue
           exit 0
 
+      - name: Generate desktop artifact checksum (Tauri Windows)
+        shell: pwsh
+        run: |
+          $artifacts = @(Get-ChildItem "dist/QwenPaw-Tauri-*-Windows-setup.exe")
+          if ($artifacts.Count -ne 1) {
+            throw "Expected exactly one Windows installer, found $($artifacts.Count)"
+          }
+          $artifact = $artifacts[0]
+          $hash = (Get-FileHash -Algorithm SHA256 $artifact.FullName).Hash.ToLowerInvariant()
+          "$hash  $($artifact.Name)" | Set-Content -Encoding ascii "$($artifact.FullName).sha256"
+
       - name: Upload desktop verify logs (Tauri Windows)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -165,7 +176,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: QwenPaw-Desktop-Tauri-Windows-${{ steps.version.outputs.version }}
-          path: dist/QwenPaw-Tauri-*-Windows-setup.exe
+          path: |
+            dist/QwenPaw-Tauri-*-Windows-setup.exe
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sha256
 
       - name: Upload Tauri Windows updater metadata
         if: hashFiles('dist/QwenPaw-Tauri-*-Windows-setup.exe.sig') != ''
@@ -257,6 +270,20 @@ jobs:
           fi
           rm -rf dist/verify-tauri
 
+      - name: Generate desktop artifact checksum (Tauri macOS)
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/QwenPaw-Tauri-*-macOS.zip)
+          if [ ${#artifacts[@]} -ne 1 ]; then
+            echo "::error::Expected exactly one macOS ZIP, found ${#artifacts[@]}"
+            exit 1
+          fi
+          artifact="${artifacts[0]}"
+          (
+            cd "$(dirname "$artifact")"
+            shasum -a 256 "$(basename "$artifact")" > "$(basename "$artifact").sha256"
+          )
+
       - name: Upload desktop verify logs (Tauri macOS)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -282,7 +309,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: QwenPaw-Desktop-Tauri-macOS-${{ steps.version.outputs.version }}
-          path: dist/QwenPaw-Tauri-*-macOS.zip
+          path: |
+            dist/QwenPaw-Tauri-*-macOS.zip
+            dist/QwenPaw-Tauri-*-macOS.zip.sha256
 
       - name: Upload Tauri macOS updater metadata
         if: hashFiles('dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig') != ''

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -101,16 +101,12 @@ jobs:
             fi
 
             echo "Promoting ${platform} ${versioned_name} -> ${latest_name}"
-            ossutil cp \
+            bash scripts/pack/oss_copy_with_readback.sh \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
-              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
-              --acl public-read \
-              --force
-            ossutil cp \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}"
+            bash scripts/pack/oss_copy_with_readback.sh \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
-              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
-              --acl public-read \
-              --force
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json"
           }
 
           promote_latest \
@@ -165,10 +161,9 @@ jobs:
             "${metadata_args[@]}" \
             --notes "$NOTES" \
             --output qwenpaw-tauri-latest-oss.json
-          ossutil cp qwenpaw-tauri-latest-oss.json \
-            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            qwenpaw-tauri-latest-oss.json \
+            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json"
 
       - name: Update desktop index
         run: |
@@ -217,10 +212,9 @@ jobs:
             "mac-tauri"
 
           # Upload updated desktop/index.json
-          ossutil cp desktop-index.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            desktop-index.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json"
 
           echo "✓ Desktop index updated"
 
@@ -260,9 +254,8 @@ jobs:
           PYTHON
 
           # Upload main index
-          ossutil cp main-index.json \
-            "oss://${OSS_BUCKET}/metadata/index.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            main-index.json \
+            "oss://${OSS_BUCKET}/metadata/index.json"
 
           echo "✓ Main index updated"

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -19,7 +19,7 @@ on:
         type: string
         required: true
       ref:
-        description: "Git ref/SHA to checkout for the packaging scripts"
+        description: "Release target ref/SHA used for product source and version"
         type: string
         required: false
         default: ""
@@ -40,11 +40,22 @@ jobs:
     env:
       OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
       OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
+      RELEASE_INFRA: ${{ github.workspace }}/.release-infra
     steps:
-      - name: Checkout (for scripts)
+      - name: Checkout release target
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout release infrastructure
+        uses: actions/checkout@v4
+        with:
+          # Helpers must come from the revision that defined this workflow,
+          # even when the release target predates those helpers.
+          ref: ${{ github.workflow_sha }}
+          path: .release-infra
+          sparse-checkout: scripts
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,7 +73,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/pack/download_desktop_artifacts.sh \
+          bash "$RELEASE_INFRA/scripts/pack/download_desktop_artifacts.sh" \
             --attempts 2 \
             --include-updater-metadata
 
@@ -101,10 +112,10 @@ jobs:
             fi
 
             echo "Promoting ${platform} ${versioned_name} -> ${latest_name}"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json"
           }
@@ -153,7 +164,7 @@ jobs:
             exit 0
           fi
           NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
-          python scripts/pack-tauri/generate_update_manifest.py manifest \
+          python "$RELEASE_INFRA/scripts/pack-tauri/generate_update_manifest.py" manifest \
             --version "$VERSION" \
             --base-url "$OSS_BASE" \
             --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
@@ -161,7 +172,7 @@ jobs:
             "${metadata_args[@]}" \
             --notes "$NOTES" \
             --output qwenpaw-tauri-latest-oss.json
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             qwenpaw-tauri-latest-oss.json \
             "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json"
 
@@ -190,7 +201,7 @@ jobs:
             if [ -z "${artifact}" ]; then
               return 0
             fi
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "${artifact}" \
               --product desktop \
               --platform "${platform}" \
@@ -212,7 +223,7 @@ jobs:
             "mac-tauri"
 
           # Upload updated desktop/index.json
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             desktop-index.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json"
 
@@ -254,7 +265,7 @@ jobs:
           PYTHON
 
           # Upload main index
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             main-index.json \
             "oss://${OSS_BUCKET}/metadata/index.json"
 

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -30,6 +30,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -57,8 +58,13 @@ jobs:
         id: version
         uses: ./.github/actions/get-version
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download and verify desktop artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/pack/download_desktop_artifacts.sh \
+            --attempts 2 \
+            --include-updater-metadata
 
       - name: Install ossutil
         run: |

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -20,7 +20,7 @@ on:
         type: string
         required: true
       ref:
-        description: "Git ref/SHA to checkout for the packaging scripts"
+        description: "Release target ref/SHA used for product source and version"
         type: string
         required: false
         default: ""
@@ -38,19 +38,31 @@ jobs:
   # ── Attach installers to the (draft) GitHub Release ────────────────────────
   upload-release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_INFRA: ${{ github.workspace }}/.release-infra
     permissions:
       actions: read
       contents: write
     steps:
-      - name: Checkout (for verification script)
+      - name: Checkout release target
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Checkout release infrastructure
+        uses: actions/checkout@v4
+        with:
+          # Helpers must come from the revision that defined this workflow,
+          # even when the release target predates those helpers.
+          ref: ${{ github.workflow_sha }}
+          path: .release-infra
+          sparse-checkout: scripts
+          persist-credentials: false
+
       - name: Download and verify desktop installers
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/pack/download_desktop_artifacts.sh --attempts 2
+        run: bash "$RELEASE_INFRA/scripts/pack/download_desktop_artifacts.sh" --attempts 2
 
       - name: Attach desktop installers to the draft release
         env:
@@ -66,7 +78,7 @@ jobs:
           fi
           echo "Attaching to draft release ${{ inputs.tag }}: ${files[*]}"
           gh release upload "${{ inputs.tag }}" "${files[@]}" --clobber --repo "$GITHUB_REPOSITORY"
-          bash scripts/pack/verify_github_release_assets.sh \
+          bash "$RELEASE_INFRA/scripts/pack/verify_github_release_assets.sh" \
             "${{ inputs.tag }}" \
             "${files[@]}"
 
@@ -77,11 +89,20 @@ jobs:
     env:
       OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
       OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
+      RELEASE_INFRA: ${{ github.workspace }}/.release-infra
     steps:
-      - name: Checkout (for scripts)
+      - name: Checkout release target
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout release infrastructure
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-infra
+          sparse-checkout: scripts
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -99,7 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/pack/download_desktop_artifacts.sh \
+          bash "$RELEASE_INFRA/scripts/pack/download_desktop_artifacts.sh" \
             --attempts 2 \
             --include-updater-metadata
 
@@ -142,17 +163,17 @@ jobs:
             fi
 
             echo "Processing ${platform} Tauri artifact: ${artifact}"
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "${artifact}" \
               --product desktop \
               --platform "${platform}" \
               --version "${VERSION}" \
               --output "${metadata}"
 
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${artifact}" \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${metadata}" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json"
           }
@@ -181,7 +202,7 @@ jobs:
             echo "No macOS .app.tar.gz found, skipping"
             exit 0
           fi
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$APP_TAR_GZ" \
             "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz"
 

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -66,6 +66,9 @@ jobs:
           fi
           echo "Attaching to draft release ${{ inputs.tag }}: ${files[*]}"
           gh release upload "${{ inputs.tag }}" "${files[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+          bash scripts/pack/verify_github_release_assets.sh \
+            "${{ inputs.tag }}" \
+            "${files[@]}"
 
   # ── Publish files + updater metadata to OSS (skipped on dry_run) ───────────
   upload-oss:
@@ -146,14 +149,12 @@ jobs:
               --version "${VERSION}" \
               --output "${metadata}"
 
-            ossutil cp "${artifact}" \
-              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
-              --acl public-read \
-              --force
-            ossutil cp "${metadata}" \
-              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
-              --acl public-read \
-              --force
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${artifact}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}"
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${metadata}" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json"
           }
 
           upload_versioned \
@@ -180,10 +181,9 @@ jobs:
             echo "No macOS .app.tar.gz found, skipping"
             exit 0
           fi
-          ossutil cp "$APP_TAR_GZ" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$APP_TAR_GZ" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz"
 
       # NOTE: the `latest` files, the updater manifest
       # (qwenpaw-tauri-latest.json) and the index are intentionally NOT uploaded

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -31,6 +31,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -38,10 +39,18 @@ jobs:
   upload-release:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Checkout (for verification script)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Download and verify desktop installers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/pack/download_desktop_artifacts.sh --attempts 2
 
       - name: Attach desktop installers to the draft release
         env:
@@ -83,8 +92,13 @@ jobs:
         id: version
         uses: ./.github/actions/get-version
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download and verify desktop artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/pack/download_desktop_artifacts.sh \
+            --attempts 2 \
+            --include-updater-metadata
 
       - name: Install ossutil
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -284,6 +284,25 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 $artifact.FullName).Hash.ToLowerInvariant()
           "$hash  $($artifact.Name)" | Set-Content -Encoding ascii "$($artifact.FullName).sha256"
 
+          $updaterSignatures = @(Get-ChildItem `
+            "dist/QwenPaw-Tauri-*-Windows-setup.exe.sig" `
+            -ErrorAction SilentlyContinue)
+          $updaterMetadata = @(Get-ChildItem `
+            "dist/tauri-windows-*-updater.json" `
+            -ErrorAction SilentlyContinue)
+          if ($updaterSignatures.Count -gt 1 `
+              -or $updaterMetadata.Count -gt 1 `
+              -or $updaterSignatures.Count -ne $updaterMetadata.Count) {
+            throw "Expected one Windows updater signature and metadata file, or neither"
+          }
+          if ($updaterSignatures.Count -eq 1) {
+            foreach ($updaterFile in @($updaterSignatures[0], $updaterMetadata[0])) {
+              $updaterHash = (Get-FileHash -Algorithm SHA256 $updaterFile.FullName).Hash.ToLowerInvariant()
+              "$updaterHash  $($updaterFile.Name)" |
+                Set-Content -Encoding ascii "$($updaterFile.FullName).sha256"
+            }
+          }
+
       - name: Upload desktop verify logs (Tauri Windows)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -324,7 +343,9 @@ jobs:
           name: tauri-updater-meta-windows
           path: |
             dist/QwenPaw-Tauri-*-Windows-setup.exe.sig
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sig.sha256
             dist/tauri-windows-x86_64-updater.json
+            dist/tauri-windows-x86_64-updater.json.sha256
 
   build-tauri-macos:
     needs: [check-release-secrets]
@@ -426,16 +447,27 @@ jobs:
           )
 
           updater_archives=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz)
+          updater_signatures=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig)
+          updater_metadata=(dist/tauri-darwin-*-updater.json)
           if [ ${#updater_archives[@]} -gt 1 ]; then
             echo "::error::Expected at most one macOS updater archive, found ${#updater_archives[@]}"
             exit 1
           fi
+          if [ ${#updater_signatures[@]} -ne ${#updater_archives[@]} ] || \
+             [ ${#updater_metadata[@]} -ne ${#updater_archives[@]} ]; then
+            echo "::error::Expected one macOS updater archive, signature and metadata file, or none"
+            exit 1
+          fi
           if [ ${#updater_archives[@]} -eq 1 ]; then
-            updater_archive="${updater_archives[0]}"
-            (
-              cd "$(dirname "$updater_archive")"
-              shasum -a 256 "$(basename "$updater_archive")" > "$(basename "$updater_archive").sha256"
-            )
+            for updater_file in \
+              "${updater_archives[0]}" \
+              "${updater_signatures[0]}" \
+              "${updater_metadata[0]}"; do
+              (
+                cd "$(dirname "$updater_file")"
+                shasum -a 256 "$(basename "$updater_file")" > "$(basename "$updater_file").sha256"
+              )
+            done
           fi
 
       - name: Upload desktop verify logs (Tauri macOS)
@@ -480,7 +512,9 @@ jobs:
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sha256
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig.sha256
             dist/tauri-darwin-*-updater.json
+            dist/tauri-darwin-*-updater.json.sha256
 
   upload-release:
     needs: [build-tauri-windows, build-tauri-macos]

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -520,17 +520,29 @@ jobs:
     needs: [build-tauri-windows, build-tauri-macos]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_INFRA: ${{ github.workspace }}/.release-infra
     permissions:
       actions: read
       contents: write
     steps:
-      - name: Checkout (for verification script)
+      - name: Checkout release target
         uses: actions/checkout@v4
+
+      - name: Checkout release infrastructure
+        uses: actions/checkout@v4
+        with:
+          # Release events check out the tag by default; keep helpers on the
+          # revision that defined this emergency workflow instead.
+          ref: ${{ github.workflow_sha }}
+          path: .release-infra
+          sparse-checkout: scripts
+          persist-credentials: false
 
       - name: Download and verify desktop installers
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/pack/download_desktop_artifacts.sh --attempts 2
+        run: bash "$RELEASE_INFRA/scripts/pack/download_desktop_artifacts.sh" --attempts 2
 
       - name: Move artifacts to root for upload
         run: |
@@ -570,7 +582,7 @@ jobs:
             echo "::error::No uploaded Release assets found to verify"
             exit 1
           fi
-          bash scripts/pack/verify_github_release_assets.sh \
+          bash "$RELEASE_INFRA/scripts/pack/verify_github_release_assets.sh" \
             "${{ github.event.release.tag_name }}" \
             "${files[@]}"
 
@@ -587,9 +599,20 @@ jobs:
     env:
       OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
       OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
+      RELEASE_INFRA: ${{ github.workspace }}/.release-infra
     steps:
-      - name: Checkout (for scripts)
+      - name: Checkout release target
         uses: actions/checkout@v4
+
+      - name: Checkout release infrastructure
+        uses: actions/checkout@v4
+        with:
+          # Release events check out the tag by default; keep helpers on the
+          # revision that defined this emergency workflow instead.
+          ref: ${{ github.workflow_sha }}
+          path: .release-infra
+          sparse-checkout: scripts
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -607,7 +630,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/pack/download_desktop_artifacts.sh \
+          bash "$RELEASE_INFRA/scripts/pack/download_desktop_artifacts.sh" \
             --attempts 2 \
             --include-updater-metadata
 
@@ -640,7 +663,7 @@ jobs:
           echo "Processing Windows artifact: $WIN_EXE"
 
           # Generate metadata
-          python scripts/pack/generate_oss_metadata.py \
+          python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
             --file "$WIN_EXE" \
             --product desktop \
             --platform win \
@@ -648,22 +671,22 @@ jobs:
             --output win-metadata.json
 
           # Upload file (versioned)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$WIN_EXE" \
             "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe"
 
           # Upload file (latest)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$WIN_EXE" \
             "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-latest.exe"
 
           # Upload metadata (versioned)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             win-metadata.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe.json"
 
           # Upload metadata (latest)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             win-metadata.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-latest.exe.json"
 
@@ -683,7 +706,7 @@ jobs:
           echo "Processing macOS artifact: $MAC_ZIP"
 
           # Generate metadata
-          python scripts/pack/generate_oss_metadata.py \
+          python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
             --file "$MAC_ZIP" \
             --product desktop \
             --platform mac \
@@ -691,22 +714,22 @@ jobs:
             --output mac-metadata.json
 
           # Upload file (versioned)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$MAC_ZIP" \
             "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip"
 
           # Upload file (latest)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$MAC_ZIP" \
             "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-latest-macOS.zip"
 
           # Upload metadata (versioned)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             mac-metadata.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip.json"
 
           # Upload metadata (latest)
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             mac-metadata.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-latest-macOS.zip.json"
 
@@ -733,23 +756,23 @@ jobs:
             fi
 
             echo "Processing ${platform} Tauri artifact: ${artifact}"
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "${artifact}" \
               --product desktop \
               --platform "${platform}" \
               --version "${VERSION}" \
               --output "${metadata}"
 
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${artifact}" \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${artifact}" \
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${metadata}" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json"
-            bash scripts/pack/oss_copy_with_readback.sh \
+            bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
               "${metadata}" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json"
           }
@@ -780,7 +803,7 @@ jobs:
             echo "No macOS .app.tar.gz found, skipping"
             exit 0
           fi
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             "$APP_TAR_GZ" \
             "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz"
 
@@ -814,7 +837,7 @@ jobs:
             exit 0
           fi
           NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
-          python scripts/pack-tauri/generate_update_manifest.py manifest \
+          python "$RELEASE_INFRA/scripts/pack-tauri/generate_update_manifest.py" manifest \
             --version "$VERSION" \
             --base-url "$OSS_BASE" \
             --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
@@ -822,7 +845,7 @@ jobs:
             "${metadata_args[@]}" \
             --notes "$NOTES" \
             --output qwenpaw-tauri-latest-oss.json
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             qwenpaw-tauri-latest-oss.json \
             "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json"
 
@@ -843,7 +866,7 @@ jobs:
 
           # Merge Windows metadata if exists
           if [ -f "win-metadata.json" ]; then
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "$(find QwenPaw-Desktop-Windows-* -name 'QwenPaw-Setup-*.exe' | head -1)" \
               --product desktop \
               --platform win \
@@ -855,7 +878,7 @@ jobs:
 
           # Merge macOS metadata if exists
           if [ -f "mac-metadata.json" ]; then
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "$(find QwenPaw-Desktop-macOS-* -name 'QwenPaw-*.zip' | head -1)" \
               --product desktop \
               --platform mac \
@@ -873,7 +896,7 @@ jobs:
             if [ ! -f "${metadata}" ]; then
               return 0
             fi
-            python scripts/pack/generate_oss_metadata.py \
+            python "$RELEASE_INFRA/scripts/pack/generate_oss_metadata.py" \
               --file "$(find ${dirs} -name "${pattern}" | head -1)" \
               --product desktop \
               --platform "${platform}" \
@@ -895,7 +918,7 @@ jobs:
             "mac-tauri"
 
           # Upload updated desktop/index.json
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             desktop-index.json \
             "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json"
 
@@ -937,7 +960,7 @@ jobs:
           PYTHON
 
           # Upload main index
-          bash scripts/pack/oss_copy_with_readback.sh \
+          bash "$RELEASE_INFRA/scripts/pack/oss_copy_with_readback.sh" \
             main-index.json \
             "oss://${OSS_BUCKET}/metadata/index.json"
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -523,7 +523,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           shopt -s nullglob
-          files=(QwenPaw-Tauri-*-Windows-setup.exe QwenPaw-Tauri-*-macOS.zip)
+          files=(
+            QwenPaw-Setup-*.exe
+            QwenPaw-[0-9]*-macOS.zip
+            QwenPaw-Tauri-*-Windows-setup.exe
+            QwenPaw-Tauri-*-macOS.zip
+          )
+          if [ -f qwenpaw-tauri-latest.json ]; then
+            files+=(qwenpaw-tauri-latest.json)
+          fi
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No uploaded Release assets found to verify"
+            exit 1
+          fi
           bash scripts/pack/verify_github_release_assets.sh \
             "${{ github.event.release.tag_name }}" \
             "${files[@]}"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -425,6 +425,19 @@ jobs:
             shasum -a 256 "$(basename "$artifact")" > "$(basename "$artifact").sha256"
           )
 
+          updater_archives=(dist/QwenPaw-Tauri-*-macOS.app.tar.gz)
+          if [ ${#updater_archives[@]} -gt 1 ]; then
+            echo "::error::Expected at most one macOS updater archive, found ${#updater_archives[@]}"
+            exit 1
+          fi
+          if [ ${#updater_archives[@]} -eq 1 ]; then
+            updater_archive="${updater_archives[0]}"
+            (
+              cd "$(dirname "$updater_archive")"
+              shasum -a 256 "$(basename "$updater_archive")" > "$(basename "$updater_archive").sha256"
+            )
+          fi
+
       - name: Upload desktop verify logs (Tauri macOS)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -465,6 +478,7 @@ jobs:
           name: tauri-updater-meta-macos
           path: |
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sha256
             dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
             dist/tauri-darwin-*-updater.json
 
@@ -503,6 +517,16 @@ jobs:
           fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify uploaded Release asset sizes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          shopt -s nullglob
+          files=(QwenPaw-Tauri-*-Windows-setup.exe QwenPaw-Tauri-*-macOS.zip)
+          bash scripts/pack/verify_github_release_assets.sh \
+            "${{ github.event.release.tag_name }}" \
+            "${files[@]}"
 
   upload-oss:
     needs: [build-tauri-windows, build-tauri-macos]
@@ -578,28 +602,24 @@ jobs:
             --output win-metadata.json
 
           # Upload file (versioned)
-          ossutil cp "$WIN_EXE" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$WIN_EXE" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe"
 
           # Upload file (latest)
-          ossutil cp "$WIN_EXE" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-latest.exe" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$WIN_EXE" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-latest.exe"
 
           # Upload metadata (versioned)
-          ossutil cp win-metadata.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            win-metadata.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe.json"
 
           # Upload metadata (latest)
-          ossutil cp win-metadata.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-latest.exe.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            win-metadata.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-latest.exe.json"
 
           echo "✓ Windows artifacts uploaded"
 
@@ -625,28 +645,24 @@ jobs:
             --output mac-metadata.json
 
           # Upload file (versioned)
-          ossutil cp "$MAC_ZIP" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$MAC_ZIP" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip"
 
           # Upload file (latest)
-          ossutil cp "$MAC_ZIP" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-latest-macOS.zip" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$MAC_ZIP" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-latest-macOS.zip"
 
           # Upload metadata (versioned)
-          ossutil cp mac-metadata.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            mac-metadata.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip.json"
 
           # Upload metadata (latest)
-          ossutil cp mac-metadata.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-latest-macOS.zip.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            mac-metadata.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-latest-macOS.zip.json"
 
           echo "✓ macOS artifacts uploaded"
 
@@ -678,22 +694,18 @@ jobs:
               --version "${VERSION}" \
               --output "${metadata}"
 
-            ossutil cp "${artifact}" \
-              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
-              --acl public-read \
-              --force
-            ossutil cp "${artifact}" \
-              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
-              --acl public-read \
-              --force
-            ossutil cp "${metadata}" \
-              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
-              --acl public-read \
-              --force
-            ossutil cp "${metadata}" \
-              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
-              --acl public-read \
-              --force
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${artifact}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}"
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${artifact}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}"
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${metadata}" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json"
+            bash scripts/pack/oss_copy_with_readback.sh \
+              "${metadata}" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json"
           }
 
           upload_tauri_artifact \
@@ -722,10 +734,9 @@ jobs:
             echo "No macOS .app.tar.gz found, skipping"
             exit 0
           fi
-          ossutil cp "$APP_TAR_GZ" \
-            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            "$APP_TAR_GZ" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz"
 
       - name: Link artifacts into updater-meta dirs for manifest generation
         if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
@@ -765,10 +776,9 @@ jobs:
             "${metadata_args[@]}" \
             --notes "$NOTES" \
             --output qwenpaw-tauri-latest-oss.json
-          ossutil cp qwenpaw-tauri-latest-oss.json \
-            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            qwenpaw-tauri-latest-oss.json \
+            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json"
 
       - name: Update desktop index
         run: |
@@ -839,10 +849,9 @@ jobs:
             "mac-tauri"
 
           # Upload updated desktop/index.json
-          ossutil cp desktop-index.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            desktop-index.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json"
 
           echo "✓ Desktop index updated"
 
@@ -882,9 +891,8 @@ jobs:
           PYTHON
 
           # Upload main index
-          ossutil cp main-index.json \
-            "oss://${OSS_BUCKET}/metadata/index.json" \
-            --acl public-read \
-            --force
+          bash scripts/pack/oss_copy_with_readback.sh \
+            main-index.json \
+            "oss://${OSS_BUCKET}/metadata/index.json"
 
           echo "✓ Main index updated"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -22,6 +22,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -272,6 +273,17 @@ jobs:
             Stop-Process -Force -ErrorAction SilentlyContinue
           exit 0
 
+      - name: Generate desktop artifact checksum (Tauri Windows)
+        shell: pwsh
+        run: |
+          $artifacts = @(Get-ChildItem "dist/QwenPaw-Tauri-*-Windows-setup.exe")
+          if ($artifacts.Count -ne 1) {
+            throw "Expected exactly one Windows installer, found $($artifacts.Count)"
+          }
+          $artifact = $artifacts[0]
+          $hash = (Get-FileHash -Algorithm SHA256 $artifact.FullName).Hash.ToLowerInvariant()
+          "$hash  $($artifact.Name)" | Set-Content -Encoding ascii "$($artifact.FullName).sha256"
+
       - name: Upload desktop verify logs (Tauri Windows)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -297,7 +309,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: QwenPaw-Desktop-Tauri-Windows-${{ steps.version.outputs.version }}
-          path: dist/QwenPaw-Tauri-*-Windows-setup.exe
+          path: |
+            dist/QwenPaw-Tauri-*-Windows-setup.exe
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sha256
 
       - name: Upload Tauri Windows updater metadata
         if: >-
@@ -397,6 +411,20 @@ jobs:
           fi
           rm -rf dist/verify-tauri
 
+      - name: Generate desktop artifact checksum (Tauri macOS)
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/QwenPaw-Tauri-*-macOS.zip)
+          if [ ${#artifacts[@]} -ne 1 ]; then
+            echo "::error::Expected exactly one macOS ZIP, found ${#artifacts[@]}"
+            exit 1
+          fi
+          artifact="${artifacts[0]}"
+          (
+            cd "$(dirname "$artifact")"
+            shasum -a 256 "$(basename "$artifact")" > "$(basename "$artifact").sha256"
+          )
+
       - name: Upload desktop verify logs (Tauri macOS)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -422,7 +450,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: QwenPaw-Desktop-Tauri-macOS-${{ steps.version.outputs.version }}
-          path: dist/QwenPaw-Tauri-*-macOS.zip
+          path: |
+            dist/QwenPaw-Tauri-*-macOS.zip
+            dist/QwenPaw-Tauri-*-macOS.zip.sha256
 
       - name: Upload Tauri macOS updater metadata
         if: >-
@@ -443,10 +473,16 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Checkout (for verification script)
+        uses: actions/checkout@v4
+
+      - name: Download and verify desktop installers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/pack/download_desktop_artifacts.sh --attempts 2
 
       - name: Move artifacts to root for upload
         run: |
@@ -497,8 +533,13 @@ jobs:
         id: version
         uses: ./.github/actions/get-version
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download and verify desktop artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/pack/download_desktop_artifacts.sh \
+            --attempts 2 \
+            --include-updater-metadata
 
       - name: Install ossutil
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: write
   issues: write
   # Needed by the freeze-main job below, which posts commit statuses

--- a/scripts/pack/download_desktop_artifacts.sh
+++ b/scripts/pack/download_desktop_artifacts.sh
@@ -12,6 +12,10 @@ include_updater_metadata=false
 while [ $# -gt 0 ]; do
   case "$1" in
     --attempts)
+      if [ $# -lt 2 ]; then
+        echo "--attempts requires a value (1 or 2)" >&2
+        exit 2
+      fi
       attempts="$2"
       shift 2
       ;;

--- a/scripts/pack/download_desktop_artifacts.sh
+++ b/scripts/pack/download_desktop_artifacts.sh
@@ -6,6 +6,7 @@
 
 set -euo pipefail
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 attempts=2
 include_updater_metadata=false
 
@@ -93,7 +94,7 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     done
   fi
 
-  if $download_ok && python3 scripts/pack/verify_desktop_artifacts.py \
+  if $download_ok && python3 "$script_dir/verify_desktop_artifacts.py" \
     --require windows \
     --require macos; then
     echo "Desktop artifacts downloaded and verified"

--- a/scripts/pack/download_desktop_artifacts.sh
+++ b/scripts/pack/download_desktop_artifacts.sh
@@ -44,6 +44,9 @@ selected=()
 
 cleanup_downloads() {
   local name
+  if [ ${#selected[@]} -eq 0 ]; then
+    return 0
+  fi
   for name in "${selected[@]}"; do
     # Names are accepted only after matching one of the fixed prefixes below.
     rm -rf -- "$name"

--- a/scripts/pack/download_desktop_artifacts.sh
+++ b/scripts/pack/download_desktop_artifacts.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Download desktop artifacts from the current workflow run. Each failed or
+# corrupt attempt is removed before retrying so a partial file cannot leak into
+# a later publish step.
+
+set -euo pipefail
+
+attempts=2
+include_updater_metadata=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --attempts)
+      attempts="$2"
+      shift 2
+      ;;
+    --include-updater-metadata)
+      include_updater_metadata=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$attempts" =~ ^[12]$ ]]; then
+  echo "--attempts must be 1 or 2" >&2
+  exit 2
+fi
+
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+artifact_names=""
+selected=()
+
+cleanup_downloads() {
+  local name
+  for name in "${selected[@]}"; do
+    # Names are accepted only after matching one of the fixed prefixes below.
+    rm -rf -- "$name"
+  done
+}
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  echo "Desktop artifact download attempt ${attempt}/${attempts}"
+  selected=()
+
+  if artifact_names=$(gh api --paginate --method GET \
+    "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+    -f per_page=100 \
+    --jq '.artifacts[] | select(.expired == false) | .name'); then
+    while IFS= read -r name; do
+      if [[ "$name" =~ ^QwenPaw-Desktop-Tauri-(Windows|macOS)- ]]; then
+        selected+=("$name")
+      elif $include_updater_metadata && \
+        [[ "$name" =~ ^tauri-updater-meta-(windows|macos)$ ]]; then
+        selected+=("$name")
+      fi
+    done <<< "$artifact_names"
+  else
+    echo "::warning::Could not list artifacts for attempt ${attempt}"
+  fi
+
+  cleanup_downloads
+
+  download_ok=true
+  if [ ${#selected[@]} -eq 0 ]; then
+    echo "::warning::No matching desktop artifacts found"
+    download_ok=false
+  else
+    for name in "${selected[@]}"; do
+      echo "Downloading artifact: $name"
+      if ! gh run download "$GITHUB_RUN_ID" \
+        --repo "$GITHUB_REPOSITORY" \
+        --name "$name" \
+        --dir "$name"; then
+        echo "::warning::Download failed for artifact: $name"
+        download_ok=false
+        break
+      fi
+    done
+  fi
+
+  if $download_ok && python3 scripts/pack/verify_desktop_artifacts.py \
+    --require windows \
+    --require macos; then
+    echo "Desktop artifacts downloaded and verified"
+    exit 0
+  fi
+
+  cleanup_downloads
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((attempt * 10))
+    echo "::warning::Desktop artifact verification failed; retrying in ${delay}s"
+    sleep "$delay"
+  fi
+done
+
+echo "::error::Desktop artifacts remained unavailable or corrupt after ${attempts} attempts"
+exit 1

--- a/scripts/pack/oss_copy_with_readback.sh
+++ b/scripts/pack/oss_copy_with_readback.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Upload or copy one OSS object, then verify its remote Content-Length.
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <local-or-oss-source> <oss-destination>" >&2
+  exit 2
+fi
+
+source_path="$1"
+destination="$2"
+attempts=2
+
+get_oss_size() {
+  local object="$1"
+  local output
+  local size
+
+  output=$(ossutil stat "$object") || return 1
+  size=$(awk -F ':' '
+    /^[[:space:]]*Content-Length[[:space:]]*:/ {
+      gsub(/[[:space:]]/, "", $2)
+      print $2
+      exit
+    }
+  ' <<< "$output")
+  [[ "$size" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$size"
+}
+
+if [[ "$source_path" == oss://* ]]; then
+  expected_size=$(get_oss_size "$source_path") || {
+    echo "::error::Could not read source OSS object size: $source_path"
+    exit 1
+  }
+else
+  expected_size=$(wc -c < "$source_path")
+  expected_size=${expected_size//[[:space:]]/}
+fi
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  echo "OSS upload/copy and size verification attempt ${attempt}/${attempts}: $destination"
+
+  if ossutil cp "$source_path" "$destination" --acl public-read --force; then
+    remote_size=$(get_oss_size "$destination") || remote_size=""
+    if [ "$remote_size" = "$expected_size" ]; then
+      echo "Verified OSS object size: $destination (${remote_size} bytes)"
+      exit 0
+    fi
+  fi
+
+  echo "::warning::OSS object size mismatch: $destination "\
+    "(expected ${expected_size} bytes, got ${remote_size:-unavailable})"
+  if [ "$attempt" -lt "$attempts" ]; then
+    sleep 10
+  fi
+done
+
+echo "::error::OSS object failed size verification after ${attempts} attempts: $destination"
+exit 1

--- a/scripts/pack/verify_desktop_artifacts.py
+++ b/scripts/pack/verify_desktop_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 from pathlib import Path
 import sys
 import zipfile
@@ -13,6 +14,7 @@ import zipfile
 ARTIFACT_PATTERNS = {
     "windows": "QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe",
     "macos": "QwenPaw-Desktop-Tauri-macOS-*/QwenPaw-Tauri-*-macOS.zip",
+    "macos-updater": ("tauri-updater-meta-macos/QwenPaw-Tauri-*-macOS.app.tar.gz"),
 }
 
 
@@ -69,6 +71,44 @@ def verify_artifact(artifact: Path, platform: str) -> None:
     print(f"verified {platform} artifact: {artifact} ({artifact.stat().st_size} bytes)")
 
 
+def verify_macos_updater_metadata(artifact: Path) -> None:
+    signature = Path(f"{artifact}.sig")
+    if not signature.is_file():
+        raise ValueError(f"missing macOS updater signature: {signature}")
+    if signature.stat().st_size == 0:
+        raise ValueError(f"empty macOS updater signature: {signature}")
+
+    metadata_files = sorted(artifact.parent.glob("tauri-darwin-*-updater.json"))
+    if len(metadata_files) != 1:
+        raise ValueError(
+            "expected exactly one macOS updater metadata file, "
+            f"found {len(metadata_files)}",
+        )
+
+    metadata_path = metadata_files[0]
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"invalid updater metadata {metadata_path}: {error}"
+        ) from error
+    if not isinstance(metadata, dict):
+        raise ValueError(f"updater metadata {metadata_path} must be a JSON object")
+
+    expected = {
+        "artifact": artifact.name,
+        "signature": signature.name,
+    }
+    for field, expected_value in expected.items():
+        if metadata.get(field) != expected_value:
+            raise ValueError(
+                f"updater metadata {metadata_path} has {field}={metadata.get(field)!r}, "
+                f"expected {expected_value!r}",
+            )
+    if not isinstance(metadata.get("target"), str) or not metadata["target"].strip():
+        raise ValueError(f"updater metadata {metadata_path} has no valid target")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -86,6 +126,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    required_platforms = set(args.require)
+    if (args.root / "tauri-updater-meta-macos").is_dir():
+        required_platforms.add("macos-updater")
+
     failed = False
     found_any = False
     for platform, pattern in ARTIFACT_PATTERNS.items():
@@ -100,13 +144,15 @@ def main() -> int:
             failed = True
             continue
         if not artifacts:
-            if platform in args.require:
+            if platform in required_platforms:
                 print(f"::error::Missing required {platform} artifact", file=sys.stderr)
                 failed = True
             continue
 
         try:
             verify_artifact(artifacts[0], platform)
+            if platform == "macos-updater":
+                verify_macos_updater_metadata(artifacts[0])
         except ValueError as error:
             print(f"::error::{error}", file=sys.stderr)
             failed = True

--- a/scripts/pack/verify_desktop_artifacts.py
+++ b/scripts/pack/verify_desktop_artifacts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Verify desktop installers after they are downloaded from Actions artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+import zipfile
+
+
+ARTIFACT_PATTERNS = {
+    "windows": "QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe",
+    "macos": "QwenPaw-Desktop-Tauri-macOS-*/QwenPaw-Tauri-*-macOS.zip",
+}
+
+
+def calculate_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_expected_sha256(sidecar: Path, artifact: Path) -> str:
+    try:
+        fields = sidecar.read_text(encoding="ascii").strip().split()
+    except OSError as error:
+        raise ValueError(f"cannot read checksum sidecar {sidecar}: {error}") from error
+
+    if len(fields) != 2 or len(fields[0]) != 64:
+        raise ValueError(f"invalid checksum sidecar: {sidecar}")
+    if Path(fields[1].lstrip("*")).name != artifact.name:
+        raise ValueError(
+            f"checksum sidecar {sidecar} names {fields[1]!r}, expected {artifact.name!r}",
+        )
+    try:
+        int(fields[0], 16)
+    except ValueError as error:
+        raise ValueError(f"invalid SHA-256 in {sidecar}") from error
+    return fields[0].lower()
+
+
+def verify_artifact(artifact: Path, platform: str) -> None:
+    sidecar = Path(f"{artifact}.sha256")
+    if not sidecar.is_file():
+        raise ValueError(f"missing checksum sidecar: {sidecar}")
+
+    expected = read_expected_sha256(sidecar, artifact)
+    actual = calculate_sha256(artifact)
+    if actual != expected:
+        raise ValueError(
+            f"SHA-256 mismatch for {artifact}: expected {expected}, got {actual}",
+        )
+
+    if platform == "macos":
+        try:
+            with zipfile.ZipFile(artifact) as archive:
+                corrupt_member = archive.testzip()
+        except (OSError, zipfile.BadZipFile) as error:
+            raise ValueError(f"invalid macOS ZIP {artifact}: {error}") from error
+        if corrupt_member is not None:
+            raise ValueError(
+                f"CRC check failed for {corrupt_member!r} in {artifact}",
+            )
+
+    print(f"verified {platform} artifact: {artifact} ({artifact.stat().st_size} bytes)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Directory containing the downloaded Actions artifact directories",
+    )
+    parser.add_argument(
+        "--require",
+        action="append",
+        choices=tuple(ARTIFACT_PATTERNS),
+        default=[],
+        help="Fail unless exactly one artifact for this platform is present",
+    )
+    args = parser.parse_args()
+
+    failed = False
+    found_any = False
+    for platform, pattern in ARTIFACT_PATTERNS.items():
+        artifacts = sorted(args.root.glob(pattern))
+        if len(artifacts) > 1:
+            print(
+                f"::error::Expected at most one {platform} artifact, found {len(artifacts)}",
+                file=sys.stderr,
+            )
+            failed = True
+            continue
+        if not artifacts:
+            if platform in args.require:
+                print(f"::error::Missing required {platform} artifact", file=sys.stderr)
+                failed = True
+            continue
+
+        found_any = True
+        try:
+            verify_artifact(artifacts[0], platform)
+        except ValueError as error:
+            print(f"::error::{error}", file=sys.stderr)
+            failed = True
+
+    if not found_any:
+        print("::error::No desktop artifacts found", file=sys.stderr)
+        failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pack/verify_desktop_artifacts.py
+++ b/scripts/pack/verify_desktop_artifacts.py
@@ -90,6 +90,8 @@ def main() -> int:
     found_any = False
     for platform, pattern in ARTIFACT_PATTERNS.items():
         artifacts = sorted(args.root.glob(pattern))
+        if artifacts:
+            found_any = True
         if len(artifacts) > 1:
             print(
                 f"::error::Expected at most one {platform} artifact, found {len(artifacts)}",
@@ -103,7 +105,6 @@ def main() -> int:
                 failed = True
             continue
 
-        found_any = True
         try:
             verify_artifact(artifacts[0], platform)
         except ValueError as error:

--- a/scripts/pack/verify_desktop_artifacts.py
+++ b/scripts/pack/verify_desktop_artifacts.py
@@ -198,8 +198,7 @@ def main() -> int:
     installer_names: dict[str, str] = {}
     for platform, pattern in ARTIFACT_PATTERNS.items():
         artifacts = sorted(args.root.glob(pattern))
-        if artifacts:
-            found_any = True
+        found_any = found_any or bool(artifacts)
         if len(artifacts) > 1:
             print(
                 f"::error::Expected at most one {platform} artifact, found {len(artifacts)}",

--- a/scripts/pack/verify_desktop_artifacts.py
+++ b/scripts/pack/verify_desktop_artifacts.py
@@ -14,7 +14,21 @@ import zipfile
 ARTIFACT_PATTERNS = {
     "windows": "QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe",
     "macos": "QwenPaw-Desktop-Tauri-macOS-*/QwenPaw-Tauri-*-macOS.zip",
-    "macos-updater": ("tauri-updater-meta-macos/QwenPaw-Tauri-*-macOS.app.tar.gz"),
+}
+
+UPDATER_SPECS = {
+    "windows-updater": {
+        "directory": "tauri-updater-meta-windows",
+        "artifact_pattern": "QwenPaw-Tauri-*-Windows-setup.exe.sig",
+        "metadata_pattern": "tauri-windows-*-updater.json",
+        "target": "windows-x86_64",
+    },
+    "macos-updater": {
+        "directory": "tauri-updater-meta-macos",
+        "artifact_pattern": "QwenPaw-Tauri-*-macOS.app.tar.gz",
+        "metadata_pattern": "tauri-darwin-*-updater.json",
+        "target": "darwin-aarch64",
+    },
 }
 
 
@@ -45,7 +59,7 @@ def read_expected_sha256(sidecar: Path, artifact: Path) -> str:
     return fields[0].lower()
 
 
-def verify_artifact(artifact: Path, platform: str) -> None:
+def verify_checksum(artifact: Path) -> None:
     sidecar = Path(f"{artifact}.sha256")
     if not sidecar.is_file():
         raise ValueError(f"missing checksum sidecar: {sidecar}")
@@ -56,6 +70,10 @@ def verify_artifact(artifact: Path, platform: str) -> None:
         raise ValueError(
             f"SHA-256 mismatch for {artifact}: expected {expected}, got {actual}",
         )
+
+
+def verify_artifact(artifact: Path, platform: str) -> None:
+    verify_checksum(artifact)
 
     if platform == "macos":
         try:
@@ -71,21 +89,22 @@ def verify_artifact(artifact: Path, platform: str) -> None:
     print(f"verified {platform} artifact: {artifact} ({artifact.stat().st_size} bytes)")
 
 
-def verify_macos_updater_metadata(artifact: Path) -> None:
-    signature = Path(f"{artifact}.sig")
-    if not signature.is_file():
-        raise ValueError(f"missing macOS updater signature: {signature}")
+def find_exactly_one(directory: Path, pattern: str, label: str) -> Path:
+    matches = sorted(directory.glob(pattern))
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {label}, found {len(matches)}")
+    return matches[0]
+
+
+def verify_updater_metadata(
+    artifact_name: str,
+    signature: Path,
+    metadata_path: Path,
+    expected_target: str,
+) -> None:
     if signature.stat().st_size == 0:
-        raise ValueError(f"empty macOS updater signature: {signature}")
+        raise ValueError(f"empty updater signature: {signature}")
 
-    metadata_files = sorted(artifact.parent.glob("tauri-darwin-*-updater.json"))
-    if len(metadata_files) != 1:
-        raise ValueError(
-            "expected exactly one macOS updater metadata file, "
-            f"found {len(metadata_files)}",
-        )
-
-    metadata_path = metadata_files[0]
     try:
         metadata = json.loads(metadata_path.read_text(encoding="utf-8-sig"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
@@ -96,8 +115,9 @@ def verify_macos_updater_metadata(artifact: Path) -> None:
         raise ValueError(f"updater metadata {metadata_path} must be a JSON object")
 
     expected = {
-        "artifact": artifact.name,
+        "artifact": artifact_name,
         "signature": signature.name,
+        "target": expected_target,
     }
     for field, expected_value in expected.items():
         if metadata.get(field) != expected_value:
@@ -105,8 +125,50 @@ def verify_macos_updater_metadata(artifact: Path) -> None:
                 f"updater metadata {metadata_path} has {field}={metadata.get(field)!r}, "
                 f"expected {expected_value!r}",
             )
-    if not isinstance(metadata.get("target"), str) or not metadata["target"].strip():
-        raise ValueError(f"updater metadata {metadata_path} has no valid target")
+
+
+def verify_updater_artifact(
+    root: Path,
+    platform: str,
+    installer_names: dict[str, str],
+) -> None:
+    spec = UPDATER_SPECS[platform]
+    directory = root / spec["directory"]
+    updater_artifact = find_exactly_one(
+        directory,
+        spec["artifact_pattern"],
+        f"{platform} artifact",
+    )
+    metadata_path = find_exactly_one(
+        directory,
+        spec["metadata_pattern"],
+        f"{platform} metadata file",
+    )
+
+    if platform == "windows-updater":
+        signature = updater_artifact
+        artifact_name = signature.name.removesuffix(".sig")
+        if artifact_name != installer_names.get("windows"):
+            raise ValueError(
+                f"Windows updater signature names {artifact_name!r}, "
+                f"expected {installer_names.get('windows')!r}",
+            )
+    else:
+        artifact_name = updater_artifact.name
+        signature = Path(f"{updater_artifact}.sig")
+        if not signature.is_file():
+            raise ValueError(f"missing macOS updater signature: {signature}")
+        verify_checksum(updater_artifact)
+
+    verify_checksum(signature)
+    verify_checksum(metadata_path)
+    verify_updater_metadata(
+        artifact_name,
+        signature,
+        metadata_path,
+        spec["target"],
+    )
+    print(f"verified {platform} metadata: {metadata_path}")
 
 
 def main() -> int:
@@ -120,18 +182,20 @@ def main() -> int:
     parser.add_argument(
         "--require",
         action="append",
-        choices=tuple(ARTIFACT_PATTERNS),
+        choices=tuple(ARTIFACT_PATTERNS) + tuple(UPDATER_SPECS),
         default=[],
         help="Fail unless exactly one artifact for this platform is present",
     )
     args = parser.parse_args()
 
     required_platforms = set(args.require)
-    if (args.root / "tauri-updater-meta-macos").is_dir():
-        required_platforms.add("macos-updater")
+    for platform, spec in UPDATER_SPECS.items():
+        if (args.root / spec["directory"]).is_dir():
+            required_platforms.add(platform)
 
     failed = False
     found_any = False
+    installer_names: dict[str, str] = {}
     for platform, pattern in ARTIFACT_PATTERNS.items():
         artifacts = sorted(args.root.glob(pattern))
         if artifacts:
@@ -149,11 +213,24 @@ def main() -> int:
                 failed = True
             continue
 
+        installer_names[platform] = artifacts[0].name
         try:
             verify_artifact(artifacts[0], platform)
-            if platform == "macos-updater":
-                verify_macos_updater_metadata(artifacts[0])
         except ValueError as error:
+            print(f"::error::{error}", file=sys.stderr)
+            failed = True
+
+    for platform, spec in UPDATER_SPECS.items():
+        if platform not in required_platforms:
+            continue
+        if not (args.root / spec["directory"]).is_dir():
+            print(f"::error::Missing required {platform} artifact", file=sys.stderr)
+            failed = True
+            continue
+        found_any = True
+        try:
+            verify_updater_artifact(args.root, platform, installer_names)
+        except (OSError, ValueError) as error:
             print(f"::error::{error}", file=sys.stderr)
             failed = True
 

--- a/scripts/pack/verify_github_release_assets.sh
+++ b/scripts/pack/verify_github_release_assets.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Verify GitHub Release asset sizes after upload. If the first check fails,
+# overwrite the asset once before checking again. Together with the initial
+# workflow upload, this caps uploads at two without downloading large assets.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <tag> <asset> [asset ...]" >&2
+  exit 2
+fi
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+tag="$1"
+shift
+attempts=2
+
+get_release_asset_size() {
+  local release_tag="$1"
+  local name="$2"
+  local size
+
+  size=$(gh release view "$release_tag" \
+    --repo "$GITHUB_REPOSITORY" \
+    --json assets \
+    --jq ".assets[] | select(.name == \"${name}\") | .size") || return 1
+  [[ "$size" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$size"
+}
+
+for asset in "$@"; do
+  asset_name=$(basename "$asset")
+  expected_size=$(wc -c < "$asset")
+  expected_size=${expected_size//[[:space:]]/}
+  verified=false
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if [ "$attempt" -gt 1 ]; then
+      echo "Retrying GitHub Release upload: $asset_name"
+      if ! gh release upload "$tag" "$asset" \
+        --repo "$GITHUB_REPOSITORY" \
+        --clobber; then
+        echo "::warning::GitHub Release retry upload failed: $asset_name"
+        continue
+      fi
+    fi
+
+    echo "GitHub Release size verification attempt ${attempt}/${attempts}: $asset_name"
+    remote_size=$(get_release_asset_size "$tag" "$asset_name") || remote_size=""
+    if [ "$remote_size" = "$expected_size" ]; then
+      echo "Verified GitHub Release asset size: $asset_name (${remote_size} bytes)"
+      verified=true
+      break
+    fi
+
+    echo "::warning::GitHub Release asset size mismatch: $asset_name "\
+      "(expected ${expected_size} bytes, got ${remote_size:-unavailable})"
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep 10
+    fi
+  done
+
+  if ! $verified; then
+    echo "::error::GitHub Release asset failed size verification: $asset_name"
+    exit 1
+  fi
+done

--- a/tests/unit/pack/test_verify_desktop_artifacts.py
+++ b/tests/unit/pack/test_verify_desktop_artifacts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Regression tests for downloaded desktop updater integrity checks."""
 
 from __future__ import annotations
@@ -60,7 +61,9 @@ def _create_valid_artifacts(root: Path) -> dict[str, Path]:
         b"windows installer",
     )
 
-    macos = root / ("QwenPaw-Desktop-Tauri-macOS-1.0.0/QwenPaw-Tauri-1.0.0-macOS.zip")
+    macos = root / (
+        "QwenPaw-Desktop-Tauri-macOS-1.0.0/QwenPaw-Tauri-1.0.0-macOS.zip"
+    )
     macos.parent.mkdir(parents=True)
     with zipfile.ZipFile(macos, "w") as archive:
         archive.writestr("QwenPaw.app/Contents/MacOS/QwenPaw", b"app")

--- a/tests/unit/pack/test_verify_desktop_artifacts.py
+++ b/tests/unit/pack/test_verify_desktop_artifacts.py
@@ -1,0 +1,152 @@
+"""Regression tests for downloaded desktop updater integrity checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+VERIFIER = REPOSITORY_ROOT / "scripts" / "pack" / "verify_desktop_artifacts.py"
+
+
+def _write_checksum(path: Path) -> None:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    Path(f"{path}.sha256").write_text(
+        f"{digest}  {path.name}\n",
+        encoding="ascii",
+    )
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    _write_checksum(path)
+    return path
+
+
+def _write_metadata(
+    path: Path,
+    *,
+    target: str,
+    artifact: str,
+    signature: str,
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "target": target,
+                "artifact": artifact,
+                "signature": signature,
+            },
+        ),
+        encoding="utf-8",
+    )
+    _write_checksum(path)
+    return path
+
+
+def _create_valid_artifacts(root: Path) -> dict[str, Path]:
+    windows_name = "QwenPaw-Tauri-1.0.0-Windows-setup.exe"
+    windows = _write_file(
+        root / "QwenPaw-Desktop-Tauri-Windows-1.0.0" / windows_name,
+        b"windows installer",
+    )
+
+    macos = root / ("QwenPaw-Desktop-Tauri-macOS-1.0.0/QwenPaw-Tauri-1.0.0-macOS.zip")
+    macos.parent.mkdir(parents=True)
+    with zipfile.ZipFile(macos, "w") as archive:
+        archive.writestr("QwenPaw.app/Contents/MacOS/QwenPaw", b"app")
+    _write_checksum(macos)
+
+    windows_updater = root / "tauri-updater-meta-windows"
+    windows_signature = _write_file(
+        windows_updater / f"{windows_name}.sig",
+        b"complete windows signature",
+    )
+    windows_metadata = _write_metadata(
+        windows_updater / "tauri-windows-x86_64-updater.json",
+        target="windows-x86_64",
+        artifact=windows.name,
+        signature=windows_signature.name,
+    )
+
+    macos_updater = root / "tauri-updater-meta-macos"
+    macos_archive = _write_file(
+        macos_updater / "QwenPaw-Tauri-1.0.0-macOS.app.tar.gz",
+        b"macOS updater archive",
+    )
+    macos_signature = _write_file(
+        Path(f"{macos_archive}.sig"),
+        b"complete macOS signature",
+    )
+    macos_metadata = _write_metadata(
+        macos_updater / "tauri-darwin-aarch64-updater.json",
+        target="darwin-aarch64",
+        artifact=macos_archive.name,
+        signature=macos_signature.name,
+    )
+
+    return {
+        "windows_signature": windows_signature,
+        "windows_metadata": windows_metadata,
+        "macos_signature": macos_signature,
+        "macos_metadata": macos_metadata,
+    }
+
+
+def _run_verifier(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(VERIFIER),
+            "--root",
+            str(root),
+            "--require",
+            "windows",
+            "--require",
+            "macos",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_valid_installers_and_updater_metadata_pass(tmp_path: Path) -> None:
+    _create_valid_artifacts(tmp_path)
+
+    result = _run_verifier(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "verified windows-updater metadata" in result.stdout
+    assert "verified macos-updater metadata" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "windows_signature",
+        "windows_metadata",
+        "macos_signature",
+        "macos_metadata",
+    ],
+)
+def test_tampered_updater_sidecar_fails_checksum(
+    tmp_path: Path,
+    key: str,
+) -> None:
+    files = _create_valid_artifacts(tmp_path)
+    files[key].write_bytes(b"x")
+
+    result = _run_verifier(tmp_path)
+
+    assert result.returncode == 1
+    assert "SHA-256 mismatch" in result.stderr

--- a/tests/unit/tauri/test_desktop_workflows.py
+++ b/tests/unit/tauri/test_desktop_workflows.py
@@ -6,10 +6,27 @@ import tomllib
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+import pytest
 import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+RELEASE_HELPERS = (
+    "scripts/pack/download_desktop_artifacts.sh",
+    "scripts/pack/verify_github_release_assets.sh",
+    "scripts/pack/oss_copy_with_readback.sh",
+    "scripts/pack/generate_oss_metadata.py",
+    "scripts/pack-tauri/generate_update_manifest.py",
+)
+
+
+def _load_workflow(name: str) -> dict:
+    return yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / name).read_text(
+            encoding="utf-8",
+        ),
+    )
 
 
 def test_fork_desktop_build_uses_supported_python() -> None:
@@ -18,11 +35,7 @@ def test_fork_desktop_build_uses_supported_python() -> None:
         (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"),
     )
     supported = SpecifierSet(project["project"]["requires-python"])
-    workflow = yaml.safe_load(
-        (REPO_ROOT / ".github/workflows/fork-verify-desktop.yml").read_text(
-            encoding="utf-8",
-        ),
-    )
+    workflow = _load_workflow("fork-verify-desktop.yml")
 
     for job_name in ("tauri-macos", "tauri-windows"):
         setup_python = next(
@@ -35,3 +48,65 @@ def test_fork_desktop_build_uses_supported_python() -> None:
             f"{job_name} bootstraps unsupported Python {version}; "
             f"project requires {supported}"
         )
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name"),
+    [
+        ("desktop-publish.yml", "upload-release"),
+        ("desktop-publish.yml", "upload-oss"),
+        ("desktop-promote.yml", "promote-oss"),
+        ("desktop-release.yml", "upload-release"),
+        ("desktop-release.yml", "upload-oss"),
+    ],
+)
+def test_publish_jobs_load_infrastructure_from_workflow_revision(
+    workflow_name: str,
+    job_name: str,
+) -> None:
+    """Old release targets must not provide the active workflow's helpers."""
+    job = _load_workflow(workflow_name)["jobs"][job_name]
+    steps = job["steps"]
+    infrastructure_checkout = next(
+        step
+        for step in steps
+        if step.get("name") == "Checkout release infrastructure"
+    )
+
+    assert infrastructure_checkout["uses"].startswith("actions/checkout@")
+    assert infrastructure_checkout["with"] == {
+        "ref": "${{ github.workflow_sha }}",
+        "path": ".release-infra",
+        "sparse-checkout": "scripts",
+        "persist-credentials": False,
+    }
+    assert job["env"]["RELEASE_INFRA"] == (
+        "${{ github.workspace }}/.release-infra"
+    )
+
+    target_checkout_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Checkout release target"
+    )
+    infrastructure_checkout_index = steps.index(infrastructure_checkout)
+    assert target_checkout_index < infrastructure_checkout_index
+
+    helper_lines = [
+        line
+        for step in steps
+        for line in step.get("run", "").splitlines()
+        if any(helper in line for helper in RELEASE_HELPERS)
+    ]
+    assert helper_lines
+    assert all("$RELEASE_INFRA/" in line for line in helper_lines)
+
+
+def test_download_helper_resolves_verifier_from_its_own_checkout() -> None:
+    """The helper must still work when the product checkout has no scripts."""
+    script = (
+        REPO_ROOT / "scripts/pack/download_desktop_artifacts.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"' in script
+    assert 'python3 "$script_dir/verify_desktop_artifacts.py"' in script


### PR DESCRIPTION
## Background

During a desktop release, downloading a GitHub Actions artifact may leave a partially written file after a network timeout. The previous download path did not always propagate that failure correctly. Because the downstream GitHub Release and OSS jobs only checked whether the file existed, a truncated macOS ZIP could be published as a valid release asset.

## Changes

- Generate SHA-256 checksum files for the Windows and macOS installers during the build and include them in the uploaded artifacts.
- Add a shared desktop artifact download script that:
  - Verifies each installer against its build-time SHA-256 checksum.
  - Performs a full ZIP/CRC validation for the macOS package.
  - Removes partial downloads before retrying.
  - Attempts the download at most twice and fails only if the second attempt is still invalid.
- Use the shared download and verification flow for GitHub Release uploads, OSS uploads, and `latest` promotion.
- Download only desktop installers and updater metadata instead of every artifact in the workflow run.
- Apply the same protection to the legacy emergency desktop release workflow.
- Add the `actions: read` permission required to retrieve artifacts from the current workflow run.

## Result

A partial artifact can no longer reach GitHub Releases or OSS. A transient download failure is automatically cleaned up and retried once; the release is stopped only after both attempts fail.

## Validation

- Valid Windows and macOS test artifacts pass verification.
- SHA-256 mismatches are rejected.
- Structurally invalid ZIP files are rejected.
- Shell syntax checks pass.
- Workflow YAML files parse successfully.
- Ruff and `git diff --check` pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
