### PR TITLE
fix(channels): support Base64 data URLs in outbound media

### DIFF
--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -27,7 +27,7 @@ from ....exceptions import ChannelError
 from ....constant import DEFAULT_MEDIA_DIR
 from ....config.config import DiscordConfig as DiscordChannelConfig
 
-from ..utils import file_url_to_local_path
+from ..utils import file_url_to_local_path, materialize_data_url
 from ..renderer import ChannelDisplayConfig
 from ..base import (
     BaseChannel,
@@ -638,7 +638,7 @@ class DiscordChannel(BaseChannel):
         for m in media_parts:
             await self.send_media(to_handle, m, meta)
 
-    async def send_media(
+    async def send_media(  # pylint: disable=too-many-return-statements
         self,
         to_handle: str,
         part: OutgoingContentPart,
@@ -663,6 +663,17 @@ class DiscordChannel(BaseChannel):
             logger.warning(
                 "discord send_media: cannot resolve target",
             )
+            return
+
+        if url.startswith("data:"):
+            with materialize_data_url(
+                url,
+                self._media_dir,
+                filename_hint=getattr(part, "filename", "image"),
+            ) as local_path:
+                if not local_path:
+                    return
+                await target.send(file=discord.File(local_path))
             return
 
         temp_path = None

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -666,14 +666,21 @@ class DiscordChannel(BaseChannel):
             return
 
         if url.startswith("data:"):
-            with materialize_data_url(
+            async with materialize_data_url(
                 url,
                 self._media_dir,
                 filename_hint=getattr(part, "filename", "image"),
-            ) as local_path:
-                if not local_path:
+            ) as media:
+                if media is None:
                     return
-                await target.send(file=discord.File(local_path))
+                attachment = discord.File(
+                    media.path,
+                    filename=media.filename,
+                )
+                try:
+                    await target.send(file=attachment)
+                finally:
+                    attachment.close()
             return
 
         temp_path = None

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -72,6 +72,7 @@ from qwenpaw.schemas import (
 from ....app.channels.renderer import ChannelDisplayConfig
 from ....app.channels.base import BaseChannel
 from ....app.channels.utils import file_url_to_local_path
+from ....app.channels.utils import parse_data_url
 from ....constant import WORKING_DIR
 
 logger = logging.getLogger("qwenpaw.channels.matrix")
@@ -2375,6 +2376,24 @@ class MatrixChannel(BaseChannel):
         if not self._client:
             return None
         try:
+            data_media = parse_data_url(file_ref)
+            if data_media is not None:
+                data = data_media.data
+                mime_type = data_media.media_type
+                filename = f"file{data_media.suffix}"
+                resp, _ = await self._client.upload(
+                    io.BytesIO(data),
+                    content_type=mime_type,
+                    filename=filename,
+                    filesize=len(data),
+                )
+                if isinstance(resp, UploadResponse):
+                    return resp.content_uri
+                logger.warning(
+                    f"MatrixChannel: data URL upload failed: {resp}",
+                )
+                return None
+
             # file_ref may be a file:// URI or a plain path
             path = Path(file_url_to_local_path(file_ref) or file_ref)
             if not path.exists():

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -72,7 +72,7 @@ from qwenpaw.schemas import (
 from ....app.channels.renderer import ChannelDisplayConfig
 from ....app.channels.base import BaseChannel
 from ....app.channels.utils import file_url_to_local_path
-from ....app.channels.utils import parse_data_url
+from ....app.channels.utils import data_url_filename, parse_data_url_async
 from ....constant import WORKING_DIR
 
 logger = logging.getLogger("qwenpaw.channels.matrix")
@@ -178,6 +178,16 @@ def _md_to_html(text: str) -> str:
 HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - for context]"
 CURRENT_MESSAGE_MARKER = "[Current message - respond to this]"
 DEFAULT_HISTORY_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class _UploadedMedia:
+    """Metadata shared by the media upload and its room event."""
+
+    uri: str
+    filename: str
+    mime_type: str
+    size: int
 
 
 @dataclass
@@ -2371,16 +2381,20 @@ class MatrixChannel(BaseChannel):
     # send_media outbound path (same role as worker _upload_file).
     # ------------------------------------------------------------------
 
-    async def _upload_file(self, file_ref: str) -> Optional[str]:
-        """Upload a local file to Matrix; return mxc:// URI or None."""
+    async def _upload_file(
+        self,
+        file_ref: str,
+        filename_hint: Optional[str] = None,
+    ) -> Optional[_UploadedMedia]:
+        """Upload media and return the URI and metadata for its room event."""
         if not self._client:
             return None
         try:
-            data_media = parse_data_url(file_ref)
+            data_media = await parse_data_url_async(file_ref)
             if data_media is not None:
                 data = data_media.data
                 mime_type = data_media.media_type
-                filename = f"file{data_media.suffix}"
+                filename = data_url_filename(filename_hint, data_media.suffix)
                 resp, _ = await self._client.upload(
                     io.BytesIO(data),
                     content_type=mime_type,
@@ -2388,7 +2402,12 @@ class MatrixChannel(BaseChannel):
                     filesize=len(data),
                 )
                 if isinstance(resp, UploadResponse):
-                    return resp.content_uri
+                    return _UploadedMedia(
+                        uri=resp.content_uri,
+                        filename=filename,
+                        mime_type=mime_type,
+                        size=len(data),
+                    )
                 logger.warning(
                     f"MatrixChannel: data URL upload failed: {resp}",
                 )
@@ -2417,7 +2436,12 @@ class MatrixChannel(BaseChannel):
                     path.name,
                     resp.content_uri,
                 )
-                return resp.content_uri
+                return _UploadedMedia(
+                    uri=resp.content_uri,
+                    filename=path.name,
+                    mime_type=mime_type,
+                    size=len(data),
+                )
             logger.warning("MatrixChannel: upload failed: %s", resp)
             return None
         except Exception as exc:
@@ -3452,8 +3476,11 @@ class MatrixChannel(BaseChannel):
             return
 
         # Upload to Matrix media repository
-        mxc_uri = await self._upload_file(file_ref)
-        if not mxc_uri:
+        uploaded = await self._upload_file(
+            file_ref,
+            filename_hint=getattr(part, "filename", None),
+        )
+        if not uploaded:
             logger.warning(
                 "MatrixChannel: send_media upload failed for %s",
                 file_ref,
@@ -3462,22 +3489,13 @@ class MatrixChannel(BaseChannel):
 
         # Build and send the Matrix room event
         try:
-            path_str = file_url_to_local_path(file_ref) or file_ref
-            filename = os.path.basename(path_str) or "file"
-            mime_type, _ = mimetypes.guess_type(path_str)
-            mime_type = mime_type or "application/octet-stream"
-            try:
-                file_size = os.path.getsize(path_str)
-            except OSError:
-                file_size = 0
-
             event_content: dict[str, Any] = {
                 "msgtype": matrix_msgtype,
-                "body": filename,
-                "url": mxc_uri,
+                "body": uploaded.filename,
+                "url": uploaded.uri,
                 "info": {
-                    "mimetype": mime_type,
-                    "size": file_size,
+                    "mimetype": uploaded.mime_type,
+                    "size": uploaded.size,
                 },
             }
             sender_id = (meta or {}).get("sender_id") or (meta or {}).get(
@@ -3496,7 +3514,7 @@ class MatrixChannel(BaseChannel):
             logger.debug(
                 "MatrixChannel: sent %s %s to %s",
                 matrix_msgtype,
-                filename,
+                uploaded.filename,
                 room_id,
             )
         except Exception as exc:

--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -29,7 +29,7 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import file_url_to_local_path
+from ..utils import file_url_to_local_path, materialize_data_url
 
 logger = logging.getLogger(__name__)
 
@@ -1030,18 +1030,25 @@ class MattermostChannel(BaseChannel):
 
         if not local_path:
             return
-        local_path = file_url_to_local_path(local_path) or local_path
-
-        file_id = await self._upload_file(mm_channel_id, local_path)
-        if file_id:
-            await self._post_message(mm_channel_id, "", root_id, [file_id])
-        else:
-            # Fallback: send file path as plain text
-            await self._post_message(
-                mm_channel_id,
-                f"[Attachment: {local_path}]",
-                root_id,
-            )
+        with materialize_data_url(
+            str(local_path),
+            self._media_dir,
+            filename_hint=getattr(part, "filename", "media"),
+        ) as materialized:
+            if not materialized:
+                return
+            local_path = file_url_to_local_path(materialized)
+            local_path = local_path or materialized
+            file_id = await self._upload_file(mm_channel_id, local_path)
+            if file_id:
+                await self._post_message(mm_channel_id, "", root_id, [file_id])
+            else:
+                # Fallback: send file path as plain text
+                await self._post_message(
+                    mm_channel_id,
+                    f"[Attachment: {local_path}]",
+                    root_id,
+                )
 
     # ------------------------------------------------------------------
     # BaseChannel interface

--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -879,6 +879,7 @@ class MattermostChannel(BaseChannel):
         self,
         mm_channel_id: str,
         local_path: str,
+        filename: Optional[str] = None,
     ) -> Optional[str]:
         """Upload a local file; return Mattermost file_id or None.
 
@@ -898,7 +899,7 @@ class MattermostChannel(BaseChannel):
                 resp = await self._http.post(
                     f"{self._url}/api/v4/files",
                     params={"channel_id": mm_channel_id},
-                    files={"files": (path.name, fh)},
+                    files={"files": (filename or path.name, fh)},
                     # No json= here; httpx handles Content-Type automatically
                 )
             if resp.status_code in (200, 201):
@@ -1030,16 +1031,23 @@ class MattermostChannel(BaseChannel):
 
         if not local_path:
             return
-        with materialize_data_url(
+        async with materialize_data_url(
             str(local_path),
             self._media_dir,
             filename_hint=getattr(part, "filename", "media"),
         ) as materialized:
-            if not materialized:
+            if materialized is None:
                 return
-            local_path = file_url_to_local_path(materialized)
-            local_path = local_path or materialized
-            file_id = await self._upload_file(mm_channel_id, local_path)
+            local_path = file_url_to_local_path(materialized.path)
+            local_path = local_path or materialized.path
+            if materialized.filename is not None:
+                file_id = await self._upload_file(
+                    mm_channel_id,
+                    local_path,
+                    filename=materialized.filename,
+                )
+            else:
+                file_id = await self._upload_file(mm_channel_id, local_path)
             if file_id:
                 await self._post_message(mm_channel_id, "", root_id, [file_id])
             else:

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -48,7 +48,7 @@ from ..base import (
 from ..utils import (
     file_url_to_local_path,
     materialize_data_url,
-    parse_data_url,
+    parse_data_url_async,
     split_text,
 )
 
@@ -564,6 +564,7 @@ async def _send_guild_image_file_async(
     path: str,
     file_path: str,
     msg_id: Optional[str] = None,
+    filename: Optional[str] = None,
 ) -> None:
     """Send an image in guild/dm via form-data ``file_image`` upload.
 
@@ -583,7 +584,7 @@ async def _send_guild_image_file_async(
     data.add_field(
         "file_image",
         file_bytes,
-        filename=Path(file_path).name,
+        filename=filename or Path(file_path).name,
     )
     async with session.post(
         api_url,
@@ -2309,13 +2310,17 @@ class QQChannel(BaseChannel):
                 return
         elif url and url.startswith("data:"):
             try:
-                data_media = parse_data_url(url)
+                data_media = await parse_data_url_async(url)
             except ValueError as exc:
                 logger.warning(f"qq: invalid media data URL: {exc}")
                 return
             if data_media is None:
                 return
-            file_data = base64.b64encode(data_media.data).decode("ascii")
+            encoded = await asyncio.to_thread(
+                base64.b64encode,
+                data_media.data,
+            )
+            file_data = await asyncio.to_thread(encoded.decode, "ascii")
             display_filename = f"file{data_media.suffix}"
         elif url:
             display_filename = Path(url.split("?")[0]).name
@@ -2396,19 +2401,20 @@ class QQChannel(BaseChannel):
 
         try:
             if url and url.startswith("data:"):
-                with materialize_data_url(
+                async with materialize_data_url(
                     url,
                     self._media_dir,
                     filename_hint="image",
-                ) as materialized_path:
-                    if not materialized_path:
+                ) as media:
+                    if media is None:
                         return
                     await _send_guild_image_file_async(
                         self._http,
                         token,
                         path,
-                        materialized_path,
+                        media.path,
                         msg_id,
+                        filename=media.filename,
                     )
             elif url:
                 await _send_guild_image_async(

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -45,7 +45,12 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import file_url_to_local_path, split_text
+from ..utils import (
+    file_url_to_local_path,
+    materialize_data_url,
+    parse_data_url,
+    split_text,
+)
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -2249,6 +2254,7 @@ class QQChannel(BaseChannel):
                 message_type,
             )
 
+    # pylint: disable=too-many-return-statements
     async def _send_media_c2c_or_group(
         self,
         *,
@@ -2301,6 +2307,16 @@ class QQChannel(BaseChannel):
                     local_path,
                 )
                 return
+        elif url and url.startswith("data:"):
+            try:
+                data_media = parse_data_url(url)
+            except ValueError as exc:
+                logger.warning(f"qq: invalid media data URL: {exc}")
+                return
+            if data_media is None:
+                return
+            file_data = base64.b64encode(data_media.data).decode("ascii")
+            display_filename = f"file{data_media.suffix}"
         elif url:
             display_filename = Path(url.split("?")[0]).name
 
@@ -2379,7 +2395,22 @@ class QQChannel(BaseChannel):
             return
 
         try:
-            if url:
+            if url and url.startswith("data:"):
+                with materialize_data_url(
+                    url,
+                    self._media_dir,
+                    filename_hint="image",
+                ) as materialized_path:
+                    if not materialized_path:
+                        return
+                    await _send_guild_image_file_async(
+                        self._http,
+                        token,
+                        path,
+                        materialized_path,
+                        msg_id,
+                    )
+            elif url:
                 await _send_guild_image_async(
                     self._http,
                     token,

--- a/src/qwenpaw/app/channels/slack/sender.py
+++ b/src/qwenpaw/app/channels/slack/sender.py
@@ -254,7 +254,10 @@ class SlackSender:
     ) -> Optional[str]:
         """Upload an image via ``files.uploadV2``."""
         url: Optional[str] = getattr(part, "image_url", None)
-        filename = getattr(part, "filename", None) or "image.png"
+        default_name = (
+            "image" if url and url.startswith("data:") else "image.png"
+        )
+        filename = getattr(part, "filename", None) or default_name
 
         if not url:
             logger.warning("slack send: image has no url")
@@ -284,7 +287,7 @@ class SlackSender:
             or getattr(part, "video_url", None)
         )
         filename = getattr(part, "filename", None)
-        if not filename and url:
+        if not filename and url and not url.startswith("data:"):
             filename = os.path.basename(url) or "file"
         filename = filename or "file"
 
@@ -320,19 +323,21 @@ class SlackSender:
         * Other remote URL → blocked (SSRF).
         """
         if url.startswith("data:"):
-            with materialize_data_url(
+            async with materialize_data_url(
                 url,
                 self._channel.media_dir,
                 filename_hint=filename,
-            ) as local_path:
-                if not local_path:
+            ) as media:
+                if media is None:
                     return None
                 return await self._upload_file_external(
                     client,
                     channel_id,
-                    local_path,
-                    filename,
-                    title=title,
+                    media.path,
+                    media.filename or filename,
+                    title=(media.filename or filename)
+                    if title == filename
+                    else title,
                     thread_ts=thread_ts,
                 )
 

--- a/src/qwenpaw/app/channels/slack/sender.py
+++ b/src/qwenpaw/app/channels/slack/sender.py
@@ -31,6 +31,7 @@ from .constants import (
 )
 from .format import chunk_slack_text, markdown_to_slack_mrkdwn
 from .utils import is_slack_host, with_retry
+from ..utils import materialize_data_url
 
 if TYPE_CHECKING:
     from slack_sdk.web.async_client import AsyncWebClient
@@ -318,6 +319,23 @@ class SlackSender:
         * Remote URL on Slack's domain → ``files.uploadV2``.
         * Other remote URL → blocked (SSRF).
         """
+        if url.startswith("data:"):
+            with materialize_data_url(
+                url,
+                self._channel.media_dir,
+                filename_hint=filename,
+            ) as local_path:
+                if not local_path:
+                    return None
+                return await self._upload_file_external(
+                    client,
+                    channel_id,
+                    local_path,
+                    filename,
+                    title=title,
+                    thread_ts=thread_ts,
+                )
+
         local_path = _resolve_local_file_path(url)
         if local_path:
             return await self._upload_file_external(

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -12,7 +12,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from telegram import BotCommand
+from telegram import BotCommand, InputFile
 from telegram.constants import ParseMode
 from telegram.error import (
     BadRequest,
@@ -35,7 +35,12 @@ from qwenpaw.schemas import (
 from ....config.config import TelegramConfig as TelegramChannelConfig
 from ....constant import WORKING_DIR
 from .format_html import markdown_to_telegram_html
-from ..utils import file_url_to_local_path, materialize_data_url
+from ..utils import (
+    MediaDataError,
+    data_url_filename,
+    file_url_to_local_path,
+    parse_data_url_async,
+)
 from ..renderer import ChannelDisplayConfig
 from ..base import (
     BaseChannel,
@@ -851,6 +856,7 @@ class TelegramChannel(BaseChannel):
                     method_name="send_document",
                     payload_name="document",
                     message_thread_id=message_thread_id,
+                    filename_hint=getattr(part, "filename", None),
                 )
         except _FileTooLargeError as exc:
             logger.warning("telegram send_media: file too large: %s", exc)
@@ -1215,28 +1221,34 @@ class TelegramChannel(BaseChannel):
         method_name: str,
         payload_name: str,
         message_thread_id: Optional[int],
+        filename_hint: Optional[str] = None,
     ) -> None:
         """Send media from URL or local file path."""
         if not value:
             return
         if isinstance(value, str) and value.startswith("data:"):
-            with materialize_data_url(
-                value,
-                self._media_dir,
-                filename_hint=payload_name,
-            ) as local_path:
-                if not local_path:
-                    raise _MediaFileUnavailableError(
-                        "Could not decode media data URL.",
-                    )
-                await self._send_media_value(
-                    bot=bot,
-                    chat_id=chat_id,
-                    value=f"file://{local_path}",
-                    method_name=method_name,
-                    payload_name=payload_name,
-                    message_thread_id=message_thread_id,
+            try:
+                media = await parse_data_url_async(value)
+            except MediaDataError as exc:
+                raise _MediaFileUnavailableError(
+                    "Could not decode media data URL.",
+                ) from exc
+            if media is None:
+                raise _MediaFileUnavailableError(
+                    "Could not decode media data URL.",
                 )
+            filename = data_url_filename(
+                filename_hint or payload_name,
+                media.suffix,
+            )
+            await self._send_media_payload(
+                bot=bot,
+                chat_id=chat_id,
+                payload=InputFile(media.data, filename=filename),
+                method_name=method_name,
+                payload_name=payload_name,
+                message_thread_id=message_thread_id,
+            )
             return
         if isinstance(value, str) and value.startswith("file://"):
             raw_path = file_url_to_local_path(value)

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -35,7 +35,7 @@ from qwenpaw.schemas import (
 from ....config.config import TelegramConfig as TelegramChannelConfig
 from ....constant import WORKING_DIR
 from .format_html import markdown_to_telegram_html
-from ..utils import file_url_to_local_path
+from ..utils import file_url_to_local_path, materialize_data_url
 from ..renderer import ChannelDisplayConfig
 from ..base import (
     BaseChannel,
@@ -1218,6 +1218,25 @@ class TelegramChannel(BaseChannel):
     ) -> None:
         """Send media from URL or local file path."""
         if not value:
+            return
+        if isinstance(value, str) and value.startswith("data:"):
+            with materialize_data_url(
+                value,
+                self._media_dir,
+                filename_hint=payload_name,
+            ) as local_path:
+                if not local_path:
+                    raise _MediaFileUnavailableError(
+                        "Could not decode media data URL.",
+                    )
+                await self._send_media_value(
+                    bot=bot,
+                    chat_id=chat_id,
+                    value=f"file://{local_path}",
+                    method_name=method_name,
+                    payload_name=payload_name,
+                    message_thread_id=message_thread_id,
+                )
             return
         if isinstance(value, str) and value.startswith("file://"):
             raw_path = file_url_to_local_path(value)

--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -8,9 +8,138 @@ from __future__ import annotations
 
 import os
 import re
-from typing import List, Optional, Tuple
+import base64
+import binascii
+import logging
+import mimetypes
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATA_URL_MAX_BYTES = 50 * 1024 * 1024
+_SAFE_MEDIA_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_DEFAULT_MEDIA_SUFFIXES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "audio/mpeg": ".mp3",
+    "audio/wav": ".wav",
+    "audio/ogg": ".ogg",
+    "video/mp4": ".mp4",
+}
+
+
+class MediaDataError(ValueError):
+    """Raised when a data URL cannot be safely decoded."""
+
+
+@dataclass(frozen=True)
+class DataUrlMedia:
+    """Decoded media data and its normalized MIME metadata."""
+
+    data: bytes
+    media_type: str
+    suffix: str
+
+    @property
+    def size(self) -> int:
+        """Return the decoded byte count."""
+        return len(self.data)
+
+
+def parse_data_url(
+    value: str,
+    *,
+    max_bytes: int = DEFAULT_DATA_URL_MAX_BYTES,
+) -> Optional[DataUrlMedia]:
+    """Decode a Base64 data URL, or return None for other references."""
+    if not isinstance(value, str) or not value.startswith("data:"):
+        return None
+
+    try:
+        header, encoded = value[5:].split(",", 1)
+    except ValueError as exc:
+        raise MediaDataError("data URL is missing a payload") from exc
+
+    header_parts = [part.strip().lower() for part in header.split(";")]
+    media_type = header_parts[0] or "application/octet-stream"
+    if "base64" not in header_parts[1:]:
+        raise MediaDataError("data URL is not Base64 encoded")
+
+    compact = "".join(encoded.split())
+    if not compact:
+        raise MediaDataError("data URL has an empty Base64 payload")
+    estimated_size = (len(compact) * 3) // 4
+    estimated_size -= compact.endswith("=")
+    estimated_size -= compact.endswith("==")
+    if estimated_size > max_bytes:
+        raise MediaDataError(
+            f"data URL exceeds the {max_bytes} byte size limit",
+        )
+
+    try:
+        data = base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise MediaDataError("data URL contains invalid Base64") from exc
+    if len(data) > max_bytes:
+        raise MediaDataError(
+            f"data URL exceeds the {max_bytes} byte size limit",
+        )
+
+    suffix = mimetypes.guess_extension(media_type, strict=False)
+    suffix = suffix or _DEFAULT_MEDIA_SUFFIXES.get(media_type, ".bin")
+    return DataUrlMedia(data=data, media_type=media_type, suffix=suffix)
+
+
+def _safe_media_stem(filename_hint: str) -> str:
+    """Return a portable filename stem for a generated media file."""
+    stem = Path(filename_hint or "media").stem
+    stem = _SAFE_MEDIA_NAME_RE.sub("_", stem).strip("._")
+    return (stem or "media")[:64]
+
+
+@contextmanager
+def materialize_data_url(
+    value: str,
+    directory: Path,
+    *,
+    filename_hint: str = "",
+    max_bytes: int = DEFAULT_DATA_URL_MAX_BYTES,
+) -> Iterator[str]:
+    """Yield a local path for a data URL and remove it after use."""
+    try:
+        media = parse_data_url(value, max_bytes=max_bytes)
+    except MediaDataError as exc:
+        logger.warning(f"media data URL rejected: {exc}")
+        yield ""
+        return
+    if media is None:
+        yield value
+        return
+
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, path = tempfile.mkstemp(
+        prefix=f"outbound_{_safe_media_stem(filename_hint)}_",
+        suffix=media.suffix,
+        dir=str(directory),
+    )
+    try:
+        with os.fdopen(fd, "wb") as media_file:
+            media_file.write(media.data)
+        yield path
+    finally:
+        try:
+            Path(path).unlink(missing_ok=True)
+        except OSError:
+            pass
+
 
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 

--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -8,22 +8,23 @@ from __future__ import annotations
 
 import os
 import re
+import asyncio
 import base64
 import binascii
 import logging
 import mimetypes
 import tempfile
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Iterator, List, Optional, Tuple
+from pathlib import Path, PureWindowsPath
+from typing import AsyncIterator, List, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_DATA_URL_MAX_BYTES = 50 * 1024 * 1024
-_SAFE_MEDIA_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_UNSAFE_MEDIA_NAME_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 _DEFAULT_MEDIA_SUFFIXES = {
     "image/jpeg": ".jpg",
     "image/png": ".png",
@@ -54,6 +55,14 @@ class DataUrlMedia:
         return len(self.data)
 
 
+@dataclass(frozen=True)
+class MaterializedMedia:
+    """Upload path and optional display name for an owned temporary file."""
+
+    path: str
+    filename: Optional[str] = None
+
+
 def parse_data_url(
     value: str,
     *,
@@ -64,11 +73,11 @@ def parse_data_url(
         return None
 
     try:
-        header, encoded = value[5:].split(",", 1)
+        header, encoded = value.split(",", 1)
     except ValueError as exc:
         raise MediaDataError("data URL is missing a payload") from exc
 
-    header_parts = [part.strip().lower() for part in header.split(";")]
+    header_parts = [part.strip().lower() for part in header[5:].split(";")]
     media_type = header_parts[0] or "application/octet-stream"
     if "base64" not in header_parts[1:]:
         raise MediaDataError("data URL is not Base64 encoded")
@@ -98,47 +107,100 @@ def parse_data_url(
     return DataUrlMedia(data=data, media_type=media_type, suffix=suffix)
 
 
-def _safe_media_stem(filename_hint: str) -> str:
-    """Return a portable filename stem for a generated media file."""
-    stem = Path(filename_hint or "media").stem
-    stem = _SAFE_MEDIA_NAME_RE.sub("_", stem).strip("._")
-    return (stem or "media")[:64]
+async def parse_data_url_async(
+    value: str,
+    *,
+    max_bytes: int = DEFAULT_DATA_URL_MAX_BYTES,
+) -> Optional[DataUrlMedia]:
+    """Decode data references in a worker; pass other references through."""
+    if not isinstance(value, str) or not value.startswith("data:"):
+        return None
+    return await asyncio.to_thread(
+        parse_data_url,
+        value,
+        max_bytes=max_bytes,
+    )
 
 
-@contextmanager
-def materialize_data_url(
+def data_url_filename(filename_hint: Optional[str], suffix: str) -> str:
+    """Choose a display basename independently of the temporary path."""
+    name = PureWindowsPath(filename_hint or "").name
+    name = _UNSAFE_MEDIA_NAME_RE.sub("_", name).strip(" .")
+    if not name:
+        return f"file{suffix}"
+    return name if Path(name).suffix else f"{name}{suffix}"
+
+
+def _materialize_data_url(
     value: str,
     directory: Path,
-    *,
-    filename_hint: str = "",
-    max_bytes: int = DEFAULT_DATA_URL_MAX_BYTES,
-) -> Iterator[str]:
-    """Yield a local path for a data URL and remove it after use."""
+    filename_hint: Optional[str],
+    max_bytes: int,
+) -> Optional[MaterializedMedia]:
+    """Decode and write one owned temporary file in a worker thread."""
     try:
         media = parse_data_url(value, max_bytes=max_bytes)
     except MediaDataError as exc:
         logger.warning(f"media data URL rejected: {exc}")
-        yield ""
-        return
+        return None
     if media is None:
-        yield value
-        return
+        return None
 
     directory.mkdir(parents=True, exist_ok=True)
     fd, path = tempfile.mkstemp(
-        prefix=f"outbound_{_safe_media_stem(filename_hint)}_",
+        prefix="outbound_",
         suffix=media.suffix,
         dir=str(directory),
     )
     try:
         with os.fdopen(fd, "wb") as media_file:
             media_file.write(media.data)
-        yield path
+        return MaterializedMedia(
+            path=path,
+            filename=data_url_filename(filename_hint, media.suffix),
+        )
+    except BaseException:
+        _remove_media_file(path)
+        raise
+
+
+def _remove_media_file(path: str) -> None:
+    """Remove an owned temporary upload file, tolerating OS errors."""
+    try:
+        Path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+@asynccontextmanager
+async def materialize_data_url(
+    value: str,
+    directory: Path,
+    *,
+    filename_hint: Optional[str] = None,
+    max_bytes: int = DEFAULT_DATA_URL_MAX_BYTES,
+) -> AsyncIterator[Optional[MaterializedMedia]]:
+    """Prepare media off-loop and clean up only owned temporary files."""
+    if not isinstance(value, str) or not value.startswith("data:"):
+        yield MaterializedMedia(path=value)
+        return
+
+    task = asyncio.create_task(
+        asyncio.to_thread(
+            _materialize_data_url,
+            value,
+            directory,
+            filename_hint,
+            max_bytes,
+        ),
+    )
+    try:
+        yield await asyncio.shield(task)
     finally:
-        try:
-            Path(path).unlink(missing_ok=True)
-        except OSError:
-            pass
+        # A cancelled sender must wait for creation before removing the file.
+        materialized = await task
+        if materialized is not None:
+            await asyncio.to_thread(_remove_media_file, materialized.path)
 
 
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1142,6 +1142,7 @@ class WeChatChannel(BaseChannel):
         file_path: str,
         content_type: ContentType,
         send_meta: Optional[Dict[str, Any]] = None,
+        filename: Optional[str] = None,
     ) -> None:
         """Send a media file (image/file/video) to WeChat.
 
@@ -1159,16 +1160,16 @@ class WeChatChannel(BaseChannel):
             return
 
         try:
-            with materialize_data_url(
+            async with materialize_data_url(
                 file_path,
                 self._media_dir,
-                filename_hint=getattr(file_path, "name", "media"),
+                filename_hint=filename,
             ) as materialized:
-                if not materialized:
+                if materialized is None or not materialized.path:
                     return
                 # Convert URL to local path if it's a file:// URL
-                local_path = file_url_to_local_path(materialized)
-                local_path = local_path or materialized
+                local_path = file_url_to_local_path(materialized.path)
+                local_path = local_path or materialized.path
 
                 # Check if file exists
                 path_obj = Path(local_path)
@@ -1188,7 +1189,7 @@ class WeChatChannel(BaseChannel):
                         context_token,
                     )
                 elif content_type == ContentType.FILE:
-                    filename = path_obj.name
+                    filename = materialized.filename or path_obj.name
                     resp = await self._client.send_file(
                         to_user_id,
                         str(path_obj),
@@ -1425,6 +1426,10 @@ class WeChatChannel(BaseChannel):
                         file_url,
                         ContentType.FILE,
                         send_meta=m,
+                        filename=getattr(p, "filename", None)
+                        or (
+                            p.get("filename") if isinstance(p, dict) else None
+                        ),
                     )
             elif t == ContentType.VIDEO:
                 # Send video

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -47,7 +47,11 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import file_url_to_local_path, split_text
+from ..utils import (
+    file_url_to_local_path,
+    materialize_data_url,
+    split_text,
+)
 from .client import ILinkClient, _DEFAULT_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -1155,46 +1159,54 @@ class WeChatChannel(BaseChannel):
             return
 
         try:
-            # Convert URL to local path if it's a file:// URL
-            file_path = file_url_to_local_path(file_path) or file_path
+            with materialize_data_url(
+                file_path,
+                self._media_dir,
+                filename_hint=getattr(file_path, "name", "media"),
+            ) as materialized:
+                if not materialized:
+                    return
+                # Convert URL to local path if it's a file:// URL
+                local_path = file_url_to_local_path(materialized)
+                local_path = local_path or materialized
 
-            # Check if file exists
-            path_obj = Path(file_path)
-            if not path_obj.exists():
-                logger.warning(
-                    "wechat _send_media_file: file not found: %s",
-                    file_path,
-                )
-                return
+                # Check if file exists
+                path_obj = Path(local_path)
+                if not path_obj.exists():
+                    logger.warning(
+                        f"wechat _send_media_file: file not found: "
+                        f"{local_path}",
+                    )
+                    return
 
-            # Send based on content type
-            resp: Optional[Dict[str, Any]] = None
-            if content_type == ContentType.IMAGE:
-                resp = await self._client.send_image(
-                    to_user_id,
-                    str(path_obj),
-                    context_token,
-                )
-            elif content_type == ContentType.FILE:
-                filename = path_obj.name
-                resp = await self._client.send_file(
-                    to_user_id,
-                    str(path_obj),
-                    filename,
-                    context_token,
-                )
-            elif content_type == ContentType.VIDEO:
-                resp = await self._client.send_video(
-                    to_user_id,
-                    str(path_obj),
-                    context_token,
-                )
-            else:
-                logger.warning(
-                    "wechat _send_media_file: unsupported content type: %s",
-                    content_type,
-                )
-                return
+                # Send based on content type
+                resp: Optional[Dict[str, Any]] = None
+                if content_type == ContentType.IMAGE:
+                    resp = await self._client.send_image(
+                        to_user_id,
+                        str(path_obj),
+                        context_token,
+                    )
+                elif content_type == ContentType.FILE:
+                    filename = path_obj.name
+                    resp = await self._client.send_file(
+                        to_user_id,
+                        str(path_obj),
+                        filename,
+                        context_token,
+                    )
+                elif content_type == ContentType.VIDEO:
+                    resp = await self._client.send_video(
+                        to_user_id,
+                        str(path_obj),
+                        context_token,
+                    )
+                else:
+                    logger.warning(
+                        f"wechat _send_media_file: unsupported type: "
+                        f"{content_type}",
+                    )
+                    return
 
             # Check response for errors (same logic as _send_text_direct)
             if isinstance(resp, dict):

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -47,7 +47,11 @@ from ..base import (
 )
 from .cards import WecomCardHandler
 from .utils import compress_image_for_wecom, format_markdown_tables
-from ..utils import file_url_to_local_path, split_text
+from ..utils import (
+    file_url_to_local_path,
+    materialize_data_url,
+    split_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -847,91 +851,96 @@ class WecomChannel(BaseChannel):
         """
         if not self._client or not self._upload_lock:
             return None
-        # Strip file:// prefix
-        local = file_url_to_local_path(path) or path
-        p = Path(local)
-        if not p.is_file():
-            logger.warning("wecom upload: file not found: %s", local[:80])
-            return None
+        filename_hint = getattr(path, "name", "") or "media"
+        with materialize_data_url(
+            path,
+            self._media_dir,
+            filename_hint=filename_hint,
+        ) as materialized:
+            # Strip file:// prefix
+            local = file_url_to_local_path(materialized) or materialized
+            p = Path(local)
+            if not p.is_file():
+                logger.warning(f"wecom upload: file not found: {local[:80]}")
+                return None
 
-        # Compress image if needed (WeCom has 2MB limit)
-        if media_type == "image":
-            data, filename = compress_image_for_wecom(local)
-        else:
-            data = p.read_bytes()
-            filename = p.name
+            # Compress image if needed (WeCom has 2MB limit)
+            if media_type == "image":
+                data, filename = compress_image_for_wecom(local)
+            else:
+                data = p.read_bytes()
+                filename = p.name
 
-        total_size = len(data)
-        md5 = hashlib.md5(data).hexdigest()
+            total_size = len(data)
+            md5 = hashlib.md5(data).hexdigest()
 
-        # Split into chunks
-        chunks: List[bytes] = [
-            data[i : i + _UPLOAD_CHUNK_SIZE]
-            for i in range(0, total_size, _UPLOAD_CHUNK_SIZE)
-        ]
-        total_chunks = len(chunks)
+            # Split into chunks
+            chunks: List[bytes] = [
+                data[i : i + _UPLOAD_CHUNK_SIZE]
+                for i in range(0, total_size, _UPLOAD_CHUNK_SIZE)
+            ]
+            total_chunks = len(chunks)
 
-        async with self._upload_lock:
-            try:
-                # Step 1: init
-                init_body = await self._send_ws_cmd(
-                    _UPLOAD_CMD_INIT,
-                    {
-                        "type": media_type,
-                        "filename": filename,
-                        "total_size": total_size,
-                        "total_chunks": total_chunks,
-                        "md5": md5,
-                    },
-                )
-                upload_id = init_body.get("upload_id", "")
-                if not upload_id:
-                    raise ChannelError(
-                        channel_name="wecom",
-                        message="wecom upload: empty upload_id",
-                    )
-                logger.debug(
-                    "wecom upload init: upload_id=%s chunks=%d",
-                    upload_id[:20],
-                    total_chunks,
-                )
-
-                # Step 2: chunks
-                for idx, chunk in enumerate(chunks):
-                    await self._send_ws_cmd(
-                        _UPLOAD_CMD_CHUNK,
+            async with self._upload_lock:
+                try:
+                    # Step 1: init
+                    init_body = await self._send_ws_cmd(
+                        _UPLOAD_CMD_INIT,
                         {
-                            "upload_id": upload_id,
-                            "chunk_index": idx,
-                            "base64_data": base64.b64encode(chunk).decode(),
+                            "type": media_type,
+                            "filename": filename,
+                            "total_size": total_size,
+                            "total_chunks": total_chunks,
+                            "md5": md5,
                         },
                     )
-
-                # Step 3: finish
-                finish_body = await self._send_ws_cmd(
-                    _UPLOAD_CMD_FINISH,
-                    {"upload_id": upload_id},
-                )
-                media_id = finish_body.get("media_id", "")
-                if not media_id:
-                    raise ChannelError(
-                        channel_name="wecom",
-                        message="wecom upload: empty media_id",
+                    upload_id = init_body.get("upload_id", "")
+                    if not upload_id:
+                        raise ChannelError(
+                            channel_name="wecom",
+                            message="wecom upload: empty upload_id",
+                        )
+                    logger.debug(
+                        f"wecom upload init: upload_id={upload_id[:20]} "
+                        f"chunks={total_chunks}",
                     )
-                logger.info(
-                    "wecom upload done: media_id=%s type=%s",
-                    media_id[:20],
-                    media_type,
-                )
-                return media_id
-            except Exception as e:
-                logger.exception(
-                    "wecom _upload_media failed path=%s error=%s",
-                    local[:60],
-                    str(e)[:100],
-                )
 
-                return None
+                    # Step 2: chunks
+                    for idx, chunk in enumerate(chunks):
+                        await self._send_ws_cmd(
+                            _UPLOAD_CMD_CHUNK,
+                            {
+                                "upload_id": upload_id,
+                                "chunk_index": idx,
+                                "base64_data": (
+                                    base64.b64encode(chunk).decode()
+                                ),
+                            },
+                        )
+
+                    # Step 3: finish
+                    finish_body = await self._send_ws_cmd(
+                        _UPLOAD_CMD_FINISH,
+                        {"upload_id": upload_id},
+                    )
+                    media_id = finish_body.get("media_id", "")
+                    if not media_id:
+                        raise ChannelError(
+                            channel_name="wecom",
+                            message="wecom upload: empty media_id",
+                        )
+                    logger.info(
+                        f"wecom upload done: media_id={media_id[:20]} "
+                        f"type={media_type}",
+                    )
+                    return media_id
+                except Exception as e:
+                    logger.exception(
+                        f"wecom _upload_media failed path={local[:60]} "
+                        f"error={str(e)[:100]}",
+                    )
+
+                    return None
 
     async def _send_media_part(
         self,

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -836,10 +836,40 @@ class WecomChannel(BaseChannel):
             )
         return ack.get("body") or {}
 
+    @staticmethod
+    async def _read_data_url_file(
+        path: str,
+        media_type: str,
+    ) -> tuple[bytes, str]:
+        """Keep the temporary file alive until its worker releases it."""
+
+        def read_file() -> tuple[bytes, str]:
+            if media_type == "image":
+                return compress_image_for_wecom(path)
+            local = Path(path)
+            return local.read_bytes(), local.name
+
+        task = asyncio.create_task(asyncio.to_thread(read_file))
+        cancelled = False
+        # Shield every wait so repeated cancellation cannot release the path.
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+            except Exception:
+                break
+        try:
+            return task.result()
+        finally:
+            if cancelled:
+                raise asyncio.CancelledError
+
     async def _upload_media(  # pylint: disable=too-many-locals
         self,
         path: str,
         media_type: str,
+        filename_hint: Optional[str] = None,
     ) -> Optional[str]:
         """Upload a local file via WebSocket chunks; return media_id.
 
@@ -851,21 +881,37 @@ class WecomChannel(BaseChannel):
         """
         if not self._client or not self._upload_lock:
             return None
-        filename_hint = getattr(path, "name", "") or "media"
-        with materialize_data_url(
+        async with materialize_data_url(
             path,
             self._media_dir,
             filename_hint=filename_hint,
         ) as materialized:
+            if materialized is None:
+                return None
             # Strip file:// prefix
-            local = file_url_to_local_path(materialized) or materialized
+            local = (
+                file_url_to_local_path(materialized.path) or materialized.path
+            )
             p = Path(local)
             if not p.is_file():
                 logger.warning(f"wecom upload: file not found: {local[:80]}")
                 return None
 
             # Compress image if needed (WeCom has 2MB limit)
-            if media_type == "image":
+            if materialized.filename is not None:
+                data, filename = await self._read_data_url_file(
+                    local,
+                    media_type,
+                )
+                if media_type == "image":
+                    filename = str(
+                        Path(materialized.filename).with_suffix(
+                            Path(filename).suffix,
+                        ),
+                    )
+                else:
+                    filename = materialized.filename
+            elif media_type == "image":
                 data, filename = compress_image_for_wecom(local)
             else:
                 data = p.read_bytes()
@@ -977,7 +1023,14 @@ class WecomChannel(BaseChannel):
         if not raw_path:
             return
 
-        media_id = await self._upload_media(raw_path, media_type)
+        if raw_path.startswith("data:"):
+            media_id = await self._upload_media(
+                raw_path,
+                media_type,
+                filename_hint=getattr(part, "filename", None),
+            )
+        else:
+            media_id = await self._upload_media(raw_path, media_type)
         if not media_id:
             logger.warning("wecom: upload failed, skipping media part")
             return

--- a/src/qwenpaw/app/channels/yuanbao/media.py
+++ b/src/qwenpaw/app/channels/yuanbao/media.py
@@ -23,6 +23,8 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import aiohttp
 
+from ..utils import parse_data_url
+
 logger = logging.getLogger(__name__)
 
 UPLOAD_INFO_PATH = "/api/resource/genUploadInfo"
@@ -297,9 +299,17 @@ async def download_and_upload_media(
     file_data: bytes
     filename: str
 
+    data_media = parse_data_url(media_path)
+    if data_media is not None:
+        file_data = data_media.data
+        filename = f"file{data_media.suffix}"
+        logger.info(
+            f"yuanbao media: decoded data URL ({len(file_data)} bytes)",
+        )
     # Resolve local file (file:// URI or absolute path)
-    local_path = _resolve_local_path(media_path)
-    if local_path and os.path.isfile(local_path):
+    else:
+        local_path = _resolve_local_path(media_path)
+    if data_media is None and local_path and os.path.isfile(local_path):
         file_data = Path(local_path).read_bytes()
         filename = os.path.basename(local_path)
         logger.info(
@@ -307,7 +317,7 @@ async def download_and_upload_media(
             filename,
             len(file_data),
         )
-    elif media_path.startswith(("http://", "https://")):
+    elif data_media is None and media_path.startswith(("http://", "https://")):
         async with session.get(media_path) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"Failed to download media: {resp.status}")

--- a/src/qwenpaw/app/channels/yuanbao/media.py
+++ b/src/qwenpaw/app/channels/yuanbao/media.py
@@ -19,11 +19,11 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple
-from urllib.parse import parse_qs, quote, unquote, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 
 import aiohttp
 
-from ..utils import parse_data_url
+from ..utils import file_url_to_local_path, parse_data_url_async
 
 logger = logging.getLogger(__name__)
 
@@ -299,17 +299,15 @@ async def download_and_upload_media(
     file_data: bytes
     filename: str
 
-    data_media = parse_data_url(media_path)
+    data_media = await parse_data_url_async(media_path)
+    local_path = None if data_media else _resolve_local_path(media_path)
     if data_media is not None:
         file_data = data_media.data
         filename = f"file{data_media.suffix}"
         logger.info(
             f"yuanbao media: decoded data URL ({len(file_data)} bytes)",
         )
-    # Resolve local file (file:// URI or absolute path)
-    else:
-        local_path = _resolve_local_path(media_path)
-    if data_media is None and local_path and os.path.isfile(local_path):
+    elif local_path and os.path.isfile(local_path):
         file_data = Path(local_path).read_bytes()
         filename = os.path.basename(local_path)
         logger.info(
@@ -317,7 +315,7 @@ async def download_and_upload_media(
             filename,
             len(file_data),
         )
-    elif data_media is None and media_path.startswith(("http://", "https://")):
+    elif media_path.startswith(("http://", "https://")):
         async with session.get(media_path) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"Failed to download media: {resp.status}")
@@ -340,7 +338,7 @@ async def download_and_upload_media(
             f"> {MAX_UPLOAD_MB} MB",
         )
 
-    mime_type = _guess_mime(filename)
+    mime_type = data_media.media_type if data_media else _guess_mime(filename)
     file_uuid = hashlib.md5(file_data).hexdigest()
     width, height = (0, 0)
     if mime_type.startswith("image/"):
@@ -376,15 +374,8 @@ async def download_and_upload_media(
 
 
 def _resolve_local_path(url: str) -> Optional[str]:
-    """Resolve file:// URI or local absolute path to filesystem path."""
-    if not url:
-        return None
-    if url.startswith("file://"):
-        parsed = urlparse(url)
-        return unquote(parsed.path)
-    if url.startswith("/") and not url.startswith("http"):
-        return url
-    return None
+    """Resolve a local path or file URI using platform-specific conversion."""
+    return file_url_to_local_path(url)
 
 
 def build_image_msg_body(result: UploadResult) -> list:

--- a/tests/unit/channels/test_discord.py
+++ b/tests/unit/channels/test_discord.py
@@ -14,6 +14,7 @@ Run:
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, Mock
+from pathlib import Path
 
 import pytest
 
@@ -21,8 +22,47 @@ from qwenpaw.schemas import (
     ContentType,
     TextContent,
     ImageContent,
+    FileContent,
 )
 from qwenpaw.exceptions import ChannelError
+
+
+@pytest.mark.parametrize("send_fails", [False, True])
+async def test_data_url_attachment_name_and_cleanup(
+    discord_channel,
+    mock_discord_client,
+    tmp_path,
+    send_fails,
+):
+    """Discord receives the display name and releases files after sending."""
+    discord_channel.enabled = True
+    discord_channel._client = mock_discord_client
+    discord_channel._media_dir = tmp_path
+    attachments = []
+
+    async def send(*, file):
+        attachments.append(file)
+        assert file.filename == "report.pdf"
+        assert file.fp.read() == b"pdf-data"
+        assert Path(file.fp.name).is_file()
+        if send_fails:
+            raise RuntimeError("upload failed")
+
+    target = Mock(send=AsyncMock(side_effect=send))
+    discord_channel._resolve_target = AsyncMock(return_value=target)
+    part = FileContent(
+        file_url="data:application/pdf;base64,cGRmLWRhdGE=",
+        filename="report.pdf",
+    )
+    if send_fails:
+        with pytest.raises(RuntimeError, match="upload failed"):
+            await discord_channel.send_media("123", part)
+    else:
+        await discord_channel.send_media("123", part)
+
+    target.send.assert_awaited_once()
+    assert attachments[0].fp.closed
+    assert not list(tmp_path.iterdir())
 
 
 # =============================================================================

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -4,6 +4,7 @@
 # pylint: disable=redefined-outer-name,unused-import
 # pylint: disable=protected-access,unused-argument
 import asyncio
+import base64
 import inspect
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -26,6 +27,7 @@ from nio.responses import (
     WhoamiResponse,
 )
 
+from qwenpaw import schemas
 from qwenpaw.schemas import (
     AgentRequest,
     ContentType,
@@ -1311,6 +1313,49 @@ class TestMatrixChannelSendContentParts:
 class TestMatrixChannelSendMedia:
     """Test send_media method."""
 
+    @pytest.mark.parametrize(
+        ("byte_count", "filename"),
+        [(8, "report.pdf"), (64 * 1024, None)],
+    )
+    async def test_data_url_event_reuses_upload_metadata(
+        self,
+        matrix_channel,
+        mock_async_client,
+        byte_count,
+        filename,
+    ):
+        """The room event contains metadata, never the encoded payload."""
+        data = b"a" * byte_count
+        encoded = base64.b64encode(data).decode("ascii")
+        matrix_channel._client = mock_async_client
+        matrix_channel._prepare_room_send = AsyncMock()
+        mock_async_client.upload.return_value = (
+            UploadResponse(content_uri="mxc://example.org/media"),
+            None,
+        )
+        part = schemas.FileContent(
+            file_url=f"data:application/pdf;base64,{encoded}",
+            filename=filename,
+        )
+
+        await matrix_channel.send_media("!room:example.com", part)
+
+        upload = mock_async_client.upload.call_args
+        assert upload.args[0].getvalue() == data
+        expected_name = filename or "file.pdf"
+        assert upload.kwargs == {
+            "content_type": "application/pdf",
+            "filename": expected_name,
+            "filesize": byte_count,
+        }
+        content = mock_async_client.room_send.call_args.args[2]
+        assert content == {
+            "msgtype": "m.file",
+            "body": expected_name,
+            "url": "mxc://example.org/media",
+            "info": {"mimetype": "application/pdf", "size": byte_count},
+        }
+
     async def test_send_media_when_client_not_initialized(
         self,
         matrix_channel,
@@ -1366,6 +1411,13 @@ class TestMatrixChannelSendMedia:
 
         mock_async_client.upload.assert_called_once()
         mock_async_client.room_send.assert_called_once()
+        content = mock_async_client.room_send.call_args.args[2]
+        assert content["body"] == test_file.name
+        assert content["info"] == {
+            "mimetype": "image/png",
+            "size": len(b"fake image data"),
+        }
+        assert test_file.read_bytes() == b"fake image data"
 
     async def test_send_media_http_url(
         self,

--- a/tests/unit/channels/test_mattermost.py
+++ b/tests/unit/channels/test_mattermost.py
@@ -38,6 +38,53 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+from qwenpaw import schemas
+
+
+@pytest.mark.parametrize("source_type", ["data", "path", "file_url"])
+async def test_file_upload_uses_display_name(
+    mattermost_channel,
+    mock_http_client,
+    tmp_path,
+    source_type,
+):
+    """Multipart filenames preserve existing local or supplied data names."""
+    local_file = tmp_path / "local.pdf"
+    local_file.write_bytes(b"pdf-data")
+    sources = {
+        "data": "data:application/pdf;base64,cGRmLWRhdGE=",
+        "path": str(local_file),
+        "file_url": local_file.as_uri(),
+    }
+    mock_http_client.expect_post(
+        url="/files",
+        response_json={"file_infos": [{"id": "file-id"}]},
+    )
+    mattermost_channel._http = mock_http_client
+    mattermost_channel._post_message = AsyncMock()
+    await mattermost_channel.send_media(
+        "recipient",
+        schemas.FileContent(
+            file_url=sources[source_type],
+            filename="report.pdf",
+        ),
+    )
+
+    upload = mock_http_client._requests[0]["kwargs"]["files"]["files"]
+    expected = "report.pdf" if source_type == "data" else "local.pdf"
+    assert upload[0] == expected
+    assert upload[1].closed
+    mattermost_channel._post_message.assert_awaited_once_with(
+        "recipient",
+        "",
+        "",
+        ["file-id"],
+    )
+    assert local_file.read_bytes() == b"pdf-data"
+    if source_type == "data":
+        assert not list(mattermost_channel._media_dir.iterdir())
+    else:
+        assert not mattermost_channel._media_dir.exists()
 
 
 # =============================================================================

--- a/tests/unit/channels/test_qq.py
+++ b/tests/unit/channels/test_qq.py
@@ -25,14 +25,70 @@ from __future__ import annotations
 import json
 import threading
 import time
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+from qwenpaw.schemas import ContentType
 
 from tests.fixtures.channels.mock_http import MockAiohttpSession
+
+
+async def test_data_url_c2c_upload_uses_encoded_bytes(qq_channel):
+    """QQ's C2C uploader receives validated Base64 and a stable filename."""
+    with (
+        patch(
+            "qwenpaw.app.channels.qq.channel._upload_media_async",
+            new=AsyncMock(return_value="file-info"),
+        ) as upload,
+        patch(
+            "qwenpaw.app.channels.qq.channel._send_media_message_async",
+            new_callable=AsyncMock,
+        ) as send,
+    ):
+        await qq_channel._send_media_c2c_or_group(
+            message_type="c2c",
+            content_type=ContentType.IMAGE,
+            sender_id="recipient",
+            group_openid=None,
+            url="data:image/png;base64,cG5nLWRhdGE=",
+            local_path=None,
+            msg_id=None,
+            token="token",
+        )
+    assert upload.call_args.kwargs["file_data"] == "cG5nLWRhdGE="
+    assert upload.call_args.kwargs["file_name"] == "file.png"
+    send.assert_awaited_once()
+
+
+async def test_data_url_guild_upload_cleans_up(qq_channel):
+    """Guild uploads receive a separate display name and a live file."""
+    paths = []
+
+    async def upload(_http, _token, _endpoint, path, _msg_id, *, filename):
+        paths.append(Path(path))
+        assert Path(path).read_bytes() == b"png-data"
+        assert filename == "image.png"
+
+    with patch(
+        "qwenpaw.app.channels.qq.channel._send_guild_image_file_async",
+        new=AsyncMock(side_effect=upload),
+    ) as send:
+        await qq_channel._send_media_guild_or_dm(
+            message_type="guild",
+            content_type=ContentType.IMAGE,
+            channel_id="channel",
+            guild_id=None,
+            url="data:image/png;base64,cG5nLWRhdGE=",
+            local_path=None,
+            msg_id=None,
+            token="token",
+        )
+    send.assert_awaited_once()
+    assert not paths[0].exists()
 
 
 # =============================================================================

--- a/tests/unit/channels/test_slack.py
+++ b/tests/unit/channels/test_slack.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+from qwenpaw.app.channels.slack import sender as slack_sender
 
 from qwenpaw.schemas import (
     AudioContent,
@@ -28,6 +29,27 @@ from qwenpaw.schemas import (
     TextContent,
     VideoContent,
 )
+
+
+@pytest.mark.parametrize("filename", [None, "report.pdf"])
+async def test_data_url_upload_has_stable_filename(
+    slack_channel,
+    mock_slack_client,
+    filename,
+):
+    """Unnamed data files use MIME-derived names rather than URL contents."""
+    sender = slack_sender.SlackSender(channel=slack_channel)
+    sender._upload_file_external = AsyncMock(return_value="uploaded")
+    part = FileContent(
+        file_url="data:application/pdf;base64,cGRmLWRhdGE=",
+        filename=filename,
+    )
+    await sender._send_file(mock_slack_client, "channel", part)
+
+    upload = sender._upload_file_external.call_args
+    assert upload.args[3] == (filename or "file.pdf")
+    assert upload.kwargs["title"] == (filename or "file.pdf")
+
 
 # =============================================================================
 # Fixtures

--- a/tests/unit/channels/test_telegram.py
+++ b/tests/unit/channels/test_telegram.py
@@ -33,6 +33,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+from qwenpaw.app.channels import utils as channel_utils
+from qwenpaw.app.channels.telegram import channel as telegram_module
 
 from qwenpaw.schemas import (
     TextContent,
@@ -42,6 +44,81 @@ from qwenpaw.schemas import (
     FileContent,
     ContentType,
 )
+
+
+@pytest.mark.parametrize("filename", [None, "report.pdf"])
+async def test_data_url_document_preserves_filename(
+    telegram_channel,
+    mock_telegram_bot,
+    filename,
+):
+    """Telegram receives named bytes without creating or reading files."""
+    telegram_channel._application = MagicMock(bot=mock_telegram_bot)
+    part = FileContent(
+        file_url="data:application/pdf;base64,cGRmLWRhdGE=",
+        filename=filename,
+    )
+    with (
+        patch.object(
+            channel_utils.tempfile,
+            "mkstemp",
+            side_effect=AssertionError("Unexpected temporary file"),
+        ),
+        patch.object(
+            Path,
+            "read_bytes",
+            side_effect=AssertionError("Unexpected file read"),
+        ),
+    ):
+        await telegram_channel.send_media("12345", part)
+
+    payload = mock_telegram_bot.send_document.call_args.kwargs["document"]
+    assert payload.filename == (filename or "document.pdf")
+    assert payload.input_file_content == b"pdf-data"
+    assert not telegram_channel._media_dir.exists()
+
+
+async def test_data_url_invalid_payload_is_unavailable(telegram_channel):
+    """Invalid Base64 retains the channel's existing media error behavior."""
+    bot = AsyncMock()
+    with pytest.raises(telegram_module._MediaFileUnavailableError):
+        await telegram_channel._send_media_value(
+            bot=bot,
+            chat_id="recipient",
+            value="data:application/pdf;base64,invalid!",
+            method_name="send_document",
+            payload_name="document",
+            message_thread_id=None,
+        )
+    bot.send_document.assert_not_awaited()
+    assert not telegram_channel._media_dir.exists()
+
+
+async def test_data_url_decode_cancellation_propagates(
+    telegram_channel,
+):
+    """Decode cancellation propagates without sending any media."""
+    bot = AsyncMock()
+
+    with (
+        patch.object(
+            telegram_module,
+            "parse_data_url_async",
+            side_effect=asyncio.CancelledError,
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await telegram_channel._send_media_value(
+            bot=bot,
+            chat_id="recipient",
+            value="data:application/pdf;base64,cGRmLWRhdGE=",
+            method_name="send_document",
+            payload_name="document",
+            message_thread_id=None,
+        )
+
+    bot.send_document.assert_not_awaited()
+    assert not telegram_channel._media_dir.exists()
 
 
 # =============================================================================

--- a/tests/unit/channels/test_utils.py
+++ b/tests/unit/channels/test_utils.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Tests for shared channel utilities."""
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app.channels.utils import (
+    MediaDataError,
+    materialize_data_url,
+    parse_data_url,
+)
+
+
+PNG_DATA_URL = (
+    "data:image/png;base64," + base64.b64encode(b"png-data").decode()
+)
+
+
+def test_parse_data_url_decodes_payload() -> None:
+    """Base64 data URLs should return bytes and normalized metadata."""
+    media = parse_data_url(PNG_DATA_URL)
+
+    assert media is not None
+    assert media.data == b"png-data"
+    assert media.media_type == "image/png"
+    assert media.suffix == ".png"
+
+
+def test_parse_data_url_rejects_invalid_base64() -> None:
+    """Malformed Base64 should fail before any filesystem access."""
+    with pytest.raises(MediaDataError):
+        parse_data_url("data:image/png;base64,not-valid!")
+
+
+def test_parse_data_url_enforces_size_limit() -> None:
+    """Decoded media must respect the configured size limit."""
+    with pytest.raises(MediaDataError):
+        parse_data_url(PNG_DATA_URL, max_bytes=2)
+
+
+def test_materialize_data_url_cleans_up_file(tmp_path) -> None:
+    """Generated files should exist only for the send operation."""
+    with materialize_data_url(
+        PNG_DATA_URL,
+        tmp_path,
+        filename_hint="screen capture.png",
+    ) as path:
+        materialized = Path(path)
+        assert materialized.read_bytes() == b"png-data"
+        assert materialized.suffix == ".png"
+
+    assert not materialized.exists()
+
+
+def test_materialize_data_url_preserves_local_path(tmp_path) -> None:
+    """Non-data references should not be rewritten."""
+    local_path = tmp_path / "file.bin"
+    local_path.write_bytes(b"data")
+
+    with materialize_data_url(str(local_path), tmp_path) as path:
+        assert path == str(local_path)

--- a/tests/unit/channels/test_utils.py
+++ b/tests/unit/channels/test_utils.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 """Tests for shared channel utilities."""
+# pylint: disable=protected-access
 
 import base64
+import asyncio
+import threading
 from pathlib import Path
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
 
 import pytest
 
 from qwenpaw.app.channels.utils import (
     MediaDataError,
+    data_url_filename,
     materialize_data_url,
     parse_data_url,
+    parse_data_url_async,
 )
+from qwenpaw.app.channels import utils as channel_utils
 
 
 PNG_DATA_URL = (
@@ -40,24 +48,181 @@ def test_parse_data_url_enforces_size_limit() -> None:
         parse_data_url(PNG_DATA_URL, max_bytes=2)
 
 
-def test_materialize_data_url_cleans_up_file(tmp_path) -> None:
+async def test_materialize_data_url_cleans_up_file(tmp_path) -> None:
     """Generated files should exist only for the send operation."""
-    with materialize_data_url(
+    async with materialize_data_url(
         PNG_DATA_URL,
         tmp_path,
         filename_hint="screen capture.png",
-    ) as path:
-        materialized = Path(path)
+    ) as media:
+        assert media is not None
+        materialized = Path(media.path)
         assert materialized.read_bytes() == b"png-data"
         assert materialized.suffix == ".png"
+        assert media.filename == "screen capture.png"
 
     assert not materialized.exists()
 
 
-def test_materialize_data_url_preserves_local_path(tmp_path) -> None:
+@pytest.mark.parametrize("as_uri", [False, True])
+async def test_materialize_data_url_preserves_local_path(
+    tmp_path,
+    as_uri,
+) -> None:
     """Non-data references should not be rewritten."""
     local_path = tmp_path / "file.bin"
     local_path.write_bytes(b"data")
 
-    with materialize_data_url(str(local_path), tmp_path) as path:
-        assert path == str(local_path)
+    source = local_path.as_uri() if as_uri else str(local_path)
+    assert await parse_data_url_async(source) is None
+    async with materialize_data_url(
+        source,
+        tmp_path / "unused",
+        filename_hint="ignored.png",
+        max_bytes=1,
+    ) as media:
+        assert media.path == source
+        assert media.filename is None
+
+    assert local_path.read_bytes() == b"data"
+    assert not (tmp_path / "unused").exists()
+
+
+@pytest.mark.parametrize(
+    ("hint", "expected"),
+    [
+        (None, "file.png"),
+        ("", "file.png"),
+        ("capture", "capture.png"),
+        ("screen capture.png", "screen capture.png"),
+        ("../../capture.png", "capture.png"),
+        (r"C:\media\capture.png", "capture.png"),
+    ],
+)
+def test_data_url_filename_uses_portable_basename(hint, expected) -> None:
+    """Display names retain the supplied basename on every platform."""
+    assert data_url_filename(hint, ".png") == expected
+
+
+@pytest.mark.parametrize("materialize", [False, True])
+async def test_data_url_preparation_runs_off_loop(
+    tmp_path,
+    materialize,
+) -> None:
+    """Parsing and file writes run on a worker while the loop progresses."""
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    started = asyncio.Event()
+    release = threading.Event()
+    original = parse_data_url
+    worker_threads = []
+
+    def slow_parse(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(timeout=5)
+        return original(*args, **kwargs)
+
+    async def prepare():
+        if materialize:
+            async with materialize_data_url(PNG_DATA_URL, tmp_path):
+                pass
+        else:
+            await parse_data_url_async(PNG_DATA_URL)
+
+    with patch.object(channel_utils, "parse_data_url", side_effect=slow_parse):
+        task = asyncio.create_task(prepare())
+        try:
+            await asyncio.wait_for(started.wait(), timeout=2)
+            assert not task.done()
+            assert len(worker_threads) == 1
+            assert worker_threads[0] != loop_thread
+        finally:
+            release.set()
+            await task
+
+
+@pytest.mark.parametrize("cancel_during_creation", [False, True])
+async def test_materialize_cancellation_cleans_up(
+    tmp_path,
+    cancel_during_creation,
+) -> None:
+    """Cancellation during preparation or sending never leaves a file."""
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    release = threading.Event()
+    sending = asyncio.Event()
+    original = channel_utils._materialize_data_url
+
+    def slow_create(*args, **kwargs):
+        media = original(*args, **kwargs)
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(timeout=5)
+        return media
+
+    async def send():
+        async with materialize_data_url(PNG_DATA_URL, tmp_path):
+            sending.set()
+            await asyncio.Future()
+
+    with patch.object(
+        channel_utils,
+        "_materialize_data_url",
+        side_effect=slow_create,
+    ):
+        task = asyncio.create_task(send())
+        try:
+            await asyncio.wait_for(started.wait(), timeout=2)
+            if not cancel_during_creation:
+                release.set()
+                await asyncio.wait_for(sending.wait(), timeout=2)
+            task.cancel()
+        finally:
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+    assert not list(tmp_path.iterdir())
+
+
+async def test_materialize_send_error_cleans_up(tmp_path) -> None:
+    """An upload failure must still release the temporary file."""
+    with pytest.raises(RuntimeError, match="upload failed"):
+        async with materialize_data_url(PNG_DATA_URL, tmp_path):
+            raise RuntimeError("upload failed")
+    assert not list(tmp_path.iterdir())
+
+
+async def test_materialize_write_error_cleans_up(tmp_path) -> None:
+    """A failed disk write propagates without leaving the created file."""
+    original = channel_utils.os.fdopen
+
+    @contextmanager
+    def failing_open(*args, **kwargs):
+        with original(*args, **kwargs):
+            yield Mock(write=Mock(side_effect=OSError("disk error")))
+
+    with patch.object(channel_utils.os, "fdopen", side_effect=failing_open):
+        with pytest.raises(OSError, match="disk error"):
+            async with materialize_data_url(PNG_DATA_URL, tmp_path):
+                pytest.fail("Preparation should have failed")
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize(
+    ("source", "max_bytes"),
+    [("data:image/png;base64,invalid!", 1024), (PNG_DATA_URL, 2)],
+)
+async def test_materialize_rejected_data_creates_no_file(
+    source,
+    max_bytes,
+    tmp_path,
+) -> None:
+    """Invalid and oversized media never enter the filesystem stage."""
+    mkdir = Mock(side_effect=AssertionError("Unexpected filesystem access"))
+    with patch.object(Path, "mkdir", mkdir):
+        async with materialize_data_url(
+            source,
+            tmp_path,
+            max_bytes=max_bytes,
+        ) as media:
+            assert media is None

--- a/tests/unit/channels/test_wechat.py
+++ b/tests/unit/channels/test_wechat.py
@@ -36,8 +36,41 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
+from qwenpaw.schemas import FileContent
 
 from tests.fixtures.channels.mock_http import MockAiohttpSession
+
+
+@pytest.mark.parametrize("source_type", ["data", "path", "file_url"])
+async def test_file_display_name_survives_send_pipeline(
+    wechat_channel,
+    mock_ilink_client,
+    tmp_path,
+    source_type,
+):
+    """Data URLs use supplied names; local sources keep their basenames."""
+    local_file = tmp_path / "local.pdf"
+    local_file.write_bytes(b"pdf-data")
+    sources = {
+        "data": "data:application/pdf;base64,cGRmLWRhdGE=",
+        "path": str(local_file),
+        "file_url": local_file.as_uri(),
+    }
+    wechat_channel._client = mock_ilink_client
+    await wechat_channel._send_content_parts_immediate(
+        "recipient",
+        [FileContent(file_url=sources[source_type], filename="report.pdf")],
+        {
+            "wechat_from_user_id": "recipient",
+            "wechat_context_token": "context",
+        },
+    )
+
+    args = mock_ilink_client.send_file.call_args.args
+    expected = "report.pdf" if source_type == "data" else "local.pdf"
+    assert args[2] == expected
+    assert local_file.read_bytes() == b"pdf-data"
+    assert not list(wechat_channel._media_dir.iterdir())
 
 
 # =============================================================================

--- a/tests/unit/channels/test_wecom.py
+++ b/tests/unit/channels/test_wecom.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 
 import threading
+import asyncio
 from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -37,6 +38,117 @@ import pytest
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
 
 from qwenpaw.exceptions import ChannelError
+from qwenpaw.schemas import FileContent
+
+
+@pytest.mark.parametrize("media_type", ["file", "image"])
+@pytest.mark.parametrize("read_fails", [False, True])
+async def test_cancelled_upload_waits_for_open_file(
+    wecom_channel,
+    mock_ws_client,
+    media_type,
+    read_fails,
+):
+    """Cancellation closes background readers before Windows-style delete."""
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    finished = asyncio.Event()
+    release = threading.Event()
+    locked = set()
+    paths = []
+    denied_deletes = []
+    original_unlink = Path.unlink
+
+    def slow_read(path):
+        try:
+            with path.open("rb") as handle:
+                locked.add(str(path))
+                paths.append(path)
+                loop.call_soon_threadsafe(started.set)
+                assert release.wait(timeout=5)
+                if read_fails:
+                    raise OSError("Read failed")
+                return handle.read()
+        finally:
+            locked.discard(str(path))
+            loop.call_soon_threadsafe(finished.set)
+
+    def windows_unlink(path, *args, **kwargs):
+        if str(path) in locked:
+            denied_deletes.append(path)
+            raise PermissionError("File is still open")
+        return original_unlink(path, *args, **kwargs)
+
+    wecom_channel._client = mock_ws_client
+    wecom_channel._upload_lock = asyncio.Lock()
+    wecom_channel._send_ws_cmd = AsyncMock()
+    with (
+        patch.object(Path, "read_bytes", slow_read),
+        patch.object(Path, "unlink", windows_unlink),
+    ):
+        task = asyncio.create_task(
+            wecom_channel._upload_media(
+                "data:image/png;base64,cG5nLWRhdGE=",
+                media_type,
+            ),
+        )
+        try:
+            await asyncio.wait_for(started.wait(), timeout=2)
+            task.cancel()
+            # Cancellation must stay pending while the worker owns the file.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+            task.cancel()
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+            assert paths[0].is_file()
+        finally:
+            release.set()
+            await asyncio.gather(task, return_exceptions=True)
+            await asyncio.wait_for(finished.wait(), timeout=2)
+
+    assert task.cancelled()
+    assert not denied_deletes
+    assert not paths[0].exists()
+    wecom_channel._send_ws_cmd.assert_not_awaited()
+
+
+@pytest.mark.parametrize("source_type", ["data", "path", "file_url"])
+async def test_file_display_name_reaches_upload_init(
+    wecom_channel,
+    mock_ws_client,
+    tmp_path,
+    source_type,
+):
+    """The upload protocol receives display names, not temporary names."""
+    local_file = tmp_path / "local.pdf"
+    local_file.write_bytes(b"pdf-data")
+    sources = {
+        "data": "data:application/pdf;base64,cGRmLWRhdGE=",
+        "path": str(local_file),
+        "file_url": local_file.as_uri(),
+    }
+    wecom_channel._client = mock_ws_client
+    wecom_channel._upload_lock = asyncio.Lock()
+    wecom_channel._send_ws_cmd = AsyncMock(
+        side_effect=[{"upload_id": "upload"}, {}, {"media_id": "media"}],
+    )
+    await wecom_channel._send_media_part(
+        "recipient",
+        FileContent(file_url=sources[source_type], filename="report.pdf"),
+        None,
+    )
+
+    init = wecom_channel._send_ws_cmd.call_args_list[0].args[1]
+    expected = "report.pdf" if source_type == "data" else "local.pdf"
+    assert init["filename"] == expected
+    assert init["total_size"] == 8
+    mock_ws_client.send_message.assert_awaited_once()
+    assert local_file.read_bytes() == b"pdf-data"
+    if source_type == "data":
+        assert not list(wecom_channel._media_dir.iterdir())
+    else:
+        assert not wecom_channel._media_dir.exists()
 
 
 # =============================================================================

--- a/tests/unit/channels/test_wecom.py
+++ b/tests/unit/channels/test_wecom.py
@@ -1199,6 +1199,28 @@ class TestWecomChannelMediaUpload:
         assert media_id == "media_456"
 
     @pytest.mark.asyncio
+    async def test_upload_media_data_url_success(
+        self,
+        wecom_channel,
+        mock_ws_client,
+    ):
+        """_upload_media should decode a Base64 data URL before upload."""
+        wecom_channel._client = mock_ws_client
+        wecom_channel._upload_lock = MagicMock()
+        wecom_channel._send_ws_cmd = AsyncMock(
+            side_effect=[
+                {"upload_id": "upload_data_url"},
+                {},
+                {"media_id": "media_data_url"},
+            ],
+        )
+
+        data_url = "data:image/png;base64,dGVzdCBpbWFnZSBkYXRh"
+        media_id = await wecom_channel._upload_media(data_url, "image")
+
+        assert media_id == "media_data_url"
+
+    @pytest.mark.asyncio
     async def test_upload_media_no_client(self, wecom_channel, tmp_path):
         """_upload_media should return None if no client."""
         test_file = tmp_path / "test.jpg"

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -12,9 +12,84 @@ Run:
 from __future__ import annotations
 
 import struct
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import nturl2path
 import pytest
+
+from qwenpaw.app.channels.yuanbao import media as yuanbao_media
+from qwenpaw.app.channels import utils as channel_utils
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (r"C:\media\report.pdf", r"C:\media\report.pdf"),
+        ("file:///C:/media/report.pdf", r"C:\media\report.pdf"),
+        ("file://C:/media/report.pdf", r"C:\media\report.pdf"),
+        ("file:///C:/media/my%20report.pdf", r"C:\media\my report.pdf"),
+        (r"\\server\share\report.pdf", r"\\server\share\report.pdf"),
+        ("file://server/share/report.pdf", r"\\server\share\report.pdf"),
+    ],
+)
+def test_resolve_windows_media_paths(source, expected):
+    """Yuanbao uses Windows drive and UNC conversion on every test host."""
+    with (
+        patch.object(channel_utils, "os", SimpleNamespace(name="nt")),
+        patch.object(channel_utils, "url2pathname", nturl2path.url2pathname),
+    ):
+        assert yuanbao_media._resolve_local_path(source) == expected
+
+
+@pytest.mark.parametrize("source_type", ["data", "path", "file_url"])
+async def test_media_source_reaches_cos_upload(tmp_path, source_type):
+    """Data URLs and existing local references reach the same upload flow."""
+    local_file = tmp_path / "report.pdf"
+    local_file.write_bytes(b"pdf-data")
+    sources = {
+        "data": "data:application/pdf;base64,cGRmLWRhdGE=",
+        "path": str(local_file),
+        "file_url": local_file.as_uri(),
+    }
+    session = MagicMock()
+    config = MagicMock()
+    with (
+        patch.object(
+            yuanbao_media,
+            "get_upload_info",
+            new=AsyncMock(return_value=config),
+        ) as get_info,
+        patch.object(
+            yuanbao_media,
+            "upload_to_cos",
+            new=AsyncMock(return_value="https://cdn.example.com/file.pdf"),
+        ) as upload,
+    ):
+        result = await yuanbao_media.download_and_upload_media(
+            sources[source_type],
+            session,
+            "yuanbao.tencent.com",
+            {},
+        )
+
+    expected_name = "file.pdf" if source_type == "data" else "report.pdf"
+    get_info.assert_awaited_once_with(
+        session,
+        "yuanbao.tencent.com",
+        {},
+        expected_name,
+    )
+    upload.assert_awaited_once_with(
+        session,
+        config,
+        b"pdf-data",
+        "application/pdf",
+    )
+    assert result.filename == expected_name
+    assert result.size == 8
+    assert result.mime_type == "application/pdf"
+    assert local_file.read_bytes() == b"pdf-data"
 
 
 # =============================================================================
@@ -291,15 +366,17 @@ class TestMediaHelpers:
         assert width == 0
         assert height == 0
 
-    def test_resolve_local_path_file_uri(self):
+    def test_resolve_local_path_file_uri(self, tmp_path):
         from qwenpaw.app.channels.yuanbao.media import _resolve_local_path
 
-        assert _resolve_local_path("file:///tmp/test.jpg") == "/tmp/test.jpg"
+        local_file = tmp_path / "test image.jpg"
+        assert _resolve_local_path(local_file.as_uri()) == str(local_file)
 
-    def test_resolve_local_path_absolute(self):
+    def test_resolve_local_path_absolute(self, tmp_path):
         from qwenpaw.app.channels.yuanbao.media import _resolve_local_path
 
-        assert _resolve_local_path("/tmp/test.jpg") == "/tmp/test.jpg"
+        local_file = tmp_path / "test.jpg"
+        assert _resolve_local_path(str(local_file)) == str(local_file)
 
     def test_resolve_local_path_url_returns_none(self):
         from qwenpaw.app.channels.yuanbao.media import _resolve_local_path


### PR DESCRIPTION
## Description

Support outbound media provided as Base64 Data URLs across channels that previously treated these values as local filesystem paths. An agent response containing `data:<mime>;base64,...` could reach calls such as `Path(data_url).is_file()` or `Path(data_url).exists()`, raising `OSError: [Errno 36] File name too long` and returning a generic `Internal error` to the user.

These channels now decode and upload the media with appropriate filenames and MIME metadata. Invalid or oversized payloads are rejected before temporary files are created.

**Related issues:** #7370, #7516

## Changes

- Add shared Base64 Data URL parsing, MIME and suffix detection, and a 50 MiB decoded payload limit. Run decoding and temporary file preparation and cleanup in worker threads.
- Support outbound Base64 media in WeCom, WeChat, Discord, Mattermost, Telegram, Slack, Matrix, Yuanbao, and QQ C2C/group and guild/DM upload paths.
- Separate attachment display names from generated temporary paths so recipients receive meaningful filenames instead of random temporary basenames.
- Reuse the uploaded filename, MIME type, and size in Matrix message events, preventing the Base64 payload from appearing in the event body or inflating its size.
- Send decoded bytes directly through Telegram's `InputFile`. For WeCom, wait for background file reads or image processing to finish before removing temporary files when sending is cancelled.
- Retain existing local file and URL sending behavior, with a Windows compatibility fix for Yuanbao that reuses the shared resolver for native paths and `file://` URLs.
- Add regression coverage for payload validation, attachment metadata, local path preservation, worker execution, temporary file cleanup, cancellation, and Windows path handling.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Channels
- [x] Tests

## Testing

The latest verification ran all tests in the following three files using conda base:

```bash
python -m pytest \
  tests/unit/channels/test_utils.py \
  tests/unit/channels/test_telegram.py \
  tests/unit/channels/test_matrix.py -q
```

File-scoped checks were run with:

```bash
python -m pre_commit run --files \
  tests/unit/channels/test_utils.py \
  tests/unit/channels/test_telegram.py \
  tests/unit/channels/test_matrix.py
git diff --check
```

## Evidence

```text
203 passed, 15 warnings in 2.70s
```

All applicable file-scoped pre-commit checks passed, including mypy, Black, flake8, and pylint. `git diff --check` also passed. The warnings came from existing Telegram and Matrix tests, including asyncio marker warnings and an unawaited typing coroutine warning.

## Additional Notes

The full repository test suite was not run for the final revision. Windows path conversion and open-file cleanup have regression tests that simulate Windows behavior; native Windows validation was not performed.
