### PR TITLE
fix(models): preserve provider-resolved context windows

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/ModelConfigEditor.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ModelConfigEditor.tsx
@@ -115,11 +115,6 @@ export function ModelConfigEditor({
     setDirty(true);
   }, []);
 
-  const handleMaxInputLengthInput = useCallback(() => {
-    setMaxInputLengthDirty(true);
-    setDirty(true);
-  }, []);
-
   const handleSave = async () => {
     const trimmed = text.trim();
     let parsed: Record<string, unknown> = {};
@@ -237,7 +232,6 @@ export function ModelConfigEditor({
             value={maxInputLength}
             placeholder="131072"
             onChange={handleMaxInputLengthChange}
-            onInput={handleMaxInputLengthInput}
           />
           <div
             style={{

--- a/console/src/pages/Settings/Models/components/modals/ModelConfigEditor.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ModelConfigEditor.tsx
@@ -115,6 +115,11 @@ export function ModelConfigEditor({
     setDirty(true);
   }, []);
 
+  const handleMaxInputLengthInput = useCallback(() => {
+    setMaxInputLengthDirty(true);
+    setDirty(true);
+  }, []);
+
   const handleSave = async () => {
     const trimmed = text.trim();
     let parsed: Record<string, unknown> = {};
@@ -232,6 +237,7 @@ export function ModelConfigEditor({
             value={maxInputLength}
             placeholder="131072"
             onChange={handleMaxInputLengthChange}
+            onInput={handleMaxInputLengthInput}
           />
           <div
             style={{

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1917,36 +1917,26 @@ def _ensure_model_context_size(
     provider: Any,
     model_id: str,
 ) -> None:
-    """Restore a missing model window from the Provider resolution path."""
+    """Restore missing or defaulted windows from provider resolution."""
     current = getattr(model, "context_size", None)
     if isinstance(current, (int, float)) and current > 0 and current != 32768:
         return
     try:
         resolved = provider.get_context_size(model_id)
-        get_model_info = getattr(provider, "get_model_info", None)
-        model_info = (
-            get_model_info(model_id) if callable(get_model_info) else None
-        )
-        explicitly_configured = bool(
-            getattr(model_info, "max_input_length_configured", False),
-        )
         needs_restore = not (isinstance(current, (int, float)) and current > 0)
-        defaulted_without_explicit_config = (
-            current == 32768
-            and resolved != 32768
-            and not explicitly_configured
-        )
+        defaulted_context = current == 32768 and resolved != 32768
         if (
             isinstance(resolved, int)
             and resolved > 0
-            and (needs_restore or defaulted_without_explicit_config)
+            and (needs_restore or defaulted_context)
         ):
             setattr(model, "context_size", resolved)
             logger.warning(
-                "Model %s:%s did not expose context_size; restored %s "
+                "Model %s:%s context_size=%r; restored %s "
                 "from Provider configuration",
                 getattr(provider, "id", "unknown"),
                 model_id,
+                current,
                 resolved,
             )
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1930,9 +1930,7 @@ def _ensure_model_context_size(
         explicitly_configured = bool(
             getattr(model_info, "max_input_length_configured", False),
         )
-        needs_restore = not (
-            isinstance(current, (int, float)) and current > 0
-        )
+        needs_restore = not (isinstance(current, (int, float)) and current > 0)
         defaulted_without_explicit_config = (
             current == 32768
             and resolved != 32768

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1912,6 +1912,54 @@ def _resolved_provider_id(provider: Any, configured_provider_id: str) -> str:
     return str(getattr(provider, "id", "") or configured_provider_id)
 
 
+def _ensure_model_context_size(
+    model: Any,
+    provider: Any,
+    model_id: str,
+) -> None:
+    """Restore a missing model window from the Provider resolution path."""
+    current = getattr(model, "context_size", None)
+    if isinstance(current, (int, float)) and current > 0 and current != 32768:
+        return
+    try:
+        resolved = provider.get_context_size(model_id)
+        get_model_info = getattr(provider, "get_model_info", None)
+        model_info = (
+            get_model_info(model_id) if callable(get_model_info) else None
+        )
+        explicitly_configured = bool(
+            getattr(model_info, "max_input_length_configured", False),
+        )
+        needs_restore = not (
+            isinstance(current, (int, float)) and current > 0
+        )
+        defaulted_without_explicit_config = (
+            current == 32768
+            and resolved != 32768
+            and not explicitly_configured
+        )
+        if (
+            isinstance(resolved, int)
+            and resolved > 0
+            and (needs_restore or defaulted_without_explicit_config)
+        ):
+            setattr(model, "context_size", resolved)
+            logger.warning(
+                "Model %s:%s did not expose context_size; restored %s "
+                "from Provider configuration",
+                getattr(provider, "id", "unknown"),
+                model_id,
+                resolved,
+            )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "Unable to restore context_size for model %s:%s: %s",
+            getattr(provider, "id", "unknown"),
+            model_id,
+            exc,
+        )
+
+
 @dataclass
 class _AgentModelSettings:
     """Model routing settings loaded for one agent."""
@@ -2029,6 +2077,11 @@ def _apply_model_fallbacks(
                 fallback_model,
                 fallback_provider_id,
             )
+            _ensure_model_context_size(
+                fallback_model,
+                fallback_provider,
+                fallback_slot.model,
+            )
             _install_model_formatter(
                 fallback_model,
                 provider_id=fallback_provider_id,
@@ -2120,6 +2173,7 @@ def create_model_and_formatter(
         with agent_thinking_level(settings.thinking_level):
             model = provider.get_chat_model_instance(model_slot.model)
         provider_id = _resolved_provider_id(provider, model_slot.provider_id)
+        selected_model_id = model_slot.model
     else:
         # Fallback to global active model
         model = ProviderManager.get_active_chat_model()
@@ -2132,14 +2186,14 @@ def create_model_and_formatter(
                     "or set an agent-specific model."
                 ),
             )
-        provider_id = _resolved_provider_id(
-            ProviderManager.get_instance().get_provider(
-                global_model.provider_id,
-            ),
+        provider = ProviderManager.get_instance().get_provider(
             global_model.provider_id,
         )
+        provider_id = _resolved_provider_id(provider, global_model.provider_id)
+        selected_model_id = global_model.model
 
     provider_id = _bind_provider_id_to_model(model, provider_id)
+    _ensure_model_context_size(model, provider, selected_model_id)
 
     # Create the formatter based on the model's native one.  In 2.0 every
     # ``ChatModelBase`` carries its own ``self.formatter`` (set by its

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -2164,9 +2164,13 @@ def create_model_and_formatter(
         selected_model_id = model_slot.model
     else:
         # Fallback to global active model
-        model = ProviderManager.get_active_chat_model()
-        global_model = ProviderManager.get_instance().get_active_model()
-        if not global_model:
+        manager = ProviderManager.get_instance()
+        global_model = manager.get_active_model()
+        if (
+            global_model is None
+            or not global_model.provider_id
+            or not global_model.model
+        ):
             raise ProviderError(
                 message=(
                     "No active model configured. "
@@ -2174,11 +2178,16 @@ def create_model_and_formatter(
                     "or set an agent-specific model."
                 ),
             )
-        provider = ProviderManager.get_instance().get_provider(
-            global_model.provider_id,
-        )
+        provider = manager.get_provider(global_model.provider_id)
+        if provider is None:
+            raise ProviderError(
+                message=(
+                    f"Active provider '{global_model.provider_id}' not found."
+                ),
+            )
         provider_id = _resolved_provider_id(provider, global_model.provider_id)
         selected_model_id = global_model.model
+        model = provider.get_chat_model_instance(selected_model_id)
 
     provider_id = _bind_provider_id_to_model(model, provider_id)
     _ensure_model_context_size(model, provider, selected_model_id)

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -137,6 +137,54 @@ def test_override_with_model_slot_config(_patch_dependencies):
     assert _patch_dependencies == ["p"]
 
 
+def test_context_size_is_restored_when_missing():
+    """Restore a missing context window from the provider."""
+    model = SimpleNamespace(context_size=None)
+    provider = SimpleNamespace(
+        id="provider",
+        get_context_size=lambda _model_id: 131_072,
+        get_model_info=lambda _model_id: SimpleNamespace(
+            max_input_length_configured=False,
+        ),
+    )
+
+    model_factory._ensure_model_context_size(model, provider, "model")
+
+    assert model.context_size == 131_072
+
+
+def test_implicit_default_context_size_is_replaced():
+    """Replace an implicit AgentScope default with provider metadata."""
+    model = SimpleNamespace(context_size=32_768)
+    provider = SimpleNamespace(
+        id="provider",
+        get_context_size=lambda _model_id: 131_072,
+        get_model_info=lambda _model_id: SimpleNamespace(
+            max_input_length_configured=False,
+        ),
+    )
+
+    model_factory._ensure_model_context_size(model, provider, "model")
+
+    assert model.context_size == 131_072
+
+
+def test_explicit_default_context_size_is_preserved():
+    """Preserve an explicitly configured 32K context window."""
+    model = SimpleNamespace(context_size=32_768)
+    provider = SimpleNamespace(
+        id="provider",
+        get_context_size=lambda _model_id: 131_072,
+        get_model_info=lambda _model_id: SimpleNamespace(
+            max_input_length_configured=True,
+        ),
+    )
+
+    model_factory._ensure_model_context_size(model, provider, "model")
+
+    assert model.context_size == 32_768
+
+
 def test_factory_binds_returned_formatter_to_provider_model():
     """Callers that ignore the formatter return still use the enhanced one."""
     with patch.object(model_factory, "RetryConfig") as retry_cls:

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -365,7 +365,7 @@ def test_global_model_switch_during_construction_keeps_context(
                 ]
             ],
         )
-        for provider_id in {"dashscope", next_provider_id}
+        for provider_id in ("dashscope", next_provider_id)
     }
     manager = object.__new__(ProviderManager)
     manager.active_model = ModelSlotConfig(

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -25,6 +25,7 @@ from qwenpaw.config import config as config_module
 from qwenpaw.config.config import ModelSlotConfig
 from qwenpaw.providers import fallback_chat_model
 from qwenpaw.providers import provider as provider_module
+from qwenpaw.providers.dashscope_provider import DashScopeProvider
 
 
 _REAL_INSTALL_MODEL_FORMATTER = model_factory._install_model_formatter
@@ -169,20 +170,51 @@ def test_implicit_default_context_size_is_replaced():
     assert model.context_size == 131_072
 
 
-def test_explicit_default_context_size_is_preserved():
-    """Preserve an explicitly configured 32K context window."""
-    model = SimpleNamespace(context_size=32_768)
-    provider = SimpleNamespace(
-        id="provider",
-        get_context_size=lambda _model_id: 131_072,
-        get_model_info=lambda _model_id: SimpleNamespace(
-            max_input_length_configured=True,
-        ),
+@pytest.mark.parametrize("configured_size", [131_072, 32_768])
+@pytest.mark.parametrize("current_size", [None, 32_768])
+def test_factory_restores_explicit_context_size(
+    monkeypatch,
+    configured_size,
+    current_size,
+):
+    """Use provider resolution for missing or defaulted model windows."""
+    model_id = "qwen3.8-max"
+    provider = DashScopeProvider(
+        id="dashscope",
+        name="DashScope",
+        models=[
+            provider_module.ModelInfo(
+                id=model_id,
+                name=model_id,
+                max_input_length_auto_detected=262_144,
+            ),
+        ],
+    )
+    assert provider.update_model_config(
+        model_id,
+        {"max_input_length": configured_size},
+    )
+    assert provider.get_context_size(model_id) == configured_size
+
+    model = _FakeChatModel(model_id)
+    model.context_size = current_size
+    monkeypatch.setattr(
+        DashScopeProvider,
+        "get_chat_model_instance",
+        lambda _self, _model_id: model,
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        lambda: SimpleNamespace(get_provider=lambda _provider_id: provider),
     )
 
-    model_factory._ensure_model_context_size(model, provider, "model")
+    actual, _ = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+        model_slot_override=f"dashscope:{model_id}",
+    )
 
-    assert model.context_size == 32_768
+    assert actual.context_size == configured_size
 
 
 def test_factory_binds_returned_formatter_to_provider_model():

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -2,6 +2,7 @@
 """Tests for ``create_model_and_formatter`` model override support."""
 
 # pylint: disable=protected-access,redefined-outer-name
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 import threading
 from types import SimpleNamespace
@@ -26,6 +27,9 @@ from qwenpaw.config.config import ModelSlotConfig
 from qwenpaw.providers import fallback_chat_model
 from qwenpaw.providers import provider as provider_module
 from qwenpaw.providers.dashscope_provider import DashScopeProvider
+from qwenpaw.providers.provider_manager import ProviderManager
+from qwenpaw.providers.retry_chat_model import RetryChatModel
+from qwenpaw.token_usage import TokenRecordingModelWrapper
 
 
 _REAL_INSTALL_MODEL_FORMATTER = model_factory._install_model_formatter
@@ -335,6 +339,136 @@ def test_no_override_uses_active_model():
         )
 
     assert model.identifier == "default-provider/default-model"
+
+
+@pytest.mark.parametrize("next_provider_id", ["dashscope", "other-dashscope"])
+def test_global_model_switch_during_construction_keeps_context(
+    monkeypatch,
+    next_provider_id,
+):
+    """Keep model identity and context from the same global selection."""
+    providers = {
+        provider_id: DashScopeProvider(
+            id=provider_id,
+            name=provider_id,
+            api_key="test-key",
+            models=[
+                provider_module.ModelInfo(
+                    id=model_id,
+                    name=model_id,
+                    max_input_length=context_size,
+                    max_input_length_configured=True,
+                )
+                for model_id, context_size in [
+                    ("model-a", 32_768),
+                    ("model-b", 131_072),
+                ]
+            ],
+        )
+        for provider_id in {"dashscope", next_provider_id}
+    }
+    manager = object.__new__(ProviderManager)
+    manager.active_model = ModelSlotConfig(
+        provider_id="dashscope",
+        model="model-a",
+    )
+    monkeypatch.setattr(manager, "get_provider", providers.get)
+    monkeypatch.setattr(ProviderManager, "get_instance", lambda: manager)
+    monkeypatch.setattr(model_factory, "ProviderManager", ProviderManager)
+    monkeypatch.setattr(model_factory, "RetryChatModel", RetryChatModel)
+    monkeypatch.setattr(
+        model_factory,
+        "TokenRecordingModelWrapper",
+        TokenRecordingModelWrapper,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_install_model_formatter",
+        _REAL_INSTALL_MODEL_FORMATTER,
+    )
+    config = SimpleNamespace(
+        active_model=None,
+        running=config_module.AgentsRunningConfig(),
+    )
+    constructed = threading.Event()
+    resume = threading.Event()
+    build_model = DashScopeProvider.get_chat_model_instance
+
+    def pause_after_construction(provider, model_id):
+        model = build_model(provider, model_id)
+        if model_id == "model-a":
+            constructed.set()
+            assert resume.wait(timeout=10), "Model switch did not finish"
+        return model
+
+    monkeypatch.setattr(
+        DashScopeProvider,
+        "get_chat_model_instance",
+        pause_after_construction,
+    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(
+            model_factory.create_model_and_formatter,
+            agent_id="agent-1",
+            agent_config=config,
+        )
+        try:
+            assert constructed.wait(timeout=10), "Model was not constructed"
+            manager.active_model = ModelSlotConfig(
+                provider_id=next_provider_id,
+                model="model-b",
+            )
+        finally:
+            resume.set()
+        actual, _ = pending.result(timeout=10)
+
+    assert actual.model == "model-a"
+    assert actual.context_size == 32_768
+    assert actual.model_key == "dashscope:model-a"
+    assert actual._inner.context_size == 32_768
+    assert actual._inner._model.context_size == 32_768
+
+    next_model, _ = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+        agent_config=config,
+    )
+    assert next_model.model_key == f"{next_provider_id}:model-b"
+    assert next_model.context_size == 131_072
+
+
+@pytest.mark.parametrize(
+    "global_slot",
+    [None, ("", "model-a"), ("dashscope", ""), ("dashscope", "model-a")],
+)
+def test_global_model_configuration_errors(monkeypatch, global_slot):
+    """Report missing global models or providers before construction."""
+    global_model = (
+        ModelSlotConfig(provider_id=global_slot[0], model=global_slot[1])
+        if global_slot is not None
+        else None
+    )
+    manager = SimpleNamespace(
+        get_active_model=lambda: global_model,
+        get_provider=lambda _provider_id: None,
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        lambda: manager,
+    )
+    expected = (
+        "Active provider 'dashscope' not found"
+        if global_slot == ("dashscope", "model-a")
+        else "No active model configured"
+    )
+    config = _patched_load_agent_config("agent-1")
+    config.active_model = None
+
+    with pytest.raises(model_factory.ProviderError, match=expected):
+        model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            agent_config=config,
+        )
 
 
 async def test_async_factory_builds_model_in_worker_thread(monkeypatch):


### PR DESCRIPTION
## Description

Some model instances may expose no valid `context_size`, or may retain
AgentScope's default value of `32768` even when the provider resolves a
larger context window. This can cause premature context compaction.

This PR restores the model context size from the provider resolution path
when appropriate, while preserving explicitly configured values.

**Related Issue:** Relates to #7576

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Evidence

Frontend unit tests:
Test Files  1 passed
Tests       3 passed

Backend regression tests:
99 passed in 1.95s

Context window comparison:
missing: before=None, resolved=131072 -> after=131072
default-implicit: before=32768, resolved=131072 -> after=131072
explicit-32k: before=32768, resolved=32768 -> after=32768

## Additional Notes

The Console Max Context Length input behavior was intentionally left
unchanged. The submitted change is limited to restoring provider-resolved
model context windows.
