### PR TITLE
fix(agents): recognize llama-server and DashScope URL audio rejections in audio-fallback classifier

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -608,7 +608,26 @@ class QwenPawAgent(CodingModeMixin, Agent):
 
     @staticmethod
     def _is_audio_fallback_error(exc: Exception) -> bool:
-        """Return whether DashScope rejected the current audio payload."""
+        """Return whether the provider rejected the current audio payload.
+
+        Recognized rejection shapes:
+
+        1. DashScope modality error — HTTP 400 with
+           ``InternalError.Algo.InvalidParameter`` and the
+           "incorrect modal ... audio ..." wording.
+        2. DashScope URL-shape error — HTTP 400 with
+           "The provided URL does not appear to be valid" when local
+           audio is serialized as raw base64 (issue #7015, first
+           failure mode).
+        3. llama.cpp ``llama-server`` (OpenAI-compatible) backed by a
+           vision-only mmproj — HTTP 500 with
+           "audio input is not supported".
+
+        Callers gate this classifier on ``_last_wire_request_had_audio()``,
+        so shape 2 cannot misclassify genuinely malformed image/video
+        URLs: those requests carry no audio blocks and never reach the
+        audio-strip retry.
+        """
         error_str = " ".join(str(exc).lower().split())
         status = extract_status_code(exc)
         has_bad_request_status = status == 400 or "<400>" in error_str
@@ -622,11 +641,20 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 "wrong position",
             )
         )
-        return (
+        if (
             has_bad_request_status
             and "internalerror.algo.invalidparameter" in error_str
             and invalid_modal
-        )
+        ):
+            return True
+        if (
+            has_bad_request_status
+            and "the provided url does not appear to be valid" in error_str
+        ):
+            return True
+        if "audio input is not supported" in error_str:
+            return True
+        return False
 
     async def _prepare_model_input(self) -> dict[str, Any]:
         """Freeze local images before they enter a provider request."""

--- a/tests/unit/agents/test_react_agent_audio_fallback.py
+++ b/tests/unit/agents/test_react_agent_audio_fallback.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Audio-fallback error classifier (follow-up to issue #7015).
+
+``_is_audio_fallback_error`` gates the strip-audio-and-retry path in
+``QwenPawAgent._reasoning``.  The original classifier only recognized
+DashScope's modality rejection ("incorrect modal ... audio ...").  Two
+rejection shapes fell through and killed the whole agent turn even
+though the audio file had already been delivered to the user:
+
+1. DashScope rejects local audio serialized as raw base64 with a
+   generic invalid-URL error (issue #7015, first failure mode).
+2. llama.cpp ``llama-server`` (OpenAI-compatible) backed by a
+   vision-only mmproj rejects ``input_audio`` with HTTP 500
+   "audio input is not supported".
+
+These tests pin the three recognized shapes and the false-positive
+guards.  The URL-shape match is deliberately gated on a 400-class
+status and, at the call site, on ``_last_wire_request_had_audio()``,
+so genuinely malformed image/video URLs cannot be misclassified as
+audio rejections.
+"""
+from __future__ import annotations
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+
+
+class _FakeAPIError(Exception):
+    """Mimics a provider SDK error carrying an HTTP status."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+def test_dashscope_modality_rejection_matches() -> None:
+    """Original shape: 400 + InvalidParameter + 'incorrect modal audio'."""
+    exc = _FakeAPIError(
+        'Error code: 400 - {"code":"InternalError.Algo.InvalidParameter",'
+        '"message":"An incorrect modal `audio` was entered, which may not '
+        "be supported by the model or was placed in the wrong position "
+        '(e.g., in system/assistant)."}',
+        status_code=400,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is True
+
+
+def test_dashscope_invalid_url_rejection_matches() -> None:
+    """Issue #7015 first failure mode: local audio serialized as raw
+    base64 is rejected as an invalid URL (HTTP 400)."""
+    exc = _FakeAPIError(
+        'data: {"error":{"code":"invalid_parameter_error","param":null,'
+        '"message":"The provided URL does not appear to be valid. Ensure '
+        'it is correctly formatted.","type":"invalid_request_error"}}',
+        status_code=400,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is True
+
+
+def test_llama_server_audio_unsupported_matches() -> None:
+    """llama.cpp llama-server with a vision-only mmproj rejects
+    input_audio with HTTP 500."""
+    exc = _FakeAPIError(
+        'Error code: 500 - {"error":{"code":500,"message":"audio input is '
+        'not supported - hint: if this is unexpected, you may need to '
+        'provide the mmproj","type":"server_error"}}',
+        status_code=500,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is True
+
+
+def test_llama_server_audio_unsupported_without_status_matches() -> None:
+    """The llama-server message is unambiguous on its own; status
+    extraction is not required for this shape."""
+    exc = Exception("audio input is not supported")
+    assert QwenPawAgent._is_audio_fallback_error(exc) is True
+
+
+def test_invalid_url_without_bad_request_status_does_not_match() -> None:
+    """The URL-shape match is gated on a 400-class status so transport
+    failures (5xx) are not misread as audio rejections."""
+    exc = _FakeAPIError(
+        "The provided URL does not appear to be valid.",
+        status_code=503,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is False
+
+
+def test_generic_server_error_does_not_match() -> None:
+    exc = _FakeAPIError(
+        'Error code: 500 - {"error":{"message":"internal server error"}}',
+        status_code=500,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is False
+
+
+def test_image_decode_error_does_not_match() -> None:
+    """A vision failure must not be misread as an audio rejection."""
+    exc = _FakeAPIError(
+        'Error code: 500 - {"error":{"message":"failed to decode image"}}',
+        status_code=500,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is False
+
+
+def test_context_overflow_error_does_not_match() -> None:
+    """Context-overflow 400s are handled by a dedicated classifier and
+    must not enter the audio-strip retry."""
+    exc = _FakeAPIError(
+        "Error code: 400 - context length exceeded",
+        status_code=400,
+    )
+    assert QwenPawAgent._is_audio_fallback_error(exc) is False

--- a/tests/unit/agents/test_react_agent_audio_fallback.py
+++ b/tests/unit/agents/test_react_agent_audio_fallback.py
@@ -63,7 +63,7 @@ def test_llama_server_audio_unsupported_matches() -> None:
     input_audio with HTTP 500."""
     exc = _FakeAPIError(
         'Error code: 500 - {"error":{"code":500,"message":"audio input is '
-        'not supported - hint: if this is unexpected, you may need to '
+        "not supported - hint: if this is unexpected, you may need to "
         'provide the mmproj","type":"server_error"}}',
         status_code=500,
     )


### PR DESCRIPTION
## Description

Follow-up to #7015 (fixed by #7024). The modality-aware audio stripping works, but its reactive learning entry point (`_is_audio_fallback_error`) only recognizes DashScope's "incorrect modal" rejection. Two rejection shapes still fall through and kill the entire agent turn *after* `send_file_to_user` has already delivered the audio file to the user:

1. **DashScope URL-shape rejection** — the first failure mode documented in #7015: local audio serialized as raw base64 is rejected with HTTP 400 `"The provided URL does not appear to be valid"`. This wording never reaches the audio classifier, so no strip-and-retry happens, no `rejects_audio` capability is learned, and **every subsequent turn re-crashes** while the audio block remains in session history (reproduced: the user had to switch the active model to recover the conversation).
2. **llama.cpp `llama-server`** (self-hosted OpenAI-compatible endpoint with a vision-only mmproj, e.g. Qwen-VL-family GGUFs) rejects `input_audio` with HTTP 500 `"audio input is not supported - hint: ..."`. Same outcome: turn dies, nothing learned.

Both shapes were reproduced in production on QwenPaw 2.2.0 (Windows 11, Python 3.12.13):

- provider `aliyun-tokenplan` / model `qwen3.8-max` → shape 1
- custom provider → local `llama-server` (b10715) serving a Qwen-VL GGUF with vision mmproj → shape 2

The fix reuses the existing strip → retry → learn machinery: both shapes now classify as audio-fallback errors, so the turn recovers and `rejects_audio` is learned for the model key (subsequent requests strip audio proactively while images keep working).

**Related Issue:** Relates to #7015

**Security Considerations:** None. The change only widens error-message classification for the existing audio strip-and-retry path; no new inputs are accepted and no credential/config handling is touched. The URL-shape match is gated on a 400-class status and, at the call site, on `_last_wire_request_had_audio()`, so malformed image/video URLs cannot be misclassified as audio rejections (addressing the concern raised in #7015 about matching the URL error broadly).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes *(on the changed files; see Evidence for the honest `--all-files` result)*
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks *(black reformatted one line of the new test file; committed as 838123a, re-run clean)*
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

New unit tests `tests/unit/agents/test_react_agent_audio_fallback.py` (8 cases):

- recognized shapes: DashScope modality 400, DashScope URL 400, llama-server 500 (with and without a structured status code)
- false-positive guards: URL error without 400-class status, generic 500, image-decode failure, context-overflow 400

Regression scope includes the existing `test_audio_modal_error_strips_audio_and_retries_once` (the strip-and-retry path itself) plus the message-normalizer / model-factory / tool-coercion suites.

```bash
pytest tests/unit/agents/test_react_agent_audio_fallback.py \
  tests/unit/agents/test_message_request_normalizer.py \
  tests/unit/agents/test_model_factory_message_normalization.py \
  tests/unit/agents/test_react_agent_tool_coercion.py \
  tests/unit/agents/test_react_agent_scroll_seen.py -q
```

## Evidence

**pre-commit on the changed files** (all hooks pass):

```
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

**pre-commit run --all-files** (honest result): mypy/pylint report failures only in pre-existing files unrelated to this PR (e.g. `tests/unit/harnesses/test_runtime.py`, `tests/unit/loop/test_handler_continuation_reset.py`, `tests/unit/plugins/computer_use/test_stop_semantics.py` — unused-argument warnings); the two files changed here pass every hook. This appears to be environment-specific (Windows / local hook envs) since main is green in CI.

**pytest** (agents unit suite incl. the new tests and the existing audio-retry test):

```
107 passed in 2.52s
```

**Production logs** from the patched 2.2.0 install (Windows 11). llama-server side — rejection, then successful recovery in the same turn:

```
32.18.508 W srv operator (): got exception: {"error":{"code":500,"message":"audio input is not supported - hint: if this is unexpected, you may need to provide the mmproj","type":"server_error"}}
32.20.361 I slot print_timing: id 1 | task 0 | total time = 704.54 ms / 22 tokens
```

QwenPaw side — fallback fired and capability learned for the DashScope model key:

```
2026-09-09 20:15:44 | WARNING | react_agent.py:866 | _reasoning failed because the provider rejected an audio payload (...); stripping audio and retrying.
2026-09-09 20:16:31 | INFO | model_capability_cache.py:84 | Learned capability for aliyun-tokenplan:qwen3.8-max: rejects_audio=True
```

## Additional Notes

**AI-assistance disclosure (per #4333):** this fix was drafted with AI assistance (by a QwenPaw agent — dogfooding). The root cause was verified by replaying `input_audio` payloads directly against both live endpoints; the diff was reviewed line-by-line by the submitter; and every command shown above was executed on the submitter's machine (Windows 11, Python 3.12.13, pytest + pytest-asyncio, pre-commit with the repo's pinned hook versions).
