### PR TITLE
test(unit): repair the approval command handler stub after #7444

### DIFF
--- a/tests/unit/runtime/test_approval_command_handler.py
+++ b/tests/unit/runtime/test_approval_command_handler.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from qwenpaw.app.approvals import ApprovalIdentityPolicy, ApprovalService
 from qwenpaw.runtime.commands.control import approval_handler as ah
 from qwenpaw.runtime.commands.control.base import ControlContext
 from qwenpaw.security.tool_guard.approval import (
@@ -43,6 +44,9 @@ def _pending(
     severity="medium",
     tool_name="Bash",
     findings_count=1,
+    identity_policy=ApprovalIdentityPolicy.AGENT,
+    user_id="u1",
+    channel="console",
 ):
     return SimpleNamespace(
         request_id=request_id,
@@ -53,6 +57,12 @@ def _pending(
         severity=severity,
         findings_count=findings_count,
         created_at=time.time() - 5,
+        # Fields read by ApprovalService.actor_can_resolve / _is_spawn_child.
+        identity_policy=identity_policy,
+        user_id=user_id,
+        channel=channel,
+        owner_agent_id=agent_id,
+        extra={},
     )
 
 
@@ -64,12 +74,18 @@ def handler():
 @pytest.fixture
 def mock_service(monkeypatch):
     svc = SimpleNamespace(
-        get_pending_by_session=AsyncMock(return_value=None),
         get_request=AsyncMock(return_value=None),
         resolve_request=AsyncMock(return_value=None),
         get_all_pending_by_agent=AsyncMock(return_value=[]),
+        get_all_pending_by_session=AsyncMock(return_value=[]),
         get_pending_by_root_session=AsyncMock(return_value=[]),
         get_pending_by_root_session_children=AsyncMock(return_value=[]),
+        # Delegate to the real policy predicate instead of stubbing a constant
+        # ``True``: the handler's caller-visibility filters are only exercised
+        # when the predicate can also return ``False``.  It is a pure
+        # staticmethod (no I/O, no lock), so the real implementation is the
+        # cheapest faithful stand-in.
+        actor_can_resolve=ApprovalService.actor_can_resolve,
     )
     monkeypatch.setattr(ah, "get_approval_service", lambda: svc)
     return svc
@@ -162,12 +178,62 @@ class TestHandleApprove:
 
     async def test_queue_head_used_when_no_id(self, handler, mock_service):
         head = _pending(request_id="head-id")
-        mock_service.get_pending_by_session.return_value = head
+        mock_service.get_all_pending_by_session.return_value = [head]
         mock_service.get_request.return_value = head
         mock_service.resolve_request.return_value = head
         ctx = _context({"action": "approve"})
         result = await handler._handle_approve(ctx)
         assert "工具已批准" in result
+
+    async def test_queue_head_skips_invisible_request(
+        self,
+        handler,
+        mock_service,
+    ):
+        """A pending owned by another agent must not become the queue head."""
+        invisible = _pending(request_id="other-id", agent_id="agent-other")
+        visible = _pending(request_id="mine-id")
+        mock_service.get_all_pending_by_session.return_value = [
+            invisible,
+            visible,
+        ]
+        mock_service.get_request.side_effect = (
+            lambda rid: visible if rid == "mine-id" else None
+        )
+        mock_service.resolve_request.return_value = visible
+        ctx = _context({"action": "approve"})
+        result = await handler._handle_approve(ctx)
+        assert "工具已批准" in result
+        # FIFO walk stopped at the first *visible* entry, not the first entry.
+        assert mock_service.get_request.await_args.args[0] == "mine-id"
+
+    async def test_queue_head_empty_when_nothing_visible(
+        self,
+        handler,
+        mock_service,
+    ):
+        invisible = _pending(request_id="other-id", agent_id="agent-other")
+        mock_service.get_all_pending_by_session.return_value = [invisible]
+        ctx = _context({"action": "approve"})
+        result = await handler._handle_approve(ctx)
+        assert "无待审批工具" in result
+        mock_service.resolve_request.assert_not_awaited()
+
+    async def test_exact_requester_policy_requires_same_identity(
+        self,
+        handler,
+        mock_service,
+    ):
+        """EXACT_REQUESTER pending from another user is filtered out."""
+        pending = _pending(
+            request_id="exact-id",
+            identity_policy=ApprovalIdentityPolicy.EXACT_REQUESTER,
+            user_id="someone-else",
+        )
+        mock_service.get_all_pending_by_session.return_value = [pending]
+        ctx = _context({"action": "approve"})
+        result = await handler._handle_approve(ctx)
+        assert "无待审批工具" in result
 
     async def test_cross_session_hint_shown(self, handler, mock_service):
         pending = _pending(session_id="other-sess")
@@ -277,8 +343,26 @@ class TestHandleList:
         ]
         ctx = _context({"action": "list", "all": True})
         result = await handler._handle_list(ctx)
-        assert "所有会话" in result
+        # Discriminates the --all branch from the current-session branch.
+        # Asserted on the stable header prefix rather than the parenthetical,
+        # which reads "(当前调用者可见)" since caller-scoped visibility landed.
+        assert "全局待审批工具列表" in result
         assert "Bash" in result
+
+    async def test_all_sessions_list_filters_invisible(
+        self,
+        handler,
+        mock_service,
+    ):
+        """--all still hides pendings the caller may not resolve."""
+        mock_service.get_all_pending_by_agent.return_value = [
+            _pending(request_id="mine", tool_name="Bash"),
+            _pending(request_id="theirs", tool_name="Secret", agent_id="b"),
+        ]
+        ctx = _context({"action": "list", "all": True})
+        result = await handler._handle_list(ctx)
+        assert "Bash" in result
+        assert "Secret" not in result
 
     async def test_subsession_annotated(self, handler, mock_service):
         mock_service.get_pending_by_root_session.return_value = [


### PR DESCRIPTION
> **Submitted by**: 墨子·BEUnit@QPQAT

## What this fixes

`tests/unit/runtime/test_approval_command_handler.py` is red on `main`: 7 cases fail on both py3.11 and py3.13.

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'get_all_pending_by_session'   (4 cases)
AttributeError: 'types.SimpleNamespace' object has no attribute 'actor_can_resolve'            (3 cases)
```

Failing cases:

```
TestHandleDispatch::test_default_action_is_approve
TestHandleApprove::test_no_pending_returns_empty_message
TestHandleApprove::test_queue_head_used_when_no_id
TestHandleDeny::test_no_pending_returns_empty_message
TestHandleList::test_current_session_list
TestHandleList::test_all_sessions_list
TestHandleList::test_subsession_annotated
```

## Why it broke: merge skew, not a logic regression

This test file was added by #7653. Both pull requests were green on their own CI and only collide once merged:

| When (UTC) | Event |
|---|---|
| 2026-09-10T08:08:24Z | #7653 CI ran on `d7c5110e7` — `conclusion=success`, unit tests passed on py3.11/py3.13 ubuntu + macos + windows |
| 2026-09-11T03:07:59Z | #7444 merged (`1174c6d9`) — added `get_all_pending_by_session()` and `actor_can_resolve()` to `ApprovalService`, and started calling them from `approval_handler.py:97/100/290` and `acp/server.py:955` |
| 2026-09-11T06:30:26Z | #7653 merged, 3h22m after #7444 — red on arrival |

#7444 updated six test files but could not update this one, because it did not exist yet (`git cat-file -e b1865f877^:tests/unit/runtime/test_approval_command_handler.py` fails). No party did anything wrong; the two changes simply never saw each other.

## What #7444 changed that the stub did not follow

Three separate contract changes, only the first of which is visible from the `AttributeError` messages:

1. **New service methods.** The `SimpleNamespace` service double lacked `get_all_pending_by_session()` and `actor_can_resolve()`, both now called from `_get_direct_queue_head()` and `_handle_list()`.
2. **Queue head source changed.** `_handle_approve()`/`_handle_deny()` no longer call `svc.get_pending_by_session()`; they walk `get_all_pending_by_session()` and keep the first entry the caller may resolve. `test_queue_head_used_when_no_id` was arranging a stub the handler never calls, so once the missing methods were added it failed on an assertion (the handler reported an empty queue) rather than on an `AttributeError`.
3. **`--all` header reworded** from an "all sessions" note to a "visible to the current caller" note. `test_all_sessions_list` asserted on that parenthetical, which is wording rather than behaviour.

## Changes

- Add the two missing methods to the service double.
- **Delegate `actor_can_resolve` to the real `ApprovalService` staticmethod** instead of stubbing a constant `True`. It is a pure function (no I/O, no lock), and a constant `True` would make every caller-visibility filter in the handler pass unconditionally — the new policy logic would become dead test code that can never fail. The `PendingApproval` fixtures gain the fields the real predicate reads (`identity_policy`, `user_id`, `channel`, `owner_agent_id`, `extra`).
- Drop the now-uncalled `get_pending_by_session` stub and drive `test_queue_head_used_when_no_id` through `get_all_pending_by_session`.
- Assert `test_all_sessions_list` on the stable header prefix that discriminates the `--all` branch from the current-session branch.

## Why the alternatives were rejected

**Stubbing `actor_can_resolve=Mock(return_value=True)`** is the smallest possible diff and does turn all 7 cases green, but it is the wrong fix. The handler gained two caller-visibility filters in #7444 (`approval_handler.py:100` and `:290`); a predicate hard-wired to `True` makes both filters pass unconditionally, so they can never fail again. The tests would go green while silently ceasing to assert anything about the new policy. That is worse than red, because red is visible. The real implementation is a `@staticmethod` with no I/O and no lock, so delegating costs nothing and keeps the filter assertions meaningful.

**Adding `identity_policy` etc. to the fixtures while keeping a stub** was considered, but then the stub's return value would have to encode the policy table by hand — a second copy of the predicate that can drift from the product code, which is exactly the drift this PR exists to repair.

**Just adding the two missing methods and stopping** does not work: it leaves `test_queue_head_used_when_no_id` and `test_all_sessions_list` red, because changes (2) and (3) above are independent of the `AttributeError`s. Only the first of the three contract changes is visible from the reported errors.

**Leaving `get_pending_by_session` in the stub** would have kept a dead double that the handler never calls. Its presence is what made the failing case look like a queue-content problem rather than a wrong-method problem, so it is removed.

## Coverage gained

Wiring in the real predicate means the caller-visibility filtering introduced by #7444 is now covered for the first time — a search over `tests/` found no prior test referencing `_get_direct_queue_head` or `actor_can_resolve`. Four cases are added:

- the FIFO walk skipping a pending the caller may not resolve
- an empty result when nothing is visible (and `resolve_request` never awaited)
- the `EXACT_REQUESTER` policy rejecting a different user
- `--all` hiding another agent's pending

## Side effects

Test-only: no product code is touched, and the file's own fixtures are local to it (no shared `conftest.py` change), so no other suite is affected. The four new cases add no skips, no `xfail`, no timing assumptions, and no platform-specific branches. Verified stable across three `pytest-randomly` runs and passing under the full `tests/unit` run.

## Verification

```
tests/unit/runtime/test_approval_command_handler.py   32 passed   (was 28: 21 pass + 7 fail)
tests/unit                                          13291 passed, 22 skipped, 0 failed
```

Stable across three runs with `pytest-randomly` enabled. `pre-commit run --files <file>` passes (black, flake8, pylint, mypy).

The full `tests/unit` run also confirms no other file added by #7653 carries the same skew.

Test-only change: no product code touched.
