### PR TITLE
docs(multi-agent): drop nonexistent `qwenpaw providers` command

### DIFF
--- a/website/public/docs/multi-agent.en.md
+++ b/website/public/docs/multi-agent.en.md
@@ -584,7 +584,6 @@ qwenpaw cron create \
 **Commands NOT Supporting `--agent-id`** (global operations):
 
 - `qwenpaw init` - initialization
-- `qwenpaw providers` - model providers
 - `qwenpaw models` - model configuration
 - `qwenpaw env` - environment variables
 

--- a/website/public/docs/multi-agent.zh.md
+++ b/website/public/docs/multi-agent.zh.md
@@ -584,7 +584,6 @@ qwenpaw cron create \
 **不支持 `--agent-id` 的命令**（全局操作）：
 
 - `qwenpaw init` - 初始化
-- `qwenpaw providers` - 模型提供商
 - `qwenpaw models` - 模型配置
 - `qwenpaw env` - 环境变量
 


### PR DESCRIPTION
## What Problem This Solves

`website/public/docs/multi-agent.en.md` and `website/public/docs/multi-agent.zh.md` list `qwenpaw providers` as a top-level CLI command. That command does not exist: the provider/model management group is registered as `qwenpaw models` (`src/qwenpaw/cli/providers_cmd.py:480`, `@click.group("models")`), and the command registry in `src/qwenpaw/cli/main.py:135` has no `providers` entry. The same bullet list already documents `qwenpaw models` one line below, so the page advertises a command a user cannot actually run, while duplicating the entry that does work.

## Solution

Remove the nonexistent `qwenpaw providers` bullet from both language versions so the list matches the real CLI surface. Deleting rather than renaming is the minimal fix, because `qwenpaw models` is already present in the same section with the same scope (model/provider configuration) — renaming would leave a duplicate bullet.

## Changes

- `website/public/docs/multi-agent.en.md`: drop the `qwenpaw providers` bullet (1 deletion)
- `website/public/docs/multi-agent.zh.md`: drop the `qwenpaw providers` bullet (1 deletion)

No other files touched, no new dependencies, no behavior change.

## Evidence

Source-of-truth checks that the command is not real:

- `src/qwenpaw/cli/main.py:135` — the `lazy_subcommands=` map contains `"models": ("qwenpaw.cli.providers_cmd", "models_group", ...)` but no `"providers"` key.
- `src/qwenpaw/cli/providers_cmd.py:480` — `@click.group("models")`. The module is named `providers_cmd.py`, but the command name it exposes is `models`.
- `git log -S'@click.group("providers")' --all` returns no commits, so the command name never existed in this repository.
- `src/qwenpaw/cli/auto.py:36` — the only dynamic command generator (`_MANAGER_CLASSES`) registers subcommands under the `auto` group, not a top-level `providers` command.
- `website/public/docs/cli.en.md:196` — the CLI reference documents this group as `qwenpaw models`.

Verification performed locally:

- `git diff` shows exactly 2 files and 2 deletions, nothing else; `git status --porcelain` lists only those two files.
- Repo-wide `grep -rn 'qwenpaw providers' website/public/docs/` is now empty.
- Format gate (the same `prettier` the CI `website format check` uses): `git show :<file> | prettier@3.0.0 --check --stdin-filepath website/public/docs/<file>` → exit 0 for both files. The identical check against the `origin/main` baseline is also exit 0, so this PR neither introduces nor "fixes" unrelated formatting.
- pre-commit hooks applicable to `.md`: `trailing-whitespace` → exit 0 and the staged content is byte-identical after the hook; `detect-private-key` → exit 0. The `prettier` hook in `.pre-commit-config.yaml:123` is scoped to `files: \.(tsx?)$` and does not apply to `.md`; the remaining hooks are Python/YAML/JSON/XML/TOML-only.
- No test in the repository reads `website/public/docs/**` (searched `tests/`), so there is no runnable test to extend for a docs-only change; this directory is covered by the website format gate.

## Notes for Reviewer

- **Conflict check (risk = 0).** `multi-agent.en.md` and `multi-agent.zh.md` do not appear in my previous PRs' file set, in the recent merged-PR file set, or in the current open-PR file set.
- My previous PRs and the files they touch: #7675 (`website/public/docs/mcp.zh.md`), #7440 (`intro.en.md`, `intro.zh.md`), #7391 (`config.en.md`, `config.zh.md`), #7390 (`tests/unit/providers/test_model_catalog.py`), #7269 (`loop-engineering.en.md`, `loop-engineering.zh.md`), #7214 (`README.md`, `README_ja.md`, `README_zh.md`). None of them overlap with this PR.
- `website/public/release-notes/v1.1.3.md:40` also mentions `qwenpaw providers update`. Release notes are historical records of what shipped at that time, so I deliberately left them untouched; this PR only fixes the current user-facing guide.
