### PR TITLE
fix(console): show app updates for mismatched versions

### DIFF
--- a/console/src/pages/AppCenter/AppMarket.test.tsx
+++ b/console/src/pages/AppCenter/AppMarket.test.tsx
@@ -399,6 +399,101 @@ describe("AppMarket", () => {
     ).toBeDisabled();
   });
 
+  it("matches official apps when the local author differs from the market owner", async () => {
+    hoisted.fetchMarketPlugins.mockResolvedValue({
+      plugins: [
+        makeEntry("@agentscope/qwenpaw-creator", {
+          owner: "agentscope",
+          developer: "ScopeMaster",
+          version: "1.2.0",
+        }),
+      ],
+      total: 1,
+    });
+
+    render(
+      <AppMarket
+        channel="official"
+        installedAppVersions={new Map([["qwenpaw-creator", "1.2.0"]])}
+        installedApps={[
+          {
+            id: "qwenpaw-creator",
+            author: "QwenPaw Creator Team",
+            version: "1.2.0",
+          },
+        ]}
+        onInstalled={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "appCenter.installedStatus",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("matches app-market apps when the local author differs from the market owner", async () => {
+    hoisted.fetchMarketPlugins.mockResolvedValue({
+      plugins: [
+        makeEntry("@zhijianma/agent-kanban", {
+          owner: "zhijianma",
+          developer: "zhijianma",
+          version: "0.1.1",
+        }),
+      ],
+      total: 1,
+    });
+
+    render(
+      <AppMarket
+        installedAppVersions={new Map([["agent-kanban", "0.1.1"]])}
+        installedApps={[
+          { id: "agent-kanban", author: "QwenPaw Team", version: "0.1.1" },
+        ]}
+        onInstalled={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "appCenter.installedStatus",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("offers an update for an official app when versions differ", async () => {
+    hoisted.fetchMarketPlugins.mockResolvedValue({
+      plugins: [
+        makeEntry("@agentscope/qwenpaw-creator", {
+          owner: "agentscope",
+          developer: "ScopeMaster",
+          version: "1.3.0",
+        }),
+      ],
+      total: 1,
+    });
+
+    render(
+      <AppMarket
+        channel="official"
+        installedAppVersions={new Map([["qwenpaw-creator", "1.2.0"]])}
+        installedApps={[
+          {
+            id: "qwenpaw-creator",
+            author: "QwenPaw Creator Team",
+            version: "1.2.0",
+          },
+        ]}
+        onInstalled={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "appCenter.update" }),
+    ).toBeEnabled();
+  });
+
   it("offers an update when the market version is newer", async () => {
     hoisted.fetchMarketPlugins.mockResolvedValue({
       plugins: [makeEntry("installed-app", { version: "2.0.0" })],

--- a/console/src/utils/marketAppState.test.ts
+++ b/console/src/utils/marketAppState.test.ts
@@ -52,7 +52,7 @@ describe("market app state", () => {
     );
   });
 
-  it("matches unscoped app IDs only when the installed author agrees", () => {
+  it("matches unscoped app IDs even when the installed author differs", () => {
     const entry = makeEntry({
       id: "@owner/app",
       owner: "owner",
@@ -64,10 +64,10 @@ describe("market app state", () => {
       ]),
     ).toBe("installed");
     expect(
-      getMarketAppState(entry, new Map([["app", "1.0.0"]]), "app", [
-        { id: "app", author: "other", version: "1.0.0" },
+      getMarketAppState(entry, new Map(), "app", [
+        { id: "app", author: "QwenPaw Team", version: "1.0.0" },
       ]),
-    ).toBe("available");
+    ).toBe("installed");
   });
 
   it("marks a newer market version as an update", () => {

--- a/console/src/utils/marketAppState.ts
+++ b/console/src/utils/marketAppState.ts
@@ -2,6 +2,7 @@ import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
 import { compareVersions } from "@/layouts/constants";
 import {
   findMatchingInstalledPlugin,
+  normalizeMarketPluginId,
   type InstalledPluginIdentity,
 } from "./marketPluginIdentity";
 
@@ -10,9 +11,10 @@ export type MarketAppState = "available" | "installed" | "update";
 /**
  * Return the installed version for a market entry when its IDs match.
  *
- * Community entries are namespaced by owner. An unscoped installed ID is only
- * accepted when its author agrees with the market owner or developer, because
- * two owners may publish apps with the same repository name.
+ * PawApp manifests currently store an unscoped app ID, while market entries
+ * use the namespaced ``@owner/name`` form. App entries therefore use the
+ * unscoped app ID as the stable local identity; regular plugin entries keep
+ * the stricter owner-aware matching in ``marketPluginIdentity``.
  */
 export function getInstalledMarketAppVersion(
   entry: MarketPluginEntry,
@@ -26,12 +28,17 @@ export function getInstalledMarketAppVersion(
 
   const normalizedId = entry.id.startsWith("@") ? entry.id.slice(1) : entry.id;
   const exactIds = [entry.id, normalizedId];
-  if (
-    (channel === "official" || channel === "app") &&
-    installedPluginList.length === 0
-  ) {
-    // Keep compatibility for callers that only have a legacy version map.
-    exactIds.push(normalizedId.split("/").pop() ?? normalizedId);
+  if (channel === "official" || channel === "app") {
+    // PawApp IDs are unscoped locally (e.g. ``agent-kanban``), and the market
+    // owner/author labels are not guaranteed to use the same naming scheme.
+    const localAppId = normalizedId.split("/").pop() ?? normalizedId;
+    const localApp = installedPluginList.find(
+      (plugin) =>
+        normalizeMarketPluginId(plugin.id) ===
+        normalizeMarketPluginId(localAppId),
+    );
+    if (localApp?.version !== undefined) return localApp.version;
+    exactIds.push(localAppId);
   }
 
   for (const id of exactIds) {


### PR DESCRIPTION
Fixed an issue where installed apps were still displayed as "Install" in the official app and the app market.
Key Changes
- Matches local PawApp entries with market listings using the App ID, eliminating reliance on inconsistent author fields.
- Displays "Installed" when the local version matches the market version.
- Displays "Update" when versions differ (covering cases where the market version is either newer or older).
- Updates status logic across the official app, app market, and desktop App Store.
- Added test cases for scenarios involving author mismatches, identical versions, and version mismatches.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
