### PR TITLE
fix(console): persist sidebar collapsed state across reloads

### DIFF
--- a/console/src/layouts/Sidebar.render.test.tsx
+++ b/console/src/layouts/Sidebar.render.test.tsx
@@ -309,6 +309,7 @@ const modelsItem = {
 describe("Sidebar", () => {
   beforeEach(() => {
     mockMobileViewport(false);
+    localStorage.removeItem("qwenpaw_sidebar_collapsed");
     mocks.sidebar.focusItemIds = ["core.workspace", "core.models"];
     mocks.sidebar.hiddenPluginItemIds = [];
     mocks.menuItems = [workspaceItem, inboxItem, modelsItem];
@@ -583,5 +584,74 @@ describe("Sidebar", () => {
     // The inbox label is wrapped in a Badge span with a ref callback
     const inboxSpans = screen.getAllByText("Inbox");
     expect(inboxSpans.length).toBeGreaterThan(0);
+  });
+
+  // TC-CON-01 checkpoint 3: the collapsed/expanded state must survive a
+  // page reload through localStorage.
+  describe("collapsed state persistence", () => {
+    function renderedSider() {
+      return document.querySelector<HTMLElement>(".ant-layout-sider");
+    }
+
+    it("restores the collapsed state after a reload", async () => {
+      const view = renderSidebar();
+      await waitFor(() => {
+        expect(screen.getByText("Workspace")).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+      await waitFor(() => {
+        expect(screen.queryByText("Workspace")).toBeNull();
+      });
+      expect(localStorage.getItem("qwenpaw_sidebar_collapsed")).toBe("true");
+      view.unmount();
+
+      // Remount simulates the reload: it must start collapsed (72px).
+      renderSidebar();
+      expect(renderedSider()).toHaveStyle({ width: "72px", minWidth: "72px" });
+      expect(screen.queryByText("Workspace")).toBeNull();
+      expect(screen.getByTestId("app-brand")).not.toBeVisible();
+    });
+
+    it("restores the expanded state after a reload", async () => {
+      localStorage.setItem("qwenpaw_sidebar_collapsed", "true");
+      const view = renderSidebar();
+      expect(renderedSider()).toHaveStyle({ width: "72px", minWidth: "72px" });
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Expand sidebar" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Workspace")).toBeTruthy();
+      });
+      expect(localStorage.getItem("qwenpaw_sidebar_collapsed")).toBeNull();
+      view.unmount();
+
+      // Remount simulates the reload: it must start expanded (280px).
+      renderSidebar();
+      expect(renderedSider()).toHaveStyle({
+        width: "280px",
+        minWidth: "280px",
+      });
+      expect(screen.getByText("Workspace")).toBeTruthy();
+    });
+
+    it("keeps the mobile collapse transient so desktop is not pinned", async () => {
+      mockMobileViewport(true);
+      renderSidebar();
+
+      expect(renderedSider()).toHaveStyle({ width: "56px", minWidth: "56px" });
+      // A viewport-driven collapse must not write the user preference.
+      expect(localStorage.getItem("qwenpaw_sidebar_collapsed")).toBeNull();
+    });
+
+    it("does not override the stored preference on mobile", async () => {
+      localStorage.setItem("qwenpaw_sidebar_collapsed", "true");
+      mockMobileViewport(true);
+      renderSidebar();
+
+      expect(renderedSider()).toHaveStyle({ width: "56px", minWidth: "56px" });
+      expect(localStorage.getItem("qwenpaw_sidebar_collapsed")).toBe("true");
+    });
   });
 });

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -34,6 +34,10 @@ import {
 import { useSidebarStore } from "../stores/sidebarStore";
 import { buildChatPath } from "../utils/sessionRoute";
 import { getOsRootHref } from "../utils/navigationMode";
+import {
+  getSidebarCollapsedPreference,
+  setSidebarCollapsedPreference,
+} from "../utils/sidebarCollapsedPreference";
 import { useAgentStore } from "../stores/agentStore";
 import sessionApi from "../pages/Chat/sessionApi";
 import { useInboxWobble } from "../hooks/useInboxWobble";
@@ -100,8 +104,11 @@ export default function Sidebar({
   const [version, setVersion] = useState("");
   const [accountForm] = Form.useForm();
   // Start collapsed on mobile so the first paint does not overlay/obscure
-  // the main content on narrow viewports.
-  const [collapsed, setCollapsed] = useState(isMobileSidebarViewport);
+  // the main content on narrow viewports. On desktop, restore the persisted
+  // preference so a reload keeps the last collapsed/expanded state.
+  const [collapsed, setCollapsed] = useState(
+    () => isMobileSidebarViewport() || getSidebarCollapsedPreference(),
+  );
   const [isMobile, setIsMobile] = useState(isMobileSidebarViewport);
   const navScrollRef = useRef<HTMLDivElement>(null);
   const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
@@ -238,9 +245,10 @@ export default function Sidebar({
     const mediaQuery = window.matchMedia(MOBILE_SIDEBAR_QUERY);
     const syncMobileSidebar = () => {
       setIsMobile(mediaQuery.matches);
-      // Collapse on mobile to avoid covering the main content; expand again
-      // when the viewport returns to desktop width.
-      setCollapsed(mediaQuery.matches);
+      // Collapse on mobile to avoid covering the main content. This is a
+      // transient viewport override: it never writes the preference, and
+      // returning to desktop width restores what the user last chose.
+      setCollapsed(mediaQuery.matches || getSidebarCollapsedPreference());
     };
 
     syncMobileSidebar();
@@ -391,6 +399,16 @@ export default function Sidebar({
   ]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Explicit user toggle: the only path that persists the collapsed state.
+   * Viewport-driven collapsing stays transient so a narrow window does not
+   * permanently pin the desktop sidebar.
+   */
+  const handleSetCollapsed = useCallback((nextCollapsed: boolean) => {
+    setCollapsed(nextCollapsed);
+    setSidebarCollapsedPreference(nextCollapsed);
+  }, []);
 
   /**
    * New chat: if we're already on the chat page, dispatch the event so
@@ -599,7 +617,7 @@ export default function Sidebar({
           <Button
             type="text"
             icon={<SparkOperateLeftLine size={18} />}
-            onClick={() => setCollapsed(true)}
+            onClick={() => handleSetCollapsed(true)}
             className={styles.brandCollapseToggle}
             aria-label={t("sidebar.collapse", "Collapse sidebar")}
           />
@@ -618,7 +636,7 @@ export default function Sidebar({
                 type="button"
                 className={styles.collapsedNavItem}
                 aria-label={t("sidebar.expand", "Expand sidebar")}
-                onClick={() => setCollapsed(false)}
+                onClick={() => handleSetCollapsed(false)}
               >
                 <SparkOperateRightLine size={18} />
               </button>

--- a/console/src/utils/sidebarCollapsedPreference.test.ts
+++ b/console/src/utils/sidebarCollapsedPreference.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getSidebarCollapsedPreference,
+  setSidebarCollapsedPreference,
+} from "./sidebarCollapsedPreference";
+
+const STORAGE_KEY = "qwenpaw_sidebar_collapsed";
+
+describe("sidebarCollapsedPreference", () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to expanded when nothing is stored", () => {
+    expect(getSidebarCollapsedPreference()).toBe(false);
+  });
+
+  it("treats malformed stored values as expanded", () => {
+    localStorage.setItem(STORAGE_KEY, "collapsed");
+    expect(getSidebarCollapsedPreference()).toBe(false);
+  });
+
+  it("persists the collapsed state and clears it on expand", () => {
+    setSidebarCollapsedPreference(true);
+    expect(getSidebarCollapsedPreference()).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+
+    setSidebarCollapsedPreference(false);
+    expect(getSidebarCollapsedPreference()).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not throw when writing to storage is denied", () => {
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(() => setSidebarCollapsedPreference(true)).not.toThrow();
+    expect(getSidebarCollapsedPreference()).toBe(false);
+  });
+
+  it("does not throw when reading from storage is denied", () => {
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(getSidebarCollapsedPreference()).toBe(false);
+  });
+});

--- a/console/src/utils/sidebarCollapsedPreference.ts
+++ b/console/src/utils/sidebarCollapsedPreference.ts
@@ -1,0 +1,34 @@
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "qwenpaw_sidebar_collapsed";
+
+/**
+ * Read the persisted sidebar collapsed preference.
+ *
+ * The default is expanded: an absent or malformed key resolves to false so
+ * a fresh profile never starts with a hidden navigation surface.
+ */
+export function getSidebarCollapsedPreference(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist the sidebar collapsed preference set by an explicit user toggle.
+ *
+ * The expanded state removes the key instead of writing "false" so the
+ * default stays storage-free. Callers must not use this for transient,
+ * viewport-driven collapsing (see the mobile override in Sidebar.tsx).
+ */
+export function setSidebarCollapsedPreference(collapsed: boolean): void {
+  try {
+    if (collapsed) {
+      localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, "true");
+    } else {
+      localStorage.removeItem(SIDEBAR_COLLAPSED_STORAGE_KEY);
+    }
+  } catch {
+    // storage unavailable
+  }
+}


### PR DESCRIPTION
## Description

The configurable sidebar introduced in #7502 supports collapsed/expanded states, but the collapsed state was **never persisted**:

- it lived in component-local `useState` — `console/src/layouts/Sidebar.tsx:104`
- it was reset unconditionally by the mobile viewport effect on mount — `Sidebar.tsx:243` (`setCollapsed(mediaQuery.matches)`, always `false` on desktop)
- `stores/sidebarStore.ts` only persists `focusItemIds` / `hiddenPluginItemIds`, so no storage key ever recorded the collapsed state

Result: collapsing the sidebar (72px) and reloading always restored the expanded sidebar (280px). Reported by QA as **TC-CON-01, checkpoint 3**.

This PR:

- adds `console/src/utils/sidebarCollapsedPreference.ts`, following the existing pattern of `utils/chatLayoutPreference.ts` and `hooks/useCollapsedChatGroups.ts` (key: `qwenpaw_sidebar_collapsed`)
- restores the preference in the `useState` initializer, so the first paint is correct and mobile still starts collapsed (no expanded flash on narrow viewports)
- persists **only** on explicit user toggles via the new `handleSetCollapsed`
- keeps the mobile collapse a **transient viewport override** that never writes the preference, and restores the user's choice when the viewport returns to desktop width

That last point matters: persisting viewport-driven collapsing would permanently pin the desktop sidebar in the collapsed state after a single window resize.

**Related Issue:** Relates to #7502 (QA case TC-CON-01, checkpoint 3)

**Security Considerations:** None. Adds a single non-sensitive UI preference key to localStorage; no channel auth, env or config handling involved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
  → ran `pre-commit run --file` on the 4 changed files instead: `detect private key` / `trim trailing whitespace` **Passed**; the `prettier` hook is configured with `exclude: ^console/`, so it correctly reports *Skipped* for console files. Full `--all-files` not run.
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
  → no auto-fixes were produced.
- [x] I ran tests locally (`pytest` or as relevant) and they pass
  → targeted console tests: 27/27 passed (see Evidence). Full `npm run test:run` not run locally; left to CI.
- [x] Documentation updated (if needed) → n/a, no user-facing docs change.
- [x] Ready for review

## Testing

```bash
cd console
npx vitest run src/utils/sidebarCollapsedPreference.test.ts \
               src/layouts/Sidebar.render.test.tsx
```

New regression coverage in `Sidebar.render.test.tsx` → `describe("collapsed state persistence")`:

1. collapse → reload (remount) keeps the 72px collapsed state
2. expand → reload keeps the 280px expanded state
3. the mobile viewport collapse does **not** write the preference key
4. a stored preference is not clobbered by the mobile override

Manual repro: collapse the sidebar → reload → stays collapsed; expand → reload → stays expanded.

## Evidence

```bash
$ npx vitest run src/utils/sidebarCollapsedPreference.test.ts \
                 src/layouts/Sidebar.render.test.tsx
 ✓ src/utils/sidebarCollapsedPreference.test.ts (5 tests) 3ms
 ✓ src/layouts/Sidebar.render.test.tsx (22 tests) 1993ms
 Test Files  2 passed (2)
      Tests  27 passed (27)

$ npx prettier --check src/utils/sidebarCollapsedPreference.ts \
    src/utils/sidebarCollapsedPreference.test.ts \
    src/layouts/Sidebar.tsx src/layouts/Sidebar.render.test.tsx
Checking formatting...
All matched files use Prettier code style!

$ pre-commit run --file console/src/layouts/Sidebar.tsx \
    console/src/layouts/Sidebar.render.test.tsx \
    console/src/utils/sidebarCollapsedPreference.ts \
    console/src/utils/sidebarCollapsedPreference.test.ts
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
prettier.................................................(no files to check)Skipped

# Reverse verification — the new regression tests fail on the unfixed
# component, proving they actually guard the reported behaviour:
$ git checkout main -- console/src/layouts/Sidebar.tsx
$ npx vitest run src/layouts/Sidebar.render.test.tsx
 × restores the collapsed state after a reload
 × restores the expanded state after a reload
 Tests  2 failed | 20 passed (22)
```

## Additional Notes

**Same-pattern audit:** `hooks/useCollapsedChatGroups.ts` already persists correctly (load in the `useState` initializer + save on toggle); `BackgroundTaskPanel.tsx:76` and `ModelSelector:97` hold intentionally transient UI state. The sidebar was the only collapsible surface missing persistence.

**Cross-platform:** the change uses only browser `localStorage` + `matchMedia`, with no path/shell/process surface. This is a static-analysis conclusion — it was not executed on macOS/Linux/Windows.

**Not run locally (repo policy):** `npm run build`, `npm run format`, and the full `npm run test:run`. Console typecheck (`tsc -b --noEmit`) therefore relies on CI.
