### PR TITLE
feat(console): improve grouped chat history

### DIFF
--- a/console/src/hooks/useCollapsedChatGroups.test.ts
+++ b/console/src/hooks/useCollapsedChatGroups.test.ts
@@ -41,5 +41,6 @@ describe("useCollapsedChatGroups", () => {
     act(() => result.current.initializeCollapsedGroups(new Set(["older"])));
 
     expect(result.current.collapsedGroups.has("older")).toBe(true);
+    expect(localStorage.getItem("qwenpaw_collapsed_chat_groups_v3")).toBeNull();
   });
 });

--- a/console/src/hooks/useCollapsedChatGroups.test.ts
+++ b/console/src/hooks/useCollapsedChatGroups.test.ts
@@ -20,4 +20,26 @@ describe("useCollapsedChatGroups", () => {
       false,
     );
   });
+
+  it("applies default collapsed groups once", () => {
+    const { result } = renderHook(() => useCollapsedChatGroups());
+
+    act(() => result.current.initializeCollapsedGroups(new Set(["older"])));
+    expect(result.current.collapsedGroups.has("older")).toBe(true);
+
+    act(() => result.current.initializeCollapsedGroups(new Set(["newer"])));
+    expect(result.current.collapsedGroups.has("newer")).toBe(false);
+  });
+
+  it("upgrades the legacy default so new group defaults can apply", () => {
+    localStorage.setItem(
+      "qwenpaw_collapsed_chat_groups_v3",
+      JSON.stringify(["cron", "subagents"]),
+    );
+    const { result } = renderHook(() => useCollapsedChatGroups());
+
+    act(() => result.current.initializeCollapsedGroups(new Set(["older"])));
+
+    expect(result.current.collapsedGroups.has("older")).toBe(true);
+  });
 });

--- a/console/src/hooks/useCollapsedChatGroups.ts
+++ b/console/src/hooks/useCollapsedChatGroups.ts
@@ -41,6 +41,7 @@ function loadCollapsed(): CollapsedState {
 function saveCollapsed(groups: Set<string>): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([...groups]));
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
   } catch {
     // Collapse state can remain memory-only.
   }

--- a/console/src/hooks/useCollapsedChatGroups.ts
+++ b/console/src/hooks/useCollapsedChatGroups.ts
@@ -1,20 +1,41 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
-const STORAGE_KEY = "qwenpaw_collapsed_chat_groups_v3";
+const STORAGE_KEY = "qwenpaw_collapsed_chat_groups_v4";
+const LEGACY_STORAGE_KEY = "qwenpaw_collapsed_chat_groups_v3";
 const CRON_GROUP_ID = "cron";
 const SUBAGENT_GROUP_ID = "subagents";
 
-function loadCollapsed(): Set<string> {
+interface CollapsedState {
+  groups: Set<string>;
+  hasPersistedState: boolean;
+}
+
+function loadCollapsed(): CollapsedState {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const currentRaw = localStorage.getItem(STORAGE_KEY);
+    const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+    const raw = currentRaw ?? legacyRaw;
     if (raw) {
       const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) return new Set(parsed);
+      if (Array.isArray(parsed)) {
+        const isLegacyDefault =
+          !currentRaw &&
+          parsed.length === 2 &&
+          parsed.includes(CRON_GROUP_ID) &&
+          parsed.includes(SUBAGENT_GROUP_ID);
+        return {
+          groups: new Set(parsed),
+          hasPersistedState: !isLegacyDefault,
+        };
+      }
     }
   } catch {
     // Keep the safe default when storage is unavailable.
   }
-  return new Set([CRON_GROUP_ID, SUBAGENT_GROUP_ID]);
+  return {
+    groups: new Set([CRON_GROUP_ID, SUBAGENT_GROUP_ID]),
+    hasPersistedState: false,
+  };
 }
 
 function saveCollapsed(groups: Set<string>): void {
@@ -26,10 +47,28 @@ function saveCollapsed(groups: Set<string>): void {
 }
 
 export function useCollapsedChatGroups() {
-  const [collapsedGroups, setCollapsedGroups] =
-    useState<Set<string>>(loadCollapsed);
+  const [initialState] = useState<CollapsedState>(loadCollapsed);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    initialState.groups,
+  );
+  const defaultsInitializedRef = useRef(initialState.hasPersistedState);
+
+  const initializeCollapsedGroups = useCallback(
+    (defaultGroups: ReadonlySet<string>) => {
+      if (defaultsInitializedRef.current || defaultGroups.size === 0) return;
+      defaultsInitializedRef.current = true;
+      setCollapsedGroups((previous) => {
+        const next = new Set(previous);
+        defaultGroups.forEach((groupId) => next.add(groupId));
+        saveCollapsed(next);
+        return next;
+      });
+    },
+    [],
+  );
 
   const toggleGroup = useCallback((groupId: string) => {
+    defaultsInitializedRef.current = true;
     setCollapsedGroups((previous) => {
       const next = new Set(previous);
       if (next.has(groupId)) next.delete(groupId);
@@ -49,5 +88,10 @@ export function useCollapsedChatGroups() {
     });
   }, []);
 
-  return { collapsedGroups, toggleGroup, expandGroup };
+  return {
+    collapsedGroups,
+    toggleGroup,
+    expandGroup,
+    initializeCollapsedGroups,
+  };
 }

--- a/console/src/layouts/SidebarSessionList.test.tsx
+++ b/console/src/layouts/SidebarSessionList.test.tsx
@@ -116,7 +116,26 @@ vi.mock("../components/SessionItem", () => ({
 }));
 
 vi.mock("../components/SessionGroupHeader", () => ({
-  default: () => <div data-testid="group-header" />,
+  default: ({
+    group,
+    count,
+    collapsed,
+    onToggle,
+  }: {
+    group: { id: string; name: string };
+    count: number;
+    collapsed: boolean;
+    onToggle: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid={`group-header-${group.id}`}
+      aria-expanded={!collapsed}
+      onClick={onToggle}
+    >
+      {group.name} {count}
+    </button>
+  ),
 }));
 
 vi.mock("../components/SessionDateHeader", () => ({
@@ -233,6 +252,7 @@ function mockData(
     collapsedGroups: new Set<string>(),
     toggleGroup: vi.fn(),
     expandGroup: vi.fn(),
+    initializeCollapsedGroups: vi.fn(),
   });
 }
 
@@ -271,6 +291,80 @@ describe("SidebarSessionList", () => {
     });
     expect(screen.getByTestId("session-item-sess-a")).toBeTruthy();
     expect(screen.getByTestId("session-item-sess-b")).toBeTruthy();
+  });
+
+  it("initializes older groups as collapsed", async () => {
+    const initializeCollapsedGroups = vi.fn();
+    mockData([sessionA, { ...sessionB, groupId: "work" }]);
+    mockCollapsedGroups.mockReturnValue({
+      collapsedGroups: new Set<string>(),
+      toggleGroup: vi.fn(),
+      expandGroup: vi.fn(),
+      initializeCollapsedGroups,
+    });
+    mockChatGroups.mockReturnValue({
+      groups: [
+        {
+          id: "default",
+          name: "Uncategorized",
+          order: 0,
+          kind: "default",
+          pinned: false,
+        },
+        {
+          id: "work",
+          name: "Work",
+          order: 1,
+          kind: "custom",
+          pinned: false,
+        },
+        {
+          id: "older",
+          name: "Older",
+          order: 2,
+          kind: "custom",
+          pinned: false,
+        },
+      ],
+      createGroup: vi.fn().mockResolvedValue({ id: "g-new" }),
+      renameGroup: vi.fn(),
+      pinGroup: vi.fn(),
+      deleteGroup: vi.fn(),
+      reorderGroups: vi.fn(),
+    });
+    renderWithProviders(<SidebarSessionList />);
+
+    await waitFor(() => expect(initializeCollapsedGroups).toHaveBeenCalled());
+    expect(initializeCollapsedGroups).toHaveBeenCalledWith(new Set(["older"]));
+  });
+
+  it("loads ten more conversations within a group", async () => {
+    const sessions = Array.from({ length: 12 }, (_, index) => ({
+      ...sessionA,
+      id: `session-${index + 1}`,
+      name: `Conversation ${index + 1}`,
+      updatedAt: new Date(Date.now() - index * 1000).toISOString(),
+    }));
+    mockData(sessions);
+    renderWithProviders(<SidebarSessionList />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-session-10")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("session-item-session-11")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Load more/ }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-session-11")).toBeTruthy();
+    });
+    expect(screen.getByTestId("session-item-session-12")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Collapse list" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse list" }));
+    await waitFor(() => {
+      expect(screen.queryByTestId("session-item-session-11")).toBeNull();
+    });
   });
 
   it("routes session clicks through the injected callback", async () => {

--- a/console/src/layouts/SidebarSessionList.test.tsx
+++ b/console/src/layouts/SidebarSessionList.test.tsx
@@ -293,7 +293,7 @@ describe("SidebarSessionList", () => {
     expect(screen.getByTestId("session-item-sess-b")).toBeTruthy();
   });
 
-  it("initializes older groups as collapsed", async () => {
+  it("initializes older unpinned groups as collapsed", async () => {
     const initializeCollapsedGroups = vi.fn();
     mockData([sessionA, { ...sessionB, groupId: "work" }]);
     mockCollapsedGroups.mockReturnValue({
@@ -323,6 +323,13 @@ describe("SidebarSessionList", () => {
           name: "Older",
           order: 2,
           kind: "custom",
+          pinned: true,
+        },
+        {
+          id: "archive",
+          name: "Archive",
+          order: 3,
+          kind: "custom",
           pinned: false,
         },
       ],
@@ -335,7 +342,80 @@ describe("SidebarSessionList", () => {
     renderWithProviders(<SidebarSessionList />);
 
     await waitFor(() => expect(initializeCollapsedGroups).toHaveBeenCalled());
-    expect(initializeCollapsedGroups).toHaveBeenCalledWith(new Set(["older"]));
+    expect(initializeCollapsedGroups).toHaveBeenCalledWith(
+      new Set(["archive"]),
+    );
+  });
+
+  it("keeps the active group expanded during default initialization", async () => {
+    const initializeCollapsedGroups = vi.fn();
+    const now = Date.now();
+    mockData([
+      { ...sessionA, updatedAt: new Date(now).toISOString() },
+      {
+        ...sessionB,
+        groupId: "work",
+        updatedAt: new Date(now - 1000).toISOString(),
+      },
+      {
+        ...sessionA,
+        id: "older-active",
+        groupId: "older",
+        updatedAt: new Date(now - 2000).toISOString(),
+      },
+    ]);
+    mockCollapsedGroups.mockReturnValue({
+      collapsedGroups: new Set<string>(),
+      toggleGroup: vi.fn(),
+      expandGroup: vi.fn(),
+      initializeCollapsedGroups,
+    });
+    mockChatGroups.mockReturnValue({
+      groups: [
+        {
+          id: "default",
+          name: "Uncategorized",
+          order: 0,
+          kind: "default",
+          pinned: false,
+        },
+        {
+          id: "work",
+          name: "Work",
+          order: 1,
+          kind: "custom",
+          pinned: false,
+        },
+        {
+          id: "older",
+          name: "Older",
+          order: 2,
+          kind: "custom",
+          pinned: false,
+        },
+        {
+          id: "archive",
+          name: "Archive",
+          order: 3,
+          kind: "custom",
+          pinned: false,
+        },
+      ],
+      createGroup: vi.fn().mockResolvedValue({ id: "g-new" }),
+      renameGroup: vi.fn(),
+      pinGroup: vi.fn(),
+      deleteGroup: vi.fn(),
+      reorderGroups: vi.fn(),
+    });
+
+    renderWithProviders(<SidebarSessionList />, {
+      initialEntries: ["/chat/older-active"],
+    });
+
+    await waitFor(() => expect(initializeCollapsedGroups).toHaveBeenCalled());
+    expect(initializeCollapsedGroups).toHaveBeenCalledWith(
+      new Set(["archive"]),
+    );
   });
 
   it("loads ten more conversations within a group", async () => {
@@ -364,6 +444,83 @@ describe("SidebarSessionList", () => {
     fireEvent.click(screen.getByRole("button", { name: "Collapse list" }));
     await waitFor(() => {
       expect(screen.queryByTestId("session-item-session-11")).toBeNull();
+    });
+  });
+
+  it("reveals an active unpinned conversation after ten pinned ones", async () => {
+    const pinnedSessions = Array.from({ length: 10 }, (_, index) => ({
+      ...sessionA,
+      id: `pinned-${index + 1}`,
+      name: `Pinned ${index + 1}`,
+      pinned: true,
+      updatedAt: new Date(Date.now() - (index + 1) * 1000).toISOString(),
+    }));
+    const activeSession = {
+      ...sessionA,
+      id: "active-session",
+      name: "Active conversation",
+      pinned: false,
+      updatedAt: new Date().toISOString(),
+    };
+    mockData([activeSession, ...pinnedSessions]);
+
+    renderWithProviders(<SidebarSessionList />, {
+      initialEntries: ["/chat/active-session"],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-active-session")).toBeTruthy();
+    });
+  });
+
+  it("keeps the active conversation visible when collapsing the list", async () => {
+    const sessions = Array.from({ length: 25 }, (_, index) => ({
+      ...sessionA,
+      id: `session-${index + 1}`,
+      name: `Conversation ${index + 1}`,
+      updatedAt: new Date(Date.now() - index * 1000).toISOString(),
+    }));
+    mockData(sessions);
+    renderWithProviders(<SidebarSessionList />, {
+      initialEntries: ["/chat/session-12"],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-session-12")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Load more/ }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Collapse list" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-session-12")).toBeTruthy();
+      expect(screen.queryByTestId("session-item-session-21")).toBeNull();
+    });
+  });
+
+  it("shows all matching conversations while searching", async () => {
+    const sessions = Array.from({ length: 12 }, (_, index) => ({
+      ...sessionA,
+      id: `session-${index + 1}`,
+      name: `Conversation ${index + 1}`,
+      updatedAt: new Date(Date.now() - index * 1000).toISOString(),
+    }));
+    mockData(sessions);
+    renderWithProviders(<SidebarSessionList />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("session-item-session-11")).toBeNull();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(await screen.findByText("Search conversations"));
+    fireEvent.change(screen.getByPlaceholderText("Search…"), {
+      target: { value: "Conversation" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-item-session-12")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: /Load more/ })).toBeNull();
     });
   });
 

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -492,6 +492,31 @@ export default function SidebarSessionList({
     [sortedSessions, searchQuery, visibleChatGroups],
   );
 
+  const activeSessionPage = useMemo(() => {
+    if (!currentSessionId || !groups) return null;
+    const activeGroup = groups.find(({ sessions }) =>
+      sessions.some(
+        (session) =>
+          session.id === currentSessionId ||
+          session.realId === currentSessionId,
+      ),
+    );
+    if (!activeGroup) return null;
+    const orderedSessions = groupChatsByDate(activeGroup.sessions).flatMap(
+      (dateGroup) => dateGroup.sessions,
+    );
+    const sessionIndex = orderedSessions.findIndex(
+      (session) =>
+        session.id === currentSessionId || session.realId === currentSessionId,
+    );
+    if (sessionIndex < 0) return null;
+    return {
+      groupId: activeGroup.group.id,
+      requiredCount:
+        Math.floor(sessionIndex / GROUP_PAGE_SIZE + 1) * GROUP_PAGE_SIZE,
+    };
+  }, [currentSessionId, groups]);
+
   const defaultCollapsedGroupIds = useMemo(() => {
     if (!groups) return new Set<string>();
 
@@ -509,6 +534,9 @@ export default function SidebarSessionList({
       recentGroupIds.add(groupId);
       if (recentGroupIds.size === 2) break;
     }
+    if (activeSessionPage) {
+      recentGroupIds.add(activeSessionPage.groupId);
+    }
 
     // If there are no conversations yet, keep the first two user groups
     // discoverable while leaving fixed system groups collapsed.
@@ -523,48 +551,51 @@ export default function SidebarSessionList({
 
     return new Set(
       groups
-        .filter(({ group }) => !recentGroupIds.has(group.id))
+        .filter(
+          ({ group }) =>
+            !recentGroupIds.has(group.id) &&
+            (group.kind === "cron" ||
+              group.kind === "subagents" ||
+              !group.pinned),
+        )
         .map(({ group }) => group.id),
     );
-  }, [groups, sortedSessions]);
+  }, [activeSessionPage, groups, sortedSessions]);
 
   useEffect(() => {
     if (loading) return;
     initializeCollapsedGroups(defaultCollapsedGroupIds);
   }, [defaultCollapsedGroupIds, initializeCollapsedGroups, loading]);
 
-  const loadMoreGroup = useCallback((groupId: string, collapse = false) => {
-    setVisibleSessionCounts((previous) => ({
-      ...previous,
-      [groupId]: collapse
-        ? GROUP_PAGE_SIZE
-        : (previous[groupId] ?? GROUP_PAGE_SIZE) + GROUP_PAGE_SIZE,
-    }));
-  }, []);
+  const loadMoreGroup = useCallback(
+    (groupId: string, collapse = false) => {
+      setVisibleSessionCounts((previous) => ({
+        ...previous,
+        [groupId]: collapse
+          ? Math.max(
+              GROUP_PAGE_SIZE,
+              activeSessionPage?.groupId === groupId
+                ? activeSessionPage.requiredCount
+                : 0,
+            )
+          : (previous[groupId] ?? GROUP_PAGE_SIZE) + GROUP_PAGE_SIZE,
+      }));
+    },
+    [activeSessionPage],
+  );
 
   useEffect(() => {
-    if (!currentSessionId || !groups) return;
-    const activeGroup = groups.find(({ sessions }) =>
-      sessions.some(
-        (session) =>
-          session.id === currentSessionId ||
-          session.realId === currentSessionId,
-      ),
-    );
-    if (!activeGroup) return;
-    const sessionIndex = activeGroup.sessions.findIndex(
-      (session) =>
-        session.id === currentSessionId || session.realId === currentSessionId,
-    );
-    if (sessionIndex < 0) return;
-    const requiredCount =
-      Math.floor(sessionIndex / GROUP_PAGE_SIZE + 1) * GROUP_PAGE_SIZE;
+    if (!activeSessionPage) return;
     setVisibleSessionCounts((previous) => {
-      const currentCount = previous[activeGroup.group.id] ?? GROUP_PAGE_SIZE;
-      if (currentCount >= requiredCount) return previous;
-      return { ...previous, [activeGroup.group.id]: requiredCount };
+      const currentCount =
+        previous[activeSessionPage.groupId] ?? GROUP_PAGE_SIZE;
+      if (currentCount >= activeSessionPage.requiredCount) return previous;
+      return {
+        ...previous,
+        [activeSessionPage.groupId]: activeSessionPage.requiredCount,
+      };
     });
-  }, [currentSessionId, groups]);
+  }, [activeSessionPage]);
 
   useRevealActiveChatGroup(currentSessionId, sortedSessions, expandGroup);
 
@@ -622,7 +653,16 @@ export default function SidebarSessionList({
             remaining: group.sessions.length - visibleCount,
             collapse: false,
           });
-        } else if (visibleCount > GROUP_PAGE_SIZE) {
+        } else if (
+          visibleCount > GROUP_PAGE_SIZE &&
+          visibleCount >
+            Math.min(
+              activeSessionPage?.groupId === group.group.id
+                ? activeSessionPage.requiredCount
+                : GROUP_PAGE_SIZE,
+              group.sessions.length,
+            )
+        ) {
           rows.push({
             kind: "loadMore",
             groupId: group.group.id,
@@ -640,6 +680,7 @@ export default function SidebarSessionList({
     searchQuery,
     filteredSessions,
     visibleSessionCounts,
+    activeSessionPage,
     t,
   ]);
 

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -56,8 +56,10 @@ const SESSION_ROW_HEIGHT = 42;
 /** Fixed height of each group header row */
 const GROUP_HEADER_HEIGHT = 42;
 const DATE_HEADER_HEIGHT = 24;
+const LOAD_MORE_ROW_HEIGHT = 44;
+const GROUP_PAGE_SIZE = 10;
 
-/** A flattened row: either a group header or a session item */
+/** A flattened row rendered by the virtualized session list. */
 type FlatRow =
   | {
       kind: "groupHeader";
@@ -70,6 +72,12 @@ type FlatRow =
       groupId: string;
       dateGroup: ChatDateGroup;
       label: string;
+    }
+  | {
+      kind: "loadMore";
+      groupId: string;
+      remaining: number;
+      collapse: boolean;
     }
   | { kind: "session"; session: ExtendedChatSession; groupId: string };
 
@@ -92,6 +100,7 @@ interface VirtualRowData {
   handleEditChange: (value: string) => void;
   handleEditSubmit: () => void;
   handleEditCancel: () => void;
+  loadMoreGroup: (groupId: string, collapse?: boolean) => void;
   groups: ChatGroup[];
   toggleGroup: (key: string) => void;
   renameGroup: (groupId: string, name: string) => void;
@@ -165,6 +174,30 @@ const VirtualRow = React.memo(function VirtualRow({
       >
         <SessionDateHeader dateGroup={row.dateGroup} label={row.label} />
       </SessionDropZone>
+    );
+  }
+
+  if (row.kind === "loadMore") {
+    const label = row.collapse
+      ? data.t("chat.groups.collapseList", "Collapse list")
+      : data.t("chat.groups.loadMore", "Load more · {{count}} remaining", {
+          count: row.remaining,
+        });
+    return (
+      <div className={styles.loadMoreRow} style={style}>
+        <button
+          type="button"
+          className={styles.loadMoreButton}
+          aria-label={label}
+          onClick={() => data.loadMoreGroup(row.groupId, row.collapse)}
+        >
+          <span>{label}</span>
+          <ChevronDown
+            size={13}
+            style={{ transform: row.collapse ? "rotate(180deg)" : undefined }}
+          />
+        </button>
+      </div>
     );
   }
 
@@ -244,8 +277,12 @@ export default function SidebarSessionList({
   const [historyCollapsed, setHistoryCollapsed] = useState(false);
   const [isSessionDragging, setIsSessionDragging] = useState(false);
   /** Collapsed chat groups — persisted so remounts keep the user's state */
-  const { collapsedGroups, toggleGroup, expandGroup } =
-    useCollapsedChatGroups();
+  const {
+    collapsedGroups,
+    toggleGroup,
+    expandGroup,
+    initializeCollapsedGroups,
+  } = useCollapsedChatGroups();
   const {
     groups: chatGroups,
     createGroup,
@@ -256,6 +293,9 @@ export default function SidebarSessionList({
   } = useChatGroups(true);
   const [creatingGroup, setCreatingGroup] = useState(false);
   const [newGroupName, setNewGroupName] = useState("");
+  const [visibleSessionCounts, setVisibleSessionCounts] = useState<
+    Record<string, number>
+  >({});
   const searchInputRef = useRef<InputRef>(null);
   const groupInputRef = useRef<InputRef>(null);
   const visibleChatGroups = useMemo(
@@ -452,6 +492,80 @@ export default function SidebarSessionList({
     [sortedSessions, searchQuery, visibleChatGroups],
   );
 
+  const defaultCollapsedGroupIds = useMemo(() => {
+    if (!groups) return new Set<string>();
+
+    const expandableGroupIds = new Set(
+      groups
+        .filter(
+          ({ group }) => group.kind !== "cron" && group.kind !== "subagents",
+        )
+        .map(({ group }) => group.id),
+    );
+    const recentGroupIds = new Set<string>();
+    for (const session of sortedSessions) {
+      const groupId = resolveChatGroupId(session);
+      if (!expandableGroupIds.has(groupId)) continue;
+      recentGroupIds.add(groupId);
+      if (recentGroupIds.size === 2) break;
+    }
+
+    // If there are no conversations yet, keep the first two user groups
+    // discoverable while leaving fixed system groups collapsed.
+    if (recentGroupIds.size === 0) {
+      groups
+        .filter(
+          ({ group }) => group.kind !== "cron" && group.kind !== "subagents",
+        )
+        .slice(0, 2)
+        .forEach(({ group }) => recentGroupIds.add(group.id));
+    }
+
+    return new Set(
+      groups
+        .filter(({ group }) => !recentGroupIds.has(group.id))
+        .map(({ group }) => group.id),
+    );
+  }, [groups, sortedSessions]);
+
+  useEffect(() => {
+    if (loading) return;
+    initializeCollapsedGroups(defaultCollapsedGroupIds);
+  }, [defaultCollapsedGroupIds, initializeCollapsedGroups, loading]);
+
+  const loadMoreGroup = useCallback((groupId: string, collapse = false) => {
+    setVisibleSessionCounts((previous) => ({
+      ...previous,
+      [groupId]: collapse
+        ? GROUP_PAGE_SIZE
+        : (previous[groupId] ?? GROUP_PAGE_SIZE) + GROUP_PAGE_SIZE,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!currentSessionId || !groups) return;
+    const activeGroup = groups.find(({ sessions }) =>
+      sessions.some(
+        (session) =>
+          session.id === currentSessionId ||
+          session.realId === currentSessionId,
+      ),
+    );
+    if (!activeGroup) return;
+    const sessionIndex = activeGroup.sessions.findIndex(
+      (session) =>
+        session.id === currentSessionId || session.realId === currentSessionId,
+    );
+    if (sessionIndex < 0) return;
+    const requiredCount =
+      Math.floor(sessionIndex / GROUP_PAGE_SIZE + 1) * GROUP_PAGE_SIZE;
+    setVisibleSessionCounts((previous) => {
+      const currentCount = previous[activeGroup.group.id] ?? GROUP_PAGE_SIZE;
+      if (currentCount >= requiredCount) return previous;
+      return { ...previous, [activeGroup.group.id]: requiredCount };
+    });
+  }, [currentSessionId, groups]);
+
   useRevealActiveChatGroup(currentSessionId, sortedSessions, expandGroup);
 
   /** Flatten groups into a single array of rows for virtual list */
@@ -475,20 +589,46 @@ export default function SidebarSessionList({
         collapsed,
       });
       if (!collapsed) {
+        const visibleCount = Math.min(
+          visibleSessionCounts[group.group.id] ?? GROUP_PAGE_SIZE,
+          group.sessions.length,
+        );
+        let renderedCount = 0;
         for (const dateGroup of groupChatsByDate(group.sessions)) {
+          const sessionsToRender = dateGroup.sessions.slice(
+            0,
+            visibleCount - renderedCount,
+          );
+          if (sessionsToRender.length === 0) break;
           rows.push({
             kind: "dateHeader",
             groupId: group.group.id,
             dateGroup: dateGroup.key,
             label: t(`chat.group.${dateGroup.key}`),
           });
-          for (const session of dateGroup.sessions) {
+          for (const session of sessionsToRender) {
             rows.push({
               kind: "session",
               session,
               groupId: group.group.id,
             });
           }
+          renderedCount += sessionsToRender.length;
+        }
+        if (visibleCount < group.sessions.length) {
+          rows.push({
+            kind: "loadMore",
+            groupId: group.group.id,
+            remaining: group.sessions.length - visibleCount,
+            collapse: false,
+          });
+        } else if (visibleCount > GROUP_PAGE_SIZE) {
+          rows.push({
+            kind: "loadMore",
+            groupId: group.group.id,
+            remaining: 0,
+            collapse: true,
+          });
         }
       }
     }
@@ -499,6 +639,7 @@ export default function SidebarSessionList({
     isSessionDragging,
     searchQuery,
     filteredSessions,
+    visibleSessionCounts,
     t,
   ]);
 
@@ -511,6 +652,8 @@ export default function SidebarSessionList({
         ? GROUP_HEADER_HEIGHT
         : row.kind === "dateHeader"
         ? DATE_HEADER_HEIGHT
+        : row.kind === "loadMore"
+        ? LOAD_MORE_ROW_HEIGHT
         : SESSION_ROW_HEIGHT;
     },
     [flatRows],
@@ -581,6 +724,7 @@ export default function SidebarSessionList({
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,
+      loadMoreGroup,
       toggleGroup,
       groups: visibleChatGroups,
       renameGroup,
@@ -604,6 +748,7 @@ export default function SidebarSessionList({
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,
+      loadMoreGroup,
       toggleGroup,
       visibleChatGroups,
       renameGroup,

--- a/console/src/layouts/sidebarSessionList.module.less
+++ b/console/src/layouts/sidebarSessionList.module.less
@@ -82,6 +82,43 @@
   margin-bottom: 4px;
 }
 
+.loadMoreRow {
+  display: flex;
+  align-items: center;
+  height: 44px;
+  padding: 0 8px;
+}
+
+.loadMoreButton {
+  display: flex;
+  width: 100%;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--app-text-tertiary);
+  cursor: pointer;
+  font-size: 11px;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.loadMoreButton:hover {
+  border-color: var(--app-accent-border);
+  background: var(--app-accent-soft);
+  color: var(--app-accent-text);
+}
+
+.loadMoreButton:focus-visible {
+  outline: 2px solid var(--app-accent-border);
+  outline-offset: 1px;
+}
+
 /* Date group label (clickable to collapse/expand) */
 .groupLabel {
   display: flex;

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -3543,6 +3543,8 @@
       "subagents": "Conversations with subagents",
       "subagentShort": "Subagent",
       "subagentsHint": "Separate conversations created for child-agent tasks; collapsed by default and fixed at the bottom",
+      "loadMore": "Load more · {{count}} remaining",
+      "collapseList": "Collapse list",
       "pin": "Pin group",
       "unpin": "Unpin group",
       "pinned": "Pinned group",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -696,7 +696,9 @@
     "newTask": "Tugas baru",
     "groups": {
       "cronShort": "Terjadwal",
-      "subagentShort": "Subagen"
+      "subagentShort": "Subagen",
+      "loadMore": "Muat lebih banyak · {{count}} tersisa",
+      "collapseList": "Ciutkan daftar"
     },
     "fileReference": {
       "codeSnippet": "Cuplikan kode · {{count}} baris"

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2765,7 +2765,9 @@
     "newTask": "新しいタスク",
     "groups": {
       "cronShort": "定期タスク",
-      "subagentShort": "サブエージェント"
+      "subagentShort": "サブエージェント",
+      "loadMore": "さらに読み込む · 残り {{count}} 件",
+      "collapseList": "リストを折りたたむ"
     },
     "fileReference": {
       "codeSnippet": "コードスニペット · {{count}} 行"

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -3009,7 +3009,9 @@
     "newTask": "Nova tarefa",
     "groups": {
       "cronShort": "Agendado",
-      "subagentShort": "Subagente"
+      "subagentShort": "Subagente",
+      "loadMore": "Carregar mais · {{count}} restantes",
+      "collapseList": "Recolher lista"
     },
     "fileReference": {
       "codeSnippet": "Trecho de código · {{count}} linhas"

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2780,7 +2780,9 @@
     "newTask": "Новая задача",
     "groups": {
       "cronShort": "Расписание",
-      "subagentShort": "Субагент"
+      "subagentShort": "Субагент",
+      "loadMore": "Загрузить ещё · осталось {{count}}",
+      "collapseList": "Свернуть список"
     },
     "fileReference": {
       "codeSnippet": "Фрагмент кода · {{count}} строк"

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -709,7 +709,9 @@
     "newTask": "Tác vụ mới",
     "groups": {
       "cronShort": "Định kỳ",
-      "subagentShort": "Tác tử con"
+      "subagentShort": "Tác tử con",
+      "loadMore": "Tải thêm · còn {{count}} mục",
+      "collapseList": "Thu gọn danh sách"
     },
     "fileReference": {
       "codeSnippet": "Đoạn mã · {{count}} dòng"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -3400,6 +3400,8 @@
       "subagents": "与子智能体的对话",
       "subagentShort": "子智能体",
       "subagentsHint": "由子智能体执行任务时创建的独立对话，默认收起并固定在列表底部",
+      "loadMore": "加载更多 · 还有 {{count}} 条",
+      "collapseList": "收起列表",
       "pin": "置顶分组",
       "unpin": "取消置顶分组",
       "pinned": "已置顶分组",

--- a/console/src/pages/Inbox/index.module.less
+++ b/console/src/pages/Inbox/index.module.less
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: var(--app-bg);
+  background: var(--app-surface);
 }
 
 .pageContent {


### PR DESCRIPTION
In-group pagination: Defaults to rendering 10 items per group; the "Load more · N items remaining" footer adds 10 items per click, switching to "Collapse list" (to reset the view) once everything is loaded. Pagination tracks the global count within the group, ensuring date headers are never left orphaned.
Visibility persistence for active sessions: If a selected session falls outside the currently loaded range, the visible count for that group automatically expands to include the full page containing that session.
Default collapse logic based on recent activity: Only the two user groups with the most recent sessions are expanded by default (excluding cron/subagents); if no sessions exist, the first two groups are expanded as a fallback.
`useCollapsedChatGroups`: Added `initializeCollapsedGroups()`, applied only when no user-persisted state exists; storage key updated from v3 to v4; v3 records matching the old default (`[cron, subagents]`) are treated as non-user-intentional, allowing the new policy to take effect.
Styling and i18n: "Load more" button utilizes semantic tokens and `:focus-visible` styling; added `chat.groups.loadMore` and `chat.groups.collapseList` keys, fully localized across 7 languages.

<img width="1666" height="1226" alt="image" src="https://github.com/user-attachments/assets/31cfd09e-1242-4ac7-ab9e-960cfe66e9b2" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
