### PR TITLE
test(e2e): rebuild the Environments suite for the unified env page (#7538)

### DIFF
--- a/e2e/pages/environments_page.py
+++ b/e2e/pages/environments_page.py
@@ -4,12 +4,38 @@ QwenPaw Environments page object.
 
 Wraps all interactions on the environment variables configuration page and
 exposes business-level methods.
+
+Rebuilt for the unified environment management page (#7538, commit 76bfb704):
+
+* The page is no longer an editable table.  It renders three read-oriented
+  sections — "Custom variables", "Live settings" and "Read-only settings" —
+  where each row shows the key in a ``<code>`` element and the value masked.
+* Adding and editing go through a Modal (``Add Variable`` / ``Edit variable``)
+  whose primary button is ``Apply now`` and which writes immediately
+  (``PATCH /api/envs``).  There is no page-level Save button any more.
+* Deleting goes through ``Modal.confirm`` (``Delete Variable`` / okText
+  ``Delete``); a configured catalogue entry can additionally be ``Reset``.
+* The pre-#7538 row checkboxes, batch delete and per-row "insert row below"
+  action were removed from the product, so this page object does not expose
+  them.
+
+Selector strategy: class names are CSS-module scoped as
+``[name]__[local]__[hash:base64:5]`` and this page's stylesheet shares the
+``index.module.less`` filename with ``components/PageHeader``, so every
+generated class begins with ``index-module__``.  Local names are therefore
+matched double-underscore bounded (``__row__``, ``__page__``) to avoid
+hitting neighbours like ``__envRow__`` or ``__pageHeader__``.  Because the
+hash changes whenever the styles change, behavioural anchors (``aria-label``,
+visible text, ``placeholder``) are preferred wherever the page provides them.
+
+The console UI is English-only under e2e (``locale="en-US"`` in
+``e2e/fixtures/__init__.py``), so no Chinese text fallbacks are kept.
 """
 from __future__ import annotations
 
 import logging
 from typing import Optional, List
-from playwright.sync_api import Page, Locator, expect, TimeoutError
+from playwright.sync_api import Page, Locator, expect
 
 from pages.base_page import BasePage
 from config.settings import config
@@ -21,12 +47,13 @@ class EnvironmentsPage(BasePage):
     """
     Environments page object.
 
-    Wraps all user interactions on the environment variables configuration page:
-    - Open the environment variables page
-    - Get the list of environment variable rows
-    - Get environment variable keys and values
-    - Click the add button
-    - Click the save button
+    Wraps the user interactions available on the environment variables page:
+    - Open the page and wait for the catalogue
+    - Count / locate variable rows by key
+    - Add a variable through the editor Modal
+    - Edit a variable through the editor Modal
+    - Delete a variable through the confirm dialog
+    - Filter variables with the search box
     """
 
     PAGE_TITLE = "QwenPaw Console"
@@ -34,15 +61,84 @@ class EnvironmentsPage(BasePage):
 
     # ========== Selector definitions ==========
 
-    # Page load indicator
-    ENV_PAGE_CONTAINER = "div[class*=environmentsPage]"
+    # Page load indicator: `styles.page` root.
+    ENV_PAGE_CONTAINER = 'div[class*="__page__"]'
     PAGE_LOAD_INDICATOR = ENV_PAGE_CONTAINER
+    # Rendered only once the catalogue has loaded (loading/error render
+    # `styles.state` instead), so it doubles as the "data arrived" signal.
+    SECTION_HEADING = 'div[class*="__sectionHeading__"]'
+    CUSTOM_SECTION_HEADING = f'{SECTION_HEADING}:has-text("Custom variables")'
+    CUSTOM_COUNT_SELECTOR = f'{CUSTOM_SECTION_HEADING} span'
 
-    # Table-related selectors
-    ENV_TABLE = ".qwenpaw-table"
-    ENV_ROW = ".qwenpaw-table-tbody tr"
-    ADD_BTN = 'button:has-text("添加"), button:has-text("Add")'
-    SAVE_BTN = 'button.qwenpaw-btn-primary:has-text("保存"), button:has-text("Save")'
+    # Rows and their cells.
+    ENV_ROW = 'div[class*="__row__"]'
+    IDENTITY_CODE = 'div[class*="__identity__"] code'
+    VALUE_CODE = 'div[class*="__valueText__"] code'
+
+    # Actions.
+    ADD_BTN = 'button:has-text("Add Variable")'
+    SEARCH_INPUT = 'input[aria-label="Search variables"]'
+    EDIT_BTN = 'button[aria-label="Edit"]'
+    DELETE_BTN = 'button[aria-label="Delete"]'
+    RESET_BTN = 'button[aria-label="Reset"]'
+    SHOW_VALUE_BTN = 'button[aria-label="Show value"]'
+
+    # Editor Modal.  `ConfigProvider prefixCls="qwenpaw"` (console/src/App.tsx)
+    # makes antd emit `qwenpaw-*`; `ant-*` is kept as a degraded alternate
+    # because both prefixes ship in the stylesheet.
+    #
+    # All modal selectors are `:visible`-scoped: antd does not destroy a
+    # closed Modal by default, so an unscoped `.first` could resolve to a
+    # stale hidden node left over from a previous interaction.
+    MODAL = '.qwenpaw-modal:visible, .ant-modal:visible'
+    MODAL_TITLE = (
+        '.qwenpaw-modal:visible .qwenpaw-modal-title, '
+        '.ant-modal:visible .ant-modal-title'
+    )
+    MODAL_KEY_INPUT = (
+        '.qwenpaw-modal:visible input[placeholder="VARIABLE_NAME"], '
+        '.ant-modal:visible input[placeholder="VARIABLE_NAME"]'
+    )
+    MODAL_VALUE_INPUT = (
+        '.qwenpaw-modal:visible input[placeholder="value"], .ant-modal:visible input[placeholder="value"], '
+        '.qwenpaw-modal:visible input[placeholder="Value"], .ant-modal:visible input[placeholder="Value"]'
+    )
+    MODAL_OK_CANDIDATES = (
+        '.qwenpaw-modal:visible .qwenpaw-modal-footer button.qwenpaw-btn-primary',
+        '.ant-modal:visible .ant-modal-footer button.ant-btn-primary',
+        '.qwenpaw-modal:visible button:has-text("Apply now")',
+        '.ant-modal:visible button:has-text("Apply now")',
+    )
+    MODAL_CANCEL_CANDIDATES = (
+        '.qwenpaw-modal:visible .qwenpaw-modal-footer button:has-text("Cancel")',
+        '.ant-modal:visible .ant-modal-footer button:has-text("Cancel")',
+        '.qwenpaw-modal:visible button:has-text("Cancel")',
+        '.ant-modal:visible button:has-text("Cancel")',
+        '.qwenpaw-modal:visible .qwenpaw-modal-close',
+        '.ant-modal:visible .ant-modal-close',
+    )
+
+    # Confirm dialog (static `Modal.confirm`, same prefix via holderRender).
+    # `:visible`-scoped for the same stale-DOM reason: a static dialog is
+    # created per call and several methods confirm more than once.
+    CONFIRM_MODAL = '.qwenpaw-modal-confirm:visible, .ant-modal-confirm:visible'
+    CONFIRM_BTNS_SCOPES = (
+        '.qwenpaw-modal-confirm-btns',
+        '.ant-modal-confirm-btns',
+    )
+    # okButtonProps {danger: !reset} => dangerous on delete, primary on reset.
+    CONFIRM_OK_STYLES = ("dangerous", "primary")
+
+    # Toasts (`useAppMessage()` → antd App context, same prefix).
+    MESSAGE_NOTICE = (
+        '.qwenpaw-message-notice-content, .qwenpaw-message-custom-content, '
+        '.ant-message-notice-content, .ant-message-custom-content'
+    )
+
+    # Shipped copy for the outcomes tests assert on.
+    MSG_APPLIED = "Environment variable applied"
+    MSG_INVALID_KEY_FORMAT = "Invalid key format"
+    MSG_DUPLICATE_KEY = "Duplicate key"
 
     # ========== Navigation ==========
 
@@ -54,64 +150,203 @@ class EnvironmentsPage(BasePage):
         return self
 
     def wait_for_page_loaded(self, timeout: Optional[int] = None) -> "EnvironmentsPage":
-        """Wait for the page to finish loading."""
+        """Wait for the page shell and the loaded catalogue."""
         timeout = timeout or self.timeout
         expect(self.page.locator(self.PAGE_LOAD_INDICATOR).first).to_be_visible(timeout=timeout)
+        expect(self.page.locator(self.SECTION_HEADING).first).to_be_visible(timeout=timeout)
+        expect(self.page.locator(self.ADD_BTN).first).to_be_visible(timeout=timeout)
         return self
 
-    # ========== Environment variable operations ==========
+    # ========== Environment variable queries ==========
 
     def get_env_rows(self) -> List[Locator]:
-        """Return all environment variable rows."""
+        """Return all variable rows across the three sections."""
         rows = self.page.locator(self.ENV_ROW).all()
         logger.info(f"Found {len(rows)} environment variable rows")
         return rows
 
+    def row_for_key(self, env_key: str) -> Locator:
+        """Return the row whose identity cell shows exactly `env_key`.
+
+        Positional anchors are unusable on this page: all three sections share
+        `styles.row`, so `.last` points into the read-only catalogue rather
+        than at a freshly created variable.
+        """
+        return self.page.locator(self.ENV_ROW).filter(
+            has=self.page.locator(f'{self.IDENTITY_CODE}:text-is("{env_key}")')
+        ).first
+
     def get_env_key(self, row: Locator) -> str:
-        """Return the environment variable key."""
-        # Try to get the key from the first column
-        key_cell = row.locator("td").first
+        """Return the environment variable key shown by a row."""
+        key_cell = row.locator(self.IDENTITY_CODE).first
         if key_cell.count() > 0:
             return key_cell.inner_text().strip()
         return ""
 
     def get_env_value(self, row: Locator) -> str:
-        """Return the environment variable value."""
-        # Try to get the value from the second column
-        value_cells = row.locator("td").all()
-        if len(value_cells) > 1:
-            return value_cells[1].inner_text().strip()
+        """Return the value shown by a row.
+
+        Custom variables render their value masked ("••••••••") until the
+        "Show value" action is used, so callers that need the real value
+        should read it from the API instead of relying on this method.
+        """
+        value_cell = row.locator(self.VALUE_CODE).first
+        if value_cell.count() > 0:
+            return value_cell.inner_text().strip()
         return ""
 
-    def click_add(self) -> "EnvironmentsPage":
-        """Click the add button."""
-        add_btn = self.page.locator(self.ADD_BTN).first
-        if add_btn.count() > 0:
-            add_btn.click()
-            logger.info("Clicked add button")
-        return self
+    def get_custom_var_count(self, timeout: Optional[int] = None) -> int:
+        """Return the count the "Custom variables" heading reports."""
+        count_el = self.page.locator(self.CUSTOM_COUNT_SELECTOR).first
+        expect(count_el).to_be_visible(timeout=timeout or self.timeout)
+        raw = count_el.inner_text().strip()
+        if not raw.isdigit():
+            raise AssertionError(f"Custom variables count is not an integer: {raw!r}")
+        return int(raw)
 
-    def click_save(self) -> "EnvironmentsPage":
-        """Click the save button."""
-        save_btn = self.page.locator(self.SAVE_BTN).first
-        if save_btn.count() > 0:
-            save_btn.click()
-            logger.info("Clicked save button")
-        return self
+    # ========== Environment variable operations ==========
+
+    def click_add(self, timeout: Optional[int] = None) -> Locator:
+        """Click "Add Variable" and return the editor Modal."""
+        timeout = timeout or self.timeout
+        add_btn = self.page.locator(self.ADD_BTN).first
+        expect(add_btn).to_be_visible(timeout=timeout)
+        add_btn.click()
+        modal = self.page.locator(self.MODAL).first
+        expect(modal).to_be_visible(timeout=timeout)
+        expect(self.page.locator(self.MODAL_KEY_INPUT).first).to_be_visible(timeout=timeout)
+        logger.info("Opened the Add Variable modal")
+        return modal
+
+    def fill_modal(self, key: Optional[str] = None, value: Optional[str] = None) -> None:
+        """Fill the Key / Value inputs of the open editor Modal."""
+        if key is not None:
+            key_input = self.page.locator(self.MODAL_KEY_INPUT).first
+            expect(key_input).to_be_visible(timeout=self.timeout)
+            key_input.fill(key)
+        if value is not None:
+            value_input = self.page.locator(self.MODAL_VALUE_INPUT).first
+            expect(value_input).to_be_visible(timeout=self.timeout)
+            value_input.fill(value)
+        self.page.wait_for_timeout(200)
+
+    def _first_visible(self, candidates) -> Locator:
+        """Return the first candidate selector resolving to a visible node.
+
+        Walked in priority order on purpose: Playwright resolves `.first` on a
+        comma-separated selector list by *document* position, so expressing
+        "prefer the precise anchor, fall back to the loose one" as one list
+        would let the loose one win whenever it appears earlier in the DOM.
+        """
+        for selector in candidates:
+            candidate = self.page.locator(selector).first
+            try:
+                if candidate.count() > 0 and candidate.is_visible():
+                    return candidate
+            except Exception:
+                continue
+        return self.page.locator(candidates[0]).first
+
+    def _confirm_ok_button(self) -> Locator:
+        """Return the visible confirm dialog's OK button (Delete or Reset)."""
+        dialog = self.page.locator(self.CONFIRM_MODAL).first
+        candidates = []
+        for scope in self.CONFIRM_BTNS_SCOPES:
+            prefix = "qwenpaw" if "qwenpaw" in scope else "ant"
+            for style in self.CONFIRM_OK_STYLES:
+                candidates.append(dialog.locator(f"{scope} button.{prefix}-btn-{style}"))
+        for candidate in candidates:
+            try:
+                if candidate.count() > 0 and candidate.first.is_visible():
+                    return candidate.first
+            except Exception:
+                continue
+        return candidates[0].first
+
+    def click_apply(self) -> None:
+        """Click the Modal primary button ("Apply now") — this writes."""
+        ok_btn = self._first_visible(self.MODAL_OK_CANDIDATES)
+        expect(ok_btn).to_be_visible(timeout=self.timeout)
+        ok_btn.click()
+        logger.info("Clicked Apply now")
+
+    def click_modal_cancel(self) -> None:
+        """Dismiss the editor Modal without writing."""
+        cancel_btn = self._first_visible(self.MODAL_CANCEL_CANDIDATES)
+        expect(cancel_btn).to_be_visible(timeout=self.timeout)
+        cancel_btn.click()
+        logger.info("Cancelled the editor modal")
+
+    def _expect_modal_closed(self) -> None:
+        """Wait until the editor Modal is gone.
+
+        `to_be_hidden()` rather than `to_have_count(0)`: antd keeps a closed
+        Modal's DOM in place, so counting nodes would still see the Key input
+        after a successful close and never pass.
+        """
+        expect(self.page.locator(self.MODAL_KEY_INPUT).first).to_be_hidden(
+            timeout=self.timeout
+        )
+
+    def add_variable(self, key: str, value: str) -> None:
+        """Create a custom variable through the UI and wait for it to appear."""
+        self.click_add()
+        self.fill_modal(key=key, value=value)
+        self.click_apply()
+        self._expect_modal_closed()
+        expect(self.row_for_key(key)).to_be_visible(timeout=self.timeout)
+        logger.info(f"Added variable {key}")
+
+    def edit_variable(self, key: str, new_value: str) -> None:
+        """Edit an existing variable's value through the row action."""
+        row = self.row_for_key(key)
+        expect(row).to_be_visible(timeout=self.timeout)
+        expect(row.locator(self.EDIT_BTN).first).to_be_visible(timeout=self.timeout)
+        row.locator(self.EDIT_BTN).first.click()
+        expect(self.page.locator(self.MODAL_KEY_INPUT).first).to_be_visible(timeout=self.timeout)
+        self.fill_modal(value=new_value)
+        self.click_apply()
+        self._expect_modal_closed()
+        expect(self.row_for_key(key)).to_be_visible(timeout=self.timeout)
+        logger.info(f"Edited variable {key}")
+
+    def delete_variable(self, key: str) -> None:
+        """Delete a custom variable through the row action + confirm dialog."""
+        row = self.row_for_key(key)
+        expect(row).to_be_visible(timeout=self.timeout)
+        expect(row.locator(self.DELETE_BTN).first).to_be_visible(timeout=self.timeout)
+        row.locator(self.DELETE_BTN).first.click()
+        expect(self.page.locator(self.CONFIRM_MODAL).first).to_be_visible(timeout=self.timeout)
+        confirm_ok = self._confirm_ok_button()
+        expect(confirm_ok).to_be_visible(timeout=self.timeout)
+        confirm_ok.click()
+        # CONFIRM_MODAL is :visible-scoped, so count 0 means "no dialog showing".
+        expect(self.page.locator(self.CONFIRM_MODAL)).to_have_count(0, timeout=self.timeout)
+        logger.info(f"Deleted variable {key}")
+
+    def search(self, query: str) -> None:
+        """Filter the catalogue with the search box."""
+        search_input = self.page.locator(self.SEARCH_INPUT).first
+        expect(search_input).to_be_visible(timeout=self.timeout)
+        search_input.fill(query)
+        self.page.wait_for_timeout(500)
+        logger.info(f"Filtered variables by {query!r}")
 
     # ========== Assertion methods ==========
 
     def assert_env_row_count(self, expected_count: int, timeout: Optional[int] = None) -> "EnvironmentsPage":
-        """Assert the environment variable row count."""
+        """Assert the total variable row count across all sections."""
         expect(self.page.locator(self.ENV_ROW)).to_have_count(
             expected_count, timeout=timeout or self.timeout
         )
         return self
 
     def assert_env_exists(self, env_key: str, timeout: Optional[int] = None) -> "EnvironmentsPage":
-        """Assert that the environment variable exists."""
-        env_row = self.page.locator(self.ENV_ROW).filter(
-            has_text=env_key
-        ).first
-        expect(env_row).to_be_visible(timeout=timeout or self.timeout)
+        """Assert that a variable row with this key is visible."""
+        expect(self.row_for_key(env_key)).to_be_visible(timeout=timeout or self.timeout)
+        return self
+
+    def assert_env_absent(self, env_key: str, timeout: Optional[int] = None) -> "EnvironmentsPage":
+        """Assert that no variable row with this key exists."""
+        expect(self.row_for_key(env_key)).to_have_count(0, timeout=timeout or self.timeout)
         return self

--- a/e2e/tests/test_cross_module.py
+++ b/e2e/tests/test_cross_module.py
@@ -58,6 +58,37 @@ def count_environment_rows(page: Page) -> int:
     return page.locator(ENV_ROW_SELECTOR).count()
 
 
+def sum_environment_section_counts(page: Page) -> int:
+    """Sum the three section-heading counts (Custom + Live + Read-only).
+
+    index.tsx renders `<span>{customVariables.length}</span>`,
+    `<span>{editableCatalog.length}</span>` and
+    `<span>{readonlyCatalog.length}</span>` inside each `styles.sectionHeading`,
+    and those three lists are exactly what produces the `styles.row` elements.
+    Their sum is therefore an independent measurement of the same quantity as
+    `count_environment_rows()`, derived from text rather than from the row
+    class name.
+
+    Comparing the two is a self-consistent invariant: it catches row-selector
+    drift (rows would count 0 while the headings still sum to the catalogue
+    size) without hard-coding the catalogue size, which upstream is free to
+    change — `src/qwenpaw/envs/registry.py` currently ships 17 `EnvVarSpec`
+    entries (2 hot_runtime + 15 startup_only), but a future entry would make a
+    literal `>= 17` assertion wrong in either direction.
+    """
+    total = 0
+    for heading_text in ("Custom variables", "Live settings", "Read-only settings"):
+        heading = page.locator(ENV_SECTION_HEADING).filter(has_text=heading_text).first
+        expect(heading).to_be_visible(timeout=10000)
+        raw = heading.locator("span").first.inner_text().strip()
+        if not raw.isdigit():
+            raise AssertionError(
+                f"'{heading_text}' section count is not an integer: {raw!r}"
+            )
+        total += int(raw)
+    return total
+
+
 def navigate_to_skills(page: Page):
     """Navigate to the skills management page."""
     page.goto(f"{BASE_URL}/skills")
@@ -660,12 +691,32 @@ class TestWorkspaceFileChatFlow:
 @pytest.mark.cross_module
 class TestEnvAndRuntimeConfigFlow:
     """
-    CROSS-005: Environment variables and runtime config linkage verification.
+    CROSS-005: Environment variables and agent (runtime) config boundary.
 
-    Verify data consistency between the environments page and the runtime config page:
-    1. View configured environment variables on the Environments page
-    2. Verify config items on the RuntimeConfig page
-    3. Confirm the two pages do not interfere with each other
+    Verify the two pages that expose the same LLM settings at different layers:
+    1. Environments page renders the whole variable catalogue, and its row
+       anchor agrees with the sum of the three section-heading counts
+    2. Agent config page (/agent-config) renders the LLM Retry and LLM Rate
+       Limiter tabs — the persisted running-config counterparts of the
+       QWENPAW_LLM_* environment variables
+    3. Confirm the two pages do not interfere with each other: navigating
+       away and back leaves the Environments catalogue unchanged
+
+    SCOPE CHANGE (#7538): the Environments row anchor had to be rebuilt for the
+    unified page (rows are `styles.row` divs in three sections, not table rows),
+    and the old navigation target `/settings/runtime-config` has never existed
+    in console/src at any revision, so step 3 used to land on a blank page
+    while step 4 logged a message instead of asserting.  Both are fixed here.
+
+    What this case deliberately does NOT assert: that changing an environment
+    variable makes the agent config page show a new number.  #7538 does connect
+    the two layers — `AgentsRunningConfig` defaults now come from
+    `EnvVarLoader.get_int("QWENPAW_LLM_MAX_RETRIES", ...)` — but that default
+    is only consulted when an agent has no persisted running config
+    (`running = agent_config.running or AgentsRunningConfig()`), so for any
+    already-configured agent the page shows stored values and never follows
+    the environment.  Asserting a live env -> UI linkage would be flaky by
+    construction.
     """
 
     @pytest.mark.test_id("CROSS-005")
@@ -685,24 +736,50 @@ class TestEnvAndRuntimeConfigFlow:
             "Environments page reported zero variable rows — the row selector "
             "no longer matches the page, so this comparison would be vacuous"
         )
-        logger.info(f"Environment variable count: {env_count}")
+        # Self-consistency guard: the row count and the sum of the three
+        # section-heading counts measure the same thing two independent ways
+        # (class name vs. rendered text).  Agreeing means the row anchor is
+        # really pointing at variable rows, not at some unrelated element that
+        # happens to match, and it stays correct when upstream adds or removes
+        # catalogue entries.
+        section_sum = sum_environment_section_counts(page)
+        assert env_count == section_sum, (
+            f"Row count ({env_count}) disagrees with the sum of the section "
+            f"heading counts ({section_sum}) — one of the two anchors is wrong"
+        )
+        logger.info(
+            f"Environment variable count: {env_count} "
+            f"(section headings sum to the same {section_sum})"
+        )
 
-        log_test_step("3. Navigate to the runtime config page")
-        page.goto(f"{BASE_URL}/settings/runtime-config")
-        page.wait_for_load_state("commit")
-        page.wait_for_timeout(2000)
+        log_test_step("3. Navigate to the agent config (runtime config) page")
+        # The authoritative route is /agent-config: console/src/layouts/registry/
+        # builtinRoutes.tsx maps core.agent-config -> /agent-config, and
+        # e2e/pages/runtime_config_page.py:31 plus e2e/tests/
+        # test_runtime_config.py:23 already use it.  "/settings/runtime-config"
+        # has never existed in console/src at any revision (zero hits across the
+        # whole history), so the previous navigation landed on a blank page and
+        # step 4 could not fail no matter what it found.
+        page.goto(f"{BASE_URL}/agent-config")
+        page.wait_for_load_state("domcontentloaded")
 
-        log_test_step("4. Verify the runtime config page loads")
-        config_area = page.locator(
-            '.qwenpaw-tabs, '
-            '.qwenpaw-form, '
-            '[class*=config], '
-            '[class*=setting]'
-        ).first
-        if config_area.is_visible(timeout=5000):
-            logger.info("Runtime config page loaded")
-        else:
-            logger.info("Runtime config page may have a different layout")
+        log_test_step("4. Verify the agent config page renders its LLM tabs")
+        # Hard assertions on the tab keys declared in
+        # console/src/pages/Agent/Config/index.tsx (key: "llmRetry" at line 165,
+        # key: "llmRateLimiter" at line 178).  These are the runtime-config
+        # counterparts of the QWENPAW_LLM_* environment variables, which is the
+        # actual boundary this cross-module case is about.  The same
+        # data-node-key anchors are already proven green in
+        # e2e/tests/test_runtime_config.py, so no new selector idiom is
+        # introduced here.
+        for tab_key in ("llmRetry", "llmRateLimiter"):
+            tab = page.locator(f'[data-node-key="{tab_key}"] .qwenpaw-tabs-tab-btn').first
+            expect(tab).to_be_visible(timeout=10000)
+            logger.info(f"Agent config tab present: {tab_key}")
+        # The two pages coexist as separate routes: #7538 unified how
+        # environment variables are read (EnvVarLoader + envs/registry.py as the
+        # single source of truth), it did not merge this page into Environments.
+        expect(page.locator('.qwenpaw-tabs').first).to_be_visible(timeout=5000)
 
         log_test_step("5. Return to the environments page and verify data unchanged")
         wait_for_environments_loaded(page)
@@ -710,7 +787,17 @@ class TestEnvAndRuntimeConfigFlow:
         env_count_after = count_environment_rows(page)
         assert env_count_after == env_count, \
             f"Environment variable count inconsistent: before={env_count}, after={env_count_after}"
-        logger.info(f"Environment variable count consistent: {env_count_after}")
+        # Re-check the invariant after the round trip: navigating away and back
+        # must not leave the two anchors disagreeing either.
+        section_sum_after = sum_environment_section_counts(page)
+        assert env_count_after == section_sum_after, (
+            f"After the round trip the row count ({env_count_after}) disagrees "
+            f"with the section heading sum ({section_sum_after})"
+        )
+        logger.info(
+            f"Environment variable count consistent: {env_count_after} "
+            f"(section headings sum to the same {section_sum_after})"
+        )
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed - environment variable and runtime config linkage verified")

--- a/e2e/tests/test_cross_module.py
+++ b/e2e/tests/test_cross_module.py
@@ -26,6 +26,37 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = config.base_url
 
+# -- Environments page anchors (rebuilt for #7538) -------------------------
+# The Environments page was rewritten by #7538 ("unify runtime environment
+# management"): rows are no longer table rows / inline inputs but
+# `styles.row` divs grouped into three sections.  The old selector list
+# (`tr.qwenpaw-table-row`, `[class*=envRow]`, `.qwenpaw-form-item`) matches
+# nothing on the new page, which would have made the before/after count
+# comparison below a vacuous `0 == 0`.
+#
+# Class names are CSS-module scoped as `[name]__[local]__[hash:base64:5]`, and
+# this stylesheet shares the `index.module.less` filename with PageHeader, so
+# every generated class starts with `index-module__`.  Matching `__row__`
+# (double-underscore bounded) hits `index-module__row__<hash>` without
+# matching neighbours such as `index-module__envRow__<hash>`.
+ENV_ROW_SELECTOR = 'div[class*="__row__"]'
+# `styles.sectionHeading` is rendered only in the loaded branch; the loading
+# and error branches render `styles.state` instead, so it doubles as a
+# "catalogue data has arrived" signal.
+ENV_SECTION_HEADING = 'div[class*="__sectionHeading__"]'
+
+
+def wait_for_environments_loaded(page: Page, timeout: int = 15000):
+    """Open the Environments page and wait for the catalogue to render."""
+    page.goto(f"{BASE_URL}/environments")
+    page.wait_for_load_state("domcontentloaded")
+    expect(page.locator(ENV_SECTION_HEADING).first).to_be_visible(timeout=timeout)
+
+
+def count_environment_rows(page: Page) -> int:
+    """Count variable rows across all three sections of the Environments page."""
+    return page.locator(ENV_ROW_SELECTOR).count()
+
 
 def navigate_to_skills(page: Page):
     """Navigate to the skills management page."""
@@ -643,17 +674,17 @@ class TestEnvAndRuntimeConfigFlow:
         test_name = request.node.name
 
         log_test_step("1. Navigate to the environments page")
-        page.goto(f"{BASE_URL}/environments")
-        page.wait_for_load_state("commit")
-        page.wait_for_timeout(2000)
+        wait_for_environments_loaded(page)
 
         log_test_step("2. Record the environment variable count")
-        env_rows = page.locator(
-            '.qwenpaw-table-tbody tr.qwenpaw-table-row, '
-            '[class*=envRow], '
-            '.qwenpaw-form-item'
-        ).all()
-        env_count = len(env_rows)
+        env_count = count_environment_rows(page)
+        # Lower-bound guard: without it a selector that stopped matching would
+        # compare 0 == 0 and this case would stay green while testing nothing
+        # (the same silent-pass family as the shard-selection blind spots).
+        assert env_count > 0, (
+            "Environments page reported zero variable rows — the row selector "
+            "no longer matches the page, so this comparison would be vacuous"
+        )
         logger.info(f"Environment variable count: {env_count}")
 
         log_test_step("3. Navigate to the runtime config page")
@@ -674,16 +705,9 @@ class TestEnvAndRuntimeConfigFlow:
             logger.info("Runtime config page may have a different layout")
 
         log_test_step("5. Return to the environments page and verify data unchanged")
-        page.goto(f"{BASE_URL}/environments")
-        page.wait_for_load_state("commit")
-        page.wait_for_timeout(2000)
+        wait_for_environments_loaded(page)
 
-        env_rows_after = page.locator(
-            '.qwenpaw-table-tbody tr.qwenpaw-table-row, '
-            '[class*=envRow], '
-            '.qwenpaw-form-item'
-        ).all()
-        env_count_after = len(env_rows_after)
+        env_count_after = count_environment_rows(page)
         assert env_count_after == env_count, \
             f"Environment variable count inconsistent: before={env_count}, after={env_count_after}"
         logger.info(f"Environment variable count consistent: {env_count_after}")

--- a/e2e/tests/test_environments.py
+++ b/e2e/tests/test_environments.py
@@ -1,102 +1,441 @@
 # -*- coding: utf-8 -*-
 """
-QwenPaw Environments module P0 end-to-end test cases.
+QwenPaw Environments module end-to-end test cases.
 
-Combined test design:
-- ENV-001: Page load + list display + empty state
-- ENV-002: Add env var + cancel add + Key required validation
-- ENV-003: Edit env var + update validation
-- ENV-004: Delete env var + confirmation flow
-- ENV-005: Multi-row add + checkbox toggle + in-row insert + refresh validation
-- ENV-006: Save persistence validation
-- ENV-007: Key format validation
-- ENV-008: Batch operations + import/export
-- ENV-009: API operation validation
+Rebuilt for the unified environment management page (#7538, commit 76bfb704).
+That change replaced the editable-table model with a read-oriented catalogue:
 
-Run: pytest tests/test_environments_p0.py -v
+  OLD (pre-#7538)                      NEW (#7538+)
+  ---------------------------------    --------------------------------------
+  rows rendered as inline inputs       rows render <code> key + masked value
+  "Add" appended a blank row           "Add Variable" opens a Modal
+  page-level "Save" batch-committed    Modal "Apply now" PATCHes immediately
+  per-row checkbox + batch delete      REMOVED (no checkbox / no batch UI)
+  "Insert row below" per row           REMOVED
+  one flat row list                    three sections: Custom variables /
+                                       Live settings / Read-only settings
+  key-required message                 invalid-format message (regex gate)
+
+Selector strategy notes (why these anchors, not class substrings):
+
+* ``console/vite.config.ts`` sets ``generateScopedName:
+  "[name]__[local]__[hash:base64:5]"`` and Environments' stylesheet shares the
+  ``index.module.less`` filename with ``components/PageHeader`` — so every
+  generated class is ``index-module__<local>__<hash>`` with no page-level
+  discrimination.  A bare ``[class*="row"]`` would match ``envRow``,
+  ``rowList``, ``arrow`` etc. across the whole app.  We therefore wrap the
+  local name in double underscores (``__row__``), which matches
+  ``index-module__row__abc12`` but not ``index-module__envRow__abc12``.
+* Class hashes change on every style edit, so behavioural anchors
+  (``aria-label``, visible text, ``placeholder``) are preferred and CSS-module
+  substrings are only used to scope a container.
+* ``.last`` / positional row indexing is no longer usable: ``styles.row`` is
+  shared by all three sections, so the last row belongs to the read-only
+  catalogue, not to a freshly added variable.  Rows are located by key text.
+* The e2e browser runs ``locale="en-US"`` (``e2e/fixtures/__init__.py``) and
+  the console is English-only, so Chinese text fallbacks can never match and
+  have been dropped instead of kept as dead alternates.
+* "Apply now" persists immediately, therefore every case that writes a
+  variable must delete it again; cleanup goes through the API so a failed UI
+  step cannot leave residue behind.
+
+Run: pytest tests/test_environments.py -v
 """
 from __future__ import annotations
 
 import logging
 import time
 import pytest
-from playwright.sync_api import Page, expect, TimeoutError
+from playwright.sync_api import Page, Locator, expect, TimeoutError
 
 from config.settings import config
-from utils.helpers import log_test_step, log_test_result
+from utils.helpers import log_test_step, log_test_result, api_get
 
 logger = logging.getLogger(__name__)
 
-# -- Page routes and selectors --
+# -- Page route ------------------------------------------------------------
 ENVIRONMENTS_URL = f"{config.base_url}/environments"
-ENV_PAGE_CONTAINER = 'div[class*="environmentsPage"]'
-ROW_SELECTOR = 'div[class*="envRow"]'
-ADD_BTN_SELECTOR = 'button[class*="addBtn"], button:has-text("添加变量")'
-DELETE_ROW_BTN_SELECTOR = 'button[title="删除行"], button[title="Delete Row"], button[title="Delete row"], button[title="delete"]'
-KEY_INPUT_SELECTOR = 'input[placeholder="Variable Name"], input[placeholder*="Key"], input[placeholder*="键"]'
-VALUE_INPUT_SELECTOR = 'input[placeholder="Value"], input[placeholder*="值"]'
-CHECKBOX_SELECTOR = '.qwenpaw-checkbox-input'
-COUNT_SELECTOR = 'span[class*="toolbarCount"]'
-SAVE_BTN_SELECTOR = 'button.qwenpaw-btn-primary:has-text("保存"), button:has-text("保 存"), button:has-text("Save")'
+
+# -- Container / section anchors ------------------------------------------
+# `styles.page` — the page root. `__page__` deliberately does not match
+# `__pageHeader__` (PageHeader renders inside it).
+ENV_PAGE_CONTAINER = 'div[class*="__page__"]'
+# `styles.sectionHeading` wraps `<h2>title</h2><span>count</span>`.
+SECTION_HEADING = 'div[class*="__sectionHeading__"]'
+CUSTOM_SECTION_HEADING = f'{SECTION_HEADING}:has-text("Custom variables")'
+CUSTOM_COUNT_SELECTOR = f'{CUSTOM_SECTION_HEADING} span'
+# `styles.row` — one variable row (shared by all three sections).
+ROW_SELECTOR = 'div[class*="__row__"]'
+# `styles.identity` holds the key `<code>`; `styles.valueText` holds the
+# masked value `<code>`, so the key must be read from the identity cell.
+IDENTITY_CODE = 'div[class*="__identity__"] code'
+
+# -- Interactive element anchors ------------------------------------------
+# Hero button: <Button type="primary" icon={Plus}>Add Variable</Button>.
+# Anchor on the visible label rather than a class hash.  The pre-#7538
+# fallback `button:has-text("添加变量")` could never match an en-US console.
+ADD_VARIABLE_BTN = 'button:has-text("Add Variable")'
+# Modal shell. `ConfigProvider prefixCls="qwenpaw"` (console/src/App.tsx) makes
+# antd emit `qwenpaw-modal-*`; `ant-modal-*` is kept as a degraded alternate
+# because both prefixes ship in the stylesheet.
+#
+# Every modal selector below is `:visible`-scoped.  antd does not destroy a
+# closed Modal by default, and several cases drive the editor more than once
+# (ENV-P1-005 opens it, cancels, opens it again; ENV-004 cancels a confirm
+# dialog then triggers another one), so an unscoped `.first` could resolve to
+# a stale hidden node left over from the previous interaction and make a
+# `to_be_visible()` assertion fail for a reason unrelated to the product.
+MODAL = '.qwenpaw-modal:visible, .ant-modal:visible'
+MODAL_TITLE = '.qwenpaw-modal:visible .qwenpaw-modal-title, .ant-modal:visible .ant-modal-title'
+MODAL_FOOTER = '.qwenpaw-modal:visible .qwenpaw-modal-footer, .ant-modal:visible .ant-modal-footer'
+# Modal form inputs.  Key placeholder is the literal "VARIABLE_NAME"
+# (index.tsx passes it as a plain string, not through i18n); the Value
+# placeholder comes from `environments.valuePlaceholder` = "value", with
+# "Value" kept as a tolerant alternate in case that copy changes case.
+MODAL_KEY_INPUT = (
+    '.qwenpaw-modal:visible input[placeholder="VARIABLE_NAME"], '
+    '.ant-modal:visible input[placeholder="VARIABLE_NAME"]'
+)
+MODAL_VALUE_INPUT = (
+    '.qwenpaw-modal:visible input[placeholder="value"], .ant-modal:visible input[placeholder="value"], '
+    '.qwenpaw-modal:visible input[placeholder="Value"], .ant-modal:visible input[placeholder="Value"]'
+)
+# Primary footer button = okText "Apply now".
+#
+# Deliberately NOT one comma-separated list with degraded alternates:
+# Playwright's `.first` on a selector list picks the first match in *document*
+# order, not in selector order, so a broad fallback could win over the precise
+# one.  `modal_ok_button()` below walks the candidates in the intended
+# priority instead.
+MODAL_OK_CANDIDATES = (
+    '.qwenpaw-modal:visible .qwenpaw-modal-footer button.qwenpaw-btn-primary',
+    '.ant-modal:visible .ant-modal-footer button.ant-btn-primary',
+    '.qwenpaw-modal:visible button:has-text("Apply now")',
+    '.ant-modal:visible button:has-text("Apply now")',
+)
+# cancelText "Cancel"; the header close icon is the last resort (SparkModal
+# passes `closeIcon: null` and renders its own, so this may not exist).
+MODAL_CANCEL_CANDIDATES = (
+    '.qwenpaw-modal:visible .qwenpaw-modal-footer button:has-text("Cancel")',
+    '.ant-modal:visible .ant-modal-footer button:has-text("Cancel")',
+    '.qwenpaw-modal:visible button:has-text("Cancel")',
+    '.ant-modal:visible button:has-text("Cancel")',
+    '.qwenpaw-modal:visible .qwenpaw-modal-close',
+    '.ant-modal:visible .ant-modal-close',
+)
+# `Modal.confirm` is a static antd call; design's ConfigProvider feeds it the
+# same prefix through `holderRender`, which is the anchor already proven green
+# in this suite (e2e/pages/chat_page.py `.qwenpaw-modal-confirm-btns`).
+# Same `:visible` rationale as above, and even more so here: a static confirm
+# dialog is created fresh per call.
+CONFIRM_MODAL = '.qwenpaw-modal-confirm:visible, .ant-modal-confirm:visible'
+CONFIRM_TITLE = '.qwenpaw-modal-confirm-title, .ant-modal-confirm-title'
+CONFIRM_CONTENT = '.qwenpaw-modal-confirm-content, .ant-modal-confirm-content'
+CONFIRM_BTNS = '.qwenpaw-modal-confirm-btns, .ant-modal-confirm-btns'
+# Row action buttons carry aria-labels from `common.*`: Edit / Delete / Reset.
+EDIT_BTN_BY_LABEL = 'button[aria-label="Edit"]'
+DELETE_BTN_BY_LABEL = 'button[aria-label="Delete"]'
+RESET_BTN_BY_LABEL = 'button[aria-label="Reset"]'
+SHOW_VALUE_BTN_BY_LABEL = 'button[aria-label="Show value"]'
+# Search box: `aria-label={t("environments.searchPlaceholder")}`.
+SEARCH_INPUT = 'input[aria-label="Search variables"]'
+# Toasts come from `useAppMessage()` (antd App context) with the same prefix.
+MESSAGE_NOTICE = (
+    '.qwenpaw-message-notice-content, .qwenpaw-message-custom-content, '
+    '.ant-message-notice-content, .ant-message-custom-content'
+)
+MESSAGE_ERROR = (
+    '.qwenpaw-message-error, .ant-message-error'
+)
+MESSAGE_SUCCESS = (
+    '.qwenpaw-message-success, .ant-message-success'
+)
+# New-version validation copy.  `environments.keyRequired` ("Key is required")
+# is no longer referenced by this page: an empty key falls through the same
+# regex gate as a malformed one and reports "Invalid key format".
+MSG_INVALID_KEY_FORMAT = "Invalid key format"
+MSG_DUPLICATE_KEY = "Duplicate key"
+MSG_APPLIED = "Environment variable applied"
 
 
-def navigate_to_environments(page: Page):
-    """Navigate to the environments page and wait for load."""
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def navigate_to_environments(page: Page, timeout: int = 15000):
+    """Open the Environments page and wait until the catalogue has rendered.
+
+    `styles.sectionHeading` only exists in the loaded branch — the loading and
+    error branches render `styles.state` instead — so waiting for it is a real
+    "data arrived" signal rather than a fixed sleep.
+    """
     page.goto(ENVIRONMENTS_URL)
     page.wait_for_load_state("domcontentloaded")
-    page.wait_for_timeout(2000)
-    container = page.locator(ENV_PAGE_CONTAINER).first
-    if container.count() > 0:
-        try:
-            expect(container).to_be_visible(timeout=10000)
-        except Exception:
-            logger.info("Page container not matched by exact selector, continuing")
+    expect(page.locator(ENV_PAGE_CONTAINER).first).to_be_visible(timeout=timeout)
+    expect(page.locator(SECTION_HEADING).first).to_be_visible(timeout=timeout)
+    expect(page.locator(ADD_VARIABLE_BTN).first).to_be_visible(timeout=timeout)
+
+
+def row_for_key(page: Page, key: str):
+    """Return the row whose identity cell shows exactly `key`.
+
+    Positional anchors are unusable after #7538 (three sections share
+    `styles.row`), so rows are addressed by their key text.
+    """
+    return page.locator(ROW_SELECTOR).filter(
+        has=page.locator(f'{IDENTITY_CODE}:text-is("{key}")')
+    ).first
+
+
+def get_custom_var_count(page: Page) -> int:
+    """Return the Custom variables count shown in its section heading.
+
+    The heading renders `<span>{customVariables.length}</span>`, which is a
+    stronger signal than counting DOM rows: it is exactly the number the page
+    itself claims, and it is immune to the read-only/Live sections.
+    """
+    count_el = page.locator(CUSTOM_COUNT_SELECTOR).first
+    expect(count_el).to_be_visible(timeout=10000)
+    raw = count_el.inner_text().strip()
+    try:
+        return int(raw)
+    except ValueError:
+        raise AssertionError(f"Custom variables count is not an integer: {raw!r}")
 
 
 def get_env_row_count(page: Page) -> int:
-    """Return the current number of env var rows."""
+    """Return the number of variable rows across all three sections."""
     return page.locator(ROW_SELECTOR).count()
 
 
 def get_count_text(page: Page) -> str:
-    """Return the toolbar variable count text."""
-    count_el = page.locator(COUNT_SELECTOR).first
-    return count_el.inner_text() if count_el.is_visible() else ""
+    """Return the Custom variables count as text ("" when unavailable)."""
+    count_el = page.locator(CUSTOM_COUNT_SELECTOR).first
+    try:
+        return count_el.inner_text().strip() if count_el.is_visible() else ""
+    except Exception:
+        return ""
 
 
-def add_env_row(page: Page) -> int:
-    """Click the add variable button and verify the row count increased."""
-    count_before = get_env_row_count(page)
-    add_btn = page.locator(ADD_BTN_SELECTOR).first
-    expect(add_btn).to_be_visible(timeout=5000)
+def open_add_variable_modal(page: Page):
+    """Click "Add Variable" and wait for the editor Modal to appear."""
+    add_btn = page.locator(ADD_VARIABLE_BTN).first
+    expect(add_btn).to_be_visible(timeout=10000)
     add_btn.click()
-    page.wait_for_timeout(800)
-    count_after = get_env_row_count(page)
-    assert count_after == count_before + 1, (
-        f"Row count did not increase after add: {count_before} -> {count_after}"
-    )
-    return count_after
+    modal = page.locator(MODAL).first
+    expect(modal).to_be_visible(timeout=10000)
+    expect(page.locator(MODAL_KEY_INPUT).first).to_be_visible(timeout=10000)
+    return modal
 
 
-def click_save_button(page: Page):
-    """Click the save button."""
-    save_btn = page.locator(SAVE_BTN_SELECTOR).first
-    if not save_btn.is_visible(timeout=3000):
-        # Try multiple fallback selectors
-        fallback_selectors = [
-            'div[class*="toolbar"] button.qwenpaw-btn-primary',
-            'button.qwenpaw-btn-primary:visible',
-            'button:has-text("保存")',
-            'button:has-text("Save")',
-        ]
-        for selector in fallback_selectors:
-            candidate = page.locator(selector).first
-            if candidate.is_visible(timeout=1000):
-                save_btn = candidate
-                break
-    expect(save_btn).to_be_visible(timeout=5000)
-    save_btn.click()
-    page.wait_for_timeout(2000)
+def fill_variable_modal(page: Page, key: str = None, value: str = None):
+    """Fill the Key / Value inputs of the open editor Modal."""
+    if key is not None:
+        key_input = page.locator(MODAL_KEY_INPUT).first
+        expect(key_input).to_be_visible(timeout=5000)
+        key_input.fill(key)
+    if value is not None:
+        value_input = page.locator(MODAL_VALUE_INPUT).first
+        expect(value_input).to_be_visible(timeout=5000)
+        value_input.fill(value)
+    page.wait_for_timeout(200)
+
+
+def _first_visible(page: Page, candidates: tuple) -> Locator:
+    """Return the first candidate selector that resolves to a visible node.
+
+    Walked in priority order on purpose: Playwright resolves `.first` on a
+    comma-separated selector list by document position, so expressing
+    "prefer the precise anchor, fall back to the loose one" as a single list
+    would let the loose one win whenever it appears earlier in the DOM.
+    """
+    for selector in candidates:
+        candidate = page.locator(selector).first
+        try:
+            if candidate.count() > 0 and candidate.is_visible():
+                return candidate
+        except Exception:
+            continue
+    # Nothing visible: hand back the primary candidate so the caller's
+    # expectation fails with a selector-specific message instead of a
+    # generic "locator resolved to 0 elements".
+    return page.locator(candidates[0]).first
+
+
+def modal_ok_button(page: Page) -> Locator:
+    """Return the editor Modal's primary button ("Apply now")."""
+    return _first_visible(page, MODAL_OK_CANDIDATES)
+
+
+def modal_cancel_button(page: Page) -> Locator:
+    """Return the editor Modal's Cancel button (or its close icon)."""
+    return _first_visible(page, MODAL_CANCEL_CANDIDATES)
+
+
+def click_modal_ok(page: Page):
+    """Click the Modal primary button ("Apply now")."""
+    ok_btn = modal_ok_button(page)
+    expect(ok_btn).to_be_visible(timeout=5000)
+    ok_btn.click()
+
+
+def click_modal_cancel(page: Page):
+    """Click the Modal "Cancel" button."""
+    cancel_btn = modal_cancel_button(page)
+    expect(cancel_btn).to_be_visible(timeout=5000)
+    cancel_btn.click()
+
+
+def expect_modal_closed(page: Page, timeout: int = 10000):
+    """Assert the editor Modal is gone.
+
+    `to_be_hidden()` rather than `to_have_count(0)`: antd keeps a closed
+    Modal's DOM in place (it is not destroyed by default), so counting nodes
+    would still see the Key input after a successful close and the assertion
+    would never pass.  "hidden" is true both when the node is gone and when it
+    is present but not displayed, which is exactly the state we want.
+    """
+    expect(page.locator(MODAL_KEY_INPUT).first).to_be_hidden(timeout=timeout)
+
+
+def expect_modal_open(page: Page):
+    """Assert the editor Modal is still open (validation rejected the input)."""
+    expect(page.locator(MODAL_KEY_INPUT).first).to_be_visible(timeout=5000)
+
+
+def expect_toast(page: Page, text: str, timeout: int = 10000) -> str:
+    """Wait for a toast carrying `text` and return its container description."""
+    toast = page.locator(MESSAGE_NOTICE).filter(has_text=text).first
+    expect(toast).to_be_visible(timeout=timeout)
+    return text
+
+
+def confirm_button(page: Page, ok: bool = True) -> Locator:
+    """Return the OK / Cancel button of the *visible* confirm dialog.
+
+    `removeVariable` passes `okButtonProps: {danger: !reset}`, so the OK button
+    is `btn-dangerous` for a delete and `btn-primary` for a reset; Cancel is
+    the footer button carrying neither.
+
+    Each candidate is a single, comma-free selector string.  Building them by
+    appending a suffix to a comma-separated constant (e.g.
+    `".a-confirm-btns, .b-confirm-btns" + " button.x"`) silently yields
+    `".a-confirm-btns"` as its own first branch — which matches the button
+    *container* and would make `.first` click the div instead of a button.
+    Both style prefixes are therefore expanded explicitly and walked in
+    priority order (document order decides `.first` inside a comma list, so a
+    loose alternate must never share one list with a precise one).
+    """
+    dialog = page.locator(CONFIRM_MODAL).first
+    candidates: list[Locator] = []
+    for prefix in ("qwenpaw", "ant"):
+        buttons_scope = f".{prefix}-modal-confirm-btns"
+        if ok:
+            for style in ("dangerous", "primary"):
+                candidates.append(
+                    dialog.locator(f"{buttons_scope} button.{prefix}-btn-{style}")
+                )
+        else:
+            candidates.append(
+                dialog.locator(
+                    f"{buttons_scope} button:not(.{prefix}-btn-primary)"
+                    f":not(.{prefix}-btn-dangerous)"
+                )
+            )
+    for candidate in candidates:
+        try:
+            if candidate.count() > 0 and candidate.first.is_visible():
+                return candidate.first
+        except Exception:
+            continue
+    return candidates[0].first
+
+
+def api_list_env_keys(api_context) -> list:
+    """Return the persisted env var keys via API (unmasked source of truth)."""
+    envs = api_get(api_context, "/api/envs")
+    if not isinstance(envs, list):
+        return []
+    return [item.get("key") for item in envs if isinstance(item, dict)]
+
+
+def api_env_value(api_context, key: str):
+    """Return the persisted value for `key`, or None when absent.
+
+    The UI masks custom values (`<ValueText secret />` renders "••••••••"
+    until "Show value" is clicked), so persistence assertions read the API.
+    """
+    envs = api_get(api_context, "/api/envs")
+    if not isinstance(envs, list):
+        return None
+    for item in envs:
+        if isinstance(item, dict) and item.get("key") == key:
+            return item.get("value")
+    return None
+
+
+def api_delete_env(api_context, key: str) -> bool:
+    """Delete one custom variable through the API. Returns success."""
+    try:
+        response = api_context.delete(f"{config.base_url}/api/envs/{key}")
+        return bool(response.ok)
+    except Exception as exc:  # pragma: no cover - cleanup best effort
+        logger.warning(f"API delete of {key} failed: {exc}")
+        return False
+
+
+def cleanup_env_var(page: Page, api_context, key: str):
+    """Remove a test variable: API first, UI as fallback.
+
+    "Apply now" writes immediately, so leaving residue behind would shift the
+    Custom variables count for every later case in the shard.
+    """
+    if not key:
+        return
+    if api_delete_env(api_context, key):
+        logger.info(f"Cleanup: {key} deleted via API")
+        return
+    logger.info(f"Cleanup: API delete failed for {key}, trying UI")
+    try:
+        navigate_to_environments(page)
+        row = row_for_key(page, key)
+        if row.count() > 0:
+            row.locator(DELETE_BTN_BY_LABEL).first.click()
+            confirm_ok = confirm_button(page, ok=True)
+            expect(confirm_ok).to_be_visible(timeout=5000)
+            confirm_ok.click()
+            page.wait_for_timeout(1000)
+            logger.info(f"Cleanup: {key} deleted via UI")
+    except Exception as exc:
+        logger.warning(f"Cleanup of {key} failed: {exc}")
+
+
+def delete_variable_via_ui(page: Page, key: str):
+    """Delete a custom variable through the row action + confirm dialog."""
+    row = row_for_key(page, key)
+    expect(row).to_be_visible(timeout=10000)
+    delete_btn = row.locator(DELETE_BTN_BY_LABEL).first
+    expect(delete_btn).to_be_visible(timeout=5000)
+    delete_btn.click()
+    # removeVariable() -> Modal.confirm({title: deleteVariable, okText: delete})
+    expect(page.locator(CONFIRM_MODAL).first).to_be_visible(timeout=10000)
+    confirm_ok = confirm_button(page, ok=True)
+    expect(confirm_ok).to_be_visible(timeout=5000)
+    confirm_ok.click()
+    # CONFIRM_MODAL is :visible-scoped, so count 0 means "no dialog showing".
+    expect(page.locator(CONFIRM_MODAL)).to_have_count(0, timeout=10000)
+
+
+def add_variable_via_ui(page: Page, api_context, key: str, value: str):
+    """Create a custom variable through the real UI flow and verify it landed.
+
+    Flow: Add Variable -> Modal -> fill Key/Value -> Apply now -> row visible.
+    """
+    open_add_variable_modal(page)
+    fill_variable_modal(page, key=key, value=value)
+    click_modal_ok(page)
+    expect_modal_closed(page)
+    expect(row_for_key(page, key)).to_be_visible(timeout=10000)
 
 
 # ============================================================================
@@ -111,65 +450,75 @@ class TestEnvironmentListDisplay:
     ENV-001: Environments page load + list display.
 
     Covers:
-    1. Page navigation and load
-    2. Breadcrumb verification
-    3. Toolbar count verification
-    4. Add button existence
-    5. Empty state handling
+    1. Page navigation and load (three-section catalogue)
+    2. Breadcrumb verification (PageHeader: Settings / Environment Variables)
+    3. Section heading counts
+    4. "Add Variable" button existence
+    5. Search box existence
+    6. Row structure or empty state
     """
 
     @pytest.mark.test_id("ENV-001")
     def test_environment_list_display(self, page: Page, request: pytest.FixtureRequest):
-        """Verify env var list renders correctly."""
+        """Verify the environment variable list renders correctly."""
         test_name = request.node.name
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
 
-        # Step 2: Verify breadcrumb
+        # Step 2: Verify breadcrumb (PageHeader still emits these classes)
         log_test_step("2. Verify breadcrumb")
         try:
             breadcrumb_settings = page.locator(
-                'span[class*="breadcrumbParent"]:has-text("设置"), '
                 'span[class*="breadcrumbParent"]:has-text("Settings")'
             ).first
             expect(breadcrumb_settings).to_be_visible(timeout=5000)
             breadcrumb_current = page.locator(
-                'span[class*="breadcrumbCurrent"]:has-text("环境"), '
-                'span[class*="breadcrumbCurrent"]:has-text("Environment")'
+                'span[class*="breadcrumbCurrent"]:has-text("Environment Variables")'
             ).first
             expect(breadcrumb_current).to_be_visible(timeout=5000)
             logger.info("Breadcrumb verification passed")
         except Exception:
             logger.warning("Breadcrumb verification skipped (possible locale mismatch)")
 
-        # Step 3: Verify toolbar count
-        log_test_step("3. Verify toolbar count")
+        # Step 3: Verify the three section headings and their counts
+        log_test_step("3. Verify section headings and counts")
+        for heading_text in ("Custom variables", "Live settings", "Read-only settings"):
+            heading = page.locator(SECTION_HEADING).filter(has_text=heading_text).first
+            expect(heading).to_be_visible(timeout=5000)
+            count_text = heading.locator("span").first.inner_text().strip()
+            assert count_text.isdigit(), (
+                f"{heading_text} heading count should be numeric, got {count_text!r}"
+            )
+            logger.info(f"Section '{heading_text}' count = {count_text}")
+
         count_text = get_count_text(page)
-        if count_text:
-            logger.info(f"Toolbar variable count: {count_text}")
-        else:
-            logger.info("Toolbar count element not found")
+        logger.info(f"Custom variable count: {count_text}")
 
-        # Step 4: Verify add button
-        log_test_step("4. Verify add button")
-        add_btn = page.locator(ADD_BTN_SELECTOR).first
+        # Step 4: Verify the Add Variable button
+        log_test_step("4. Verify Add Variable button")
+        add_btn = page.locator(ADD_VARIABLE_BTN).first
         expect(add_btn).to_be_visible(timeout=5000)
-        logger.info("Add env var button is visible")
+        logger.info("Add Variable button is visible")
 
-        # Step 5: Verify env var list or empty state
-        log_test_step("5. Verify env var list or empty state")
+        # Step 5: Verify the search box
+        log_test_step("5. Verify search box")
+        search_input = page.locator(SEARCH_INPUT).first
+        expect(search_input).to_be_visible(timeout=5000)
+        logger.info("Search box is visible")
+
+        # Step 6: Verify rows or the empty state of the custom section
+        log_test_step("6. Verify variable rows or empty state")
         row_count = get_env_row_count(page)
         if row_count > 0:
-            logger.info(f"Env var list rendered, current rows: {row_count}")
+            logger.info(f"Variable rows rendered, current rows: {row_count}")
+            first_row = page.locator(ROW_SELECTOR).first
+            expect(first_row.locator("code").first).to_be_visible(timeout=5000)
         else:
-            empty_css = page.locator('.qwenpaw-empty, [class*=empty]').first
-            empty_text = page.locator('text=暂无环境变量').or_(page.locator('text=No environment variables')).first
-            if empty_css.is_visible(timeout=3000) or empty_text.is_visible(timeout=1000):
-                logger.info("Empty state rendered correctly")
-            else:
-                logger.info("No env var rows and no empty state indicator")
+            empty_el = page.locator('div[class*="__empty__"]').first
+            expect(empty_el).to_be_visible(timeout=5000)
+            logger.info("Empty state rendered correctly")
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed - env var list display verified")
@@ -184,17 +533,24 @@ class TestEnvironmentListDisplay:
 @pytest.mark.envs
 class TestAddEnvironment:
     """
-    ENV-002: Add env var + cancel add + Key required validation.
+    ENV-002: Add env var through the editor Modal.
 
     Covers:
-    1. Click add button -> row count increases
-    2. Fill Key/Value -> verify input values
-    3. Cancel add -> row count restored
-    4. Key required validation
+    1. Click "Add Variable" -> Modal opens
+    2. Fill Key/Value -> verify the inputs echo the values
+    3. Click "Apply now" -> Modal closes and the variable is listed
+    4. Verify persistence through the API (the UI masks custom values)
+    5. Cleanup
+
+    Note: the pre-#7538 version of this case filled a blank table row and then
+    deleted it without saving, so it never exercised a real write.  "Apply now"
+    now persists immediately, which makes the positive path actually assertable.
     """
 
     @pytest.mark.test_id("ENV-002")
-    def test_add_environment_success(self, page: Page, request: pytest.FixtureRequest):
+    def test_add_environment_success(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Verify adding an env var succeeds."""
         test_name = request.node.name
         timestamp = str(int(time.time()))[-6:]
@@ -205,49 +561,71 @@ class TestAddEnvironment:
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
 
-        # Step 2: Record the initial row count
-        log_test_step("2. Record initial row count")
-        initial_row_count = get_env_row_count(page)
-        logger.info(f"Initial row count: {initial_row_count}")
+        # Step 2: Record the initial custom variable count
+        log_test_step("2. Record initial custom variable count")
+        initial_count = get_custom_var_count(page)
+        logger.info(f"Initial custom variable count: {initial_count}")
 
-        # Step 3: Click the add variable button
-        log_test_step("3. Click add variable button")
-        new_row_count = add_env_row(page)
-        logger.info(f"Row added successfully, current count: {new_row_count}")
+        try:
+            # Step 3: Open the editor Modal
+            log_test_step("3. Click Add Variable -> Modal opens")
+            open_add_variable_modal(page)
+            modal_title = page.locator(MODAL_TITLE).first
+            expect(modal_title).to_contain_text("Add Variable", timeout=5000)
+            logger.info("Editor Modal opened with title 'Add Variable'")
 
-        # Step 4: Fill Key and Value
-        log_test_step("4. Fill Key and Value")
-        last_row = page.locator(ROW_SELECTOR).last
-        key_input = last_row.locator(KEY_INPUT_SELECTOR).first
-        value_input = last_row.locator(VALUE_INPUT_SELECTOR).first
-        expect(key_input).to_be_visible(timeout=5000)
-        expect(value_input).to_be_visible(timeout=5000)
+            # Step 4: Fill Key and Value
+            log_test_step("4. Fill Key and Value")
+            key_input = page.locator(MODAL_KEY_INPUT).first
+            value_input = page.locator(MODAL_VALUE_INPUT).first
+            expect(key_input).to_be_visible(timeout=5000)
+            expect(value_input).to_be_visible(timeout=5000)
 
-        key_input.fill(test_key)
-        value_input.fill(test_value)
-        page.wait_for_timeout(500)
+            key_input.fill(test_key)
+            value_input.fill(test_value)
+            page.wait_for_timeout(300)
 
-        filled_key = key_input.input_value()
-        filled_value = value_input.input_value()
-        assert filled_key == test_key, f"Key not filled correctly: expected {test_key}, got {filled_key}"
-        assert filled_value == test_value, f"Value not filled correctly: expected {test_value}, got {filled_value}"
-        logger.info(f"Filled successfully: {test_key}={test_value}")
+            filled_key = key_input.input_value()
+            filled_value = value_input.input_value()
+            assert filled_key == test_key, (
+                f"Key not filled correctly: expected {test_key}, got {filled_key}"
+            )
+            assert filled_value == test_value, (
+                f"Value not filled correctly: expected {test_value}, got {filled_value}"
+            )
+            logger.info(f"Filled successfully: {test_key}={test_value}")
 
-        # Step 5: Delete the test row (do not save, to avoid polluting data)
-        log_test_step("5. Delete test row")
-        delete_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        expect(delete_btn).to_be_visible(timeout=5000)
-        delete_btn.click()
-        page.wait_for_timeout(800)
+            # Step 5: Apply now -> the variable is written and listed
+            log_test_step("5. Click Apply now")
+            click_modal_ok(page)
+            expect_modal_closed(page)
+            logger.info("Modal closed after Apply now")
 
-        after_delete_count = get_env_row_count(page)
-        assert after_delete_count == initial_row_count, (
-            f"Row count incorrect after delete: expected {initial_row_count}, got {after_delete_count}"
-        )
-        logger.info(f"Delete succeeded, row count restored to {after_delete_count}")
+            log_test_step("6. Verify the variable is listed")
+            new_row = row_for_key(page, test_key)
+            expect(new_row).to_be_visible(timeout=10000)
+            new_count = get_custom_var_count(page)
+            assert new_count == initial_count + 1, (
+                f"Custom count did not increase: {initial_count} -> {new_count}"
+            )
+            logger.info(f"Variable listed, custom count {initial_count} -> {new_count}")
 
-        log_test_result(test_name, True, 0)
-        logger.info(f"Test {test_name} passed - add env var works")
+            # Step 7: Verify the persisted value through the API.
+            # The row shows "••••••••" until "Show value" is clicked, so the
+            # API is the only place the real value can be asserted.
+            log_test_step("7. Verify persisted value via API")
+            persisted = api_env_value(api_context, test_key)
+            assert persisted == test_value, (
+                f"Persisted value mismatch: expected {test_value}, got {persisted!r}"
+            )
+            logger.info(f"API confirms {test_key}={persisted}")
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed - add env var works")
+        finally:
+            log_test_step("Cleanup: delete test variable")
+            cleanup_env_var(page, api_context, test_key)
+
 
 # ============================================================================
 # ENV-002b: Add env var — cancel & validation (p2 tier)
@@ -265,32 +643,55 @@ class TestAddEnvironmentP2:
     @pytest.mark.p2
     @pytest.mark.test_id("ENV-002-CANCEL")
     def test_add_environment_cancel(self, page: Page, request: pytest.FixtureRequest):
-        """Verify cancelling add env var."""
+        """Verify cancelling the editor Modal writes nothing.
+
+        The pre-#7538 version approximated "cancel" by reloading the page
+        (unsaved table rows were dropped).  The Modal now has a real Cancel
+        button (`cancelText={t("common.cancel")}`), so cancellation is a
+        first-class user action and is asserted directly.
+        """
         test_name = request.node.name
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
 
-        # Step 2: Record the initial row count
-        log_test_step("2. Record initial row count")
-        initial_row_count = get_env_row_count(page)
+        # Step 2: Record the initial count
+        log_test_step("2. Record initial custom variable count")
+        initial_count = get_custom_var_count(page)
 
-        # Step 3: Add a row
-        log_test_step("3. Add a row")
-        add_env_row(page)
+        # Step 3: Open the Modal and type a key without applying
+        log_test_step("3. Open Modal and fill Key without applying")
+        open_add_variable_modal(page)
+        fill_variable_modal(page, key="E2E_CANCEL_SHOULD_NOT_EXIST", value="x")
 
-        # Step 4: Reload page (simulate cancel; unsaved data should be lost)
-        log_test_step("4. Reload page to verify cancel effect")
+        # Step 4: Cancel
+        log_test_step("4. Click Cancel")
+        click_modal_cancel(page)
+        expect_modal_closed(page)
+        logger.info("Modal closed after Cancel")
+
+        # Step 5: Nothing was written
+        log_test_step("5. Verify nothing was written")
+        after_count = get_custom_var_count(page)
+        assert after_count == initial_count, (
+            f"Cancel should not change the count: {initial_count} -> {after_count}"
+        )
+        expect(
+            row_for_key(page, "E2E_CANCEL_SHOULD_NOT_EXIST")
+        ).to_have_count(0, timeout=3000)
+
+        # Step 6: Reload — still nothing persisted
+        log_test_step("6. Reload and verify persistence")
         page.reload()
         page.wait_for_load_state("domcontentloaded")
-        page.wait_for_timeout(2000)
-
-        refreshed_count = get_env_row_count(page)
-        assert refreshed_count == initial_row_count, (
-            f"Row count should be restored after reload: expected {initial_row_count}, got {refreshed_count}"
+        navigate_to_environments(page)
+        refreshed_count = get_custom_var_count(page)
+        assert refreshed_count == initial_count, (
+            f"Count should be unchanged after reload: expected {initial_count}, "
+            f"got {refreshed_count}"
         )
-        logger.info("Cancel add verified (unsaved data was cleared)")
+        logger.info("Cancel verified: no variable was created")
 
         log_test_result(test_name, True, 0)
 
@@ -298,62 +699,65 @@ class TestAddEnvironmentP2:
     @pytest.mark.p2
     @pytest.mark.test_id("ENV-002-VALIDATION")
     def test_add_environment_key_required(self, page: Page, request: pytest.FixtureRequest):
-        """Verify Key is required."""
+        """Verify an empty Key is rejected.
+
+        #7538 dropped the dedicated `environments.keyRequired` message: an
+        empty key now fails the same `/^[A-Za-z_][A-Za-z0-9_]*$/` gate as a
+        malformed one and reports "Invalid key format".  The assertion follows
+        the shipped behaviour rather than the removed copy.
+        """
         test_name = request.node.name
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
+        initial_count = get_custom_var_count(page)
 
-        # Step 2: Add a row
-        log_test_step("2. Add a row")
-        add_env_row(page)
+        # Step 2: Open the Modal
+        log_test_step("2. Open the editor Modal")
+        open_add_variable_modal(page)
 
         # Step 3: Fill Value only, leave Key empty
         log_test_step("3. Fill Value only, leave Key empty")
-        last_row = page.locator(ROW_SELECTOR).last
-        value_input = last_row.locator(VALUE_INPUT_SELECTOR).first
-        value_input.fill("test_value_no_key")
-        page.wait_for_timeout(500)
+        fill_variable_modal(page, value="test_value_no_key")
+        key_input = page.locator(MODAL_KEY_INPUT).first
+        assert key_input.input_value() == "", "Key input should start empty"
 
-        # Step 4: Try to save
-        log_test_step("4. Try to save")
-        save_btn = page.locator(SAVE_BTN_SELECTOR).first
-        if save_btn.is_visible(timeout=3000):
-            save_btn.click()
-            page.wait_for_timeout(1000)
+        # Step 4: Try to apply
+        log_test_step("4. Click Apply now")
+        click_modal_ok(page)
+        page.wait_for_timeout(800)
 
-        # Step 5: Verify error message or submission is blocked
-        log_test_step("5. Verify error message or submission is blocked")
-        # Check several possible error indicators
-        error_css = page.locator(
-            '.qwenpaw-form-item-validate-error, .qwenpaw-message-error, '
-            '.qwenpaw-form-item-explain-error, .qwenpaw-message-notice-content'
-        ).first
-        error_text = page.locator('text=Key 不能为空').or_(page.locator('text=Key is required')).first
+        # Step 5: The submission is blocked and an error is reported
+        log_test_step("5. Verify the empty Key is rejected")
+        expect_modal_open(page)
+        logger.info("Modal stayed open: empty Key was not accepted")
 
-        has_error_css = error_css.is_visible(timeout=3000)
-        has_error_text = error_text.is_visible(timeout=1000) if not has_error_css else False
+        rejected = False
+        try:
+            expect_toast(page, MSG_INVALID_KEY_FORMAT, timeout=5000)
+            rejected = True
+            logger.info(f"Validation message detected: {MSG_INVALID_KEY_FORMAT}")
+        except Exception:
+            error_toast = page.locator(MESSAGE_ERROR).first
+            if error_toast.count() > 0 and error_toast.is_visible():
+                rejected = True
+                logger.info(
+                    f"Error toast detected: {error_toast.inner_text().strip()!r}"
+                )
+        assert rejected, "Empty Key should be rejected with an error indicator"
 
-        if has_error_css or has_error_text:
-            logger.info("Key required validation passed: error message detected")
-        else:
-            # Reload to verify data was not saved (empty Key rows may be silently dropped)
-            page.reload()
-            page.wait_for_load_state("domcontentloaded")
-            page.wait_for_timeout(2000)
-            refreshed_count = get_env_row_count(page)
-            logger.info(f"No explicit error message detected; row count after reload: {refreshed_count} (empty Key row dropped)")
-
-        # Cleanup: delete the test row
-        delete_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        if delete_btn.is_visible():
-            delete_btn.click()
-            page.wait_for_timeout(500)
+        # Step 6: Nothing was written
+        log_test_step("6. Verify nothing was written")
+        click_modal_cancel(page)
+        expect_modal_closed(page)
+        after_count = get_custom_var_count(page)
+        assert after_count == initial_count, (
+            f"Rejected submission must not change the count: "
+            f"{initial_count} -> {after_count}"
+        )
 
         log_test_result(test_name, True, 0)
-
-
 
 
 # ============================================================================
@@ -368,67 +772,105 @@ class TestEditEnvironment:
     ENV-003: Edit env var + update validation.
 
     Covers:
-    1. Add variable and fill Key/Value
-    2. Modify Value -> verify value changed
-    3. Delete test row
+    1. Create a variable through the UI
+    2. Open the row editor (aria-label="Edit")
+    3. Verify the Key input is locked for an existing variable
+    4. Change the Value -> Apply now -> verify the new value persisted
+    5. Cleanup
+
+    Note: editing used to happen inline in the table row.  #7538 moved it into
+    the same Modal as adding, with the Key input `disabled` because renaming
+    would create a second variable (the write path is `PATCH {[key]: value}`).
     """
 
     @pytest.mark.test_id("ENV-003")
-    def test_edit_environment(self, page: Page, request: pytest.FixtureRequest):
+    def test_edit_environment(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Verify editing an env var."""
         test_name = request.node.name
-        test_key = f"E2E_EDIT_{int(time.time())}"
-        test_value = f"edit_val_{int(time.time())}"
+        stamp = str(int(time.time()))[-6:]
+        test_key = f"E2E_EDIT_{stamp}"
+        test_value = f"edit_val_{stamp}"
+        edited_value = f"edited_{stamp}"
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
+        initial_count = get_custom_var_count(page)
 
-        # Step 2: Record the initial row count
-        log_test_step("2. Record initial row count")
-        initial_row_count = get_env_row_count(page)
+        try:
+            # Step 2: Create the variable under test
+            log_test_step("2. Create the variable through the UI")
+            add_variable_via_ui(page, api_context, test_key, test_value)
+            assert api_env_value(api_context, test_key) == test_value, (
+                "Precondition failed: created variable is not persisted"
+            )
+            logger.info(f"Created {test_key}={test_value}")
 
-        # Step 3: Add a variable and fill it
-        log_test_step("3. Add a variable and fill it")
-        add_env_row(page)
-        last_row = page.locator(ROW_SELECTOR).last
-        key_input = last_row.locator(KEY_INPUT_SELECTOR).first
-        value_input = last_row.locator(VALUE_INPUT_SELECTOR).first
-        expect(key_input).to_be_visible(timeout=5000)
-        expect(value_input).to_be_visible(timeout=5000)
+            # Step 3: Open the row editor
+            log_test_step("3. Open the row editor")
+            row = row_for_key(page, test_key)
+            edit_btn = row.locator(EDIT_BTN_BY_LABEL).first
+            expect(edit_btn).to_be_visible(timeout=5000)
+            edit_btn.click()
+            expect(page.locator(MODAL_KEY_INPUT).first).to_be_visible(timeout=10000)
+            modal_title = page.locator(MODAL_TITLE).first
+            expect(modal_title).to_contain_text("Edit variable", timeout=5000)
+            logger.info("Editor Modal opened with title 'Edit variable'")
 
-        key_input.fill(test_key)
-        value_input.fill(test_value)
-        page.wait_for_timeout(500)
-        logger.info(f"Filled successfully: {test_key}={test_value}")
+            # Step 4: The Key is locked and pre-filled
+            log_test_step("4. Verify Key is locked and pre-filled")
+            key_input = page.locator(MODAL_KEY_INPUT).first
+            assert key_input.input_value() == test_key, (
+                f"Key should be pre-filled with {test_key}, "
+                f"got {key_input.input_value()!r}"
+            )
+            assert key_input.is_disabled(), (
+                "Key input should be disabled when editing an existing variable"
+            )
+            logger.info("Key input is locked as expected")
 
-        # Step 4: Edit Value
-        log_test_step("4. Edit Value")
-        edited_value = f"edited_{int(time.time())}"
-        value_input.fill(edited_value)
-        page.wait_for_timeout(500)
+            # Step 5: Change the Value and apply
+            log_test_step("5. Change the Value and Apply now")
+            value_input = page.locator(MODAL_VALUE_INPUT).first
+            expect(value_input).to_be_visible(timeout=5000)
+            assert value_input.input_value() == test_value, (
+                f"Value should be pre-filled with {test_value}, "
+                f"got {value_input.input_value()!r}"
+            )
+            value_input.fill(edited_value)
+            page.wait_for_timeout(300)
+            assert value_input.input_value() == edited_value, (
+                f"Value not updated in the input: got {value_input.input_value()!r}"
+            )
+            click_modal_ok(page)
+            expect_modal_closed(page)
+            logger.info("Edit applied")
 
-        edited_actual = value_input.input_value()
-        assert edited_actual == edited_value, (
-            f"Value incorrect after edit: expected {edited_value}, got {edited_actual}"
-        )
-        logger.info(f"Edit succeeded: Value changed to {edited_value}")
+            # Step 6: Verify the new value persisted
+            log_test_step("6. Verify the edited value persisted")
+            expect(row_for_key(page, test_key)).to_be_visible(timeout=10000)
+            persisted = api_env_value(api_context, test_key)
+            assert persisted == edited_value, (
+                f"Value incorrect after edit: expected {edited_value}, got {persisted!r}"
+            )
+            logger.info(f"Edit verified: {test_key}={persisted}")
 
-        # Step 5: Delete test row
-        log_test_step("5. Delete test row")
-        delete_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        expect(delete_btn).to_be_visible(timeout=5000)
-        delete_btn.click()
-        page.wait_for_timeout(800)
+            # Step 7: The variable was updated, not duplicated
+            log_test_step("7. Verify no duplicate was created")
+            after_count = get_custom_var_count(page)
+            assert after_count == initial_count + 1, (
+                f"Edit should not add a variable: expected {initial_count + 1}, "
+                f"got {after_count}"
+            )
+            logger.info(f"Custom count unchanged by edit: {after_count}")
 
-        after_delete_count = get_env_row_count(page)
-        assert after_delete_count == initial_row_count, (
-            f"Row count incorrect after delete: expected {initial_row_count}, got {after_delete_count}"
-        )
-        logger.info(f"Delete succeeded, row count restored to {after_delete_count}")
-
-        log_test_result(test_name, True, 0)
-        logger.info(f"Test {test_name} passed - edit env var works")
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed - edit env var works")
+        finally:
+            log_test_step("Cleanup: delete test variable")
+            cleanup_env_var(page, api_context, test_key)
 
 
 # ============================================================================
@@ -443,54 +885,112 @@ class TestDeleteEnvironment:
     ENV-004: Delete env var + confirmation flow.
 
     Covers:
-    1. Add variable -> delete -> verify row count decreases
-    2. Verify count update
+    1. Create a variable through the UI
+    2. Click the row delete action (aria-label="Delete")
+    3. Verify the confirm dialog (title "Delete Variable", okText "Delete")
+    4. Confirm -> row disappears and the count drops
+    5. Verify the variable is gone from the API
+    6. Cancel path: the variable survives
+
+    Note: deleting an unsaved table row needed no confirmation before #7538.
+    Deletion now always goes through `Modal.confirm`, so the dialog itself is
+    part of the asserted flow.
     """
 
     @pytest.mark.test_id("ENV-004")
-    def test_delete_environment(self, page: Page, request: pytest.FixtureRequest):
+    def test_delete_environment(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Verify deleting an env var."""
         test_name = request.node.name
+        stamp = str(int(time.time()))[-6:]
+        test_key = f"E2E_DEL_{stamp}"
+        test_value = f"del_val_{stamp}"
+        keep_key = f"E2E_DEL_KEEP_{stamp}"
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
+        initial_count = get_custom_var_count(page)
+        logger.info(f"Initial custom variable count: {initial_count}")
 
-        # Step 2: Record the initial row count
-        log_test_step("2. Record initial row count")
-        initial_row_count = get_env_row_count(page)
-        logger.info(f"Initial row count: {initial_row_count}")
+        try:
+            # Step 2: Create two variables (one to delete, one to keep)
+            log_test_step("2. Create the variables under test")
+            add_variable_via_ui(page, api_context, test_key, test_value)
+            add_variable_via_ui(page, api_context, keep_key, test_value)
+            after_add = get_custom_var_count(page)
+            assert after_add == initial_count + 2, (
+                f"Expected {initial_count + 2} custom variables, got {after_add}"
+            )
+            logger.info(f"Created 2 variables, count = {after_add}")
 
-        # Step 3: Add a row
-        log_test_step("3. Add a row")
-        new_count = add_env_row(page)
-        logger.info(f"Row added successfully, current count: {new_count}")
+            # Step 3: Cancel the confirm dialog — nothing should be deleted
+            log_test_step("3. Open delete confirm and cancel it")
+            row = row_for_key(page, test_key)
+            row.locator(DELETE_BTN_BY_LABEL).first.click()
+            expect(page.locator(CONFIRM_MODAL).first).to_be_visible(timeout=10000)
+            confirm_title = page.locator(CONFIRM_MODAL).first.locator(CONFIRM_TITLE).first
+            expect(confirm_title).to_contain_text("Delete Variable", timeout=5000)
+            confirm_body = page.locator(CONFIRM_MODAL).first.locator(CONFIRM_CONTENT).first
+            expect(confirm_body).to_contain_text(test_key, timeout=5000)
+            logger.info("Confirm dialog shows the variable name")
 
-        # Step 4: Delete the just-added row
-        log_test_step("4. Delete the just-added row")
-        last_row = page.locator(ROW_SELECTOR).last
-        delete_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        expect(delete_btn).to_be_visible(timeout=5000)
-        delete_btn.click()
-        page.wait_for_timeout(800)
+            cancel_btn = confirm_button(page, ok=False)
+            if cancel_btn.count() > 0 and cancel_btn.is_visible():
+                cancel_btn.click()
+                page.wait_for_timeout(800)
+                expect(row_for_key(page, test_key)).to_be_visible(timeout=5000)
+                assert get_custom_var_count(page) == after_add, (
+                    "Cancelling the confirm dialog must not delete the variable"
+                )
+                logger.info("Cancel path verified: variable survived")
+            else:
+                logger.warning("Cancel button not found, closing dialog via Escape")
+                page.keyboard.press("Escape")
+                page.wait_for_timeout(800)
 
-        after_delete_count = get_env_row_count(page)
-        assert after_delete_count == initial_row_count, (
-            f"Row count incorrect after delete: expected {initial_row_count}, got {after_delete_count}"
-        )
-        logger.info(f"Delete succeeded, row count restored to {after_delete_count}")
+            # Step 4: Delete for real
+            log_test_step("4. Delete the variable and confirm")
+            count_before_delete = get_custom_var_count(page)
+            delete_variable_via_ui(page, test_key)
 
-        # Step 5: Verify count update
-        log_test_step("5. Verify count update")
-        count_text = get_count_text(page)
-        logger.info(f"Variable count after delete: {count_text}")
+            # Step 5: The row is gone and the count dropped
+            log_test_step("5. Verify the row is removed")
+            expect(row_for_key(page, test_key)).to_have_count(0, timeout=10000)
+            after_delete_count = get_custom_var_count(page)
+            assert after_delete_count == count_before_delete - 1, (
+                f"Count did not drop after delete: expected {count_before_delete - 1}, "
+                f"got {after_delete_count}"
+            )
+            logger.info(
+                f"Delete succeeded, count {count_before_delete} -> {after_delete_count}"
+            )
 
-        log_test_result(test_name, True, 0)
-        logger.info(f"Test {test_name} passed - delete env var works")
+            # Step 6: The kept variable is untouched
+            log_test_step("6. Verify the other variable is untouched")
+            expect(row_for_key(page, keep_key)).to_be_visible(timeout=5000)
+
+            # Step 7: The API agrees
+            log_test_step("7. Verify deletion through the API")
+            keys = api_list_env_keys(api_context)
+            assert test_key not in keys, f"{test_key} should be deleted, API still has it"
+            assert keep_key in keys, f"{keep_key} should still exist"
+            logger.info("API confirms the deletion")
+
+            count_text = get_count_text(page)
+            logger.info(f"Custom variable count after delete: {count_text}")
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed - delete env var works")
+        finally:
+            log_test_step("Cleanup: delete test variables")
+            cleanup_env_var(page, api_context, test_key)
+            cleanup_env_var(page, api_context, keep_key)
 
 
 # ============================================================================
-# ENV-005: Multi-row add + checkbox toggle + in-row insert + refresh validation
+# ENV-005: Multiple variables in sequence + row addressing + persistence
 # ============================================================================
 
 @pytest.mark.integration
@@ -498,124 +998,147 @@ class TestDeleteEnvironment:
 @pytest.mark.envs
 class TestEnvVarMultiRowAndCheckbox:
     """
-    ENV-005: Multi-row add + checkbox toggle + in-row insert + refresh validation.
+    ENV-005: Create several variables in sequence, address them individually,
+    delete one, and verify what survives a reload.
 
     Covers:
-    1. Add 2 rows in a row
-    2. Verify checkbox check/uncheck
-    3. Add row via the "insert row below" button
-    4. Delete a specific row and verify row count
-    5. Reload to verify empty state restored (unsaved data is not persisted)
+    1. Add 2 variables one after another
+    2. Verify both are listed and the count reflects both
+    3. Address each row by its own key (not by position)
+    4. Reveal a masked value with the "Show value" action
+    5. Delete one specific variable and verify the count drops by one
+    6. Reload -> the deleted one stays gone, the other persists
+
+    SCOPE CHANGE (#7538): this case used to assert row checkboxes
+    (`checkbox.check()` / `is_checked()`) and the per-row "Insert row below"
+    button.  The unified page removed the selection model and the insert
+    action entirely — `index.tsx` no longer references `selected`,
+    `shiftIndices`, `deleteSelected` or `insertRowBelow`, and upstream deleted
+    its own three batch-selection unit tests in the same commit.  There is no
+    selector that can reach a control the product no longer renders, so the
+    "multiple rows" intent is kept and the checkbox/insert steps are replaced
+    by the equivalent capabilities that do exist: sequential creation,
+    per-key row addressing, value reveal and individual deletion.
+    The class name and test_id are preserved so historical reporting stays
+    comparable and the shard selection is unchanged.
     """
 
     @pytest.mark.test_id("ENV-005")
-    def test_env_var_multi_row_and_checkbox(self, page: Page, request: pytest.FixtureRequest):
-        """Verify multi-row add, checkbox and delete."""
+    def test_env_var_multi_row_and_checkbox(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
+        """Verify sequential multi-variable add, per-key addressing and delete."""
         test_name = request.node.name
+        stamp = str(int(time.time()))[-6:]
+        key_one = f"E2E_ROW_ONE_{stamp}"
+        key_two = f"E2E_ROW_TWO_{stamp}"
+        value_one = f"row_one_value_{stamp}"
+        value_two = f"row_two_value_{stamp}"
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
-        initial_row_count = get_env_row_count(page)
-        logger.info(f"Initial row count: {initial_row_count}")
+        initial_count = get_custom_var_count(page)
+        logger.info(f"Initial custom variable count: {initial_count}")
 
-        # Step 2: Add 2 rows in a row
-        log_test_step("2. Add 2 rows in a row")
-        add_env_row(page)
-        add_env_row(page)
-        current_count = get_env_row_count(page)
-        assert current_count == initial_row_count + 2, (
-            f"Row count incorrect after adding 2 rows: expected {initial_row_count + 2}, got {current_count}"
-        )
-        logger.info(f"Added 2 rows successfully, current count: {current_count}")
-
-        # Step 3: Fill the first row
-        log_test_step("3. Fill first row data")
-        rows = page.locator(ROW_SELECTOR).all()
-        first_new_row = rows[initial_row_count]
-        key_input_1 = first_new_row.locator(KEY_INPUT_SELECTOR).first
-        value_input_1 = first_new_row.locator(VALUE_INPUT_SELECTOR).first
-        key_input_1.fill("ROW_ONE_KEY")
-        value_input_1.fill("row_one_value")
-        page.wait_for_timeout(300)
-        assert key_input_1.input_value() == "ROW_ONE_KEY", "First row Key not filled"
-        logger.info("First row data filled successfully")
-
-        # Step 4: Fill the second row
-        log_test_step("4. Fill second row data")
-        second_new_row = rows[initial_row_count + 1]
-        key_input_2 = second_new_row.locator(KEY_INPUT_SELECTOR).first
-        value_input_2 = second_new_row.locator(VALUE_INPUT_SELECTOR).first
-        key_input_2.fill("ROW_TWO_KEY")
-        value_input_2.fill("row_two_value")
-        page.wait_for_timeout(300)
-        assert key_input_2.input_value() == "ROW_TWO_KEY", "Second row Key not filled"
-        logger.info("Second row data filled successfully")
-
-        # Step 5: Verify checkbox check
-        log_test_step("5. Verify checkbox check")
-        checkbox_1 = first_new_row.locator(CHECKBOX_SELECTOR).first
-        expect(checkbox_1).to_be_visible(timeout=5000)
-        assert not checkbox_1.is_checked(), "Checkbox should start unchecked"
-
-        checkbox_1.check()
-        page.wait_for_timeout(300)
-        assert checkbox_1.is_checked(), "Checkbox should be checked after check()"
-        logger.info("Checkbox check verified")
-
-        # Step 6: Uncheck
-        log_test_step("6. Uncheck the checkbox")
-        checkbox_1.uncheck()
-        page.wait_for_timeout(300)
-        assert not checkbox_1.is_checked(), "Checkbox should be unchecked after uncheck()"
-        logger.info("Checkbox uncheck verified")
-
-        # Step 7: Add row via "insert row below" button
-        log_test_step("7. Add row via insert button")
-        insert_btn = first_new_row.locator('button[title="在下方插入行"], button[title="Insert Row Below"], button[title="Insert row below"], button[title="insert"]').first
-        if insert_btn.is_visible():
-            count_before_insert = get_env_row_count(page)
-            insert_btn.click()
-            page.wait_for_timeout(800)
-            count_after_insert = get_env_row_count(page)
-            assert count_after_insert == count_before_insert + 1, (
-                f"Row count did not increase after insert: {count_before_insert} -> {count_after_insert}"
+        try:
+            # Step 2: Add the first variable
+            log_test_step("2. Add the first variable")
+            add_variable_via_ui(page, api_context, key_one, value_one)
+            count_after_first = get_custom_var_count(page)
+            assert count_after_first == initial_count + 1, (
+                f"Count incorrect after first add: expected {initial_count + 1}, "
+                f"got {count_after_first}"
             )
-            logger.info(f"In-row insert button added a row, current count: {count_after_insert}")
-        else:
-            logger.info("Insert button not visible, skipping this step")
+            logger.info(f"First variable added, count = {count_after_first}")
 
-        # Step 8: Delete the first newly-added row
-        log_test_step("8. Delete the first newly-added row")
-        count_before_delete = get_env_row_count(page)
-        rows_updated = page.locator(ROW_SELECTOR).all()
-        target_row = rows_updated[initial_row_count]
-        del_btn = target_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        expect(del_btn).to_be_visible(timeout=5000)
-        del_btn.click()
-        page.wait_for_timeout(800)
+            # Step 3: Add the second variable
+            log_test_step("3. Add the second variable")
+            add_variable_via_ui(page, api_context, key_two, value_two)
+            count_after_second = get_custom_var_count(page)
+            assert count_after_second == initial_count + 2, (
+                f"Count incorrect after second add: expected {initial_count + 2}, "
+                f"got {count_after_second}"
+            )
+            logger.info(f"Second variable added, count = {count_after_second}")
 
-        count_after_delete = get_env_row_count(page)
-        assert count_after_delete == count_before_delete - 1, (
-            f"Row count did not decrease after delete: {count_before_delete} -> {count_after_delete}"
-        )
-        logger.info(f"Row delete succeeded, current count: {count_after_delete}")
+            # Step 4: Address each row by its own key
+            log_test_step("4. Address each row by key")
+            row_one = row_for_key(page, key_one)
+            row_two = row_for_key(page, key_two)
+            expect(row_one).to_be_visible(timeout=5000)
+            expect(row_two).to_be_visible(timeout=5000)
+            for row, key in ((row_one, key_one), (row_two, key_two)):
+                shown_key = row.locator(IDENTITY_CODE).first.inner_text().strip()
+                assert shown_key == key, f"Row key mismatch: expected {key}, got {shown_key}"
+                for label in ("Edit", "Delete"):
+                    expect(row.locator(f'button[aria-label="{label}"]').first).to_be_visible(
+                        timeout=5000
+                    )
+            logger.info("Both rows are individually addressable with Edit/Delete actions")
 
-        # Step 9: Reload to verify (unsaved data should not persist)
-        log_test_step("9. Reload to verify persistence")
-        page.reload()
-        page.wait_for_load_state("domcontentloaded")
-        page.wait_for_timeout(2000)
+            # Step 5: Reveal the masked value of the first variable
+            log_test_step("5. Reveal the masked value")
+            masked = row_one.locator('div[class*="__valueText__"] code').first
+            expect(masked).to_be_visible(timeout=5000)
+            masked_text = masked.inner_text().strip()
+            logger.info(f"Value before reveal: {masked_text!r}")
+            show_btn = row_one.locator(SHOW_VALUE_BTN_BY_LABEL).first
+            if show_btn.count() > 0 and show_btn.is_visible():
+                show_btn.click()
+                page.wait_for_timeout(500)
+                revealed = masked.inner_text().strip()
+                assert revealed == value_one, (
+                    f"Revealed value mismatch: expected {value_one}, got {revealed!r}"
+                )
+                logger.info(f"Value after reveal: {revealed}")
+                hide_btn = row_one.locator('button[aria-label="Hide value"]').first
+                if hide_btn.count() > 0 and hide_btn.is_visible():
+                    hide_btn.click()
+                    page.wait_for_timeout(300)
+                    logger.info("Value re-masked via Hide value")
+            else:
+                logger.info("Show value action not present, skipping reveal")
 
-        refreshed_count = get_env_row_count(page)
-        logger.info(f"Row count after reload: {refreshed_count} (initial: {initial_row_count})")
-        assert refreshed_count == initial_row_count, (
-            f"Row count should restore to initial after reload: expected {initial_row_count}, got {refreshed_count}"
-        )
-        logger.info("Unsaved data cleared after reload, state restored")
+            # Step 6: Delete the first variable only
+            log_test_step("6. Delete the first variable")
+            count_before_delete = get_custom_var_count(page)
+            delete_variable_via_ui(page, key_one)
+            expect(row_for_key(page, key_one)).to_have_count(0, timeout=10000)
+            count_after_delete = get_custom_var_count(page)
+            assert count_after_delete == count_before_delete - 1, (
+                f"Count did not drop after delete: {count_before_delete} -> "
+                f"{count_after_delete}"
+            )
+            logger.info(f"Row delete succeeded, count = {count_after_delete}")
 
-        log_test_result(test_name, True, 0)
-        logger.info(f"Test {test_name} passed - multi-row add, checkbox, delete and reload verified")
+            # Step 7: The second variable survived
+            log_test_step("7. Verify the second variable survived")
+            expect(row_for_key(page, key_two)).to_be_visible(timeout=5000)
+
+            # Step 8: Reload — the write is durable, the deletion too
+            log_test_step("8. Reload and verify persistence")
+            page.reload()
+            page.wait_for_load_state("domcontentloaded")
+            navigate_to_environments(page)
+            refreshed_count = get_custom_var_count(page)
+            assert refreshed_count == initial_count + 1, (
+                f"After reload expected {initial_count + 1} custom variables, "
+                f"got {refreshed_count}"
+            )
+            expect(row_for_key(page, key_two)).to_be_visible(timeout=10000)
+            expect(row_for_key(page, key_one)).to_have_count(0, timeout=3000)
+            logger.info("Persistence verified after reload")
+
+            log_test_result(test_name, True, 0)
+            logger.info(
+                f"Test {test_name} passed - sequential add, per-key addressing, "
+                f"value reveal, delete and reload verified"
+            )
+        finally:
+            log_test_step("Cleanup: delete test variables")
+            cleanup_env_var(page, api_context, key_one)
+            cleanup_env_var(page, api_context, key_two)
 
 
 # ============================================================================
@@ -630,119 +1153,150 @@ class TestEnvVarSaveAndPersist:
     ENV-006: Env var save persistence validation.
 
     Covers:
-    1. Add new variable (Key/Value)
-    2. Click save button
-    3. Verify save success indicator
-    4. Reload -> verify new variable still exists
-    5. Delete the variable and save (cleanup)
+    1. Add a new variable (Key/Value) through the Modal
+    2. "Apply now" writes it (there is no page-level Save button any more)
+    3. Verify the success toast
+    4. Reload -> the variable still exists
+    5. Verify the value survived through the API (the UI masks it)
+    6. Delete the variable and verify the removal persists
+    7. Cleanup
+
+    Note: persistence used to be proven by reading the value back from the row
+    input.  Custom values are now rendered masked (`<ValueText secret />` shows
+    "••••••••"), so the durable value is asserted against `GET /api/envs`.
     """
 
     @pytest.mark.test_id("ENV-006")
-    def test_env_var_save_and_persist(self, page: Page, request: pytest.FixtureRequest):
+    def test_env_var_save_and_persist(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Verify env var save and persistence."""
         test_name = request.node.name
-        test_key = "E2E_PERSIST_TEST"
-        test_value = "test_value"
+        stamp = str(int(time.time()))[-6:]
+        test_key = f"E2E_PERSIST_{stamp}"
+        test_value = f"persist_value_{stamp}"
         data_saved = False
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
-
-        # Step 2: Record the initial row count
-        log_test_step("2. Record initial row count")
-        initial_row_count = get_env_row_count(page)
-        logger.info(f"Initial row count: {initial_row_count}")
+        initial_count = get_custom_var_count(page)
+        logger.info(f"Initial custom variable count: {initial_count}")
 
         try:
-            # Step 3: Add a new variable
-            log_test_step("3. Add new variable")
-            new_row_count = add_env_row(page)
-            logger.info(f"Row added successfully, current count: {new_row_count}")
-
-            last_row = page.locator(ROW_SELECTOR).last
-            key_input = last_row.locator(KEY_INPUT_SELECTOR).first
-            value_input = last_row.locator(VALUE_INPUT_SELECTOR).first
+            # Step 2: Add a new variable
+            log_test_step("2. Add a new variable")
+            open_add_variable_modal(page)
+            key_input = page.locator(MODAL_KEY_INPUT).first
+            value_input = page.locator(MODAL_VALUE_INPUT).first
             expect(key_input).to_be_visible(timeout=5000)
             expect(value_input).to_be_visible(timeout=5000)
 
             key_input.fill(test_key)
             value_input.fill(test_value)
-            page.wait_for_timeout(500)
+            page.wait_for_timeout(300)
 
-            filled_key = key_input.input_value()
-            filled_value = value_input.input_value()
-            assert filled_key == test_key, f"Key not filled correctly: expected {test_key}, got {filled_key}"
-            assert filled_value == test_value, f"Value not filled correctly: expected {test_value}, got {filled_value}"
+            assert key_input.input_value() == test_key, (
+                f"Key not filled correctly: expected {test_key}, "
+                f"got {key_input.input_value()!r}"
+            )
+            assert value_input.input_value() == test_value, (
+                f"Value not filled correctly: expected {test_value}, "
+                f"got {value_input.input_value()!r}"
+            )
             logger.info(f"Variable filled: {test_key}={test_value}")
 
-            # Step 4: Click save button
-            log_test_step("4. Click save button")
-            click_save_button(page)
+            # Step 3: Apply now — this is the write
+            log_test_step("3. Click Apply now")
+            click_modal_ok(page)
             data_saved = True
+            expect_modal_closed(page)
 
-            # Step 5: Verify save success indicator
-            log_test_step("5. Verify save success indicator")
-            success_msg = page.locator(
-                '.qwenpaw-message-success, '
-                '.qwenpaw-message-notice-content:has-text("保存")'
-            ).first
-            if success_msg.is_visible():
-                logger.info("Save success indicator visible")
-            else:
-                logger.info("No obvious success indicator detected, continuing")
+            # Step 4: Verify the success toast
+            log_test_step("4. Verify save success indicator")
+            try:
+                expect_toast(page, MSG_APPLIED, timeout=8000)
+                logger.info(f"Success toast detected: {MSG_APPLIED}")
+            except Exception:
+                success_msg = page.locator(MESSAGE_SUCCESS).first
+                if success_msg.count() > 0 and success_msg.is_visible():
+                    logger.info(
+                        f"Success indicator visible: {success_msg.inner_text().strip()!r}"
+                    )
+                else:
+                    logger.info("No obvious success indicator detected, continuing")
+
+            # Step 5: The variable is listed
+            log_test_step("5. Verify the variable is listed")
+            expect(row_for_key(page, test_key)).to_be_visible(timeout=10000)
+            assert get_custom_var_count(page) == initial_count + 1, (
+                "Custom count should have increased by one"
+            )
 
             # Step 6: Reload
             log_test_step("6. Reload page")
             page.reload()
             page.wait_for_load_state("domcontentloaded")
-            page.wait_for_timeout(2000)
+            navigate_to_environments(page)
 
-            # Step 7: Verify new variable still exists
-            log_test_step("7. Verify new variable still exists")
-            refreshed_row_count = get_env_row_count(page)
-            logger.info(f"Row count after reload: {refreshed_row_count}")
+            # Step 7: The variable is still there after reload
+            log_test_step("7. Verify the variable still exists after reload")
+            refreshed_count = get_custom_var_count(page)
+            logger.info(f"Custom count after reload: {refreshed_count}")
+            assert refreshed_count == initial_count + 1, (
+                f"Variable did not persist: expected {initial_count + 1}, "
+                f"got {refreshed_count}"
+            )
+            expect(row_for_key(page, test_key)).to_be_visible(timeout=10000)
+            logger.info(f"Variable persisted across reload: {test_key}")
 
-            rows = page.locator(ROW_SELECTOR).all()
-            found = False
-            for row in rows:
-                row_key_input = row.locator(KEY_INPUT_SELECTOR).first
-                if row_key_input.is_visible():
-                    row_key = row_key_input.input_value()
-                    if row_key == test_key:
-                        found = True
-                        row_value_input = row.locator(VALUE_INPUT_SELECTOR).first
-                        row_value = row_value_input.input_value()
-                        assert row_value == test_value, (
-                            f"Value mismatch: expected {test_value}, got {row_value}"
-                        )
-                        logger.info(f"Found persisted variable: {test_key}={row_value}")
-                        break
+            # Step 8: The value persisted (API, because the UI masks it)
+            log_test_step("8. Verify the persisted value via API")
+            persisted = api_env_value(api_context, test_key)
+            assert persisted == test_value, (
+                f"Value mismatch after reload: expected {test_value}, got {persisted!r}"
+            )
+            logger.info(f"Persisted value verified: {test_key}={persisted}")
 
-            assert found, f"Test variable not found after reload: {test_key}"
+            # Step 9: Reveal it in the UI as well
+            log_test_step("9. Reveal the value in the UI")
+            row = row_for_key(page, test_key)
+            show_btn = row.locator(SHOW_VALUE_BTN_BY_LABEL).first
+            if show_btn.count() > 0 and show_btn.is_visible():
+                show_btn.click()
+                page.wait_for_timeout(500)
+                revealed = row.locator('div[class*="__valueText__"] code').first.inner_text().strip()
+                assert revealed == test_value, (
+                    f"Revealed value mismatch: expected {test_value}, got {revealed!r}"
+                )
+                logger.info(f"UI reveal matches the persisted value: {revealed}")
+            else:
+                logger.info("Show value action not present, relying on API assertion")
+
+            # Step 10: Delete it and verify the removal persists
+            log_test_step("10. Delete the variable and verify removal persists")
+            delete_variable_via_ui(page, test_key)
+            expect(row_for_key(page, test_key)).to_have_count(0, timeout=10000)
+            data_saved = False
+
+            page.reload()
+            page.wait_for_load_state("domcontentloaded")
+            navigate_to_environments(page)
+            final_count = get_custom_var_count(page)
+            assert final_count == initial_count, (
+                f"Count should be back to {initial_count} after delete, got {final_count}"
+            )
+            assert test_key not in api_list_env_keys(api_context), (
+                f"{test_key} should be gone from the API after deletion"
+            )
+            logger.info("Deletion persisted across reload")
+
             log_test_result(test_name, True, 0)
-
         finally:
-            # Cleanup: delete the test variable and save
+            # Cleanup: make sure the test variable is gone even on failure
             if data_saved:
-                try:
-                    log_test_step("Cleanup: delete test variable")
-                    navigate_to_environments(page)
-                    fresh_rows = page.locator(ROW_SELECTOR).all()
-                    for row in fresh_rows:
-                        row_key_input = row.locator(KEY_INPUT_SELECTOR).first
-                        if row_key_input.is_visible():
-                            row_key = row_key_input.input_value()
-                            if row_key == test_key:
-                                delete_btn = row.locator(DELETE_ROW_BTN_SELECTOR).first
-                                if delete_btn.is_visible(timeout=3000):
-                                    delete_btn.click()
-                                    page.wait_for_timeout(800)
-                                    click_save_button(page)
-                                    logger.info("Test variable deleted and saved")
-                                break
-                except Exception as cleanup_error:
-                    logger.warning(f"Cleanup of test variable failed: {cleanup_error}")
+                log_test_step("Cleanup: delete test variable")
+                cleanup_env_var(page, api_context, test_key)
         logger.info(f"Test {test_name} passed - env var save and persistence verified")
 
 
@@ -758,98 +1312,106 @@ class TestEnvVarKeyValidation:
     ENV-007: Key format validation.
 
     Covers:
-    1. Input invalid Keys ("123invalid", "has space", "has-dash") -> verify error message
-    2. Input valid Key ("VALID_KEY_123") -> verify no error
-    3. Delete test row
+    1. Invalid Keys ("123invalid", "has space", "has-dash") are rejected with
+       "Invalid key format" and the Modal stays open
+    2. A valid Key ("E2E_VALID_KEY_<ts>") is accepted and written
+    3. Cleanup
+
+    Note: validation moved from a per-row form field (which rendered
+    `.qwenpaw-form-item-explain-error` under the input) to a gate inside
+    `saveEditor`, which reports through a toast and keeps the Modal open.
+    The assertions follow the gate: `saveEditor` rejects anything that fails
+    `/^[A-Za-z_][A-Za-z0-9_]*$/` before any request is sent.
     """
 
     @pytest.mark.test_id("ENV-007")
-    def test_env_var_key_format_validation(self, page: Page, request: pytest.FixtureRequest):
+    def test_env_var_key_format_validation(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Verify env var Key format validation."""
         test_name = request.node.name
+        stamp = str(int(time.time()))[-6:]
+        valid_key = f"E2E_VALID_KEY_{stamp}"
 
         # Step 1: Visit the environments page
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
+        initial_count = get_custom_var_count(page)
 
-        # Step 2: Add a new variable row
-        log_test_step("2. Add a new variable row")
-        add_env_row(page)
-        logger.info("New row added")
-
-        last_row = page.locator(ROW_SELECTOR).last
-        key_input = last_row.locator(KEY_INPUT_SELECTOR).first
-        value_input = last_row.locator(VALUE_INPUT_SELECTOR).first
+        # Step 2: Open the editor Modal
+        log_test_step("2. Open the editor Modal")
+        open_add_variable_modal(page)
+        key_input = page.locator(MODAL_KEY_INPUT).first
         expect(key_input).to_be_visible(timeout=5000)
-        expect(value_input).to_be_visible(timeout=5000)
+        fill_variable_modal(page, value="format_probe_value")
 
-        error_selector = '.qwenpaw-form-item-explain-error, [class*="error"]:has-text("格式")'
+        rejected_keys = []
+        # Step 3-5: Each invalid Key must be rejected
+        for index, invalid_key in enumerate(("123invalid", "has space", "has-dash"), start=3):
+            log_test_step(f"{index}. Test invalid Key: {invalid_key!r}")
+            key_input.fill(invalid_key)
+            page.wait_for_timeout(300)
+            click_modal_ok(page)
+            page.wait_for_timeout(800)
 
-        # Step 3: Test invalid Key - "123invalid"
-        log_test_step("3. Test invalid Key: 123invalid")
-        key_input.fill("123invalid")
-        page.wait_for_timeout(1000)
+            # The Modal must stay open: saveEditor returns before the request.
+            expect_modal_open(page)
 
-        error_msg = page.locator(error_selector).first
-        has_error = error_msg.count() > 0 and error_msg.is_visible()
-        if not has_error:
-            input_wrapper = key_input.locator('..').first
-            wrapper_class = input_wrapper.get_attribute('class') or ''
-            has_error = 'error' in wrapper_class
-        logger.info(f"Error detected after entering '123invalid': {has_error}")
+            has_error = False
+            try:
+                expect_toast(page, MSG_INVALID_KEY_FORMAT, timeout=5000)
+                has_error = True
+            except Exception:
+                error_toast = page.locator(MESSAGE_ERROR).first
+                if error_toast.count() > 0 and error_toast.is_visible():
+                    has_error = True
+                    logger.info(
+                        f"Error toast for {invalid_key!r}: "
+                        f"{error_toast.inner_text().strip()!r}"
+                    )
+            logger.info(f"Rejected {invalid_key!r}: {has_error}")
+            if has_error:
+                rejected_keys.append(invalid_key)
 
-        # Step 4: Test invalid Key - "has space"
-        log_test_step("4. Test invalid Key: has space")
-        key_input.fill("has space")
-        page.wait_for_timeout(1000)
+        assert rejected_keys, (
+            "No invalid Key was rejected — the format gate did not fire"
+        )
+        logger.info(f"Rejected keys: {rejected_keys}")
 
-        error_msg_space = page.locator(error_selector).first
-        has_error_space = error_msg_space.count() > 0 and error_msg_space.is_visible()
-        if not has_error_space:
-            input_wrapper = key_input.locator('..').first
-            wrapper_class = input_wrapper.get_attribute('class') or ''
-            has_error_space = 'error' in wrapper_class
-        logger.info(f"Error detected after entering 'has space': {has_error_space}")
+        # Step 6: The Key input keeps the last rejected value (nothing was sent)
+        log_test_step("6. Verify no invalid Key was written")
+        assert key_input.input_value() == "has-dash", (
+            f"Key input should still hold the last rejected value, "
+            f"got {key_input.input_value()!r}"
+        )
+        assert get_custom_var_count(page) == initial_count, (
+            "Rejected Keys must not create variables"
+        )
 
-        # Step 5: Test invalid Key - "has-dash"
-        log_test_step("5. Test invalid Key: has-dash")
-        key_input.fill("has-dash")
-        page.wait_for_timeout(1000)
+        # Step 7: A valid Key is accepted
+        log_test_step("7. Test valid Key")
+        key_input.fill(valid_key)
+        page.wait_for_timeout(300)
+        click_modal_ok(page)
+        expect_modal_closed(page, timeout=10000)
+        expect(row_for_key(page, valid_key)).to_be_visible(timeout=10000)
+        logger.info(f"Valid Key accepted and written: {valid_key}")
 
-        error_msg_dash = page.locator(error_selector).first
-        has_error_dash = error_msg_dash.count() > 0 and error_msg_dash.is_visible()
-        if not has_error_dash:
-            input_wrapper = key_input.locator('..').first
-            wrapper_class = input_wrapper.get_attribute('class') or ''
-            has_error_dash = 'error' in wrapper_class
-        logger.info(f"Error detected after entering 'has-dash': {has_error_dash}")
-
-        # Step 6: Test valid Key - "VALID_KEY_123"
-        log_test_step("6. Test valid Key: VALID_KEY_123")
-        key_input.fill("VALID_KEY_123")
-        page.wait_for_timeout(1000)
-
-        error_msg_valid = page.locator(error_selector).first
-        has_error_valid = error_msg_valid.is_visible() if error_msg_valid.count() > 0 else False
-        if has_error_valid:
-            error_text = error_msg_valid.inner_text()
-            logger.info(f"Still has error after entering 'VALID_KEY_123': {error_text}")
-        logger.info("Valid Key input complete")
-
-        # Step 7: Delete test row
-        log_test_step("7. Delete test row")
-        delete_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-        expect(delete_btn).to_be_visible(timeout=5000)
-        delete_btn.click()
-        page.wait_for_timeout(800)
-        logger.info("Test row deleted")
+        # Step 8: Cleanup
+        log_test_step("8. Delete the valid test variable")
+        delete_variable_via_ui(page, valid_key)
+        expect(row_for_key(page, valid_key)).to_have_count(0, timeout=10000)
+        assert get_custom_var_count(page) == initial_count, (
+            "Count should be back to the initial value after cleanup"
+        )
+        logger.info("Test variable deleted")
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed - Key format validation verified")
 
 
 # ============================================================================
-# ENV-008: Batch operations + import/export
+# ENV-008: Bulk create/filter/delete of several variables
 # ============================================================================
 
 @pytest.mark.integration
@@ -857,60 +1419,114 @@ class TestEnvVarKeyValidation:
 @pytest.mark.envs
 class TestBatchOperations:
     """
-    ENV-008: Batch operations + import/export.
+    ENV-008: Work with several variables at once — bulk create, filter them
+    with the search box, then remove them all.
 
     Covers:
-    1. Batch select button
-    2. Checkbox existence
-    3. Import/export buttons
+    1. Create 3 variables in sequence
+    2. Verify the count reflects all three
+    3. Filter with the search box and verify only matching rows remain
+    4. Clear the filter and verify all rows come back
+    5. Delete all three and verify the count returns to the baseline
+
+    SCOPE CHANGE (#7538): this case used to tick per-row checkboxes and assert
+    `checked_count > 0` before a batch delete.  The unified page has no
+    selection model at all — no checkbox, no select-all, no "Delete Selected"
+    action (`index.tsx` references none of `selected`, `allSelected`,
+    `someSelected` or `deleteSelected`, and upstream removed its three
+    batch-selection unit tests in the same commit).  A checkbox assertion can
+    only ever fail against the shipped UI, so the "operate on many variables"
+    intent is kept and re-expressed through the capabilities that replaced it:
+    bulk creation, the new search filter, and per-variable deletion in a loop.
+    The class name and test_id are preserved so historical reporting stays
+    comparable and the shard selection is unchanged.
     """
 
     @pytest.mark.test_id("ENV-008")
-    def test_batch_operations(self, page: Page, request: pytest.FixtureRequest):
-        """Verify batch ops: add multiple rows -> select all -> batch delete -> verify row count."""
+    def test_batch_operations(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
+        """Verify bulk create + search filter + bulk delete of env vars."""
         test_name = request.node.name
+        stamp = str(int(time.time()))[-6:]
+        keys = [f"E2E_BATCH_{stamp}_{suffix}" for suffix in ("A", "B", "C")]
+        value = f"batch_value_{stamp}"
 
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
-        initial_count = get_env_row_count(page)
-        logger.info(f"Initial row count: {initial_count}")
+        initial_count = get_custom_var_count(page)
+        logger.info(f"Initial custom variable count: {initial_count}")
 
-        log_test_step("2. Add 3 rows for batch op testing")
-        for _ in range(3):
-            add_env_row(page)
-        after_add_count = get_env_row_count(page)
-        assert after_add_count == initial_count + 3, \
-            f"Row count incorrect after adding 3 rows: expected {initial_count + 3}, got {after_add_count}"
-        logger.info(f"Added 3 rows successfully, current count: {after_add_count}")
+        try:
+            log_test_step("2. Create 3 variables for bulk operation testing")
+            for key in keys:
+                add_variable_via_ui(page, api_context, key, value)
+            after_add_count = get_custom_var_count(page)
+            assert after_add_count == initial_count + 3, (
+                f"Count incorrect after creating 3 variables: "
+                f"expected {initial_count + 3}, got {after_add_count}"
+            )
+            logger.info(f"Created 3 variables, count = {after_add_count}")
 
-        log_test_step("3. Find checkboxes and check the new rows")
-        rows = page.locator(ROW_SELECTOR).all()
-        checked_count = 0
-        for i in range(initial_count, min(initial_count + 3, len(rows))):
-            checkbox = rows[i].locator(CHECKBOX_SELECTOR).first
-            if checkbox.count() > 0 and checkbox.is_visible():
-                checkbox.check()
-                page.wait_for_timeout(200)
-                checked_count += 1
-        assert checked_count > 0, "Failed to check any checkbox"
-        logger.info(f"Checked {checked_count} checkboxes")
+            log_test_step("3. Verify all three rows are listed")
+            for key in keys:
+                expect(row_for_key(page, key)).to_be_visible(timeout=5000)
 
-        log_test_step("4. Delete the new rows one by one and verify the row count decreases")
-        for i in range(3):
-            current_count = get_env_row_count(page)
-            last_row = page.locator(ROW_SELECTOR).last
-            del_btn = last_row.locator(DELETE_ROW_BTN_SELECTOR).first
-            if del_btn.count() > 0 and del_btn.is_visible():
-                del_btn.click()
-                page.wait_for_timeout(500)
+            log_test_step("4. Filter with the search box")
+            search_input = page.locator(SEARCH_INPUT).first
+            expect(search_input).to_be_visible(timeout=5000)
+            search_input.fill(keys[0])
+            page.wait_for_timeout(800)
+            expect(row_for_key(page, keys[0])).to_be_visible(timeout=5000)
+            expect(row_for_key(page, keys[1])).to_have_count(0, timeout=5000)
+            expect(row_for_key(page, keys[2])).to_have_count(0, timeout=5000)
+            filtered_count = get_custom_var_count(page)
+            assert filtered_count == 1, (
+                f"Search filter should leave 1 custom variable, got {filtered_count}"
+            )
+            logger.info(f"Search filter works: {keys[0]} only, count = {filtered_count}")
 
-        final_count = get_env_row_count(page)
-        assert final_count == initial_count, \
-            f"Row count incorrect after delete: expected {initial_count}, got {final_count}"
-        logger.info(f"Batch delete verified, row count restored to {final_count}")
+            log_test_step("5. Clear the filter and verify all rows return")
+            search_input.fill("")
+            page.wait_for_timeout(800)
+            for key in keys:
+                expect(row_for_key(page, key)).to_be_visible(timeout=5000)
+            assert get_custom_var_count(page) == initial_count + 3, (
+                "Clearing the filter should restore the full list"
+            )
+            logger.info("Filter cleared, all rows restored")
 
-        log_test_result(test_name, True, 0)
+            log_test_step("6. Delete the three variables one by one")
+            deleted = 0
+            for key in keys:
+                count_before = get_custom_var_count(page)
+                delete_variable_via_ui(page, key)
+                expect(row_for_key(page, key)).to_have_count(0, timeout=10000)
+                count_after = get_custom_var_count(page)
+                assert count_after == count_before - 1, (
+                    f"Count did not drop after deleting {key}: "
+                    f"{count_before} -> {count_after}"
+                )
+                deleted += 1
+            assert deleted == 3, f"Expected to delete 3 variables, deleted {deleted}"
 
+            final_count = get_custom_var_count(page)
+            assert final_count == initial_count, (
+                f"Count incorrect after bulk delete: expected {initial_count}, "
+                f"got {final_count}"
+            )
+            logger.info(f"Bulk delete verified, count restored to {final_count}")
+
+            remaining = api_list_env_keys(api_context)
+            for key in keys:
+                assert key not in remaining, f"{key} should be gone from the API"
+            logger.info("API confirms all three variables were removed")
+
+            log_test_result(test_name, True, 0)
+        finally:
+            log_test_step("Cleanup: delete any leftover test variables")
+            for key in keys:
+                cleanup_env_var(page, api_context, key)
 
 
 # ============================================================================
@@ -939,8 +1555,6 @@ class TestEnvironmentAPI:
         try:
             # Step 1: API - get env var list
             log_test_step("1. API: get env var list")
-            from utils.helpers import api_get
-
             envs = api_get(api_context, "/api/envs")
             logger.info(f"Env var list: {envs}")
             assert isinstance(envs, list), "API response should be a list"
@@ -980,7 +1594,6 @@ class TestEnvironmentAPI:
             if test_key:
                 try:
                     log_test_step("Cleanup: API delete test variable")
-                    from utils.helpers import api_get
                     current_envs = api_get(api_context, "/api/envs")
                     # Build a dict excluding the test variable to do a full overwrite
                     remaining_dict = {
@@ -1012,126 +1625,113 @@ class TestEnvKeyDuplicateDetection:
     ENV-P1-005: Key duplicate conflict detection.
 
     Covers:
-    1. Add two env vars with the same Key
-    2. Verify duplicate Key error message
-    3. Verify conflict detection on save
+    1. Create a variable with a given Key
+    2. Open the editor again and submit the same Key
+    3. Verify the "Duplicate key" rejection and that nothing was written
+    4. Verify the duplicate is also rejected against a known (catalogue) key
+    5. Cleanup
+
+    Note: this case used to click a broad `button:has-text("Add")` twice and
+    then look for a second input row.  After #7538 that first click opens the
+    Modal, whose Key placeholder is "VARIABLE_NAME" (not matched by the old
+    `input[placeholder*="KEY"]` guess), and the second click lands on the
+    button *behind the Modal overlay* — which is what produced the 60s
+    `Locator.click` timeout in the nightly run.  Duplicate detection now lives
+    in `saveEditor`: it compares the upper-cased key against both the stored
+    variables and the catalogue, reports `environments.duplicateKey` through a
+    toast, and leaves the Modal open without sending a request.
     """
 
     @pytest.mark.test_id("ENV-P1-005")
-    def test_env_key_duplicate_detection(self, page: Page, request: pytest.FixtureRequest):
+    def test_env_key_duplicate_detection(
+        self, page: Page, request: pytest.FixtureRequest, api_context
+    ):
         """Test env var Key duplicate conflict detection."""
         test_name = request.node.name
-        duplicate_key = "DUPLICATE_TEST_KEY"
+        stamp = str(int(time.time()))[-6:]
+        duplicate_key = f"E2E_DUP_{stamp}"
+        duplicate_value = f"dup_value_{stamp}"
 
         log_test_step("1. Visit environments page")
         navigate_to_environments(page)
+        initial_count = get_custom_var_count(page)
 
         try:
-            log_test_step("2. Add first env var")
-            add_btn = page.locator('button:has-text("Add"), button:has-text("添加")').first
-            expect(add_btn).to_be_visible(timeout=5000)
-            add_btn.click()
+            log_test_step("2. Create the first variable")
+            add_variable_via_ui(page, api_context, duplicate_key, duplicate_value)
+            logger.info(f"First variable created: {duplicate_key}")
+
+            log_test_step("3. Submit the same Key again")
+            open_add_variable_modal(page)
+            key_input = page.locator(MODAL_KEY_INPUT).first
+            expect(key_input).to_be_visible(timeout=5000)
+            # Exact case first, then a lower-cased variant: the duplicate check
+            # upper-cases both sides, so casing must not matter.
+            key_input.fill(duplicate_key)
+            fill_variable_modal(page, value="second_value_should_be_rejected")
+            click_modal_ok(page)
             page.wait_for_timeout(1000)
 
-            # Find the last row's Key input and fill it (broaden selector)
+            log_test_step("4. Verify the duplicate Key is rejected")
+            expect_modal_open(page)
+            logger.info("Modal stayed open: duplicate Key was not accepted")
+
+            detected = False
+            try:
+                expect_toast(page, MSG_DUPLICATE_KEY, timeout=6000)
+                detected = True
+                logger.info(f"Duplicate rejection detected: {MSG_DUPLICATE_KEY}")
+            except Exception:
+                error_toast = page.locator(MESSAGE_ERROR).first
+                if error_toast.count() > 0 and error_toast.is_visible():
+                    toast_text = error_toast.inner_text().strip()
+                    logger.info(f"Error toast detected: {toast_text!r}")
+                    detected = "uplicate" in toast_text
+            assert detected, "Duplicate Key should be rejected with an error message"
+
+            log_test_step("5. Verify a lower-cased duplicate is rejected too")
+            key_input.fill(duplicate_key.lower())
+            page.wait_for_timeout(300)
+            click_modal_ok(page)
             page.wait_for_timeout(1000)
-            key_inputs = page.locator(
-                'input[placeholder*="KEY"], input[placeholder*="key"], input[placeholder*="Key"], '
-                'input[placeholder*="Name"], input[placeholder*="name"], '
-                'input[placeholder*="Variable"], input[placeholder*="variable"]'
-            ).all()
-            if len(key_inputs) == 0:
-                # Try locating the first input in the table row
-                row_inputs = page.locator('tr:last-child input, .qwenpaw-form-item input').all()
-                key_inputs = row_inputs
-            if len(key_inputs) == 0:
-                logger.info("Key input not found, skipping test")
-                log_test_result(test_name, True, 0)
-                return
-            last_key_input = key_inputs[-1]
-            last_key_input.fill(duplicate_key)
-            page.wait_for_timeout(500)
-            logger.info(f"First Key filled: {duplicate_key}")
+            expect_modal_open(page)
+            logger.info("Case-insensitive duplicate rejected as well")
 
-            log_test_step("3. Add second env var with the same Key")
-            add_btn.click()
-            page.wait_for_timeout(1500)
+            log_test_step("6. Verify nothing extra was written")
+            click_modal_cancel(page)
+            expect_modal_closed(page)
+            after_count = get_custom_var_count(page)
+            assert after_count == initial_count + 1, (
+                f"Duplicate submissions must not add variables: "
+                f"expected {initial_count + 1}, got {after_count}"
+            )
+            keys = api_list_env_keys(api_context)
+            assert keys.count(duplicate_key) == 1, (
+                f"{duplicate_key} should exist exactly once, API has "
+                f"{keys.count(duplicate_key)}"
+            )
+            assert api_env_value(api_context, duplicate_key) == duplicate_value, (
+                "The rejected duplicate must not have overwritten the original value"
+            )
+            logger.info("No duplicate written, original value intact")
 
-            key_inputs = page.locator(
-                'input[placeholder*="KEY"], input[placeholder*="key"], input[placeholder*="Key"], '
-                'input[placeholder*="Name"], input[placeholder*="name"], '
-                'input[placeholder*="Variable"], input[placeholder*="variable"]'
-            ).all()
-            if len(key_inputs) == 0:
-                row_inputs = page.locator('tr:last-child input, .qwenpaw-form-item input').all()
-                key_inputs = row_inputs
-            if len(key_inputs) == 0:
-                logger.info("Step 3 Key input not found, skipping test")
-                log_test_result(test_name, True, 0)
-                return
-            last_key_input = key_inputs[-1]
-            last_key_input.fill(duplicate_key)
-            page.wait_for_timeout(1000)
-            logger.info(f"Second duplicate Key filled: {duplicate_key}")
+            log_test_step("7. Verify the page is still healthy")
+            page_content = page.locator("body").inner_text()
+            assert len(page_content) > 0, "Page content should not be empty"
+            expect(page.locator(ADD_VARIABLE_BTN).first).to_be_visible(timeout=5000)
+            logger.info("Page remained healthy after the rejected duplicates")
 
-            log_test_step("4. Verify duplicate Key error message")
-            # Try saving to trigger validation
-            save_btn = page.locator('button:has-text("Save"), button:has-text("保存")').first
-            if save_btn.count() > 0 and save_btn.is_visible():
-                save_btn.click()
-                page.wait_for_timeout(1500)
-
-            # Check for error indicators (red border, error text, etc.)
-            error_indicators = page.locator(
-                '.qwenpaw-form-item-has-error, '
-                '[style*="border-color: red"], '
-                '[style*="color: red"], '
-                '.qwenpaw-form-item-explain-error, '
-                ':text("重复"), :text("duplicate"), :text("Duplicate")'
-            ).all()
-
-            has_error = len(error_indicators) > 0
-            if has_error:
-                logger.info(f"Detected {len(error_indicators)} duplicate Key error indicators")
-            else:
-                # Verify the page is still healthy after save (may have auto-deduped or saved successfully)
-                page.wait_for_timeout(1000)
-                key_inputs_after = page.locator(
-                    'input[placeholder*="KEY"], input[placeholder*="key"], input[placeholder*="Key"], '
-                    'input[placeholder*="Name"], input[placeholder*="name"], '
-                    'input[placeholder*="Variable"], input[placeholder*="variable"]'
-                ).all()
-                if len(key_inputs_after) > 0:
-                    duplicate_count = sum(1 for inp in key_inputs_after if inp.input_value() == duplicate_key)
-                    logger.info(f"Found {duplicate_count} rows with the same Key after save")
-                else:
-                    logger.info("Inputs cleared after save (may be auto-deduped or page refreshed)")
-                # Just verify page didn't crash
-                page_content = page.locator('body').inner_text()
-                assert len(page_content) > 0, "Page content should not be empty"
-                logger.info("Page remained healthy, duplicate Key detection verification complete")
+            log_test_step("8. Delete the test variable through the UI")
+            delete_variable_via_ui(page, duplicate_key)
+            expect(row_for_key(page, duplicate_key)).to_have_count(0, timeout=10000)
+            assert get_custom_var_count(page) == initial_count, (
+                "Count should be back to the initial value after cleanup"
+            )
+            logger.info("Test variable deleted")
 
             log_test_result(test_name, True, 0)
 
         finally:
-            # Cleanup: delete rows containing the test Key and save
-            try:
-                log_test_step("Cleanup: delete test rows")
-                navigate_to_environments(page)
-                fresh_rows = page.locator(ROW_SELECTOR).all()
-                deleted_count = 0
-                for row in fresh_rows:
-                    row_key_input = row.locator(KEY_INPUT_SELECTOR).first
-                    if row_key_input.is_visible():
-                        row_key = row_key_input.input_value()
-                        if row_key == duplicate_key:
-                            delete_btn = row.locator(DELETE_ROW_BTN_SELECTOR).first
-                            if delete_btn.is_visible(timeout=3000):
-                                delete_btn.click()
-                                page.wait_for_timeout(500)
-                                deleted_count += 1
-                if deleted_count > 0:
-                    click_save_button(page)
-                    logger.info(f"Deleted {deleted_count} test rows and saved")
-            except Exception as cleanup_error:
-                logger.warning(f"Cleanup of test rows failed: {cleanup_error}")
+            # Cleanup: make sure the test key is gone even on failure
+            log_test_step("Cleanup: delete test variable")
+            cleanup_env_var(page, api_context, duplicate_key)


### PR DESCRIPTION
> **Submitted by**: 李时珍·E2E@QPQAT

## What this PR does

Upstream #7538 (`76bfb704`) rebuilt the Environments page from a table with
inline editing into a unified environment-variable page (three sections plus
modal-based editing). That left 11 cases in `e2e/tests/test_environments.py`
failing deterministically in nightly — each still red after 3-4 reruns, so it
was a real selector/interaction mismatch rather than flakiness.

This PR rebuilds that suite's row anchors, interaction model and assertions
against the new UI.

It also fixes one **independent defect that had nothing to do with #7538 and
had been latent for three months**: CROSS-005 in `e2e/tests/test_cross_module.py`
has navigated to a route that never existed (`/settings/runtime-config`, zero
hits across the whole frontend history) since the day it was migrated in
2026-05-29, and its step 4 only logged instead of asserting — so a blank page
still "passed". #7538 merely broke the other half of that case (the row count),
which is what exposed the older problem. The two root causes are different, so
they are described separately here to avoid reading this as blaming a
three-month-old mistake on the recent rebuild.

## Changes (3 files, +1733/-787)

| File | Change |
| --- | --- |
| `e2e/tests/test_environments.py` | Rebuild all 11 cases: row anchor `div[class*="__row__"]`; locate rows by key text (all three sections share the row class, so `.last` would pick the wrong section); `aria-label` action buttons (Edit/Delete/Reset); search box `input[aria-label="Search variables"]`; show-value button; modal `Apply now` for write confirmation; `Modal.confirm` for delete confirmation; validation copy `Invalid key format` / `Duplicate key` |
| `e2e/pages/environments_page.py` | Rebuild the page object in step. This file was previously dead code but still exported; it is now genuinely usable |
| `e2e/tests/test_cross_module.py` | Four fixes to CROSS-005: ① `goto` the authoritative route `/agent-config` (`builtinRoutes.tsx` maps `core.agent-config` → `/agent-config`, matching `runtime_config_page.py:31` and `test_runtime_config.py:23`) ② step 4 becomes a hard assertion that the `llmRetry` and `llmRateLimiter` tabs are `to_be_visible` (anchors `[data-node-key=...]` come from `Agent/Config/index.tsx` and are already proven green by `test_runtime_config.py`, so no new selector idiom is introduced) ③ new row anchor plus a real load wait ④ the lower-bound assertion is upgraded to a self-consistent invariant: row count == sum of the three section-heading counts. Two independent reads of the same quantity, so any anchor drift makes them disagree. Deliberately **not** hardcoded to 17, which would fail in both directions once upstream adds a section |

## Two cases have their intent redefined (please review this part)

The new UI **removed three product features** — multi-row checkboxes, row
insertion, and batch selection. This is not a selector mismatch: the thing
under test no longer exists. Both cases keep their class name and `test_id`
(so historical reports stay comparable and the selected set is unchanged) and
are redefined instead:

- **ENV-005** (`TestEnvVarMultiRowAndCheckbox`) now covers: create several
  variables in a row, locate each row by key, reveal a value, delete a single
  row, reload and confirm persistence.
- **ENV-008** (`TestBatchOperations`) now covers: create 3 rows, filter with
  the new search box, delete them one by one back to the baseline.

Both scope changes are recorded in the class docstrings and stated here
explicitly, so this cannot be read as silently deleting cases to go green.

## What CROSS-005 deliberately does not assert (stated in the docstring)

#7538 did connect the two layers (`AgentsRunningConfig` now reads its default
from `EnvVarLoader`), but that default is only consulted when an agent has no
persisted running config. For any already-configured agent the page shows the
stored value and never follows the environment. Asserting "change an env var →
the number on the config page changes" would be inherently flaky, so this case
only verifies that both pages render correctly and that navigating between
them does not interfere.

## Verification

1. **Fork CI green on all three shards** (head `14ddd621`): runs `34167593651`
   (p0), `34167599159` (p1), `34167604862` (p2), plus Pre-commit Checks and
   NPM Format. The previous head `8d08385f` was green on all three as well.
   p2 reported `0 failed` with **rerun=0** — before this fix those same 3 cases
   each reran 3-4 times and stayed red, so the green is not a retry artifact.
2. **No effect on the shard gate**: selection is `71/105/47`, and the collected
   node IDs are **identical to the baseline one by one** (verified by md5 of
   `--collect-only` output for each shard against the merge-base worktree).
   No marker was touched and no case was added or removed. The identity
   `deselected + selected = collected = 239` holds on all three shards.
3. **Local probes**: a static probe that reconstructs the DOM element by
   element from upstream source passes `probe_selectors.py` 47/47 and
   `probe_page_object.py` 14/14. Selectors are imported from the test module
   rather than retyped. The probes additionally caught two real defects of my
   own, now fixed: a confirm-button selector that split its alternatives with a
   comma instead of building separate branches, and antd keeping the Modal in
   the DOM after close, which made `to_have_count(0)` never pass.
4. **Coverage boundary stated honestly**: the probes only prove that the
   selector syntax is correct and matches the expected nodes on a faithfully
   reconstructed DOM. They cannot prove the real product DOM matches that
   reconstruction — that risk is closed by fork CI, which builds the real
   console.
5. **Re-verified against current upstream `main` before opening this PR**: the
   15 commits upstream advanced since this branch's base touch `e2e/` **zero**
   times, and `console/src/pages/Settings/Environments/` zero times, so no
   rebase is needed (`git merge-tree` reports no conflict). Each anchor this
   suite depends on was re-checked at the right layer on `upstream/main`:
   `.row` still exists in `index.module.less` (compiling to
   `index-module__row__<hash>`), `searchPlaceholder: "Search variables"` and
   `applyNow: "Apply now"` still exist in `locales/en.json`, and
   `core.agent-config` → `/agent-config` still exists in `builtinRoutes.tsx`.

## Risk and blast radius

- No tier marker changed and no case added or removed, so the nightly
  three-way shard split is unaffected.
- No test file outside `test_environments.py` is touched, except CROSS-005 in
  `test_cross_module.py`, which is explicitly in scope for this PR.
- No product code is changed; this is test-side only.
