### PR TITLE
fix(history): repair FTS corruption and retention cleanup (#7596)

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -87,11 +87,23 @@ class HistoryStore:
         try:
             self._open_and_init()
         except sqlite3.DatabaseError as exc:
+            if not (
+                self._is_corruption(exc)
+                or getattr(exc, "sqlite_errorcode", None)
+                == sqlite3.SQLITE_NOTADB
+                or str(exc).startswith("quick_check failed:")
+            ):
+                if hasattr(self, "_conn"):
+                    self._conn.close()
+                raise
             # A corrupt / unreadable DB (truncated file, stale WAL trio, bad
             # page) would crash every task at startup. Quarantine the bad file
             # and recreate fresh, degrading "broken memory" to "lost history".
             self._quarantine(exc)
             self._open_and_init()
+        except RuntimeError:
+            self._conn.close()
+            raise
 
     def _open_and_init(self) -> None:
         # check_same_thread=False: used from both loop and worker threads;
@@ -105,12 +117,96 @@ class HistoryStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
         # Probe for corruption that only surfaces on read.
-        row = self._conn.execute("PRAGMA quick_check").fetchone()
-        if not row or row[0] != "ok":
-            raise sqlite3.DatabaseError(
-                f"quick_check failed: {row[0] if row else None}",
-            )
+        results = [r[0] for r in self._conn.execute("PRAGMA quick_check")]
+        if results != ["ok"]:
+            # Some SQLite builds also report FTS damage here. Repair that
+            # derived index before considering whole-database quarantine.
+            if results and all(
+                r == "malformed inverted index for FTS5 table "
+                "main.conversation_history_fts"
+                for r in results
+            ):
+                self._repair_fts()
+                results = [
+                    r[0] for r in self._conn.execute("PRAGMA quick_check")
+                ]
+            if results != ["ok"]:
+                raise sqlite3.DatabaseError(f"quick_check failed: {results}")
         self._init_schema()
+        if self._fts:
+            try:
+                with self._conn:
+                    self._check_fts()
+            except sqlite3.DatabaseError as exc:
+                if not self._is_corruption(exc):
+                    raise
+                self._repair_fts()
+
+    @staticmethod
+    def _is_corruption(exc: sqlite3.DatabaseError) -> bool:
+        # Extended codes such as SQLITE_CORRUPT_VTAB share this primary code.
+        code = getattr(exc, "sqlite_errorcode", None)
+        return code is not None and (code & 0xFF) == sqlite3.SQLITE_CORRUPT
+
+    def _check_fts(self) -> None:
+        # Do not use rank=1: recall-tool rows are deliberately absent from
+        # this external-content index, so full content equality is invalid.
+        self._conn.execute(
+            "INSERT INTO conversation_history_fts"
+            "(conversation_history_fts) VALUES('integrity-check')",
+        )
+
+    def _rebuild_fts(self) -> None:
+        self._conn.execute(
+            "INSERT INTO conversation_history_fts"
+            "(conversation_history_fts) VALUES('rebuild')",
+        )
+        # Rebuild includes every source row. Remove the deliberately excluded
+        # rows now, while we know they are indexed, in the same transaction.
+        for row in self._conn.execute(
+            "SELECT seq, content FROM conversation_history "
+            "WHERE name IN (?, ?)",
+            _RECALL_TOOL_NAMES,
+        ).fetchall():
+            self._conn.execute(
+                "INSERT INTO conversation_history_fts"
+                "(conversation_history_fts, rowid, content) "
+                "VALUES('delete', ?, ?)",
+                (row["seq"], row["content"] or ""),
+            )
+
+    def _repair_fts(self) -> None:
+        logger.warning("Rebuilding damaged history FTS index: %s", self._path)
+        try:
+            with self._conn:
+                self._rebuild_fts()
+                self._check_fts()
+        except sqlite3.DatabaseError as exc:
+            # Keep the source history even if repair fails. In particular,
+            # do not let the constructor quarantine it as a corrupt database.
+            raise RuntimeError(
+                f"History FTS repair failed; history preserved: {self._path}",
+            ) from exc
+        logger.info("History FTS index repaired: %s", self._path)
+
+    def _delete_fts_row(self, row: sqlite3.Row) -> None:
+        # Older rebuilds may have indexed recall rows. The docsize table
+        # records actual membership (SELECT on the virtual table instead
+        # reads external content, including rows that were never indexed).
+        if (
+            row["name"] in _RECALL_TOOL_NAMES
+            and not self._conn.execute(
+                "SELECT 1 FROM conversation_history_fts_docsize WHERE id = ?",
+                (row["seq"],),
+            ).fetchone()
+        ):
+            return
+        self._conn.execute(
+            "INSERT INTO conversation_history_fts"
+            "(conversation_history_fts, rowid, content) "
+            "VALUES('delete', ?, ?)",
+            (row["seq"], row["content"] or ""),
+        )
 
     def _quarantine(self, exc: Exception) -> None:
         """Move the unreadable DB + its -wal/-shm aside with a timestamp."""
@@ -219,12 +315,11 @@ class HistoryStore:
                 "content_rowid='seq', tokenize='porter unicode61')",
             )
             if not existed:
-                self._conn.execute(
-                    "INSERT INTO conversation_history_fts"
-                    "(conversation_history_fts) VALUES('rebuild')",
-                )
+                self._rebuild_fts()
             self._fts = True
         except sqlite3.OperationalError as exc:
+            if "no such module: fts5" not in str(exc).lower():
+                raise
             self._fts = False
             if not HistoryStore._fts_unavailable_warned:
                 HistoryStore._fts_unavailable_warned = True
@@ -377,17 +472,16 @@ class HistoryStore:
         first-write values. ``seq`` is unchanged. Omitting ``metadata`` keeps
         the stored value unchanged for backwards-compatible direct callers.
         """
-        # Recall-tool rows are never FTS-indexed (see ``_RECALL_TOOL_NAMES``),
-        # so don't touch the index for them on update either.
-        fts_sync = self._fts and name not in _RECALL_TOOL_NAMES
         with self._lock, self._conn:
-            old_content = None
-            if fts_sync:
-                r = self._conn.execute(
-                    "SELECT content FROM conversation_history WHERE seq = ?",
-                    (seq,),
-                ).fetchone()
-                old_content = r["content"] if r else None
+            old_row = self._conn.execute(
+                "SELECT seq, content, name FROM conversation_history "
+                "WHERE seq = ?",
+                (seq,),
+            ).fetchone()
+            if old_row is None:
+                return
+            if self._fts:
+                self._delete_fts_row(old_row)
             # Keep every column name below as a hard-coded literal. Only
             # values are parameterized; never add caller-controlled names.
             assignments = [
@@ -420,14 +514,7 @@ class HistoryStore:
                 + " WHERE seq = ?",
                 values,
             )
-            if fts_sync:
-                if old_content is not None:
-                    self._conn.execute(
-                        "INSERT INTO conversation_history_fts"
-                        "(conversation_history_fts, rowid, content) "
-                        "VALUES('delete', ?, ?)",
-                        (seq, old_content),
-                    )
+            if self._fts and name not in _RECALL_TOOL_NAMES:
                 self._conn.execute(
                     "INSERT INTO conversation_history_fts(rowid, content) "
                     "VALUES (?, ?)",
@@ -499,7 +586,7 @@ class HistoryStore:
                         ownership = " AND (agent_id = ? OR agent_id IS NULL)"
                         params.append(agent_id)
                     rows = self._conn.execute(
-                        "SELECT seq, dedup_key, content "
+                        "SELECT seq, dedup_key, content, name "
                         "FROM conversation_history "
                         "WHERE session_id = ? AND dedup_key IN ("
                         + placeholders
@@ -533,12 +620,7 @@ class HistoryStore:
 
                     if self._fts:
                         for row in duplicates:
-                            self._conn.execute(
-                                "INSERT INTO conversation_history_fts"
-                                "(conversation_history_fts, rowid, content) "
-                                "VALUES('delete', ?, ?)",
-                                (row["seq"], row["content"] or ""),
-                            )
+                            self._delete_fts_row(row)
                     if duplicates:
                         self._conn.executemany(
                             "DELETE FROM conversation_history WHERE seq = ?",
@@ -683,28 +765,37 @@ class HistoryStore:
         but the file does not shrink on disk until a separate vacuum.
         """
         where, params = self._purge_where(before, kinds)
-        with self._lock, self._conn:
-            doomed = self._conn.execute(
-                "SELECT seq, content FROM conversation_history WHERE " + where,
-                params,
-            ).fetchall()
-            if not doomed:
-                return 0
-            if dry_run:
-                return len(doomed)
-            if self._fts:
-                for row in doomed:
-                    self._conn.execute(
-                        "INSERT INTO conversation_history_fts"
-                        "(conversation_history_fts, rowid, content) "
-                        "VALUES('delete', ?, ?)",
-                        (row["seq"], row["content"] or ""),
-                    )
-            self._conn.execute(
-                "DELETE FROM conversation_history WHERE " + where,
-                params,
-            )
-            return len(doomed)
+        with self._lock:
+            for attempt in range(2):
+                try:
+                    with self._conn:
+                        doomed = self._conn.execute(
+                            "SELECT seq, content, name "
+                            "FROM conversation_history WHERE " + where,
+                            params,
+                        ).fetchall()
+                        if dry_run or not doomed:
+                            return len(doomed)
+                        if self._fts:
+                            for row in doomed:
+                                self._delete_fts_row(row)
+                        self._conn.execute(
+                            "DELETE FROM conversation_history WHERE " + where,
+                            params,
+                        )
+                    return len(doomed)
+                except sqlite3.DatabaseError as exc:
+                    # The transaction has rolled back before rebuilding. Never
+                    # rebuild for operational errors or retry more than once.
+                    if (
+                        attempt
+                        or dry_run
+                        or not self._fts
+                        or not self._is_corruption(exc)
+                    ):
+                        raise
+                    self._repair_fts()
+        raise AssertionError("unreachable")
 
     def vacuum(self) -> None:
         """Rebuild the database file to reclaim space freed by ``purge``.

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -135,12 +135,31 @@ class HistoryStore:
         self._init_schema()
         if self._fts:
             try:
-                with self._conn:
-                    self._check_fts()
+                # FTS integrity-check is an INSERT and needs a writer lock.
+                # This optional probe must not stall request construction
+                # behind an ordinary writer; subsequent opens try it again.
+                try:
+                    self._conn.execute("PRAGMA busy_timeout=0")
+                    with self._conn:
+                        self._check_fts()
+                finally:
+                    self._conn.execute(
+                        f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}",
+                    )
             except sqlite3.DatabaseError as exc:
-                if not self._is_corruption(exc):
+                code = getattr(exc, "sqlite_errorcode", None)
+                if code is not None and (code & 0xFF) in (
+                    sqlite3.SQLITE_BUSY,
+                    sqlite3.SQLITE_LOCKED,
+                ):
+                    logger.debug(
+                        "Deferring history FTS check until a later open: %s",
+                        self._path,
+                    )
+                elif self._is_corruption(exc):
+                    self._repair_fts()
+                else:
                     raise
-                self._repair_fts()
 
     @staticmethod
     def _is_corruption(exc: sqlite3.DatabaseError) -> bool:

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import sys
 import threading
@@ -121,15 +122,16 @@ class HistoryStore:
         if results != ["ok"]:
             # Some SQLite builds also report FTS damage here. Repair that
             # derived index before considering whole-database quarantine.
-            if results and all(
-                r == "malformed inverted index for FTS5 table "
-                "main.conversation_history_fts"
-                for r in results
-            ):
+            if self._is_fts_only_corruption(results):
                 self._repair_fts()
                 results = [
                     r[0] for r in self._conn.execute("PRAGMA quick_check")
                 ]
+            if self._is_fts_only_corruption(results):
+                raise RuntimeError(
+                    "History FTS corruption remains after repair; "
+                    f"history preserved: {self._path}: {results}",
+                )
             if results != ["ok"]:
                 raise sqlite3.DatabaseError(f"quick_check failed: {results}")
         self._init_schema()
@@ -160,6 +162,22 @@ class HistoryStore:
                     self._repair_fts()
                 else:
                     raise
+
+    @staticmethod
+    def _is_fts_only_corruption(results: Sequence[str]) -> bool:
+        # SQLite versions describe FTS damage differently. Match the error
+        # category and exact index name, not a single diagnostic spelling.
+        # Mixed results or corruption in another table must not be treated
+        # as repairable damage to this derived index alone.
+        pattern = (
+            r"(?:malformed inverted index for FTS5 table "
+            r"(?:main\.)?conversation_history_fts|"
+            r"fts5: corruption\b.* from table "
+            r'"(?:main\.)?conversation_history_fts")'
+        )
+        return bool(results) and all(
+            re.fullmatch(pattern, result) is not None for result in results
+        )
 
     @staticmethod
     def _is_corruption(exc: sqlite3.DatabaseError) -> bool:

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -780,3 +780,101 @@ def test_startup_lock_does_not_quarantine(tmp_path):
             "SELECT content FROM conversation_history",
         ).fetchone() == ("aardvark",)
     assert not list(tmp_path.glob("*.corrupt-*"))
+
+
+def test_startup_fts_check_defers_while_wal_writer_is_active(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "history.db"
+    initial = HistoryStore(path)
+    initial.append(session_id="s", entry=_entry("aardvark"))
+    initial.close()
+    original_check = HistoryStore._check_fts
+    attempts = []
+
+    def check(store):
+        # Only the optional probe gets a zero wait, not normal writes/repair.
+        assert store._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 0
+        try:
+            original_check(store)
+        except sqlite3.DatabaseError as exc:
+            attempts.append(exc.sqlite_errorcode & 0xFF)
+            raise
+        attempts.append("ok")
+
+    monkeypatch.setattr(HistoryStore, "_check_fts", check)
+    writer = sqlite3.connect(path)
+    opened = None
+    try:
+        writer.execute("BEGIN IMMEDIATE")
+        opened = HistoryStore(path)
+        assert attempts == [sqlite3.SQLITE_BUSY]
+        assert opened.count("s") == 1
+        assert _fts_hits(opened, "aardvark")
+        assert opened.quarantined_to is None
+        assert opened._fts is True
+        assert not opened._conn.in_transaction
+        assert (
+            opened._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+        )
+        writer.rollback()
+        opened.append(session_id="s", entry=_entry("zebra"))
+        assert opened.count("s") == 2
+    finally:
+        writer.close()
+        if opened is not None:
+            opened.close()
+    reopened = HistoryStore(path)
+    try:
+        assert attempts == [sqlite3.SQLITE_BUSY, "ok"]
+        assert reopened.count("s") == 2
+    finally:
+        reopened.close()
+    assert not list(tmp_path.glob("*.corrupt-*"))
+
+
+@pytest.mark.parametrize(
+    "code,deferred",
+    [
+        (sqlite3.SQLITE_LOCKED, True),
+        (sqlite3.SQLITE_LOCKED_SHAREDCACHE, True),
+        (sqlite3.SQLITE_BUSY_SNAPSHOT, True),
+        (sqlite3.SQLITE_IOERR, False),
+        (sqlite3.SQLITE_FULL, False),
+    ],
+)
+def test_startup_fts_defers_only_contention(
+    tmp_path,
+    monkeypatch,
+    code,
+    deferred,
+):
+    path = tmp_path / "history.db"
+    HistoryStore(path).close()
+
+    def check(store):
+        error = sqlite3.OperationalError("synthetic FTS check error")
+        error.sqlite_errorcode = code
+        raise error
+
+    def repair(store):
+        pytest.fail("Operational errors must not trigger FTS repair")
+
+    monkeypatch.setattr(HistoryStore, "_check_fts", check)
+    monkeypatch.setattr(HistoryStore, "_repair_fts", repair)
+    if deferred:
+        store = HistoryStore(path)
+        try:
+            assert store._fts is True
+            assert not store._conn.in_transaction
+            assert (
+                store._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+                == 5000
+            )
+        finally:
+            store.close()
+    else:
+        with pytest.raises(sqlite3.OperationalError, match="synthetic"):
+            HistoryStore(path)
+    assert not list(tmp_path.glob("*.corrupt-*"))

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -499,3 +499,284 @@ def test_corrupt_db_is_quarantined_and_recreated(tmp_path: Path):
         assert store.count("s") == 1
     finally:
         store.close()
+
+
+@pytest.mark.parametrize("legacy_rebuild", [False, True])
+def test_purge_recall_rows_preserves_search_exclusion(store, legacy_rebuild):
+    if not store._fts:
+        pytest.skip("SQLite build lacks FTS5")
+    store.append(
+        session_id="s",
+        entry=_entry("expired", created_at="2020-01-01"),
+    )
+    for name in ("recall_history", "recall_history_python"):
+        store.append(
+            session_id="s",
+            entry=_entry("recall output", name=name, created_at="2020-01-01"),
+        )
+    recent = store.append(
+        session_id="s",
+        entry=_entry("zebra", created_at="2099-01-01"),
+    )
+    if legacy_rebuild:
+        with store._conn:
+            store._conn.execute(
+                "INSERT INTO conversation_history_fts"
+                "(conversation_history_fts) VALUES('rebuild')",
+            )
+    assert store.purge(before="2026-01-01", dry_run=True) == 3
+    assert store.count("s") == 4
+    assert store.purge(before="2026-01-01") == 3
+    assert store.count("s") == 1
+    assert _fts_hits(store, "zebra") == [recent]
+    assert _fts_hits(store, "recall") == []
+    with store._conn:
+        store._check_fts()
+
+
+def _fts_hits(store, term):
+    return [
+        row[0]
+        for row in store._conn.execute(
+            "SELECT rowid FROM conversation_history_fts "
+            "WHERE conversation_history_fts MATCH ?",
+            (term,),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "old_name,new_name",
+    [
+        (None, "recall_history"),
+        ("recall_history", None),
+        ("recall_history_python", "recall_history"),
+    ],
+)
+def test_update_moves_into_and_out_of_search(store, old_name, new_name):
+    seq = store.append(session_id="s", entry=_entry("aardvark", name=old_name))
+    store.update_entry(
+        seq,
+        content="zebra",
+        name=new_name,
+        headline=None,
+        blocks=None,
+    )
+    assert _fts_hits(store, "aardvark") == []
+    assert _fts_hits(store, "zebra") == ([seq] if new_name is None else [])
+    assert store.count("s") == 1
+
+
+def test_reconcile_unindexed_recall_duplicate(store):
+    for session in ("canonical", "source"):
+        store.append(
+            session_id=session,
+            dedup_key="same",
+            entry=_entry("recall output", name="recall_history"),
+        )
+    assert store.reconcile_session_rows(
+        {"source"},
+        "canonical",
+        {"same"},
+    ) == (0, 1, 0)
+    assert store.count("canonical") == 1
+    assert store.count("source") == 0
+
+
+def _damage_fts(store):
+    with store._conn:
+        store._conn.execute(
+            "UPDATE conversation_history_fts_data SET block=x'00' WHERE id>10",
+        )
+
+
+@pytest.mark.parametrize("reopen", [False, True, "fts_only"])
+def test_fts_repair_preserves_history_and_exclusions(
+    tmp_path,
+    reopen,
+    monkeypatch,
+):
+    path = tmp_path / "history.db"
+    store = HistoryStore(path)
+    try:
+        if not store._fts:
+            pytest.skip("SQLite build lacks FTS5")
+        store.append(
+            session_id="s",
+            entry=_entry("expired", created_at="2020-01-01"),
+        )
+        recent = store.append(
+            session_id="s",
+            entry=_entry("zebra", created_at="2099-01-01"),
+        )
+        store.append(
+            session_id="s",
+            entry=_entry(
+                "aardvark",
+                name="recall_history",
+                created_at="2099-01-01",
+            ),
+        )
+        if reopen:
+            _damage_fts(store)
+            store.close()
+            if reopen == "fts_only":
+                # Emulate builds/damage where quick_check misses FTS damage.
+                original_connect = sqlite3.connect
+
+                class QuickCheckPasses(sqlite3.Connection):
+                    def execute(self, sql, *args, **kwargs):
+                        if sql == "PRAGMA quick_check":
+                            sql = "SELECT 'ok'"
+                        return super().execute(sql, *args, **kwargs)
+
+                def connect(*args, **kwargs):
+                    return original_connect(
+                        *args,
+                        factory=QuickCheckPasses,
+                        **kwargs,
+                    )
+
+                monkeypatch.setattr(sqlite3, "connect", connect)
+            store = HistoryStore(path)
+            assert store.count("s") == 3
+            assert store.quarantined_to is None
+        else:
+            # Simulate a missing index with intact external content. FTS
+            # delete will fail even though the internal integrity check passes.
+            with store._conn:
+                store._conn.execute(
+                    "INSERT INTO conversation_history_fts"
+                    "(conversation_history_fts) VALUES('delete-all')",
+                )
+            assert store.purge(before="2026-01-01", dry_run=True) == 1
+            assert _fts_hits(store, "zebra") == []
+        assert store.purge(before="2026-01-01") == 1
+        assert store.count("s") == 2
+        assert _fts_hits(store, "zebra") == [recent]
+        assert _fts_hits(store, "aardvark") == []
+        assert _fts_hits(store, "expired") == []
+        with store._conn:
+            store._check_fts()
+        assert not list(tmp_path.glob("*.corrupt-*"))
+    finally:
+        store.close()
+
+
+def test_failed_repair_rolls_back_purge(store, monkeypatch):
+    for word in ("aardvark", "zebra"):
+        store.append(
+            session_id="s",
+            entry=_entry(word, created_at="2020-01-01"),
+        )
+    original = store._delete_fts_row
+    calls = []
+
+    def delete(row):
+        calls.append(row["seq"])
+        if len(calls) == 2:
+            error = sqlite3.DatabaseError("database disk image is malformed")
+            error.sqlite_errorcode = sqlite3.SQLITE_CORRUPT_VTAB
+            raise error
+        original(row)
+
+    def rebuild():
+        raise sqlite3.OperationalError("disk full")
+
+    monkeypatch.setattr(store, "_delete_fts_row", delete)
+    monkeypatch.setattr(store, "_rebuild_fts", rebuild)
+    with pytest.raises(RuntimeError, match="history preserved"):
+        store.purge(before="2026-01-01")
+    assert store.count("s") == 2
+    assert len(_fts_hits(store, "aardvark")) == 1
+    assert len(_fts_hits(store, "zebra")) == 1
+    assert not store._conn.in_transaction
+
+
+def test_purge_operational_error_does_not_repair(store, monkeypatch):
+    store.append(session_id="s", entry=_entry(created_at="2020-01-01"))
+
+    def delete(row):
+        raise sqlite3.OperationalError("database is locked")
+
+    def repair():
+        pytest.fail("Must not rebuild for an operational error")
+
+    monkeypatch.setattr(store, "_delete_fts_row", delete)
+    monkeypatch.setattr(store, "_repair_fts", repair)
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        store.purge(before="2026-01-01")
+    assert store.count("s") == 1
+
+
+def test_purge_retries_only_once(store, monkeypatch):
+    store.append(session_id="s", entry=_entry(created_at="2020-01-01"))
+    calls = []
+
+    def delete(row):
+        calls.append(row["seq"])
+        error = sqlite3.DatabaseError("database disk image is malformed")
+        error.sqlite_errorcode = sqlite3.SQLITE_CORRUPT_VTAB
+        raise error
+
+    monkeypatch.setattr(store, "_delete_fts_row", delete)
+    with pytest.raises(sqlite3.DatabaseError):
+        store.purge(before="2026-01-01")
+    assert len(calls) == 2
+    assert store.count("s") == 1
+
+
+def test_startup_failed_fts_repair_preserves_file(tmp_path, monkeypatch):
+    path = tmp_path / "history.db"
+    store = HistoryStore(path)
+    store.append(session_id="s", entry=_entry("aardvark"))
+    _damage_fts(store)
+    store.close()
+
+    def rebuild(self):
+        raise sqlite3.OperationalError("disk full")
+
+    monkeypatch.setattr(HistoryStore, "_rebuild_fts", rebuild)
+    with pytest.raises(RuntimeError, match="history preserved"):
+        HistoryStore(path)
+    with sqlite3.connect(path) as conn:
+        assert conn.execute(
+            "SELECT content FROM conversation_history",
+        ).fetchone() == ("aardvark",)
+    assert not list(tmp_path.glob("*.corrupt-*"))
+
+
+def test_initial_fts_backfill_excludes_recall(tmp_path):
+    path = tmp_path / "history.db"
+    store = HistoryStore(path)
+    store.append(session_id="s", entry=_entry("zebra"))
+    store.append(
+        session_id="s",
+        entry=_entry("aardvark", name="recall_history"),
+    )
+    with store._conn:
+        store._conn.execute("DROP TABLE conversation_history_fts")
+    store.close()
+    store = HistoryStore(path)
+    try:
+        assert store.count("s") == 2
+        assert len(_fts_hits(store, "zebra")) == 1
+        assert _fts_hits(store, "aardvark") == []
+    finally:
+        store.close()
+
+
+def test_startup_lock_does_not_quarantine(tmp_path):
+    path = tmp_path / "history.db"
+    store = HistoryStore(path)
+    store.append(session_id="s", entry=_entry("aardvark"))
+    store.close()
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            HistoryStore(path)
+        assert conn.execute(
+            "SELECT content FROM conversation_history",
+        ).fetchone() == ("aardvark",)
+    assert not list(tmp_path.glob("*.corrupt-*"))

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -878,3 +878,120 @@ def test_startup_fts_defers_only_contention(
         with pytest.raises(sqlite3.OperationalError, match="synthetic"):
             HistoryStore(path)
     assert not list(tmp_path.glob("*.corrupt-*"))
+
+
+_FTS_QUICK_CHECK_DIAGNOSTICS = [
+    "malformed inverted index for FTS5 table main.conversation_history_fts",
+    "fts5: corruption found reading blob 137438953473 "
+    'from table "conversation_history_fts"',
+]
+
+
+@pytest.mark.parametrize("diagnostic", _FTS_QUICK_CHECK_DIAGNOSTICS)
+@pytest.mark.parametrize("repair_fails", [False, True])
+def test_quick_check_fts_diagnostic_preserves_source(
+    tmp_path,
+    monkeypatch,
+    diagnostic,
+    repair_fails,
+):
+    path = tmp_path / "history.db"
+    store = HistoryStore(path)
+    store.append(session_id="s", entry=_entry("zebra"))
+    _damage_fts(store)
+    store.close()
+    original_connect = sqlite3.connect
+    original_rebuild = HistoryStore._rebuild_fts
+    checks = []
+    rebuilds = []
+
+    class DiagnosticConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if sql == "PRAGMA quick_check":
+                checks.append(sql)
+                if len(checks) == 1:
+                    return super().execute("SELECT ?", (diagnostic,))
+            return super().execute(sql, *args, **kwargs)
+
+    def connect(*args, **kwargs):
+        return original_connect(*args, factory=DiagnosticConnection, **kwargs)
+
+    def rebuild(history):
+        rebuilds.append(history.path)
+        if repair_fails:
+            raise sqlite3.OperationalError("disk full")
+        original_rebuild(history)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    monkeypatch.setattr(HistoryStore, "_rebuild_fts", rebuild)
+    if repair_fails:
+        with pytest.raises(RuntimeError, match="history preserved"):
+            HistoryStore(path)
+    else:
+        reopened = HistoryStore(path)
+        try:
+            assert reopened.quarantined_to is None
+            assert reopened.count("s") == 1
+            assert len(_fts_hits(reopened, "zebra")) == 1
+            assert len(checks) == 2
+        finally:
+            reopened.close()
+    assert rebuilds == [path]
+    conn = original_connect(path)
+    try:
+        assert conn.execute(
+            "SELECT content FROM conversation_history",
+        ).fetchall() == [("zebra",)]
+    finally:
+        conn.close()
+    assert not list(tmp_path.glob("*.corrupt-*"))
+
+
+@pytest.mark.parametrize(
+    "results",
+    [
+        [],
+        ["ok"],
+        [_FTS_QUICK_CHECK_DIAGNOSTICS[1], "invalid page number 99"],
+        ['fts5: corruption found reading blob 123 from table "other_fts"'],
+        [
+            "fts5: corruption found reading blob 123 "
+            'from table "conversation_history_fts_other"',
+        ],
+    ],
+)
+def test_quick_check_does_not_misclassify_other_corruption(results):
+    assert not HistoryStore._is_fts_only_corruption(results)
+
+
+def test_quick_check_persistent_fts_damage_is_not_quarantined(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "history.db"
+    HistoryStore(path).close()
+    original_connect = sqlite3.connect
+    checks = []
+
+    class PersistentDiagnosticConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if sql == "PRAGMA quick_check":
+                checks.append(sql)
+                return super().execute(
+                    "SELECT ?",
+                    (_FTS_QUICK_CHECK_DIAGNOSTICS[1],),
+                )
+            return super().execute(sql, *args, **kwargs)
+
+    def connect(*args, **kwargs):
+        return original_connect(
+            *args,
+            factory=PersistentDiagnosticConnection,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    with pytest.raises(RuntimeError, match="history preserved"):
+        HistoryStore(path)
+    assert len(checks) == 2
+    assert not list(tmp_path.glob("*.corrupt-*"))


### PR DESCRIPTION
## Summary

Fixes #7596.

History retention can fail with `SQLITE_CORRUPT_VTAB` when purge attempts to remove recall-tool rows that were never indexed.

- Keep FTS maintenance consistent across updates, retention cleanup, and duplicate removal, including legacy indexed recall rows.
- Detect and repair FTS corruption at startup. If purge encounters corruption, roll back, rebuild, and retry once.
- Preserve history and recall-tool search exclusions during recovery. Avoid rebuilding or quarantining databases for ordinary operational errors.

## Validation

- 164 related tests passed, covering retention, corruption recovery, rollback, search exclusions, and retry limits.
- All pre-commit checks passed.