### PR TITLE
fix(files): show upload only in workspace

### DIFF
--- a/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.interaction.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getSystemPromptFiles: vi.fn(),
   listDirectory: vi.fn(),
   listFiles: vi.fn(),
+  listMemoryFiles: vi.fn(),
   setSystemPromptFiles: vi.fn(),
 }));
 
@@ -14,7 +15,11 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, values?: { name?: string }) => {
       const labels: Record<string, string> = {
+        "files.workspace": "Workspace",
         "files.profile": "Profile",
+        "files.daily": "Daily",
+        "files.digest": "Digest",
+        "files.upload": "Upload",
         "files.addSystemPrompt": "Add from workspace",
         "files.addSystemPromptTitle": "Add a system prompt file",
         "files.addSystemPromptDescription": "Choose a file",
@@ -33,6 +38,7 @@ vi.mock("../../api/modules/workspace", () => ({
     getSystemPromptFiles: mocks.getSystemPromptFiles,
     listDirectory: mocks.listDirectory,
     listFiles: mocks.listFiles,
+    listMemoryFiles: mocks.listMemoryFiles,
     setSystemPromptFiles: mocks.setSystemPromptFiles,
   },
 }));
@@ -91,7 +97,28 @@ describe("FilesNavigator system prompt interactions", () => {
       next_cursor: null,
       has_more: false,
     });
+    mocks.listMemoryFiles.mockResolvedValue([]);
     mocks.setSystemPromptFiles.mockImplementation(async (files) => files);
+  });
+
+  it("shows upload only in the workspace tab", async () => {
+    mocks.listFiles.mockResolvedValue([]);
+    mocks.getSystemPromptFiles.mockResolvedValue([]);
+
+    renderNavigator();
+    expect(
+      await screen.findByRole("button", { name: "Upload" }),
+    ).toBeInTheDocument();
+
+    for (const tab of ["Profile", "Daily", "Digest"]) {
+      fireEvent.click(screen.getByRole("tab", { name: tab }));
+      expect(
+        screen.queryByRole("button", { name: "Upload" }),
+      ).not.toBeInTheDocument();
+    }
+
+    fireEvent.click(screen.getByRole("tab", { name: "Workspace" }));
+    expect(screen.getByRole("button", { name: "Upload" })).toBeInTheDocument();
   });
 
   it("can add a custom prompt again after disabling it", async () => {

--- a/console/src/features/files-workspace/FilesNavigator.tsx
+++ b/console/src/features/files-workspace/FilesNavigator.tsx
@@ -893,19 +893,21 @@ export default function FilesNavigator({
             >
               <RefreshCw size={15} />
             </button>
-            <button
-              type="button"
-              className={styles.iconButton}
-              onClick={() => uploadRef.current?.click()}
-              aria-label={t("files.upload")}
-              disabled={uploading}
-            >
-              {uploading ? (
-                <LoaderCircle className={styles.spin} size={15} />
-              ) : (
-                <Upload size={15} />
-              )}
-            </button>
+            {source === "workspace" && (
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => uploadRef.current?.click()}
+                aria-label={t("files.upload")}
+                disabled={uploading}
+              >
+                {uploading ? (
+                  <LoaderCircle className={styles.spin} size={15} />
+                ) : (
+                  <Upload size={15} />
+                )}
+              </button>
+            )}
           </div>
         </div>
         <input

--- a/console/src/features/files-workspace/FilesWorkspace.module.less
+++ b/console/src/features/files-workspace/FilesWorkspace.module.less
@@ -267,6 +267,7 @@
 }
 
 .directoryToolbar {
+  min-height: 73px;
   display: flex;
   align-items: stretch;
   gap: 6px;


### PR DESCRIPTION
## Description

Show the file upload button only on the Workspace tab. Profile, Daily, and Digest are read-only navigation sources for this action and no longer display the upload entry.

**Related Issue:** None

**Security Considerations:** No security impact. This only changes frontend visibility; the upload implementation is unchanged.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Console (frontend web UI)
- [x] Tests

## Checklist

- [x] I ran tests locally (as relevant) and they pass
- [x] Documentation updated (not needed)
- [x] Ready for review

## Testing

- Added an interaction test covering upload visibility across Workspace, Profile, Daily, and Digest.
- Ran targeted Vitest, Prettier, ESLint, and git diff checks.

## Evidence

```text
Test Files  1 passed (1)
Tests       2 passed (2)
All matched files use Prettier code style.
ESLint passed with no findings.
git diff --check passed.
```

## Additional Notes

The upload flow is unchanged; rendering is gated by the existing navigator source state.