### PR TITLE
fix(agents): diagnose dropped subagent model overrides

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -1125,9 +1125,13 @@ async def _build_subagent_request_context(
         if subagent_model is not None:
             rc["model_slot_override"] = subagent_model.model_dump()
     except Exception:  # pylint: disable=broad-exception-caught
-        # Subagents must remain usable when an optional per-agent model
-        # override cannot be loaded from a stale or synthetic test identity.
-        pass
+        # Subagents remain usable, but a dropped configured override must be
+        # diagnosable instead of looking like an unset field.
+        logger.warning(
+            "Failed to load subagent model override for agent=%s",
+            current_agent_id,
+            exc_info=True,
+        )
     if extra:
         rc.update(extra)
     if allowed_tools is not None:

--- a/tests/unit/app/routers/test_console_model_override.py
+++ b/tests/unit/app/routers/test_console_model_override.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Regression coverage for subagent model override transport."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents.tools import agent_management
+from qwenpaw.app.routers import console
+from qwenpaw.runtime.builder import AgentBuilder
+from qwenpaw.schemas import AgentRequest
+
+
+def test_subagent_model_override_survives_native_payload_conversion() -> None:
+    override = {
+        "provider_id": "llamacpp",
+        "model": "local-model",
+    }
+    request_data = {
+        "session_id": "sub-session",
+        "request_context": {"model_slot_override": override},
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "reply OK"}],
+            },
+        ],
+    }
+
+    native_payload = console._extract_session_and_payload(request_data)
+
+    request_context = native_payload["meta"]["request_context"]
+    actual_override = request_context["model_slot_override"]
+    assert actual_override == override
+
+
+def test_console_channel_restores_subagent_model_override() -> None:
+    from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+    channel = object.__new__(ConsoleChannel)
+    channel.channel = "console"
+    channel.resolve_session_id = lambda _sender_id, _meta: "sub-session"
+
+    def build_request(**_kwargs):
+        return AgentRequest()
+
+    channel.build_agent_request_from_user_content = build_request
+
+    override = {
+        "provider_id": "llamacpp",
+        "model": "local-model",
+    }
+    request = channel.build_agent_request_from_native(
+        {
+            "channel_id": "console",
+            "sender_id": "default",
+            "content_parts": [],
+            "meta": {"request_context": {"model_slot_override": override}},
+        },
+    )
+
+    context = AgentBuilder._build_request_context(
+        SimpleNamespace(request=request),
+    )
+
+    assert context["model_slot_override"] == override
+
+
+@pytest.mark.asyncio
+async def test_subagent_model_override_load_failure_is_logged(
+    monkeypatch,
+    caplog,
+):
+    def fail_load(_agent_id):
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(agent_management, "load_agent_config", fail_load)
+
+    with caplog.at_level("WARNING", logger=agent_management.__name__):
+        context = await agent_management._build_subagent_request_context("bot")
+
+    assert "model_slot_override" not in context
+    message = "Failed to load subagent model override for agent=bot"
+    assert message in caplog.text


### PR DESCRIPTION
## Description

A configured subagent model override could disappear silently: `_build_subagent_request_context` swallowed every exception while loading the per-agent config, so the failure looked like an unset field. Log the failure with the agent id and exception trace instead of dropping it, and add regression coverage that the request transport carries `model_slot_override` end to end (console payload → native payload → `AgentBuilder` request context). Subagents stay usable when the override cannot be loaded.

**Related Issue:** Relates to #7676

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/app/routers/test_console_model_override.py` — 3 passed: the console payload round-trip, the `AgentBuilder` request-context round-trip, and the new load-failure warning.
- `flake8` on the two changed Python files, `python -m compileall`, and `git diff --check` are clean.

## Evidence

Focused run of `tests/unit/app/routers/test_console_model_override.py` on this branch passes, including the assertion that the warning is emitted and that `model_slot_override` is absent from the context when the config load raises. The full pre-commit and channel matrices run upstream in CI.

## Additional Notes

The console payload drop was fixed in #6304; this change only makes a failed override load visible in logs and adds regression coverage for the request path.
