### PR TITLE
fix(hub): audit login attempts and denied runtime creation

### DIFF
--- a/src/qwenpaw/hub/control_app.py
+++ b/src/qwenpaw/hub/control_app.py
@@ -298,6 +298,9 @@ def create_hub_app(  # pylint: disable=too-many-statements
         resource_type: str,
         resource_id: str,
         detail: dict[str, Any] | None = None,
+        *,
+        outcome: str = "success",
+        remote_address: str | None = None,
     ) -> None:
         await run_in_threadpool(
             operations.record,
@@ -307,7 +310,48 @@ def create_hub_app(  # pylint: disable=too-many-statements
             resource_type=resource_type,
             resource_id=resource_id,
             detail=detail,
+            outcome=outcome,
+            remote_address=remote_address,
         )
+
+    async def record_auth_event(
+        action: str,
+        username: str,
+        remote_address: str,
+        *,
+        outcome: str,
+        user: HubUser | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Persist one authentication attempt on a best-effort basis.
+
+        Rejected attempts have no authenticated actor yet, so the
+        attempted username is the only usable identity. Telemetry must
+        never turn a granted login into a server error, nor replace the
+        real rejection status of a failed attempt, so store failures are
+        logged instead of propagated.
+        """
+        try:
+            await run_in_threadpool(
+                operations.record,
+                actor_user_id=user.user_id if user is not None else "",
+                actor_username=(
+                    user.username if user is not None else username
+                ),
+                action=action,
+                resource_type="user",
+                resource_id=(
+                    user.user_id if user is not None else username
+                ),
+                detail={"reason": reason} if reason else None,
+                outcome=outcome,
+                remote_address=remote_address,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logging.getLogger(__name__).warning(
+                "Hub authentication audit event %s was not persisted",
+                action,
+            )
 
     async def personal_runtime(user: HubUser) -> RuntimeRecord:
         try:
@@ -485,8 +529,22 @@ def create_hub_app(  # pylint: disable=too-many-statements
                 body.password,
             )
         except PermissionError as exc:
+            await record_auth_event(
+                "auth.register",
+                body.username,
+                client_ip,
+                outcome="failure",
+                reason=str(exc),
+            )
             raise HTTPException(status_code=403, detail=str(exc)) from exc
         except ValueError as exc:
+            await record_auth_event(
+                "auth.register",
+                body.username,
+                client_ip,
+                outcome="failure",
+                reason=str(exc),
+            )
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         await record_audit(
             user,
@@ -494,6 +552,7 @@ def create_hub_app(  # pylint: disable=too-many-statements
             "user",
             user.user_id,
             {"role": user.role},
+            remote_address=client_ip,
         )
         return {
             "token": token,
@@ -515,8 +574,22 @@ def create_hub_app(  # pylint: disable=too-many-statements
             )
         except PermissionError as exc:
             access_security.record_attempt("login", client_ip)
+            await record_auth_event(
+                "auth.login",
+                body.username,
+                client_ip,
+                outcome="failure",
+                reason=str(exc),
+            )
             raise HTTPException(status_code=401, detail=str(exc)) from exc
         access_security.clear("login", client_ip)
+        await record_auth_event(
+            "auth.login",
+            body.username,
+            client_ip,
+            outcome="success",
+            user=user,
+        )
         return {
             "token": token,
             "username": user.username,
@@ -935,6 +1008,26 @@ def create_hub_app(  # pylint: disable=too-many-statements
                     "Runtime backend settings are " "administrator-controlled."
                 ),
             )
+
+        async def audit_creation_failure(reason: str) -> None:
+            """Audit one denied creation without masking its real status."""
+            try:
+                await record_audit(
+                    user,
+                    "runtime.create",
+                    "runtime",
+                    body.runtime_id,
+                    {
+                        "auto_start": body.auto_start,
+                        "reason": reason[:200],
+                    },
+                    outcome="failure",
+                )
+            except Exception:  # pylint: disable=broad-except
+                logging.getLogger(__name__).warning(
+                    "Hub runtime.create failure audit was not persisted",
+                )
+
         try:
             record = await run_in_threadpool(
                 runtime_service.create,
@@ -951,25 +1044,29 @@ def create_hub_app(  # pylint: disable=too-many-statements
                     "start",
                     body.runtime_id,
                 )
-            await record_audit(
-                user,
-                "runtime.create",
-                "runtime",
-                record.runtime_id,
-                {
-                    "auto_start": body.auto_start,
-                    "provisioner": record.provisioner,
-                },
-            )
-            return await runtime_payload(record)
         except RuntimeOperationConflictError as exc:
+            await audit_creation_failure(str(exc))
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except RuntimeProvisionerUnavailableError as exc:
+            await audit_creation_failure(str(exc))
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         except ValueError as exc:
+            await audit_creation_failure(str(exc))
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except Exception as exc:
+            await audit_creation_failure(str(exc))
             raise HTTPException(status_code=500, detail=str(exc)) from exc
+        await record_audit(
+            user,
+            "runtime.create",
+            "runtime",
+            record.runtime_id,
+            {
+                "auto_start": body.auto_start,
+                "provisioner": record.provisioner,
+            },
+        )
+        return await runtime_payload(record)
 
     @app.get("/api/hub/runtimes/{runtime_id}")
     async def get_runtime(

--- a/src/qwenpaw/hub/control_app.py
+++ b/src/qwenpaw/hub/control_app.py
@@ -340,9 +340,7 @@ def create_hub_app(  # pylint: disable=too-many-statements
                 ),
                 action=action,
                 resource_type="user",
-                resource_id=(
-                    user.user_id if user is not None else username
-                ),
+                resource_id=(user.user_id if user is not None else username),
                 detail={"reason": reason} if reason else None,
                 outcome=outcome,
                 remote_address=remote_address,

--- a/tests/unit/hub/test_control_app.py
+++ b/tests/unit/hub/test_control_app.py
@@ -1302,6 +1302,140 @@ def test_operations_overview_and_audit_are_real_and_sanitized(
         }
 
 
+def test_login_attempts_are_audited_with_outcome_and_source(
+    tmp_path: Path,
+) -> None:
+    """Granted and rejected logins must both reach the audit log."""
+    with _client(tmp_path) as client:
+        token = _register(client, "owner")
+        granted = client.post(
+            "/api/auth/login",
+            json={"username": "owner", "password": "safe-password"},
+        )
+        rejected = client.post(
+            "/api/auth/login",
+            json={"username": "owner", "password": "wrong-password"},
+        )
+
+        audit = client.get(
+            "/api/hub/admin/audit?action=auth.login&page_size=10",
+            headers=_headers(token),
+        )
+        events = audit.json()["items"]
+
+        assert granted.status_code == 200
+        assert rejected.status_code == 401
+        assert audit.json()["total"] == 2
+        assert {event["outcome"] for event in events} == {
+            "failure",
+            "success",
+        }
+        failure = next(
+            event for event in events if event["outcome"] == "failure"
+        )
+        success = next(
+            event for event in events if event["outcome"] == "success"
+        )
+        assert failure["actor_username"] == "owner"
+        assert failure["remote_address"]
+        assert failure["detail"]["reason"]
+        assert success["actor_user_id"]
+        assert "wrong-password" not in audit.text
+
+
+def test_rejected_registration_is_audited(tmp_path: Path) -> None:
+    """A denied registration attempt must leave an audit trail."""
+    with _client(tmp_path) as client:
+        token = _register(client, "owner")
+        duplicate = client.post(
+            "/api/auth/register",
+            json={"username": "owner", "password": "safe-password"},
+        )
+
+        audit = client.get(
+            "/api/hub/admin/audit?action=auth.register",
+            headers=_headers(token),
+        )
+        events = audit.json()["items"]
+
+        assert duplicate.status_code in (403, 409)
+        assert audit.json()["total"] == 2
+        denied = next(
+            event for event in events if event["outcome"] == "failure"
+        )
+        assert denied["actor_username"] == "owner"
+        assert denied["detail"]["reason"]
+
+
+def test_failed_runtime_creation_is_audited(tmp_path: Path) -> None:
+    """A rejected runtime creation must be audited, not silently lost."""
+    with _client(tmp_path, provisioner_available=False) as client:
+        token = _register(client, "owner")
+        created = client.post(
+            "/api/hub/runtimes",
+            json={"runtime_id": "blocked-runtime"},
+            headers=_headers(token),
+        )
+
+        audit = client.get(
+            "/api/hub/admin/audit?action=runtime.create",
+            headers=_headers(token),
+        )
+        events = audit.json()["items"]
+
+        assert created.status_code == 503
+        assert audit.json()["total"] == 1
+        assert events[0]["outcome"] == "failure"
+        assert events[0]["resource_id"] == "blocked-runtime"
+        assert "sandbox unavailable" in events[0]["detail"]["reason"]
+
+
+def test_audit_store_failure_never_blocks_authentication(
+    tmp_path: Path,
+) -> None:
+    """Broken telemetry must not mask the real authentication result."""
+    with _client(tmp_path) as client:
+        _register(client, "owner")
+        with patch.object(
+            client.app.state.operations,
+            "record",
+            side_effect=RuntimeError("database is locked"),
+        ):
+            granted = client.post(
+                "/api/auth/login",
+                json={"username": "owner", "password": "safe-password"},
+            )
+            rejected = client.post(
+                "/api/auth/login",
+                json={"username": "owner", "password": "wrong-password"},
+            )
+
+        assert granted.status_code == 200
+        assert granted.json()["token"]
+        assert rejected.status_code == 401
+
+
+def test_audit_store_failure_keeps_runtime_error_status(
+    tmp_path: Path,
+) -> None:
+    """Broken telemetry must not replace the real runtime error status."""
+    with _client(tmp_path, provisioner_available=False) as client:
+        token = _register(client, "owner")
+        with patch.object(
+            client.app.state.operations,
+            "record",
+            side_effect=RuntimeError("database is locked"),
+        ):
+            created = client.post(
+                "/api/hub/runtimes",
+                json={"runtime_id": "blocked-runtime"},
+                headers=_headers(token),
+            )
+
+        assert created.status_code == 503
+        assert "sandbox unavailable" in created.json()["detail"]
+
+
 @pytest.mark.parametrize(
     ("start_path", "callback_path"),
     [


### PR DESCRIPTION
## What

Audit logging on the Hub control plane was missing the two most
security-relevant events: **authentication attempts** and **denied
runtime creation**.

## Why

`GET /api/hub/admin/audit` never contained any `login` record, and a
failed `POST /api/hub/runtimes` produced no event at all.

Root cause is not a missing design — it is an unfinished wiring:

- `hub_audit_events.outcome` (`database.py:312-323`) and the
  `?outcome=` filter on `/api/hub/admin/audit` already existed, but
  none of the 15 `record_audit` call sites ever passed a value, so
  `outcome` was permanently `"success"`.
- `/api/auth/login` (`control_app.py`) had **zero** `record_audit`
  calls, while the neighbouring `/api/auth/register` had one — a
  single-point omission, not a systemic one.
- In `POST /api/hub/runtimes`, `record_audit` sat inside the `try`
  block *after* `runtime_service.create()` succeeded, so the
  409 / 503 / 500 branches never reached it.

Reproduced before the fix:

```
AUDIT total 2  actions ['auth.register', 'runtime.create']
?action=auth.login -> 0   ?outcome=failure -> 0
runtime create (provisioner down) -> 503 -> AUDIT total 1
```

## How

No schema change — the existing `outcome` column is reused.

| Change | Location |
|---|---|
| `record_audit` gains keyword-only `outcome` / `remote_address` passthrough | `control_app.py:295-314` |
| New `record_auth_event` helper: supports anonymous actors, best-effort write | `control_app.py:316-352` |
| `/api/auth/login` records both granted and rejected attempts as `auth.login` | `control_app.py:574-592` |
| `/api/auth/register` records the 403 / 409 denial paths (same class of gap) | `control_app.py:529-547` |
| `POST /api/hub/runtimes` records `outcome="failure"` in all four except branches | `control_app.py:1011-1063` |

Telemetry is deliberately isolated from the primary response: a store
failure is logged, never propagated, so it cannot turn a granted login
into a 500 nor replace a real 503 detail such as
`provisioner 'local' is unavailable: bwrap missing`.

## Verification

```
CHECKPOINT 1  total=8  actions=['auth.login','auth.register','runtime.create']
              ?action=auth.login -> 6    ?outcome=failure -> 3      PASS
CHECKPOINT 2  every event carries created_at + actor_username + action  PASS
CHECKPOINT 3  overview total_users=1 total_runtimes=1                PASS
REGRESSION    503 create -> failure event x1; 503 preserved when the
              audit store raises                                    PASS
SECURITY      no plaintext password appears in the audit body       PASS
```

- `pytest tests/unit/hub/ tests/integration/test_hub_control_app_module.py
  tests/unit/cli/test_hub_cmd.py` -> **162 passed, 1 skipped**
- 5 new regression tests, including two that lock in "telemetry must not
  mask the real status code"
- `flake8` -> only the 3 pre-existing E203 findings already on `main`
  (confirmed by stashed-baseline comparison)
- `pylint` -> 10.00/10

Cross-platform: the change touches only Python and sqlite writes — no
platform-specific paths, shell commands, or signal handling. This is a
**static analysis conclusion**; it was not executed on Linux/Windows.

## Out of scope (deliberately unchanged)

- Admin endpoint failure paths (`user.create`, `settings.update`,
  `runtime.start`, ...) still have no failure audit — same class of gap,
  but a larger surface. Happy to follow up if wanted.
- 429 rate-limit and 403 IP-blacklist rejections return early inside
  `require_auth_access` and are not instrumented.
- No logout endpoint exists in the repository (verified by grep), so
  there is nothing to audit there.

Failed logins write one audit row per attempt; growth is bounded by
`login_rate_limit` (default 10 attempts / 300s window, 900s block), so
this introduces no write-amplification risk.
