### PR TITLE
feat(plugins): add bot-manager — unified multi-channel bot management plugin

### DIFF
--- a/plugins/bot-manager/README.md
+++ b/plugins/bot-manager/README.md
@@ -1,0 +1,74 @@
+# Bot 管理器 v1.0.0
+
+统一管理多个智能体的各渠道 Bot 配置。当前支持微信、钉钉，架构可扩展。
+
+## 支持渠道
+
+| 渠道 | 绑定方式 | 特有配置 |
+|------|---------|---------|
+| 微信 | 扫码二维码 | 私聊策略、群聊策略 |
+| 钉钉 | 手动输入凭据 | 消息类型、流式回复、群聊共享、@发送者、卡片模板 |
+
+## 架构设计
+
+### 渠道适配器模式
+
+```
+backend/
+├── channels.py   ← 渠道适配器注册中心，新增渠道在此注册
+└── main.py        ← 统一 API，通过 channel 参数路由到对应适配器
+
+ui/
+└── index.js       ← CHANNEL_DEFS 定义各渠道 UI 行为，新增渠道加一条即可
+```
+
+### 新增渠道步骤
+
+1. **后端**：在 `channels.py` 中继承 `ChannelAdapter`，实现 `has_credentials()` 和 `get_status_fields()`，调用 `register_channel()`
+2. **前端**：在 `index.js` 的 `CHANNEL_DEFS` 中添加渠道定义（名称、图标、绑定方式、表格列、编辑字段）
+
+无需修改其他代码。
+
+### ChannelAdapter 接口
+
+```python
+class ChannelAdapter:
+    channel_key: str          # 渠道标识，如 "feishu"
+    display_name: str         # 显示名称，如 "飞书"
+    binding_method: str       # "qrcode" | "manual"
+    credential_fields: list   # 凭据字段，清除时置空
+
+    def get_config(agent_config) -> dict      # 从 agent.json 提取渠道配置
+    def update_config(agent_config, update)   # 更新渠道配置
+    def has_credentials(config) -> bool        # 是否已配置凭据
+    def clear_credentials(agent_config)        # 清除凭据
+    def get_status_fields(config) -> dict      # 表格展示字段
+```
+
+### API 端点
+
+所有 API 以 `{channel}` 为路径参数自动路由：
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `/channels` | GET | 列出所有支持的渠道 |
+| `/{channel}/agents` | GET | 列出智能体配置 |
+| `/{channel}/agents/{id}` | GET | 获取单个配置 |
+| `/{channel}/agents/{id}/config` | POST | 更新配置 |
+| `/{channel}/agents/{id}/toggle` | POST | 切换启用 |
+| `/{channel}/agents/{id}/clear-credentials` | POST | 清除凭据 |
+| `/{channel}/agents/batch-update` | POST | 批量更新 |
+| `/{channel}/status` | GET | 渠道统计 |
+
+## 安装
+
+```
+~/.qwenpaw/plugins/bot-manager/
+```
+
+重启 QwenPaw 后生效。
+
+## 与旧插件的关系
+
+本插件取代 `wechat-bot-manager` 和 `dingtalk-bot-manager`。
+安装本插件后应禁用或删除旧插件以避免冲突。

--- a/plugins/bot-manager/backend/channels.py
+++ b/plugins/bot-manager/backend/channels.py
@@ -1,0 +1,137 @@
+"""
+Channel adapters — extensible registry for supported bot channels.
+
+To add a new channel: sub-class ChannelAdapter, implement the required
+methods, and call register_channel(). No other code changes needed.
+"""
+
+import logging
+from typing import Dict, List, Optional, Any
+
+logger = logging.getLogger(__name__)
+
+# ── Registry ────────────────────────────────────────────
+
+_CHANNEL_REGISTRY: Dict[str, "ChannelAdapter"] = {}
+
+
+def register_channel(adapter: "ChannelAdapter") -> None:
+    _CHANNEL_REGISTRY[adapter.channel_key] = adapter
+    logger.info(f"[bot-manager] Registered channel: {adapter.channel_key}")
+
+
+def get_channel(channel_key: str) -> Optional["ChannelAdapter"]:
+    return _CHANNEL_REGISTRY.get(channel_key)
+
+
+def list_channels() -> List[str]:
+    return sorted(_CHANNEL_REGISTRY.keys())
+
+
+# ── Base adapter ───────────────────────────────────────
+
+
+class ChannelAdapter:
+    """Base adapter — sub-class and override for each channel."""
+
+    channel_key: str = ""
+    display_name: str = ""
+    binding_method: str = "manual"  # "manual" | "qrcode"
+    credential_fields: List[str] = []  # fields wiped on "clear credentials"
+
+    # ── core read/write ──
+
+    def get_config(self, agent_config: Dict) -> Dict:
+        """Extract this channel's config from agent.json."""
+        return agent_config.get("channels", {}).get(self.channel_key, {})
+
+    def update_config(self, agent_config: Dict, update: Dict) -> Dict:
+        """Merge *update* into this channel's config inside agent.json."""
+        if "channels" not in agent_config:
+            agent_config["channels"] = {}
+        ch = agent_config["channels"].setdefault(self.channel_key, {})
+        for k, v in update.items():
+            ch[k] = v
+        return agent_config
+
+    # ── credentials ──
+
+    def has_credentials(self, config: Dict) -> bool:
+        """Whether the agent has valid credentials for this channel."""
+        raise NotImplementedError
+
+    def clear_credentials(self, agent_config: Dict) -> Dict:
+        """Wipe credential fields."""
+        wipe = {f: "" for f in self.credential_fields}
+        return self.update_config(agent_config, wipe)
+
+    # ── status ──
+
+    def get_status_fields(self, config: Dict) -> Dict:
+        """Extra fields returned in ``GET /agents`` for the table."""
+        return {}
+
+    def get_status(self, agents_config: List[Dict]) -> Dict:
+        """Aggregate stats across all agents."""
+        total = len(agents_config)
+        enabled = 0
+        with_creds = 0
+        for cfg in agents_config:
+            ch = self.get_config(cfg)
+            if ch.get("enabled"):
+                enabled += 1
+            if self.has_credentials(ch):
+                with_creds += 1
+        return {
+            "channel": self.channel_key,
+            "total_agents": total,
+            "enabled_agents": enabled,
+            "agents_with_credentials": with_creds,
+        }
+
+
+# ── Built-in adapters ──────────────────────────────────
+
+
+class WechatChannel(ChannelAdapter):
+    channel_key = "wechat"
+    display_name = "微信"
+    binding_method = "qrcode"
+    credential_fields = ["bot_token"]
+
+    def has_credentials(self, config: Dict) -> bool:
+        return bool(config.get("bot_token"))
+
+    def get_status_fields(self, config: Dict) -> Dict:
+        return {
+            "bot_prefix": config.get("bot_prefix", ""),
+            "dm_policy": config.get("dm_policy", "open"),
+            "group_policy": config.get("group_policy", "open"),
+            "has_native_config": bool(config),
+        }
+
+
+class DingtalkChannel(ChannelAdapter):
+    channel_key = "dingtalk"
+    display_name = "钉钉"
+    binding_method = "manual"
+    credential_fields = ["client_id", "client_secret", "robot_code"]
+
+    def has_credentials(self, config: Dict) -> bool:
+        return bool(config.get("client_id") and config.get("client_secret"))
+
+    def get_status_fields(self, config: Dict) -> Dict:
+        return {
+            "message_type": config.get("message_type", "markdown"),
+            "bot_prefix": config.get("bot_prefix", ""),
+            "streaming_enabled": config.get("streaming_enabled", False),
+            "share_session_in_group": config.get("share_session_in_group", False),
+            "at_sender_on_reply": config.get("at_sender_on_reply", False),
+            "robot_code": config.get("robot_code", ""),
+        }
+
+
+# ── Register built-in channels ─────────────────────────
+
+register_channel(WechatChannel())
+register_channel(DingtalkChannel())

--- a/plugins/bot-manager/backend/main.py
+++ b/plugins/bot-manager/backend/main.py
@@ -1,0 +1,303 @@
+"""
+Bot 管理器 - 后端统一 API
+通过 channel 适配器支持多渠道，新增渠道只需在 channels.py 注册适配器。
+"""
+
+import os
+import json
+import logging
+from typing import Dict, List, Optional, Any
+from pathlib import Path
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+try:
+    from qwenpaw.plugins.api import PluginApi
+except ImportError:
+    PluginApi = None
+
+from .channels import get_channel, list_channels
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ============ 工具函数 ============
+
+def get_working_dir() -> Path:
+    """获取 QwenPaw working directory"""
+    wd = os.environ.get("QWENPAW_WORKING_DIR")
+    if wd:
+        return Path(wd)
+    return Path.home() / ".qwenpaw"
+
+
+def get_agent_config_path(agent_id: str) -> Optional[Path]:
+    """获取智能体的 agent.json 路径"""
+    p = get_working_dir() / "workspaces" / agent_id / "agent.json"
+    return p if p.exists() else None
+
+
+def load_agent_config(agent_id: str) -> Optional[Dict]:
+    """加载智能体配置"""
+    p = get_agent_config_path(agent_id)
+    if not p:
+        return None
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"[bot-manager] load config {agent_id}: {e}")
+        return None
+
+
+def save_agent_config(agent_id: str, config: Dict) -> bool:
+    """保存智能体配置"""
+    p = get_agent_config_path(agent_id)
+    if not p:
+        return False
+    try:
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, ensure_ascii=False)
+        logger.info(f"[bot-manager] saved config for {agent_id}")
+        return True
+    except Exception as e:
+        logger.error(f"[bot-manager] save config {agent_id}: {e}")
+        return False
+
+
+def list_all_agents() -> List[str]:
+    """列出所有智能体 ID"""
+    wd = get_working_dir()
+    # 优先从 config.json 读取
+    cp = wd / "config.json"
+    if cp.exists():
+        try:
+            with open(cp, "r", encoding="utf-8") as f:
+                c = json.load(f)
+            profiles = c.get("agents", {}).get("profiles", {})
+            valid = [aid for aid, p in profiles.items() if p.get("enabled", False)]
+            return sorted(valid)
+        except Exception:
+            pass
+    # 回退到目录遍历
+    wsd = wd / "workspaces"
+    if not wsd.exists():
+        return []
+    return sorted(
+        d.name for d in wsd.iterdir()
+        if d.is_dir() and (d / "agent.json").exists()
+    )
+
+
+def _require_channel(ch_key: str):
+    """获取适配器，不存在则 404"""
+    adapter = get_channel(ch_key)
+    if not adapter:
+        raise HTTPException(status_code=404, detail=f"Unsupported channel: {ch_key}")
+    return adapter
+
+
+# ============ API Models ============
+
+class ConfigUpdate(BaseModel):
+    """通用配置更新 — 所有字段可选"""
+    enabled: Optional[bool] = None
+    bot_prefix: Optional[str] = None
+    # 黄金字段
+    bot_token: Optional[str] = None
+    dm_policy: Optional[str] = None
+    group_policy: Optional[str] = None
+    # 钉钉字段
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    robot_code: Optional[str] = None
+    message_type: Optional[str] = None
+    cron_message_type: Optional[str] = None
+    card_template_id: Optional[str] = None
+    card_auto_layout: Optional[bool] = None
+    at_sender_on_reply: Optional[bool] = None
+    streaming_enabled: Optional[bool] = None
+    share_session_in_group: Optional[bool] = None
+    endpoint: Optional[str] = None
+
+
+class BatchUpdateRequest(BaseModel):
+    agent_ids: List[str]
+    enabled: Optional[bool] = None
+    bot_prefix: Optional[str] = None
+    message_type: Optional[str] = None
+
+
+# ============ API Routes ============
+
+@router.get("/channels")
+async def get_channels():
+    """返回所有支持的渠道列表"""
+    result = []
+    for ch_key in list_channels():
+        ad = get_channel(ch_key)
+        result.append({
+            "key": ad.channel_key,
+            "name": ad.display_name,
+            "binding_method": ad.binding_method,
+        })
+    return {"channels": result}
+
+
+@router.get("/{channel}/agents")
+async def list_agents(channel: str):
+    """获取所有智能体的指定渠道配置"""
+    ad = _require_channel(channel)
+    agents = list_all_agents()
+    result = []
+
+    for aid in agents:
+        cfg = load_agent_config(aid)
+        if not cfg:
+            continue
+        ch_cfg = ad.get_config(cfg)
+        entry = {
+            "agent_id": aid,
+            "name": cfg.get("name", aid),
+            "enabled": ch_cfg.get("enabled", False),
+            "has_credentials": ad.has_credentials(ch_cfg),
+            "has_native_config": bool(ch_cfg),
+        }
+        entry.update(ad.get_status_fields(ch_cfg))
+        result.append(entry)
+
+    return {"agents": result, "total": len(result), "channel": channel}
+
+
+@router.get("/{channel}/agents/{agent_id}")
+async def get_agent(channel: str, agent_id: str):
+    """获取单个智能体的渠道配置"""
+    ad = _require_channel(channel)
+    cfg = load_agent_config(agent_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+    ch_cfg = ad.get_config(cfg)
+    return {
+        "agent_id": agent_id,
+        "name": cfg.get("name", agent_id),
+        "channel": channel,
+        **ch_cfg,
+        "enabled": ch_cfg.get("enabled", False),
+        "has_credentials": ad.has_credentials(ch_cfg),
+    }
+
+
+@router.post("/{channel}/agents/{agent_id}/config")
+async def update_agent_config(channel: str, agent_id: str, request: Request):
+    """更新智能体渠道配置"""
+    ad = _require_channel(channel)
+    cfg = load_agent_config(agent_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    # 过滤掉 None 值，只更新提供的字段
+    update = {k: v for k, v in body.items() if v is not None}
+    logger.info(f"[bot-manager] update {channel}/{agent_id}: {list(update.keys())}")
+
+    cfg = ad.update_config(cfg, update)
+    if save_agent_config(agent_id, cfg):
+        return {"success": True, "message": f"Updated {channel} config for {agent_id}"}
+    raise HTTPException(status_code=500, detail="Failed to save config")
+
+
+@router.post("/{channel}/agents/{agent_id}/toggle")
+async def toggle_agent(channel: str, agent_id: str):
+    """切换启用状态"""
+    ad = _require_channel(channel)
+    cfg = load_agent_config(agent_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    ch_cfg = ad.get_config(cfg)
+    new_enabled = not ch_cfg.get("enabled", False)
+    cfg = ad.update_config(cfg, {"enabled": new_enabled})
+
+    if save_agent_config(agent_id, cfg):
+        return {"success": True, "enabled": new_enabled}
+    raise HTTPException(status_code=500, detail="Failed to save")
+
+
+@router.post("/{channel}/agents/{agent_id}/clear-credentials")
+async def clear_credentials(channel: str, agent_id: str):
+    """清除凭据"""
+    ad = _require_channel(channel)
+    cfg = load_agent_config(agent_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    cfg = ad.clear_credentials(cfg)
+    if save_agent_config(agent_id, cfg):
+        return {"success": True, "message": "Credentials cleared"}
+    raise HTTPException(status_code=500, detail="Failed to save")
+
+
+@router.post("/{channel}/agents/batch-update")
+async def batch_update(channel: str, request: BatchUpdateRequest):
+    """批量更新"""
+    ad = _require_channel(channel)
+    results = []
+
+    for aid in request.agent_ids:
+        cfg = load_agent_config(aid)
+        if not cfg:
+            results.append({"agent_id": aid, "success": False, "error": "Not found"})
+            continue
+
+        update = {}
+        if request.enabled is not None:
+            update["enabled"] = request.enabled
+        if request.bot_prefix is not None:
+            update["bot_prefix"] = request.bot_prefix
+        if request.message_type is not None:
+            update["message_type"] = request.message_type
+
+        cfg = ad.update_config(cfg, update)
+        ok = save_agent_config(aid, cfg)
+        results.append({"agent_id": aid, "success": ok})
+
+    return {"results": results}
+
+
+@router.get("/{channel}/status")
+async def get_status(channel: str):
+    """获取渠道统计"""
+    ad = _require_channel(channel)
+    agents = list_all_agents()
+    configs = [load_agent_config(a) for a in agents]
+    configs = [c for c in configs if c]
+    return ad.get_status(configs)
+
+
+# ============ Plugin Class ============
+
+class BotManagerPlugin:
+    """Bot 管理器插件"""
+
+    def __init__(self):
+        self.id = "bot-manager"
+        self.name = "Bot 管理器"
+        self.version = "1.0.0"
+        self.router = router
+
+    def register(self, api: PluginApi) -> None:
+        api.register_http_router(
+            self.router,
+            prefix="/plugins/bot-manager",
+            tags=["bot-manager"],
+        )
+        logger.info("[bot-manager] Plugin registered")
+
+
+# REQUIRED: 模块级 plugin 实例
+plugin = BotManagerPlugin()

--- a/plugins/bot-manager/plugin.json
+++ b/plugins/bot-manager/plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "bot-manager",
+  "name": "Bot 管理器",
+  "version": "1.0.0",
+  "description": "统一管理多个智能体的各渠道 Bot 配置，当前支持微信、钉钉，架构可扩展",
+  "author": "星致",
+  "type": "app",
+  "min_version": "2.0.0",
+  "qwenpaw_version": {
+    "min": "2.0.0",
+    "max": "2.1.0"
+  },
+  "entry": {
+    "backend": "backend/main.py",
+    "frontend": "ui/index.js"
+  },
+  "permissions": [
+    "agent.chat",
+    "workspace.write",
+    "workspace.read"
+  ],
+  "meta": {
+    "category": "productivity",
+    "icon": "bot",
+    "pawapp": {
+      "icon": "bot",
+      "category": "productivity",
+      "entry_page": "/apps/bot-manager",
+      "launch_scope": "page"
+    },
+    "permissions": {
+      "chat": true,
+      "storage": true
+    }
+  }
+}

--- a/plugins/bot-manager/ui/index.js
+++ b/plugins/bot-manager/ui/index.js
@@ -1,0 +1,565 @@
+/**
+ * Bot 管理器 - 前端
+ * 统一管理多个渠道 Bot 配置，当前支持微信(扫码) + 钉钉(凭据)
+ * 渠道定义集中管理，新增渠道只需在 CHANNEL_DEFS 加一个条目
+ */
+(function () {
+  'use strict';
+
+  if (!window.QwenPaw || !window.QwenPaw.host) {
+    console.error("[bot-manager] QwenPaw not ready");
+    return;
+  }
+
+  var QP = window.QwenPaw;
+  var React = QP.host.React;
+  var h = React.createElement;
+  var useState = React.useState;
+  var useEffect = React.useEffect;
+  var useRef = React.useRef;
+
+  var PLUGIN_ID = "bot-manager";
+
+  // ============ 图标 ============
+  var WechatIcon = function (p) {
+    return h("svg", Object.assign({ width: "24", height: "24", viewBox: "0 0 24 24", fill: "currentColor" }, p || {}),
+      h("path", { d: "M8.5,14.5c0.6,0,1.2-0.1,1.8-0.2c0.5,0.9,1.5,1.5,2.7,1.5c0.4,0,0.8-0.1,1.2-0.2l2.4,1.3c0.2,0.1,0.4,0,0.5-0.2c0.1-0.2,0-0.4-0.2-0.5l-1.8-1c0.4-0.4,0.7-0.9,0.7-1.5c0-1.6-1.6-2.9-3.5-2.9c-1.9,0-3.5,1.3-3.5,2.9S6.6,14.5,8.5,14.5z M17.8,12.6c-3.4,0-6.2,2.4-6.2,5.2c0,2.9,2.8,5.2,6.2,5.2s6.2-2.4,6.2-5.2C24,14.9,21.2,12.6,17.8,12.6z", fill: "#07C160" })
+    );
+  };
+  var DingtalkIcon = function (p) {
+    return h("svg", Object.assign({ width: "24", height: "24", viewBox: "0 0 1024 1024", fill: "currentColor" }, p || {}), [
+      h("path", { d: "M571.7 473.5l63.5-62.6c4-3.9 1.4-7.6-2.6-7.6h-52.4l-49.5 50.6c-2.1 2.2-3.3 5.1-3.3 8.2v18.8c0 6.3 5.1 11.4 11.4 11.4h84.8c5.6 0 8.5-6.7 4.5-10.7l-56.4-58.1z", fill: "#0089FF" }),
+      h("path", { d: "M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm153.7 546.3c-1.4 6.1-7.5 9.9-13.6 8.5l-8.1-1.9c-5.9-1.4-9.7-7.1-8.7-13.1 6-35.7-8.8-67.4-40.3-86.1-5.7-3.4-7.6-10.8-4.2-16.5l4.3-7.2c3.4-5.7 10.8-7.6 16.6-4.3 40.6 24.2 62.6 66.3 54.3 120.6zm-89.5-86.4c-19.3-11.8-42.9-16.2-65.5-12.9-6.3.9-12.1-3.4-13.2-9.7l-1.4-8.4c-1-6.2 3.1-12.1 9.3-13.3 28.9-5.6 59.3 0 84 15.3 7.1 4.4 9.3 13.7 4.9 20.8l-4.7 7.6c-4.3 7.1-13.6 9.4-20.7 5l2.3-4z", fill: "#0089FF" })
+    ]);
+  };
+
+  // ============ 渠道定义（核心可扩展结构） ============
+  // 新增渠道：在此添加一个条目即可，无需改其他代码
+  var CHANNEL_DEFS = {
+    wechat: {
+      name: "微信",
+      icon: WechatIcon,
+      color: "#07C160",
+      binding: "qrcode",
+      credentialLabel: "Token",
+      hasCreds: function (c) { return !!c.bot_token; },
+      columns: [
+        { key: "bot_prefix", label: "前缀" },
+        { key: "dm_policy", label: "私聊策略" },
+        { key: "group_policy", label: "群聊策略" },
+      ],
+      editFields: [
+        { key: "bot_prefix", label: "Bot 前缀", type: "input", placeholder: "如: [助手]" },
+        { key: "dm_policy", label: "私聊策略", type: "select", options: [["open", "开放"], ["whitelist", "白名单"], ["closed", "关闭"]] },
+        { key: "group_policy", label: "群聊策略", type: "select", options: [["open", "开放"], ["whitelist", "白名单"], ["closed", "关闭"]] },
+      ],
+      batchFields: [
+        { key: "enabled", label: "启用状态", type: "select-tri", options: [["true", "启用"], ["false", "禁用"]] },
+        { key: "bot_prefix", label: "Bot 前缀", type: "input" },
+      ],
+      credentialHint: "Token 必须通过扫码获取，不可手动输入",
+    },
+    dingtalk: {
+      name: "钉钉",
+      icon: DingtalkIcon,
+      color: "#0089FF",
+      binding: "manual",
+      credentialLabel: "凭据",
+      hasCreds: function (c) { return !!(c.client_id && c.client_secret); },
+      columns: [
+        { key: "message_type", label: "消息类型" },
+        { key: "bot_prefix", label: "前缀" },
+      ],
+      credentialFields: [
+        { key: "client_id", label: "Client ID (AppKey)", type: "text", placeholder: "钉钉开放平台 → AppKey" },
+        { key: "client_secret", label: "Client Secret (AppSecret)", type: "password", placeholder: "钉钉开放平台 → AppSecret" },
+        { key: "robot_code", label: "Robot Code（可选）", type: "text", placeholder: "机器人的 robot_code" },
+      ],
+      editFields: [
+        { key: "bot_prefix", label: "Bot 前缀", type: "input", placeholder: "如: [助手]" },
+        { key: "message_type", label: "消息类型", type: "select", options: [["markdown", "Markdown"], ["text", "纯文本"]] },
+        { key: "cron_message_type", label: "Cron 消息类型", type: "select", options: [["markdown", "Markdown"], ["text", "纯文本"]] },
+        { key: "streaming_enabled", label: "流式回复", type: "switch" },
+        { key: "share_session_in_group", label: "群聊共享会话", type: "switch" },
+        { key: "at_sender_on_reply", label: "回复@发送者", type: "switch" },
+        { key: "card_auto_layout", label: "卡片自动排版", type: "switch" },
+        { key: "card_template_id", label: "卡片模板 ID", type: "input", placeholder: "钉钉互动卡片模板 ID" },
+        { key: "endpoint", label: "自定义 Endpoint", type: "input", placeholder: "留空使用默认" },
+      ],
+      batchFields: [
+        { key: "enabled", label: "启用状态", type: "select-tri", options: [["true", "启用"], ["false", "禁用"]] },
+        { key: "message_type", label: "消息类型", type: "select-tri", options: [["markdown", "Markdown"], ["text", "纯文本"]] },
+        { key: "bot_prefix", label: "Bot 前缀", type: "input" },
+      ],
+      credentialHint: "获取方式：登录钉钉开放平台（open.dingtalk.com）→ 创建应用 → 添加「机器人」能力 → 复制 AppKey 和 AppSecret",
+    },
+  };
+
+  // ============ API ============
+  function fetchApi(path, options) {
+    var url = QP.host.getApiUrl("/plugins/bot-manager" + path);
+    return fetch(url, options).then(function (r) {
+      if (!r.ok) throw new Error("API " + r.status);
+      return r.json();
+    });
+  }
+
+  function notify(type, msg) {
+    var colors = { success: "#52c41a", error: "#ff4d4f", warning: "#faad14" };
+    var icons = { success: "✓", error: "✗", warning: "⚠" };
+    var n = document.createElement("div");
+    n.style.cssText = "position:fixed;top:20px;right:20px;background:#fff;border-left:4px solid " + (colors[type] || "#1890ff") + ";padding:14px 18px;border-radius:4px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:9999;display:flex;gap:10px;font-size:14px;animation:bmIn .3s ease;";
+    n.innerHTML = '<span style="color:' + (colors[type] || "#1890ff") + ';font-weight:bold">' + (icons[type] || "ℹ") + "</span><span>" + msg + "</span>";
+    var s = document.createElement("style"); s.textContent = "@keyframes bmIn{from{transform:translateX(100%);opacity:0}to{transform:translateX(0);opacity:1}}";
+    document.head.appendChild(s); document.body.appendChild(n);
+    setTimeout(function () { n.style.animation = "bmIn .3s reverse"; setTimeout(function () { n.parentNode && n.parentNode.removeChild(n); }, 300); }, 2500);
+  }
+
+  // ============ 小组件 ============
+  function ToggleSwitch(props) {
+    var on = props.checked;
+    return h("div", {
+      style: { width: "40px", height: "22px", borderRadius: "22px", position: "relative", cursor: "pointer", background: on ? "#0089FF" : "#d9d9d9", transition: "background .3s" },
+      onClick: function () { props.onChange(!on); }
+    }, h("div", { style: { width: "18px", height: "18px", borderRadius: "50%", background: "#fff", position: "absolute", top: "2px", left: on ? "20px" : "2px", transition: "left .3s" } }));
+  }
+
+  // ============ 扫码 Hook（用于 qrcode 渠道） ============
+  function useQrCode(config) {
+    var channel = config.channel;
+    var onSuccess = config.onSuccess || function () {};
+    var onError = config.onError || function () {};
+    var onStatus = config.onStatusChange || function () {};
+
+    var [img, setImg] = useState("");
+    var [loading, setLoading] = useState(false);
+    var timer = useRef(null);
+    var done = useRef(false);
+
+    function stop() { if (timer.current) { clearTimeout(timer.current); timer.current = null; } }
+
+    function reset() { stop(); setImg(""); done.current = false; }
+
+    function poll(token) {
+      timer.current = setTimeout(function () {
+        var url = QP.host.getApiUrl("/config/channels/" + channel + "/qrcode/status?token=" + encodeURIComponent(token));
+        fetch(url, { headers: QP.host.getAuthHeaders ? QP.host.getAuthHeaders() : {} })
+          .then(function (r) { return r.ok ? r.json() : Promise.reject("status " + r.status); })
+          .then(function (res) {
+            onStatus(res.status, res);
+            if (res.status === "confirmed") {
+              if (done.current) return;
+              done.current = true; setImg("");
+              var creds = res.credentials || {};
+              var bt = creds.bot_token || res.bot_token || creds.token || res.token;
+              if (bt) { var c = res.credentials || {}; c.bot_token = bt; onSuccess(c); }
+              else onError("token not found");
+            } else if (res.status === "expired" || res.status === "fail") {
+              setImg(""); onError(res.status);
+            } else { poll(token); }
+          })
+          .catch(function () { poll(token); });
+      }, 2000);
+    }
+
+    function fetchQr() {
+      reset(); setLoading(true);
+      var url = QP.host.getApiUrl("/config/channels/" + channel + "/qrcode");
+      fetch(url, { headers: QP.host.getAuthHeaders ? QP.host.getAuthHeaders() : {} })
+        .then(function (r) { return r.ok ? r.json() : Promise.reject("qrcode " + r.status); })
+        .then(function (res) {
+          if (!res || !res.qrcode_img) { onError("fetch"); return; }
+          setImg(res.qrcode_img); poll(res.poll_token);
+        })
+        .catch(function () { onError("fetch"); })
+        .finally(function () { setLoading(false); });
+    }
+
+    useEffect(function () { return stop; }, []);
+    return { img: img, loading: loading, fetchQr: fetchQr, stopPoll: stop, reset: reset };
+  }
+
+  // ============ 样式 ============
+  var S = {
+    container: { padding: "20px", maxWidth: "1200px", margin: "0 auto" },
+    header: { marginBottom: "20px", borderBottom: "1px solid #eee", paddingBottom: "15px" },
+    title: { fontSize: "24px", fontWeight: "bold", marginBottom: "6px", display: "flex", alignItems: "center", gap: "10px" },
+    subtitle: { color: "#666", fontSize: "14px" },
+    tabs: { display: "flex", gap: "8px", marginBottom: "16px" },
+    tab: function (active, color) {
+      return { padding: "8px 20px", borderRadius: "6px", cursor: "pointer", border: "1px solid " + (active ? color : "#d9d9d9"), background: active ? color : "#fff", color: active ? "#fff" : "#333", fontWeight: active ? "600" : "400", display: "flex", alignItems: "center", gap: "6px", fontSize: "14px" };
+    },
+    stats: { display: "flex", gap: "16px", marginBottom: "16px" },
+    statCard: { background: "#f5f5f5", padding: "14px", borderRadius: "8px", minWidth: "120px" },
+    statValue: { fontSize: "24px", fontWeight: "bold", color: "#0089FF" },
+    statLabel: { fontSize: "12px", color: "#666" },
+    toolbar: { display: "flex", gap: "10px", marginBottom: "14px", alignItems: "center" },
+    btn: { padding: "8px 16px", border: "1px solid #d9d9d9", borderRadius: "4px", cursor: "pointer", background: "#fff", fontSize: "14px" },
+    btnPrimary: function (c) { return { padding: "8px 16px", border: "none", borderRadius: "4px", cursor: "pointer", background: c || "#0089FF", color: "#fff", fontSize: "14px" }; },
+    table: { width: "100%", borderCollapse: "collapse", background: "#fff", borderRadius: "8px", overflow: "hidden" },
+    th: { padding: "12px", textAlign: "left", borderBottom: "1px solid #eee", background: "#fafafa", fontWeight: "600" },
+    td: { padding: "12px", borderBottom: "1px solid #eee" },
+    badge: { padding: "4px 8px", borderRadius: "4px", fontSize: "12px", fontWeight: "500" },
+    badgeOk: { background: "#52c41a", color: "#fff" },
+    badgeNo: { background: "#faad14", color: "#fff" },
+    badgeOff: { background: "#ff4d4f", color: "#fff" },
+    actBtn: function (primary, color) { return { padding: "4px 8px", margin: "0 2px", border: primary ? "none" : "1px solid #d9d9d9", borderRadius: "4px", cursor: "pointer", background: primary ? (color || "#0089FF") : "#fff", color: primary ? "#fff" : "#333", fontSize: "12px" }; },
+    modal: { position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 },
+    modalContent: { background: "#fff", padding: "24px", borderRadius: "8px", minWidth: "420px", maxWidth: "560px", maxHeight: "85vh", overflowY: "auto" },
+    modalTitle: { fontSize: "18px", fontWeight: "bold", marginBottom: "16px" },
+    formGroup: { marginBottom: "16px" },
+    label: { display: "block", marginBottom: "6px", fontWeight: "500", fontSize: "14px" },
+    input: { width: "100%", padding: "8px", border: "1px solid #d9d9d9", borderRadius: "4px", boxSizing: "border-box" },
+    select: { width: "100%", padding: "8px", border: "1px solid #d9d9d9", borderRadius: "4px", boxSizing: "border-box" },
+    switchRow: { display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 0" },
+    actions: { display: "flex", gap: "10px", justifyContent: "flex-end", marginTop: "20px" },
+    empty: { textAlign: "center", padding: "40px", color: "#999" },
+    loading: { textAlign: "center", padding: "40px", color: "#666" },
+    error: { color: "#ff4d4f", padding: "20px", background: "#fff2f0", borderRadius: "4px" },
+    hint: { background: "#e3f2fd", border: "1px solid #2196f3", borderRadius: "4px", padding: "10px 14px", fontSize: "13px", color: "#1565c0", marginTop: "12px", lineHeight: "1.6" },
+  };
+
+  // ============ 动态字段渲染器 ============
+  function FieldRenderer(props) {
+    var field = props.field;
+    var value = props.value;
+    var onChange = props.onChange;
+    var chDef = props.chDef;
+
+    if (field.type === "input") {
+      return h("input", { style: S.input, type: "text", value: value || "", onChange: function (e) { onChange(e.target.value); }, placeholder: field.placeholder || "" });
+    }
+    if (field.type === "text" || field.type === "password") {
+      return h("input", { style: S.input, type: field.type === "password" ? (props.showSecret ? "text" : "password") : "text", value: value || "", onChange: function (e) { onChange(e.target.value); }, placeholder: field.placeholder || "" });
+    }
+    if (field.type === "select") {
+      return h("select", { style: S.select, value: value || "", onChange: function (e) { onChange(e.target.value); } },
+        (field.options || []).map(function (opt) { return h("option", { key: opt[0], value: opt[0] }, opt[1]); })
+      );
+    }
+    if (field.type === "switch") {
+      return h("div", { style: S.switchRow },
+        h("span", { style: { fontSize: "14px" } }, field.label),
+        h(ToggleSwitch, { checked: !!value, onChange: onChange })
+      );
+    }
+    return null;
+  }
+
+  // ============ 主组件 ============
+  function BotManager() {
+    var channelKeys = Object.keys(CHANNEL_DEFS);
+    var [currentChannel, setCurrentChannel] = useState(channelKeys[0]);
+    var [agents, setAgents] = useState([]);
+    var [loading, setLoading] = useState(true);
+    var [error, setError] = useState(null);
+    var [selected, setSelected] = useState([]);
+    var [showBatch, setShowBatch] = useState(false);
+    var [editing, setEditing] = useState(null);
+    var [credentialAgent, setCredentialAgent] = useState(null);
+    var [scanningAgent, setScanningAgent] = useState(null);
+    var [status, setStatus] = useState(null);
+    var [showGuide, setShowGuide] = useState(false);
+
+    var chDef = CHANNEL_DEFS[currentChannel];
+
+    // — 扫码相关状态（仅 qrcode 渠道用） —
+    var [scanErr, setScanErr] = useState(null);
+    var [scanOk, setScanOk] = useState(false);
+    var [scanStatus, setScanStatus] = useState("");
+    var scanAgentRef = useRef(null);
+
+    // ── 数据加载 ──
+    function loadAgents() {
+      setLoading(true);
+      fetchApi("/" + currentChannel + "/agents")
+        .then(function (d) { setAgents(d.agents || []); setLoading(false); })
+        .catch(function (e) { setError(e.message); setLoading(false); });
+    }
+
+    function loadStatus() {
+      fetchApi("/" + currentChannel + "/status")
+        .then(function (d) { if (d && typeof d.total_agents !== "undefined") setStatus(d); })
+        .catch(function () {});
+    }
+
+    useEffect(function () { loadAgents(); setSelected([]); setStatus(null); }, [currentChannel]);
+    useEffect(function () { if (agents.length >= 0) { var e = 0, w = 0; agents.forEach(function (a) { if (a.enabled) e++; if (a.has_credentials) w++; }); setStatus({ total_agents: agents.length, enabled_agents: e, agents_with_credentials: w }); } }, [agents]);
+
+    // ── 操作 ──
+    function toggleAgent(id) { fetchApi("/" + currentChannel + "/agents/" + id + "/toggle", { method: "POST" }).then(loadAgents).catch(function (e) { notify("error", "切换失败: " + e.message); }); }
+    function clearCreds(id) { if (!confirm("确定清除凭据？")) return; fetchApi("/" + currentChannel + "/agents/" + id + "/clear-credentials", { method: "POST" }).then(function () { loadAgents(); notify("success", "凭据已清除"); }).catch(function (e) { notify("error", "清除失败: " + e.message); }); }
+
+    function updateAgent(id, config) {
+      return fetchApi("/" + currentChannel + "/agents/" + id + "/config", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(config) })
+        .then(function () { setEditing(null); setCredentialAgent(null); loadAgents(); notify("success", "配置已保存"); })
+        .catch(function (e) { notify("error", "保存失败: " + e.message); throw e; });
+    }
+
+    function doBatch(body) {
+      fetchApi("/" + currentChannel + "/agents/batch-update", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) })
+        .then(function () { setShowBatch(false); setSelected([]); loadAgents(); notify("success", "批量更新完成"); })
+        .catch(function (e) { notify("error", "批量更新失败: " + e.message); });
+    }
+
+    function toggleSel(id) { setSelected(function (p) { return p.indexOf(id) >= 0 ? p.filter(function (x) { return x !== id; }) : p.concat([id]); }); }
+    function selectAll() { setSelected(selected.length === agents.length ? [] : agents.map(function (a) { return a.agent_id; })); }
+
+    // ── 扫码逻辑 ──
+    var qrHook = useQrCode({
+      channel: currentChannel,
+      onSuccess: function (creds) {
+        var id = scanAgentRef.current;
+        if (!id || !creds) return;
+        var token = creds.bot_token || creds.token || creds.access_token;
+        if (!token) return;
+        setScanOk(true); setScanStatus("confirmed"); qrHook.stopPoll();
+        var url = QP.host.getApiUrl("/plugins/bot-manager/" + currentChannel + "/agents/" + id + "/config");
+        var headers = QP.host.getAuthHeaders ? QP.host.getAuthHeaders() : {};
+        headers["Content-Type"] = "application/json";
+        fetch(url, { method: "POST", headers: headers, body: JSON.stringify({ bot_token: token, enabled: true }) })
+          .then(function (r) { return r.json(); })
+          .then(function () { notify("success", "绑定成功！"); setTimeout(function () { setScanningAgent(null); scanAgentRef.current = null; setScanErr(null); setScanOk(false); setScanStatus(""); loadAgents(); }, 1200); })
+          .catch(function (e) { setScanOk(false); setScanStatus("fail"); setScanErr({ type: "error", message: "保存失败: " + e.message }); });
+      },
+      onError: function (t) { qrHook.stopPoll(); setScanOk(false); setScanStatus("fail"); setScanErr({ type: t === "expired" ? "warning" : "error", message: t === "expired" ? "二维码已过期" : t === "fetch" ? "获取二维码失败" : "绑定失败: " + t }); },
+      onStatusChange: function (s) { setScanStatus(s); }
+    });
+
+    function startScan(agent) { setScanningAgent(agent); scanAgentRef.current = agent.agent_id; qrHook.fetchQr(); }
+    function cancelScan() { qrHook.stopPoll(); qrHook.reset(); setScanningAgent(null); scanAgentRef.current = null; setScanErr(null); setScanOk(false); setScanStatus(""); }
+
+    // ── 渲染：渠道 Tab ──
+    function renderTabs() {
+      return h("div", { style: S.tabs },
+        channelKeys.map(function (key) {
+          var def = CHANNEL_DEFS[key];
+          var active = key === currentChannel;
+          return h("div", { key: key, style: S.tab(active, def.color), onClick: function () { setCurrentChannel(key); } },
+            h(def.icon, { width: 18, height: 18 }), def.name
+          );
+        })
+      );
+    }
+
+    // ── 渲染：扫码弹窗 ──
+    function ScanModal() {
+      var statusText = scanOk ? "✅ 绑定成功！" : qrHook.loading ? "正在获取二维码..." : scanStatus === "scanned" ? "⏳ 等待确认..." : qrHook.img ? "请使用" + chDef.name + "扫码绑定" : "准备中...";
+      var statusColor = scanOk ? "#52c41a" : scanStatus === "scanned" ? "#faad14" : qrHook.img ? chDef.color : "#666";
+
+      return h("div", { style: S.modal },
+        h("div", { style: Object.assign({}, S.modalContent, { maxWidth: "400px", textAlign: "center" }) },
+          h("div", { style: S.modalTitle }, scanOk ? "✅ 扫码成功" : "📱 扫码绑定" + chDef.name + " - " + scanningAgent.name),
+          !scanOk && !scanStatus !== "scanned" && scanErr && h("div", { style: { background: scanErr.type === "error" ? "#fff2f0" : "#fff7e6", border: "1px solid " + (scanErr.type === "error" ? "#ffccc7" : "#ffe58f"), borderRadius: "4px", padding: "10px", marginBottom: "12px", fontSize: "13px", color: scanErr.type === "error" ? "#cf1322" : "#d46b08" } }, scanErr.message),
+          !scanOk && scanStatus !== "scanned" && h("div", { style: { background: "#f5f5f5", borderRadius: "8px", padding: "16px", marginBottom: "12px" } },
+            qrHook.img ? h("img", { src: "data:image/png;base64," + qrHook.img, alt: "二维码", style: { width: "200px", height: "200px", display: "block", margin: "0 auto", borderRadius: "4px" } })
+              : h("div", { style: { width: "200px", height: "200px", margin: "0 auto", display: "flex", alignItems: "center", justifyContent: "center", background: "#e8e8e8", borderRadius: "4px", color: "#999" } }, qrHook.loading ? "加载中..." : "点击获取二维码")
+          ),
+          h("div", { style: { fontSize: "16px", fontWeight: "500", color: statusColor } }, statusText),
+          h("div", { style: S.actions, justifyContent: "center" },
+            !scanOk && !qrHook.img && !qrHook.loading && h("button", { style: S.btnPrimary(chDef.color), onClick: function () { setScanErr(null); qrHook.fetchQr(); } }, scanErr ? "重新获取" : "获取二维码"),
+            h("button", { style: S.btn, onClick: cancelScan }, scanOk ? "关闭" : "取消")
+          )
+        )
+      );
+    }
+
+    // ── 渲染：凭据输入弹窗（manual 渠道） ──
+    function CredentialModal() {
+      var [form, setForm] = useState({});
+      var [showSecret, setShowSecret] = useState(false);
+      useEffect(function () {
+        var init = {};
+        (chDef.credentialFields || []).forEach(function (f) { init[f.key] = credentialAgent[f.key] || ""; });
+        setForm(init);
+      }, []);
+
+      function submit(e) {
+        e.preventDefault();
+        var update = {}; var hasNew = false;
+        chDef.credentialFields.forEach(function (f) {
+          var val = form[f.key] || "";
+          if (val.trim()) { update[f.key] = val.trim(); hasNew = true; }
+          else if (f.key === "client_id" && val.trim()) { update[f.key] = val.trim(); }
+        });
+        if (!hasNew && !credentialAgent.has_credentials) { notify("warning", "请填写凭据"); return; }
+        update.enabled = true;
+        updateAgent(credentialAgent.agent_id, update);
+      }
+
+      return h("div", { style: S.modal },
+        h("div", { style: S.modalContent },
+          h("div", { style: S.modalTitle }, "🔑 配置" + chDef.name + "凭据 - " + credentialAgent.name),
+          h("form", { onSubmit: submit },
+            (chDef.credentialFields || []).map(function (f) {
+              var isPwd = f.type === "password";
+              return h("div", { key: f.key, style: S.formGroup },
+                h("label", { style: S.label }, f.label, isPwd && credentialAgent.has_credentials ? h("span", { style: { fontSize: "12px", color: "#999", marginLeft: "8px" } }, "（留空不修改）") : ""),
+                h(FieldRenderer, { field: f, value: form[f.key], showSecret: showSecret, onChange: function (v) { setForm(Object.assign({}, form, { [f.key]: v })); }, chDef: chDef }),
+                isPwd && h("label", { style: { display: "flex", alignItems: "center", gap: "6px", marginTop: "6px", fontSize: "12px", color: "#666", cursor: "pointer" } },
+                  h("input", { type: "checkbox", checked: showSecret, onChange: function (e) { setShowSecret(e.target.checked); } }), "显示密文")
+              );
+            }),
+            chDef.credentialHint && h("div", { style: S.hint }, chDef.credentialHint),
+            h("div", { style: S.actions },
+              h("button", { style: S.btn, onClick: function () { setCredentialAgent(null); } }, "取消"),
+              h("button", { style: S.btnPrimary(chDef.color), type: "submit" }, "保存并启用")
+            )
+          )
+        )
+      );
+    }
+
+    // ── 渲染：编辑弹窗（动态字段） ──
+    function EditModal() {
+      var [form, setForm] = useState({});
+      useEffect(function () {
+        var init = { enabled: editing.enabled };
+        chDef.editFields.forEach(function (f) { init[f.key] = editing[f.key] !== undefined ? editing[f.key] : (f.type === "switch" ? false : ""); });
+        setForm(init);
+      }, []);
+
+      function setF(k, v) { setForm(Object.assign({}, form, { [k]: v })); }
+
+      function submit() { updateAgent(editing.agent_id, form); }
+
+      return h("div", { style: S.modal },
+        h("div", { style: S.modalContent },
+          h("div", { style: S.modalTitle }, "编辑" + chDef.name + "配置 - " + editing.name),
+          h("div", { style: S.formGroup },
+            h("label", { style: S.label }, "启用状态"),
+            h("select", { style: S.select, value: form.enabled ? "true" : "false", onChange: function (e) { setF("enabled", e.target.value === "true"); } },
+              h("option", { value: "true" }, "已启用"), h("option", { value: "false" }, "已禁用"))
+          ),
+          chDef.editFields.map(function (f) {
+            if (f.type === "switch") { return h("div", { key: f.key }, h(FieldRenderer, { field: f, value: form[f.key], onChange: function (v) { setF(f.key, v); }, chDef: chDef })); }
+            return h("div", { key: f.key, style: S.formGroup },
+              h("label", { style: S.label }, f.label),
+              h(FieldRenderer, { field: f, value: form[f.key], onChange: function (v) { setF(f.key, v); }, chDef: chDef })
+            );
+          }),
+          h("div", { style: S.hint }, "如需配置更多高级选项，请前往「控制 → 频道 → " + chDef.name + "」"),
+          h("div", { style: S.actions },
+            h("button", { style: S.btn, onClick: function () { setEditing(null); } }, "取消"),
+            h("button", { style: S.btnPrimary(chDef.color), onClick: submit }, "保存")
+          )
+        )
+      );
+    }
+
+    // ── 渲染：批量操作弹窗 ──
+    function BatchModal() {
+      var [form, setForm] = useState({});
+
+      function submit() {
+        var body = { agent_ids: selected };
+        Object.keys(form).forEach(function (k) { if (form[k] !== "" && form[k] !== null) body[k] = k === "enabled" ? form[k] === "true" : form[k]; });
+        doBatch(body);
+      }
+
+      return h("div", { style: S.modal },
+        h("div", { style: S.modalContent },
+          h("div", { style: S.modalTitle }, "批量更新 (" + selected.length + " 个)"),
+          (chDef.batchFields || []).map(function (f) {
+            return h("div", { key: f.key, style: S.formGroup },
+              h("label", { style: S.label }, f.label + "（留空不修改）"),
+              f.type === "input" ? h("input", { style: S.input, type: "text", value: form[f.key] || "", onChange: function (e) { setF(f.key, e.target.value); }, placeholder: "如: [助手]" })
+                : h("select", { style: S.select, value: form[f.key] || "", onChange: function (e) { setF(f.key, e.target.value); } },
+                  [h("option", { value: "" }, "-- 不修改 --")].concat((f.options || []).map(function (o) { return h("option", { key: o[0], value: o[0] }, o[1]); })))
+            );
+            function setF(k, v) { setForm(Object.assign({}, form, { [k]: v })); }
+          }),
+          h("div", { style: S.actions },
+            h("button", { style: S.btn, onClick: function () { setShowBatch(false); } }, "取消"),
+            h("button", { style: S.btnPrimary(chDef.color), onClick: submit }, "批量更新")
+          )
+        )
+      );
+    }
+
+    // ── 主渲染 ──
+    if (loading) return h("div", { style: S.loading }, "加载中...");
+    if (error) return h("div", { style: S.error }, "错误: " + error);
+
+    return h("div", { style: S.container },
+      h("div", { style: S.header },
+        h("div", { style: S.title }, "🤖 Bot 管理器"),
+        h("div", { style: S.subtitle }, "统一管理微信、钉钉等渠道 Bot 配置"),
+        h("button", { onClick: function () { setShowGuide(!showGuide); }, style: { marginTop: "10px", padding: "6px 14px", background: chDef.color, color: "#fff", border: "none", borderRadius: "4px", cursor: "pointer", fontSize: "13px" } }, showGuide ? "收起说明 ▲" : "查看说明 ▼")
+      ),
+
+      showGuide && h("div", { style: { background: "#f0f7ff", borderRadius: "8px", padding: "16px", marginBottom: "16px", fontSize: "13px", color: "#555", lineHeight: "1.7" } }, [
+        h("strong", { key: "t" }, "使用指南"),
+        h("br", { key: "b1" }),
+        "• 切换上方 Tab 选择渠道（" + channelKeys.map(function (k) { return CHANNEL_DEFS[k].name; }).join(" / ") + "）",
+        h("br", { key: "b2" }),
+        chDef.binding === "qrcode" ? "• 点击「扫码绑定」获取二维码，用" + chDef.name + "扫码即可绑定" : "• 点击「🔑 配置凭据」手动输入" + chDef.name + " AppKey/AppSecret",
+        h("br", { key: "b3" }),
+        "• 点击「编辑」修改消息类型、开关等配置",
+        h("br", { key: "b4" }),
+        "• 勾选多个智能体后可批量操作",
+        h("br", { key: "b5" }),
+        "• 新增渠道：在 backend/channels.py 注册适配器 + ui/index.js 的 CHANNEL_DEFS 添加条目",
+      ]),
+
+      renderTabs(),
+
+      // 统计
+      status && h("div", { style: S.stats },
+        h("div", { style: S.statCard }, h("div", { style: S.statValue }, status.total_agents || 0), h("div", { style: S.statLabel }, "智能体总数")),
+        h("div", { style: S.statCard }, h("div", { style: Object.assign({}, S.statValue, { color: "#52c41a" }) }, status.enabled_agents || 0), h("div", { style: S.statLabel }, "已启用" + chDef.name)),
+        h("div", { style: S.statCard }, h("div", { style: Object.assign({}, S.statValue, { color: "#faad14" }) }, status.agents_with_credentials || 0), h("div", { style: S.statLabel }, "已配置凭据"))
+      ),
+
+      // 工具栏
+      h("div", { style: S.toolbar },
+        h("button", { style: S.btn, onClick: loadAgents }, "🔄 刷新"),
+        h("button", { style: S.btn, onClick: selectAll }, selected.length === agents.length ? "取消全选" : "全选"),
+        selected.length > 0 && h("button", { style: S.btnPrimary(chDef.color), onClick: function () { setShowBatch(true); } }, "批量更新 (" + selected.length + ")")
+      ),
+
+      // 表格
+      agents.length === 0 ? h("div", { style: S.empty }, "暂无智能体") :
+        h("table", { style: S.table },
+          h("thead", null, h("tr", null,
+            h("th", { style: S.th }, h("input", { type: "checkbox", checked: selected.length === agents.length && agents.length > 0, onChange: selectAll })),
+            h("th", { style: S.th }, "智能体"),
+            h("th", { style: S.th }, "状态"),
+            h("th", { style: S.th }, chDef.credentialLabel),
+            chDef.columns.map(function (col) { return h("th", { key: col.key, style: S.th }, col.label); }),
+            h("th", { style: S.th }, "操作")
+          )),
+          h("tbody", null, agents.map(function (a) {
+            return h("tr", { key: a.agent_id },
+              h("td", { style: S.td }, h("input", { type: "checkbox", checked: selected.indexOf(a.agent_id) >= 0, onChange: function () { toggleSel(a.agent_id); } })),
+              h("td", { style: S.td }, h("div", null, a.name), h("div", { style: { fontSize: "12px", color: "#999" } }, a.agent_id)),
+              h("td", { style: S.td }, h("span", { style: Object.assign({}, S.badge, a.enabled ? S.badgeOk : S.badgeOff) }, a.enabled ? "已启用" : "已禁用")),
+              h("td", { style: S.td }, h("span", { style: Object.assign({}, S.badge, a.has_credentials ? S.badgeOk : S.badgeNo) }, a.has_credentials ? "已配置" : "未配置")),
+              chDef.columns.map(function (col) { return h("td", { key: col.key, style: S.td }, a[col.key] || "-"); }),
+              h("td", { style: S.td },
+                // 凭据按钮
+                h("button", { style: S.actBtn(true, chDef.color), onClick: function () { chDef.binding === "qrcode" ? startScan(a) : setCredentialAgent(a); } }, chDef.binding === "qrcode" ? "📱 扫码绑定" : "🔑 配置凭据"),
+                // 启用/禁用
+                h("button", { style: S.actBtn(), onClick: function () { toggleAgent(a.agent_id); } }, a.enabled ? "禁用" : "启用"),
+                // 编辑
+                h("button", { style: S.actBtn(), onClick: function () { setEditing(a); } }, "编辑"),
+                // 清除
+                a.has_credentials && h("button", { style: Object.assign({}, S.actBtn(), { color: "#ff4d4f" }), onClick: function () { clearCreds(a.agent_id); } }, "清除")
+              )
+            );
+          }))
+        ),
+
+      // 弹窗
+      scanningAgent && h(ScanModal),
+      credentialAgent && h(CredentialModal),
+      editing && h(EditModal),
+      showBatch && h(BatchModal)
+    );
+  }
+
+  // ============ 注册 ============
+  if (QP.registerRoutes) { try { QP.registerRoutes(PLUGIN_ID, [{ path: "/apps/" + PLUGIN_ID, component: BotManager, label: "Bot 管理器", icon: function () { return h("span", null, "🤖"); } }]); console.info("[" + PLUGIN_ID + "] registerRoutes OK"); } catch (e) { console.warn("[" + PLUGIN_ID + "] registerRoutes:", e); } }
+  if (QP.menu && QP.menu.add) { try { QP.menu.add(PLUGIN_ID, [{ id: PLUGIN_ID + ".menu", location: "primary.settings", label: "Bot 管理", icon: function () { return h("span", null, "🤖"); }, route: PLUGIN_ID + ".home", order: 49 }]); console.info("[" + PLUGIN_ID + "] menu.add OK"); } catch (e) { console.warn("[" + PLUGIN_ID + "] menu.add:", e); } }
+  if (QP.route && QP.route.add) { try { QP.route.add(PLUGIN_ID, [{ id: PLUGIN_ID + ".home", path: "/plugin/" + PLUGIN_ID, component: BotManager }]); console.info("[" + PLUGIN_ID + "] route.add OK"); } catch (e) { console.warn("[" + PLUGIN_ID + "] route.add:", e); } }
+})();


### PR DESCRIPTION
## What Problem This Solves

Managing bot configurations across multiple channels (WeChat, DingTalk, etc.) was fragmented — each channel needed its own separate plugin. Users with multiple agents and multiple channels had no unified view of which agent was bound to which channel, and no way to batch-manage configurations.

This plugin provides a single unified UI with a **channel adapter pattern** that:
- Consolidates WeChat (QR scan) and DingTalk (manual credential) management into one interface
- Makes adding new channels a 2-step process (register adapter + add CHANNEL_DEFS entry)
- Supports multi-agent batch operations (enable/disable, message type, prefix)
- Shows real-time statistics across all channels

## Evidence

**Validation:**
```
$ qwenpaw plugin validate plugins/bot-manager
✅ Plugin validation passed
Plugin: Bot 管理器 (v1.0.0)
ID: bot-manager
```

**Smoke test (4 agents × 2 channels):**
```
=== Bot Manager Smoke Test ===
Registered channels: [dingtalk, wechat]
Agents found: [QwenPaw_QA_Agent_0.2, default, myq, zhouwen]

── 钉钉 (dingtalk) ── binding=manual
  QwenPaw_QA_Agent_0.2: enabled=False, creds=⚠️, type=markdown
  default: enabled=True, creds=✅, type=markdown
  myq: enabled=False, creds=⚠️, type=markdown
  zhouwen: enabled=False, creds=⚠️, type=markdown

── 微信 (wechat) ── binding=qrcode
  QwenPaw_QA_Agent_0.2: enabled=False, creds=⚠️, dm=open
  default: enabled=True, creds=✅, dm=open
  myq: enabled=False, creds=⚠️, dm=open
  zhouwen: enabled=False, creds=⚠️, dm=open

Status dingtalk: total=4, enabled=1, with_creds=1
Status wechat: total=4, enabled=1, with_creds=1
=== All checks PASSED ===
```

**Architecture:**
```
backend/
├── channels.py    ← Channel adapter registry (BaseChannelAdapter + Wechat/Dingtalk adapters)
└── main.py         ← Unified FastAPI API (8 routes, {channel} path param auto-routes to adapter)

ui/
└── index.js        ← CHANNEL_DEFS declarative channel definitions + adaptive UI
```

**Adding a new channel (e.g. Feishu) — only 2 steps, no other code changes:**

Backend:
```python
class FeishuChannel(ChannelAdapter):
    channel_key = "feishu"
    display_name = "飞书"
    binding_method = "manual"
    credential_fields = ["app_id", "app_secret"]
    def has_credentials(self, config):
        return bool(config.get("app_id") and config.get("app_secret"))

register_channel(FeishuChannel())
```

Frontend:
```javascript
feishu: { name: "飞书", icon: FeishuIcon, color: "#3370FF", binding: "manual", ... }
```

**API (all routes use {channel} parameter for auto-routing):**

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/channels` | GET | List supported channels |
| `/{channel}/agents` | GET | List agent configs |
| `/{channel}/agents/{id}/config` | POST | Update config |
| `/{channel}/agents/{id}/toggle` | POST | Toggle enabled |
| `/{channel}/agents/{id}/clear-credentials` | POST | Clear credentials |
| `/{channel}/agents/batch-update` | POST | Batch update |
| `/{channel}/status` | GET | Channel stats |

**Installation:**
```bash
qwenpaw plugin install plugins/bot-manager
```
