### PR TITLE
docs(mcp): fix wrong agent.json field name in Chinese MCP page

### DIFF
--- a/website/public/docs/mcp.zh.md
+++ b/website/public/docs/mcp.zh.md
@@ -401,7 +401,7 @@ QwenPaw 提供了一组开箱即用的内置工具，智能体可以直接调用
 
 ### 工具配置参考
 
-内置工具的配置存储在 `agent.json` 的 `tools.builtins` 字段中。
+内置工具的配置存储在 `agent.json` 的 `tools.builtin_tools` 字段中。
 
 **配置示例：**
 


### PR DESCRIPTION
## Description

**Related Issue:** N/A — self-contained documentation-correctness fix (no tracking issue).

`website/public/docs/mcp.zh.md` states that built-in tool configuration is stored in the `tools.builtins` field of `agent.json`. There is no such field — the real field is `tools.builtin_tools`. A user who follows the Chinese page writes `tools.builtins` into `agent.json`, and the setting is silently ignored: no error, no effect.

Three independent confirmations that `tools.builtins` is wrong:

1. **The document contradicts itself.** The JSON example in the same section uses `"builtin_tools"` (mcp.zh.md:411), seven lines below the incorrect sentence at mcp.zh.md:404.
2. **The English version is already correct.** `mcp.en.md:390` reads "stored in the `tools.builtin_tools` field of `agent.json`".
3. **The source uses `builtin_tools`.**
   - `src/qwenpaw/agents/react_agent.py:1254-1262` reads the field as `getattr(getattr(self._agent_config, "tools", None), "builtin_tools", None)`.
   - Defaults are built by `_default_builtin_tools()` in `src/qwenpaw/config/config.py:2695`.
   - A repo-wide search for `tools.builtins` returns exactly one hit — the line this PR fixes. `builtins` appears nowhere in the source.

**Security Considerations:** None. Documentation-only change; no config, credential, or channel handling is touched.

## Type of Change

- [x] Documentation

## Component(s) Affected

- [x] Documentation (website)

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

Why the two unchecked boxes above:

- The full `pre-commit run --all-files` harness cannot run on this machine — its cache cleanup trips a sandbox file-deletion guard (`[safe-delete][SAFE_DELETE_FAIL_CLOSED]`). Instead I ran the official hook implementations from `pre-commit-hooks==4.3.0` directly against the exact LF content that lands in the commit (`git show :website/public/docs/mcp.zh.md`).
- Only two hooks in `.pre-commit-config.yaml` match a `.md` file: `trailing-whitespace` (exit 0, no rewrite) and `detect-private-key` (exit 0). Every other hook is out of scope for this file type — `check-ast` / `check-docstring-first` / `fix-encoding-pragma` / `add-trailing-comma` / `black` / `flake8` / `mypy` are Python-only; `check-json` / `check-yaml` / `check-xml` / `check-toml` / `sort-simple-yaml` target other formats; `pylint` excludes `\.md$`; `prettier` is scoped to `files: \.(tsx?)$`; `actionlint` targets workflows.
- No `pytest` test reads `website/public/docs/**` (verified by searching `tests/`), so there is no existing test covering this file. The markdown prose is covered by the website format gate instead, which I ran below.

## Testing

`pnpm run format:check` in `website/` is `tsc -b --noEmit && prettier --check .`, and `website/.prettierignore` only excludes `dist/`, `build/`, `node_modules/`, and cache dirs — so `public/docs/*.md` is in scope. I verified the staged content with the same prettier version the workflow pins (`prettier@3.0.0`):

```bash
cd website
git show :website/public/docs/mcp.zh.md | ./node_modules/.bin/prettier --check --stdin-filepath website/public/docs/mcp.zh.md
# exit 0 (no output)
```

The pre-change baseline (`git show origin/main:website/public/docs/mcp.zh.md | ... prettier --check`) also exits 0, so this edit neither fixes nor introduces a formatting violation.

## Evidence

```bash
$ git diff --stat
 website/public/docs/mcp.zh.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

$ git diff
diff --git a/website/public/docs/mcp.zh.md b/website/public/docs/mcp.zh.md
@@ -401,7 +401,7 @@ QwenPaw 提供了一组开箱即用的内置工具，智能体可以直接调用
 ### 工具配置参考
 
-内置工具的配置存储在 `agent.json` 的 `tools.builtins` 字段中。
+内置工具的配置存储在 `agent.json` 的 `tools.builtin_tools` 字段中。
 
 **配置示例：**

$ grep -rn 'tools\.builtins' . | grep -v node_modules | grep -v '^./.git/'
(no output — residual reference cleared)

$ python -m pre_commit_hooks.trailing_whitespace_fixer <exported-LF-file>
exit 0

$ python -m pre_commit_hooks.detect_private_key <exported-LF-file>
exit 0
```

## Additional Notes

**Notes for Reviewer**

- Conflict check against my own prior PRs to this repository: #7214 / #7255 (`README.md`, `README_ja.md`, `README_zh.md`), #7269 (`website/public/docs/loop-engineering.{en,zh}.md`), #7390 (`tests/unit/providers/test_model_catalog.py`), #7391 (`website/public/docs/config.{en,zh}.md`), #7440 (`website/public/docs/intro.{en,zh}.md`). None of these touch `website/public/docs/mcp.zh.md`, so there is no file overlap and no rebase conflict.
- Scope is deliberately limited to the incorrect field name. While reviewing this page I also noticed unrelated EN/ZH structural drift in the same document: the Chinese page has extra `#### 配置项说明` and `#### 配置验证规则` subsections that the English page lacks, and the field-description table sits under an `###` heading in Chinese but a `####` heading in English. Which side is authoritative is not obvious, so it is intentionally left out of this PR.
