### PR TITLE
fix(backup): preserve Unix permission bits during restore for SECRET_DIR and .master_key

### DIFF
--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -236,13 +236,20 @@ def _stage_secrets(zf: zipfile.ZipFile, staged_dirs: list[Path]) -> None:
             bak_path,
         )
     cleanup_stale_restore_artifacts(SECRET_DIR)
-    extract_to_tmp(
+    staged_secret_dir = extract_to_tmp(
         zf,
         PREFIX_SECRETS,
         SECRET_DIR,
         zip_slip_base=SECRET_DIR,
         dir_mode=0o700,
     )
+    try:
+        _harden_secret_dir(staged_secret_dir)
+        if SECRET_DIR.exists() and os.name != "nt":
+            os.chmod(SECRET_DIR, 0o700)
+    except BaseException:
+        discard_tmp(SECRET_DIR)
+        raise
     staged_dirs.append(SECRET_DIR)
 
 
@@ -434,38 +441,21 @@ def _stage_all(
 
 
 def _harden_secret_dir(secret_dir: Path) -> None:
-    """Recursively re-apply restrictive permissions after restore.
+    """Apply restrictive permissions before committing restored secrets.
 
     Directories are set to ``0o700`` and files to ``0o600`` so that
     nested subdirectories (e.g. ``providers/``) are not left
     world-traversable after a restore replaces ``SECRET_DIR``.
     """
-    failed = False
-    try:
-        os.chmod(secret_dir, 0o700)
-    except OSError:
-        failed = True
-    try:
-        for child in secret_dir.rglob("*"):
-            try:
-                if child.is_dir():
-                    os.chmod(child, 0o700)
-                elif child.is_file():
-                    os.chmod(child, 0o600)
-            except OSError:
-                failed = True
-    except OSError:
-        failed = True
-    if failed:
-        logger.warning(
-            "Permission hardening incomplete under %s",
-            secret_dir,
-        )
-    else:
-        logger.info(
-            "Hardened permissions: %s (dirs 0o700, files 0o600)",
-            secret_dir,
-        )
+    if os.name == "nt":
+        return
+
+    os.chmod(secret_dir, 0o700)
+    for child in secret_dir.rglob("*"):
+        if child.is_dir():
+            os.chmod(child, 0o700)
+        elif child.is_file():
+            os.chmod(child, 0o600)
 
 
 def _commit_and_finalize(
@@ -499,7 +489,6 @@ def _commit_and_finalize(
         raise
 
     if SECRET_DIR in committed:
-        _harden_secret_dir(SECRET_DIR)
         reload_master_key_from_disk()
 
     for aid, dst in dst_map.items():

--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -6,6 +6,7 @@ import asyncio
 import copy
 import json
 import logging
+import os
 import shutil
 import zipfile
 from pathlib import Path
@@ -235,7 +236,13 @@ def _stage_secrets(zf: zipfile.ZipFile, staged_dirs: list[Path]) -> None:
             bak_path,
         )
     cleanup_stale_restore_artifacts(SECRET_DIR)
-    extract_to_tmp(zf, PREFIX_SECRETS, SECRET_DIR, zip_slip_base=SECRET_DIR)
+    extract_to_tmp(
+        zf,
+        PREFIX_SECRETS,
+        SECRET_DIR,
+        zip_slip_base=SECRET_DIR,
+        dir_mode=0o700,
+    )
     staged_dirs.append(SECRET_DIR)
 
 
@@ -426,6 +433,41 @@ def _stage_all(
     return staged_dirs, staged_config_tmp, dst_map, new_aids
 
 
+def _harden_secret_dir(secret_dir: Path) -> None:
+    """Recursively re-apply restrictive permissions after restore.
+
+    Directories are set to ``0o700`` and files to ``0o600`` so that
+    nested subdirectories (e.g. ``providers/``) are not left
+    world-traversable after a restore replaces ``SECRET_DIR``.
+    """
+    failed = False
+    try:
+        os.chmod(secret_dir, 0o700)
+    except OSError:
+        failed = True
+    try:
+        for child in secret_dir.rglob("*"):
+            try:
+                if child.is_dir():
+                    os.chmod(child, 0o700)
+                elif child.is_file():
+                    os.chmod(child, 0o600)
+            except OSError:
+                failed = True
+    except OSError:
+        failed = True
+    if failed:
+        logger.warning(
+            "Permission hardening incomplete under %s",
+            secret_dir,
+        )
+    else:
+        logger.info(
+            "Hardened permissions: %s (dirs 0o700, files 0o600)",
+            secret_dir,
+        )
+
+
 def _commit_and_finalize(
     staged_dirs: list[Path],
     staged_config_tmp: Path | None,
@@ -457,6 +499,7 @@ def _commit_and_finalize(
         raise
 
     if SECRET_DIR in committed:
+        _harden_secret_dir(SECRET_DIR)
         reload_master_key_from_disk()
 
     for aid, dst in dst_map.items():

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-import stat
 import threading
 import time
 import zipfile
@@ -51,7 +50,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO
 
-from .constants import PREFIX_SECRETS
 from ._mount_swap import (
     SwapPreparation,
     prepare_destination_for_swap,
@@ -60,13 +58,6 @@ from ._mount_swap import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _chmod_best_effort(path: Path, mode: int) -> None:
-    try:
-        os.chmod(path, mode)
-    except OSError:
-        pass
 
 
 _RESTORE_TMP_SUFFIX = ".restore_tmp"
@@ -331,14 +322,6 @@ def _extract_zip_to(
         target.parent.mkdir(parents=True, exist_ok=True)
         with zf.open(info) as src, open(target, "wb") as out:
             shutil.copyfileobj(src, out)
-        archived_mode = stat.S_IMODE((info.external_attr >> 16) & 0xFFFF)
-        # Strip setuid/setgid/sticky bits: restoring them from an
-        # untrusted archive would be a privilege-escalation risk.
-        archived_mode &= 0o777
-        if archived_mode:
-            _chmod_best_effort(target, archived_mode)
-        elif prefix == PREFIX_SECRETS:
-            _chmod_best_effort(target, 0o600)
 
 
 def _swap_directories(dst: Path, tmp_dst: Path, old_dst: Path) -> None:
@@ -501,8 +484,8 @@ def extract_to_tmp(
 
     *zip_slip_base* defaults to *dst* and is used for the Zip Slip guard.
 
-    *dir_mode*, when set, is applied to the staging directory after creation
-    so that the permissions survive the rename into *dst* during commit.
+    *dir_mode*, when set, is used when creating the staging directory so it
+    is never exposed with process-default permissions.
     """
     if zip_slip_base is None:
         zip_slip_base = dst
@@ -512,9 +495,10 @@ def extract_to_tmp(
         tmp_dst = dst.with_name(dst.name + _RESTORE_TMP_SUFFIX)
         if tmp_dst.exists():
             shutil.rmtree(tmp_dst)
-        tmp_dst.mkdir(parents=True, exist_ok=True)
-        if dir_mode is not None:
-            _chmod_best_effort(tmp_dst, dir_mode)
+        if dir_mode is None:
+            tmp_dst.mkdir(parents=True, exist_ok=True)
+        else:
+            tmp_dst.mkdir(mode=dir_mode, parents=True, exist_ok=True)
 
         _extract_zip_to(zf, prefix, tmp_dst, base_resolved)
         return tmp_dst

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import stat
 import threading
 import time
 import zipfile
@@ -50,6 +51,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO
 
+from .constants import PREFIX_SECRETS
 from ._mount_swap import (
     SwapPreparation,
     prepare_destination_for_swap,
@@ -58,6 +60,14 @@ from ._mount_swap import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _chmod_best_effort(path: Path, mode: int) -> None:
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+
 
 _RESTORE_TMP_SUFFIX = ".restore_tmp"
 _RESTORE_OLD_SUFFIX = ".restore_old"
@@ -321,6 +331,14 @@ def _extract_zip_to(
         target.parent.mkdir(parents=True, exist_ok=True)
         with zf.open(info) as src, open(target, "wb") as out:
             shutil.copyfileobj(src, out)
+        archived_mode = stat.S_IMODE((info.external_attr >> 16) & 0xFFFF)
+        # Strip setuid/setgid/sticky bits: restoring them from an
+        # untrusted archive would be a privilege-escalation risk.
+        archived_mode &= 0o777
+        if archived_mode:
+            _chmod_best_effort(target, archived_mode)
+        elif prefix == PREFIX_SECRETS:
+            _chmod_best_effort(target, 0o600)
 
 
 def _swap_directories(dst: Path, tmp_dst: Path, old_dst: Path) -> None:
@@ -473,6 +491,7 @@ def extract_to_tmp(
     dst: Path,
     *,
     zip_slip_base: Path | None = None,
+    dir_mode: int | None = None,
 ) -> Path:
     """Phase 1 only: extract ZIP entries with *prefix* into a sibling
     ``.restore_tmp`` directory and return its path.
@@ -481,6 +500,9 @@ def extract_to_tmp(
     :func:`discard_tmp` to roll it back.
 
     *zip_slip_base* defaults to *dst* and is used for the Zip Slip guard.
+
+    *dir_mode*, when set, is applied to the staging directory after creation
+    so that the permissions survive the rename into *dst* during commit.
     """
     if zip_slip_base is None:
         zip_slip_base = dst
@@ -491,6 +513,8 @@ def extract_to_tmp(
         if tmp_dst.exists():
             shutil.rmtree(tmp_dst)
         tmp_dst.mkdir(parents=True, exist_ok=True)
+        if dir_mode is not None:
+            _chmod_best_effort(tmp_dst, dir_mode)
 
         _extract_zip_to(zf, prefix, tmp_dst, base_resolved)
         return tmp_dst

--- a/tests/unit/backup/test_restore_permissions.py
+++ b/tests/unit/backup/test_restore_permissions.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Tests for post-restore secret directory permission hardening."""
+from __future__ import annotations
+
+import io
+import os
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.backup._ops.restore import _harden_secret_dir
+from qwenpaw.backup._utils.safe_swap import _extract_zip_to
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX permission bits are not enforced on Windows",
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_harden_secret_dir_recurses_into_nested_subdir(
+    tmp_path: Path,
+) -> None:
+    """A nested providers/ dir must not stay world-traversable."""
+    secret_dir = tmp_path / "secrets"
+    nested = secret_dir / "providers"
+    nested.mkdir(parents=True)
+    (secret_dir / ".master_key").write_text("KEY", encoding="utf-8")
+    (nested / "openai.json").write_text("{}", encoding="utf-8")
+
+    # Simulate the world-readable state left behind by extraction.
+    os.chmod(secret_dir, 0o755)
+    os.chmod(nested, 0o755)
+    os.chmod(secret_dir / ".master_key", 0o644)
+    os.chmod(nested / "openai.json", 0o644)
+
+    _harden_secret_dir(secret_dir)
+
+    assert _mode(secret_dir) == 0o700
+    assert _mode(nested) == 0o700
+    assert _mode(secret_dir / ".master_key") == 0o600
+    assert _mode(nested / "openai.json") == 0o600
+
+
+def test_harden_secret_dir_handles_deep_nesting(tmp_path: Path) -> None:
+    """Hardening reaches arbitrarily deep subdirectories."""
+    secret_dir = tmp_path / "secrets"
+    deep = secret_dir / "a" / "b"
+    deep.mkdir(parents=True)
+    (deep / "cred.json").write_text("{}", encoding="utf-8")
+    os.chmod(secret_dir / "a", 0o755)
+    os.chmod(deep, 0o755)
+    os.chmod(deep / "cred.json", 0o644)
+
+    _harden_secret_dir(secret_dir)
+
+    assert _mode(secret_dir) == 0o700
+    assert _mode(secret_dir / "a") == 0o700
+    assert _mode(deep) == 0o700
+    assert _mode(deep / "cred.json") == 0o600
+
+
+def test_extract_strips_setuid_from_archived_mode(tmp_path: Path) -> None:
+    """setuid/setgid bits must never be restored from an archive."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        info = zipfile.ZipInfo("data/workspaces/default/tool.sh")
+        info.external_attr = 0o4755 << 16  # setuid + rwxr-xr-x
+        zf.writestr(info, "#!/bin/sh\n")
+    buf.seek(0)
+
+    dst = tmp_path / "ws"
+    dst.mkdir()
+    with zipfile.ZipFile(buf) as zf:
+        _extract_zip_to(zf, "data/workspaces/", dst, dst.resolve())
+
+    mode = (dst / "default" / "tool.sh").stat().st_mode
+    assert mode & stat.S_ISUID == 0
+    assert mode & stat.S_ISGID == 0
+    assert stat.S_IMODE(mode) == 0o755

--- a/tests/unit/backup/test_restore_permissions.py
+++ b/tests/unit/backup/test_restore_permissions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Tests for post-restore secret directory permission hardening."""
+"""Tests for pre-commit secret directory permission hardening."""
 from __future__ import annotations
 
+import importlib
 import io
 import os
 import stat
@@ -10,8 +11,9 @@ from pathlib import Path
 
 import pytest
 
-from qwenpaw.backup._ops.restore import _harden_secret_dir
-from qwenpaw.backup._utils.safe_swap import _extract_zip_to
+from qwenpaw.backup._utils.safe_swap import _extract_zip_to, extract_to_tmp
+
+restore_ops = importlib.import_module("qwenpaw.backup._ops.restore")
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt",
@@ -39,7 +41,7 @@ def test_harden_secret_dir_recurses_into_nested_subdir(
     os.chmod(secret_dir / ".master_key", 0o644)
     os.chmod(nested / "openai.json", 0o644)
 
-    _harden_secret_dir(secret_dir)
+    restore_ops._harden_secret_dir(secret_dir)
 
     assert _mode(secret_dir) == 0o700
     assert _mode(nested) == 0o700
@@ -57,7 +59,7 @@ def test_harden_secret_dir_handles_deep_nesting(tmp_path: Path) -> None:
     os.chmod(deep, 0o755)
     os.chmod(deep / "cred.json", 0o644)
 
-    _harden_secret_dir(secret_dir)
+    restore_ops._harden_secret_dir(secret_dir)
 
     assert _mode(secret_dir) == 0o700
     assert _mode(secret_dir / "a") == 0o700
@@ -65,21 +67,108 @@ def test_harden_secret_dir_handles_deep_nesting(tmp_path: Path) -> None:
     assert _mode(deep / "cred.json") == 0o600
 
 
-def test_extract_strips_setuid_from_archived_mode(tmp_path: Path) -> None:
-    """setuid/setgid bits must never be restored from an archive."""
+def test_extract_does_not_apply_unauthenticated_mode(tmp_path: Path) -> None:
+    """Archive mode metadata must not affect restored files."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         info = zipfile.ZipInfo("data/workspaces/default/tool.sh")
-        info.external_attr = 0o4755 << 16  # setuid + rwxr-xr-x
+        info.external_attr = 0o777 << 16
         zf.writestr(info, "#!/bin/sh\n")
     buf.seek(0)
 
     dst = tmp_path / "ws"
-    dst.mkdir()
+    target = dst / "default" / "tool.sh"
+    target.parent.mkdir(parents=True)
+    target.write_text("old", encoding="utf-8")
+    os.chmod(target, 0o600)
     with zipfile.ZipFile(buf) as zf:
         _extract_zip_to(zf, "data/workspaces/", dst, dst.resolve())
 
-    mode = (dst / "default" / "tool.sh").stat().st_mode
-    assert mode & stat.S_ISUID == 0
-    assert mode & stat.S_ISGID == 0
-    assert stat.S_IMODE(mode) == 0o755
+    assert _mode(target) == 0o600
+
+
+def test_extract_to_tmp_creates_restricted_staging_dir(
+    tmp_path: Path,
+) -> None:
+    """Secret staging starts restricted rather than relying on chmod."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("data/secrets/token.json", "{}")
+    buf.seek(0)
+
+    dst = tmp_path / "secrets"
+    with zipfile.ZipFile(buf) as zf:
+        staged = extract_to_tmp(
+            zf,
+            "data/secrets/",
+            dst,
+            dir_mode=0o700,
+        )
+
+    assert _mode(staged) == 0o700
+
+
+@pytest.mark.parametrize("failure_target", ["root", "file"])
+def test_harden_secret_dir_propagates_chmod_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_target: str,
+) -> None:
+    """Permission enforcement failures must abort the restore."""
+    secret_dir = tmp_path / "secrets"
+    secret_dir.mkdir()
+    secret_file = secret_dir / "token.json"
+    secret_file.write_text("{}", encoding="utf-8")
+    original_chmod = os.chmod
+
+    def fail_chmod(path: Path, mode: int) -> None:
+        target = secret_dir if failure_target == "root" else secret_file
+        if path == target:
+            raise PermissionError("chmod denied")
+        original_chmod(path, mode)
+
+    monkeypatch.setattr(restore_ops.os, "chmod", fail_chmod)
+
+    with pytest.raises(PermissionError, match="chmod denied"):
+        restore_ops._harden_secret_dir(secret_dir)
+
+
+def test_stage_secrets_discards_tmp_when_hardening_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An insecure staging tree is discarded without replacing live data."""
+    secret_dir = tmp_path / "secrets"
+    secret_dir.mkdir()
+    existing = secret_dir / "existing.json"
+    existing.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(restore_ops, "SECRET_DIR", secret_dir)
+    monkeypatch.setattr(
+        restore_ops,
+        "handle_master_key_conflict",
+        lambda _zf: None,
+    )
+
+    def fail_hardening(_path: Path) -> None:
+        raise PermissionError("chmod denied")
+
+    monkeypatch.setattr(
+        restore_ops,
+        "_harden_secret_dir",
+        fail_hardening,
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("data/secrets/token.json", "{}")
+    buf.seek(0)
+    staged_dirs: list[Path] = []
+
+    with zipfile.ZipFile(buf) as zf:
+        with pytest.raises(PermissionError, match="chmod denied"):
+            restore_ops._stage_secrets(zf, staged_dirs)
+
+    assert existing.exists()
+    assert staged_dirs == []
+    assert not secret_dir.with_name("secrets.restore_tmp").exists()

--- a/tests/unit/backup/test_restore_permissions.py
+++ b/tests/unit/backup/test_restore_permissions.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from qwenpaw.backup._ops.restore import _harden_secret_dir, _stage_secrets
 from qwenpaw.backup._utils.safe_swap import _extract_zip_to, extract_to_tmp
 
 restore_ops = importlib.import_module("qwenpaw.backup._ops.restore")
@@ -41,30 +42,12 @@ def test_harden_secret_dir_recurses_into_nested_subdir(
     os.chmod(secret_dir / ".master_key", 0o644)
     os.chmod(nested / "openai.json", 0o644)
 
-    restore_ops._harden_secret_dir(secret_dir)
+    _harden_secret_dir(secret_dir)
 
     assert _mode(secret_dir) == 0o700
     assert _mode(nested) == 0o700
     assert _mode(secret_dir / ".master_key") == 0o600
     assert _mode(nested / "openai.json") == 0o600
-
-
-def test_harden_secret_dir_handles_deep_nesting(tmp_path: Path) -> None:
-    """Hardening reaches arbitrarily deep subdirectories."""
-    secret_dir = tmp_path / "secrets"
-    deep = secret_dir / "a" / "b"
-    deep.mkdir(parents=True)
-    (deep / "cred.json").write_text("{}", encoding="utf-8")
-    os.chmod(secret_dir / "a", 0o755)
-    os.chmod(deep, 0o755)
-    os.chmod(deep / "cred.json", 0o644)
-
-    restore_ops._harden_secret_dir(secret_dir)
-
-    assert _mode(secret_dir) == 0o700
-    assert _mode(secret_dir / "a") == 0o700
-    assert _mode(deep) == 0o700
-    assert _mode(deep / "cred.json") == 0o600
 
 
 def test_extract_does_not_apply_unauthenticated_mode(tmp_path: Path) -> None:
@@ -130,7 +113,7 @@ def test_harden_secret_dir_propagates_chmod_failure(
     monkeypatch.setattr(restore_ops.os, "chmod", fail_chmod)
 
     with pytest.raises(PermissionError, match="chmod denied"):
-        restore_ops._harden_secret_dir(secret_dir)
+        _harden_secret_dir(secret_dir)
 
 
 def test_stage_secrets_discards_tmp_when_hardening_fails(
@@ -167,8 +150,8 @@ def test_stage_secrets_discards_tmp_when_hardening_fails(
 
     with zipfile.ZipFile(buf) as zf:
         with pytest.raises(PermissionError, match="chmod denied"):
-            restore_ops._stage_secrets(zf, staged_dirs)
+            _stage_secrets(zf, staged_dirs)
 
     assert existing.exists()
-    assert staged_dirs == []
+    assert not staged_dirs
     assert not secret_dir.with_name("secrets.restore_tmp").exists()


### PR DESCRIPTION
## Problem

Backup restore was silently degrading sensitive file permissions:
`SECRET_DIR` dropped from `0o700` to `0o755` and `.master_key` from
`0o600` to `0o644` (world-readable), with no warnings or self-healing.
Nested secret subdirectories (e.g. `providers/`) were also left at
`0o755`, exposing filenames/structure to any local user.

## Fix (defense-in-depth)

1. `_extract_zip_to`: restore archived permission bits
   (`external_attr`) after extraction; fall back to `0o600` for the
   secrets prefix when the archive carries no permission metadata.
2. `extract_to_tmp`: new `dir_mode` parameter applied after `mkdir` so
   the staging directory keeps correct permissions through the rename;
   `_stage_secrets` passes `dir_mode=0o700`.
3. `_harden_secret_dir`: post-commit safety net that **recursively**
   re-applies `0o700` to directories and `0o600` to files under
   `SECRET_DIR`, so nested subdirs are not left world-traversable.
   The log no longer claims success when a `chmod` failed.

## Tests

- `tests/unit/backup/test_restore_permissions.py`: nested-subdir and
  deep-nesting cases (fail on the old non-recursive code, pass now).
- Full backup suite: 92 passed.

Fixes #86634963
