### PR TITLE
fix(console): align qwenpaw CSS selectors

### DIFF
--- a/console/src/pages/Coding/GitPanel.module.less
+++ b/console/src/pages/Coding/GitPanel.module.less
@@ -25,6 +25,7 @@
   flex: 1;
   min-width: 0;
 
+  :global(.qwenpaw-select-selector),
   :global(.ant-select-selector) {
     font-size: 12px !important;
   }
@@ -44,17 +45,20 @@
   display: flex;
   flex-direction: column;
 
+  :global(.qwenpaw-tabs-nav),
   :global(.ant-tabs-nav) {
     margin-bottom: 0;
     padding: 0 8px;
   }
 
+  :global(.qwenpaw-tabs-content-holder),
   :global(.ant-tabs-content-holder) {
     flex: 1;
     overflow-y: auto;
     min-height: 0;
   }
 
+  :global(.qwenpaw-tabs-tabpane),
   :global(.ant-tabs-tabpane) {
     height: 100%;
   }

--- a/console/src/styles/form-override.css
+++ b/console/src/styles/form-override.css
@@ -4,6 +4,7 @@
  */
 
 /* Protect red asterisk for Ant Design form required marks */
+.qwenpaw-form-item-required::before,
 .ant-form-item-required::before {
   color: #ff4d4f !important;
 }


### PR DESCRIPTION
Fixed an issue where some global styles failed to apply when `prefixCls="qwenpaw"` was used for the Console, as they were still relying on `.ant-*` selectors.
Changes:
- Added `qwenpaw-*` selectors for GitPanel's Select and Tabs components.
- Added the `.qwenpaw-form-item-required` style for form required-field markers.
- Retained `.ant-*` selectors to ensure compatibility with components explicitly using `prefixCls="ant"`.

Fixes #5688
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
