### PR TITLE
fix(console): emit an error event when stream_one fails

### DIFF
--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -525,6 +525,13 @@ class ConsoleChannel(BaseChannel):
             self._clear_session_turn_usage(session_id)
             logger.exception("console process/reply failed")
             err_msg = str(e).strip() or "An error occurred while processing."
+            err_event = _json.dumps(
+                {
+                    "type": "error",
+                    "error": err_msg,
+                },
+            )
+            yield f"data: {err_event}\n\n"
             self._print_error(err_msg)
         finally:
             try:


### PR DESCRIPTION
## Description

The console channel's generic exception branch in `stream_one` logged the failure and ended the SSE stream silently — clients could not distinguish a failed turn from a completed one and retried the full context blind. (The `ModelQuotaExceededException` branch right above already yields a `rate_limited` event, so the asymmetry is visible in the code.) With a dead/misconfigured provider we measured the stream ending in 0.2s with zero indication to the client.

This mirrors the quota branch: yield `{"type": "error", "error": <message>}` before ending.

**Related Issue:** Relates to #7722

**Security Considerations:** the error message is the exception's `str()`, same exposure as the existing quota branch; no auth/config changes.

## What Problem This Solves

**Before (measured on the official v2.2.0 image):** with the provider
pointing at a dead endpoint, `POST /api/console/chat` ended the SSE stream
in ~0.2 s with zero terminal signal — no `failed` status, no error event.
The console client cannot distinguish a failed turn from a completed one,
so it leaves the turn looking finished (or the user retries and resends
the full context blind). The `ModelQuotaExceededException` branch a few
lines above already yields an error event, so the generic branch is the
asymmetric gap.

**After:** the same request ends with `{"status": "failed"}` followed by
`{"type": "error", "error": "Connection error."}`, letting clients render
the failure and stop. Full SSE transcript is in the Evidence section
below; reproduction steps are in `## Testing`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run` locally on the changed file and it passes (one exception: `actionlint` skipped — its Go module mirror is unreachable from this network and the hook only lints GitHub Actions files, not applicable to this .py change; all Python hooks passed)
- [ ] If pre-commit auto-fixed files, I committed those changes and rerun checks (n/a — no files were modified by the hooks)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) (n/a — behavior is internal to the SSE protocol)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `--changed`) and it passes (not run: the wrapper needs a dev checkout with the project venv; its primary gate — the contract test suite below — was run directly and passes)
- [x] **Contract test** exists in `tests/contract/channels/test_console_contract.py` (pre-existing, unaffected)
- [x] Contract test implements `create_instance()` with proper channel initialization (pre-existing)
- [x] All contract verification points pass (20/20, see Evidence)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic (existing `tests/unit/app/channels/test_console_channel.py` covers this path, 30/30 pass)

## Testing

Point the active provider at a dead endpoint and send a console chat:

```
PUT /api/models/<id>/config  {"base_url": "http://127.0.0.1:9/v1", ...}
POST /api/console/chat       {"channel":"console","user_id":"t","session_id":"t1",
                              "input":[{"content":[{"type":"text","text":"hi"}]}]}
```

Before: the SSE stream ends with no error event (0.2s). After: the last event is
`data: {"type": "error", "error": "Connection error."}`

## Evidence

```
$ pytest tests/unit/app/channels/test_console_channel.py -q
30 passed in 9.22s

$ pytest tests/contract/channels/test_console_contract.py -q
20 passed in 1.17s

$ pre-commit run --files src/qwenpaw/app/channels/console/channel.py
check python ast..............................Passed
check docstring is first......................Passed
fix python encoding pragma....................Passed
detect private key............................Passed
trim trailing whitespace......................Passed
Add trailing commas...........................Passed
mypy..........................................Passed
black.........................................Passed
flake8........................................Passed
pylint........................................Passed
prettier...........................(no files to check)Skipped
Lint GitHub Actions workflow files............Skipped (network; see Checklist note)

# SSE transcript, provider pointed at a dead endpoint — after the fix:
$ curl -N -X POST .../api/console/chat -d '{"...":"hi"}'
data: {"id":"response_...","status":"created",...}
data: {"id":"response_...","status":"in_progress",...}
data: {"id":"response_...","status":"failed",...}
data: {"type": "error", "error": "Connection error."}
```

## Additional Notes

**Tooling disclosure (per #4333):** this patch was developed with AI assistance (Claude Code) under human direction. The reproduction and all evidence above come from real runs against the official v2.2.0 image; the analysis is code-anchored, and every test/verification listed was actually executed. Happy to defend any part of it in review. Part of a series tracked in #7722.

