### PR TITLE
fix(memory): fall back when plugin backend is unavailable

### DIFF
--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -51,14 +51,48 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_MEMORY_BACKEND_FALLBACK = "remelight"
 
-def _memory_backend_context(ws: "Workspace") -> "MemoryBackendContext":
+
+def _configured_memory_backend_id(ws: "Workspace") -> str:
+    """Return the canonical backend selected in persisted Agent config."""
+    return ws.config.running.memory_manager_backend.strip().lower()
+
+
+def _effective_memory_backend_id(ws: "Workspace") -> str:
+    """Resolve the runtime backend without rewriting the configured choice."""
+    from ...memory import (
+        MemoryBackendUnavailableError,
+        get_memory_manager_backend,
+    )
+
+    configured = _configured_memory_backend_id(ws)
+    try:
+        get_memory_manager_backend(configured)
+    except MemoryBackendUnavailableError:
+        if configured == _MEMORY_BACKEND_FALLBACK:
+            raise
+        logger.warning(
+            "Configured memory backend '%s' is unavailable for agent '%s'; "
+            "using '%s' until the configured backend is available",
+            sanitize_log_value(configured),
+            sanitize_log_value(ws.agent_id),
+            _MEMORY_BACKEND_FALLBACK,
+        )
+        return _MEMORY_BACKEND_FALLBACK
+    return configured
+
+
+def _memory_backend_context(
+    ws: "Workspace",
+    backend_id: str | None = None,
+) -> "MemoryBackendContext":
     """Snapshot all construction settings used by core and plugin backends."""
     from ...memory import MemoryBackendContext
 
     config = ws.config
     running = config.running
-    backend_id = running.memory_manager_backend.strip().lower()
+    backend_id = backend_id or _configured_memory_backend_id(ws)
     backend_configs = getattr(running, "memory_backend_configs", {})
     raw_config = dict(backend_configs.get(backend_id, {}) or {})
     try:
@@ -94,7 +128,10 @@ def _memory_manager_reuse_compatible(
     old_context = getattr(instance, "context", None)
     if old_context is None:
         return False
-    return old_context == _memory_backend_context(workspace)
+    return old_context == _memory_backend_context(
+        workspace,
+        _effective_memory_backend_id(workspace),
+    )
 
 
 class Workspace:
@@ -434,6 +471,25 @@ class Workspace:
 
         sm = self._service_manager
 
+        def _memory_manager_class(ws: "Workspace") -> type:
+            return get_memory_manager_backend(_effective_memory_backend_id(ws))
+
+        def _create_memory_manager(ws: "Workspace") -> Any:
+            configured = _configured_memory_backend_id(ws)
+            try:
+                return create_memory_manager_backend(
+                    configured,
+                    _memory_backend_context(ws, configured),
+                )
+            except MemoryBackendUnavailableError:
+                if configured == _MEMORY_BACKEND_FALLBACK:
+                    raise
+                fallback = _effective_memory_backend_id(ws)
+                return create_memory_manager_backend(
+                    fallback,
+                    _memory_backend_context(ws, fallback),
+                )
+
         # Priority 5: LocalWorkspace (tool routing)
         def _init_local_workspace(
             ws: "Workspace",
@@ -471,13 +527,8 @@ class Workspace:
         sm.register(
             ServiceDescriptor(
                 name="memory_manager",
-                service_class=lambda ws: get_memory_manager_backend(
-                    ws._config.running.memory_manager_backend,
-                ),
-                create_service=lambda ws: create_memory_manager_backend(
-                    ws.config.running.memory_manager_backend,
-                    _memory_backend_context(ws),
-                ),
+                service_class=_memory_manager_class,
+                create_service=_create_memory_manager,
                 start_method="start",
                 stop_method="close",
                 reusable=True,
@@ -489,8 +540,8 @@ class Workspace:
                 # longer ships; let the workspace boot without
                 # memory_manager when its import fails.
                 optional=True,
-                # A configured-but-unregistered plugin is a configuration
-                # error, not an optional ReMe dependency failure.
+                # The configured backend falls back before construction. A
+                # missing core fallback remains a fatal installation error.
                 fatal_exceptions=(MemoryBackendUnavailableError,),
             ),
         )

--- a/tests/unit/app/test_multi_agent_manager_startup.py
+++ b/tests/unit/app/test_multi_agent_manager_startup.py
@@ -20,6 +20,9 @@ from qwenpaw.app.multi_agent_manager import MultiAgentManager
 from qwenpaw.app.task_tracker import REPLAY_END_SSE, TaskTracker
 from qwenpaw.app.workspace import Workspace
 from qwenpaw.agents.memory.dummy import NoopMemoryManager
+from qwenpaw.agents.memory.reme_light_memory_manager import (
+    ReMeLightMemoryManager,
+)
 from qwenpaw.constant import BUILTIN_QA_AGENT_ID
 from qwenpaw.memory import MemoryBackendContext, memory_registry
 
@@ -118,6 +121,49 @@ def test_workspace_reload_reuses_memory_manager(tmp_path) -> None:
     descriptor = workspace._service_manager.descriptors["memory_manager"]
     assert descriptor.reusable is True
     assert descriptor.require_clean_stop is True
+
+
+@pytest.mark.asyncio
+async def test_workspace_falls_back_to_remelight_for_unregistered_backend(
+    monkeypatch,
+    tmp_path,
+    caplog,
+) -> None:
+    workspace = Workspace(
+        agent_id="agent-1",
+        workspace_dir=str(tmp_path),
+    )
+    workspace._config = SimpleNamespace(
+        language="zh",
+        running=SimpleNamespace(
+            memory_manager_backend="missing-memory-plugin",
+            memory_backend_configs={
+                "missing-memory-plugin": {"token": "keep-me"},
+            },
+            light_context_config=SimpleNamespace(
+                token_count_estimate_divisor=4.0,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        ReMeLightMemoryManager,
+        "_initialize_reme",
+        lambda _self: None,
+    )
+
+    descriptor = workspace._service_manager.descriptors["memory_manager"]
+    await workspace._service_manager._start_service(descriptor)
+
+    assert isinstance(workspace.memory_manager, ReMeLightMemoryManager)
+    assert workspace.memory_manager.context.backend_config == {}
+    assert (
+        workspace.config.running.memory_manager_backend
+        == "missing-memory-plugin"
+    )
+    assert workspace.config.running.memory_backend_configs == {
+        "missing-memory-plugin": {"token": "keep-me"},
+    }
+    assert "using 'remelight'" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -513,11 +513,12 @@ Undo restores the previous Embedding configuration that matches the existing vec
 
 QwenPaw's memory system uses a pluggable backend architecture. ReMeLight remains
 the built-in default; ADBPG and PowerContext are independently installable
-plugins. A configured plugin backend must be installed and registered before
-its Agent starts. If it is missing or fails to load, QwenPaw reports the backend
-as unavailable instead of silently switching to ReMeLight. Select a backend via
-`memory_manager_backend`; plugin-owned per-Agent settings are stored under
-`memory_backend_configs.<backend_id>`.
+plugins. If the selected plugin is missing or fails to load when an Agent
+starts, the runtime temporarily uses ReMeLight while preserving the configured
+backend and its plugin settings. The fallback is recorded in the logs. Reload
+the Agent after the plugin becomes available to restore the configured backend.
+Select a backend via `memory_manager_backend`; plugin-owned per-Agent settings
+are stored under `memory_backend_configs.<backend_id>`.
 
 ### ADBPG (AnalyticDB for PostgreSQL)
 

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -481,10 +481,10 @@ POST /api/agents/{agentId}/memory/reindex/undo
 ## 其他 Memory Backend
 
 QwenPaw 的记忆系统采用可插拔的 Backend 架构。ReMeLight 仍是内置默认后端；ADBPG 和
-PowerContext 已拆分为可独立安装的插件。Agent 启动前，对应插件必须已经安装并完成注册；
-若插件缺失或加载失败，QwenPaw 会明确报告 backend 不可用，不会静默切换到 ReMeLight。
-通过 `memory_manager_backend` 选择后端，插件拥有的每 Agent 配置统一保存在
-`memory_backend_configs.<backend_id>`。
+PowerContext 已拆分为可独立安装的插件。若 Agent 启动时所选插件缺失或加载失败，运行时会
+暂时使用 ReMeLight，并保留原 backend 选择和插件配置；日志会记录此次兜底。插件恢复后，
+重新加载 Agent 即可恢复原 backend。通过 `memory_manager_backend` 选择后端，插件拥有的每
+Agent 配置统一保存在 `memory_backend_configs.<backend_id>`。
 
 ### ADBPG（AnalyticDB for PostgreSQL）
 


### PR DESCRIPTION
## Description

When an Agent selects a memory backend whose plugin is not registered, temporarily run the Agent with the built-in ReMeLight backend instead of failing workspace startup.

The configured backend and its plugin-owned settings remain unchanged on disk. After the plugin becomes available, reloading the Agent restores the configured backend. The fallback is recorded in the logs.

The running-config API continues to reject newly submitted unavailable backends, so invalid selections and typos are not persisted through the Console.

## Why

ADBPG and PowerContext moved from core to independently installed plugins in #7616. Existing users may still have either backend selected during an upgrade before installing the corresponding plugin. Falling back at runtime keeps those Agents available without silently overwriting their intended backend selection.

## Validation

- 175 focused memory, configuration, router, workspace, and contract tests passed
- changed-file pre-commit checks passed
- `git diff --check` passed