### PR TITLE
fix(workspace): replace blocking watchfiles.awatch SSE watcher with threaded polling

### DIFF
--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -13,11 +13,13 @@ import io
 import json
 import logging
 import mimetypes
+import os
+import queue
 import secrets
 import shutil
 import stat
 import tempfile
-import os
+import threading
 import zipfile
 from collections.abc import Mapping
 from datetime import datetime, timezone
@@ -35,7 +37,6 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
-from watchfiles import awatch, Change
 from pydantic import BaseModel, Field
 
 from ..utils import check_upload_size, safe_join, schedule_agent_reload
@@ -91,7 +92,8 @@ router = APIRouter(prefix="/workspace", tags=["workspace"])
 logger = logging.getLogger(__name__)
 _FILESYSTEM_SEMAPHORE = asyncio.Semaphore(8)
 _WATCH_HEARTBEAT_SECONDS = 30.0
-_WATCH_POLL_TIMEOUT_MS = 1_000
+_WATCH_POLL_INTERVAL_SECONDS = 2.0
+_WATCH_QUEUE_TIMEOUT_SECONDS = 1.0
 
 
 class MdFileInfo(BaseModel):
@@ -245,10 +247,6 @@ _SKIP_NAMES: frozenset[str] = frozenset(
         ".hypothesis",
     },
 )
-
-
-def _should_skip(rel_parts: tuple[str, ...]) -> bool:
-    return any(p.startswith(".") or p in _SKIP_NAMES for p in rel_parts)
 
 
 def _is_skipped_name(name: str) -> bool:
@@ -1064,6 +1062,84 @@ async def write_code_file(
     return {"path": file_path, "size": size}
 
 
+def _scan_snapshot(watch_dir: Path) -> dict[str, tuple[int, int]]:
+    """Walk ``watch_dir`` and snapshot every non-ignored file.
+
+    Returns ``{rel_posix_path: (mtime_ns, size)}``. Dotfiles and
+    ``_SKIP_NAMES`` entries (``node_modules``, ``.venv``, ``.git``, ...) are
+    pruned while walking so huge dependency trees never get scanned. Runs as
+    plain Python, so it releases the GIL at bytecode boundaries and is safe
+    to call from a background thread.
+    """
+    snapshot: dict[str, tuple[int, int]] = {}
+    stack: list[tuple[Path, str]] = [(watch_dir, "")]
+    while stack:
+        dir_path, rel = stack.pop()
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if _is_skipped_name(entry.name):
+                        continue
+                    rel_path = f"{rel}/{entry.name}" if rel else entry.name
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append((Path(entry.path), rel_path))
+                        else:
+                            st = entry.stat(follow_symlinks=False)
+                            snapshot[rel_path] = (st.st_mtime_ns, st.st_size)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return snapshot
+
+
+def _diff_events(
+    prev: dict[str, tuple[int, int]],
+    cur: dict[str, tuple[int, int]],
+) -> list[dict[str, str]]:
+    """Diff two snapshots into ``{"change": ..., "path": ...}`` events."""
+    events: list[dict[str, str]] = []
+    for path in sorted(cur.keys() - prev.keys()):
+        events.append({"change": "added", "path": path})
+    for path in sorted(prev.keys() - cur.keys()):
+        events.append({"change": "deleted", "path": path})
+    for path in sorted(prev.keys() & cur.keys()):
+        if cur[path] != prev[path]:
+            events.append({"change": "modified", "path": path})
+    return events
+
+
+def _poll_watch_worker(
+    watch_dir: Path,
+    out: queue.Queue[tuple[str, object]],
+    stop: threading.Event,
+    interval: float,
+) -> None:
+    """Background poller: baseline snapshot, then periodic diff.
+
+    Emits ``("ready", None)`` after the initial scan, ``("changes", events)``
+    for each poll that observed file changes, and ``("done", None)`` when
+    stopped. Runs entirely off the event loop — the initial baseline scan is
+    the expensive part on large workspaces and must never block the loop
+    (see https://github.com/agentscope-ai/QwenPaw/issues/7721).
+    """
+    try:
+        prev = _scan_snapshot(watch_dir)
+        out.put(("ready", None))
+        while not stop.wait(interval):
+            try:
+                cur = _scan_snapshot(watch_dir)
+            except Exception:
+                continue
+            events = _diff_events(prev, cur)
+            prev = cur
+            if events:
+                out.put(("changes", events))
+    finally:
+        out.put(("done", None))
+
+
 @router.get(
     "/watch",
     summary="SSE stream for agent workspace file changes",
@@ -1098,64 +1174,65 @@ async def workspace_watch_events(
     request: Request,
     watch_dir: Path,
 ) -> AsyncIterator[str]:
-    """Yield workspace file changes without cancelling the watcher on idle."""
+    """Yield workspace file changes without cancelling the watcher on idle.
+
+    A background thread owns all filesystem scanning: the initial baseline
+    scan (the expensive part on large workspaces) and every poll run off the
+    event loop, so opening the file browser on a huge tree can never freeze
+    the server (see https://github.com/agentscope-ai/QwenPaw/issues/7721).
+    """
     yield 'data: {"type": "connected"}\n\n'
-    watcher = awatch(
-        watch_dir,
-        rust_timeout=_WATCH_POLL_TIMEOUT_MS,
-        yield_on_timeout=True,
+    loop = asyncio.get_running_loop()
+    stop = threading.Event()
+    out: queue.Queue[tuple[str, object]] = queue.Queue()
+    thread = threading.Thread(
+        target=_poll_watch_worker,
+        args=(watch_dir, out, stop, _WATCH_POLL_INTERVAL_SECONDS),
+        name="workspace-watch",
+        daemon=True,
     )
-    last_emit = asyncio.get_running_loop().time()
+    thread.start()
+    last_emit = loop.time()
     try:
         while True:
             if await request.is_disconnected():
                 break
             try:
-                raw_changes = await watcher.__anext__()
-            except (
-                StopAsyncIteration,
-                asyncio.CancelledError,
-                GeneratorExit,
-            ):
+                kind, payload = await asyncio.to_thread(
+                    out.get,
+                    True,
+                    _WATCH_QUEUE_TIMEOUT_SECONDS,
+                )
+            except queue.Empty:
+                kind, payload = None, None
+
+            now = loop.time()
+            if kind == "ready":
+                # Initial baseline scan finished; incremental events follow.
+                yield 'data: {"type": "ready"}\n\n'
+                last_emit = now
+            elif kind == "changes":
+                events = payload
+                if events:
+                    payload_json = json.dumps(
+                        {"type": "file_change", "events": events},
+                        ensure_ascii=False,
+                    )
+                    yield f"data: {payload_json}\n\n"
+                    last_emit = now
+            elif kind == "done":
                 break
 
-            events = []
-            for change_type, path in raw_changes:
-                try:
-                    rel = Path(path).relative_to(watch_dir)
-                except ValueError:
-                    continue
-                if _should_skip(rel.parts):
-                    continue
-                change_name = (
-                    "added"
-                    if change_type is Change.added
-                    else "deleted"
-                    if change_type is Change.deleted
-                    else "modified"
-                )
-                events.append(
-                    {"change": change_name, "path": rel.as_posix()},
-                )
-
-            now = asyncio.get_running_loop().time()
-            if events:
-                payload = json.dumps(
-                    {"type": "file_change", "events": events},
-                    ensure_ascii=False,
-                )
-                yield f"data: {payload}\n\n"
-                last_emit = now
-            elif now - last_emit >= _WATCH_HEARTBEAT_SECONDS:
+            # Heartbeat also fires during a long initial scan (the loop is
+            # never blocked waiting for it), keeping proxies from timing out.
+            if now - last_emit >= _WATCH_HEARTBEAT_SECONDS:
                 yield ": heartbeat\n\n"
                 last_emit = now
     except (asyncio.CancelledError, GeneratorExit):
         pass
     finally:
-        try:
-            await watcher.aclose()
-        except Exception:
-            pass
+        stop.set()
+        thread.join(timeout=_WATCH_POLL_INTERVAL_SECONDS + 1.0)
 
 
 @router.get(

--- a/tests/unit/app/routers/test_workspace_files_router.py
+++ b/tests/unit/app/routers/test_workspace_files_router.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from watchfiles import Change
 
 from qwenpaw.app.routers import workspace as workspace_router
 
@@ -338,55 +337,32 @@ async def test_watch_remains_open_after_idle_poll(
     watch_dir = tmp_path / "project"
     watch_dir.mkdir()
     target = watch_dir / "notes.md"
-    captured: dict[str, object] = {}
-
-    class FakeWatcher:
-        def __init__(self) -> None:
-            self.calls = 0
-            self.closed = False
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            self.calls += 1
-            if self.calls == 1:
-                return set()
-            if self.calls == 2:
-                return {(Change.modified, str(target))}
-            raise StopAsyncIteration
-
-        async def aclose(self) -> None:
-            self.closed = True
-
-    watcher = FakeWatcher()
-
-    def fake_awatch(path: Path, **kwargs):
-        captured["path"] = path
-        captured.update(kwargs)
-        return watcher
+    target.write_text("v1")
+    monkeypatch.setattr(workspace_router, "_WATCH_POLL_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_QUEUE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_HEARTBEAT_SECONDS", 0.15)
 
     class ConnectedRequest:
         async def is_disconnected(self) -> bool:
             return False
 
-    monkeypatch.setattr(workspace_router, "awatch", fake_awatch)
-    messages = [
-        message
-        async for message in workspace_router.workspace_watch_events(
-            ConnectedRequest(),
-            watch_dir,
-        )
-    ]
+    agen = workspace_router.workspace_watch_events(
+        ConnectedRequest(),
+        watch_dir,
+    )
+    assert (await anext(agen)) == 'data: {"type": "connected"}\n\n'
+    assert (await anext(agen)) == 'data: {"type": "ready"}\n\n'
 
-    assert captured == {
-        "path": watch_dir,
-        "rust_timeout": 1_000,
-        "yield_on_timeout": True,
-    }
-    assert any('"path": "notes.md"' in message for message in messages)
-    assert watcher.calls == 3
-    assert watcher.closed is True
+    # Idle wake-up: the stream stays open and emits a heartbeat instead of
+    # closing the watcher.
+    assert (await anext(agen)) == ": heartbeat\n\n"
+
+    # A real change after the idle wake-up is still reported.
+    target.write_text("v2")
+    message = await anext(agen)
+    assert '"type": "file_change"' in message
+    assert '"modified"' in message and '"notes.md"' in message
+    await agen.aclose()
 
 
 @pytest.mark.asyncio
@@ -397,18 +373,9 @@ async def test_watch_checks_disconnect_after_idle_poll(
     """An idle wake-up must promptly observe a disconnected client."""
     watch_dir = tmp_path / "project"
     watch_dir.mkdir()
-
-    class IdleWatcher:
-        def __init__(self) -> None:
-            self.calls = 0
-            self.closed = False
-
-        async def __anext__(self):
-            self.calls += 1
-            return set()
-
-        async def aclose(self) -> None:
-            self.closed = True
+    monkeypatch.setattr(workspace_router, "_WATCH_POLL_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_QUEUE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_HEARTBEAT_SECONDS", 0.15)
 
     class DisconnectingRequest:
         def __init__(self) -> None:
@@ -418,14 +385,7 @@ async def test_watch_checks_disconnect_after_idle_poll(
             self.calls += 1
             return self.calls > 1
 
-    watcher = IdleWatcher()
     request = DisconnectingRequest()
-    monkeypatch.setattr(
-        workspace_router,
-        "awatch",
-        lambda *_args, **_kwargs: watcher,
-    )
-
     messages = [
         message
         async for message in workspace_router.workspace_watch_events(
@@ -434,7 +394,9 @@ async def test_watch_checks_disconnect_after_idle_poll(
         )
     ]
 
-    assert messages == ['data: {"type": "connected"}\n\n']
-    assert watcher.calls == 1
-    assert request.calls == 2
-    assert watcher.closed is True
+    assert messages[0] == 'data: {"type": "connected"}\n\n'
+    # The stream ends promptly after an idle wake-up observes the disconnect
+    # (a "ready" event may or may not have landed first — either way the
+    # generator must stop, never spin forever).
+    assert len(messages) <= 2
+    assert request.calls >= 2

--- a/tests/unit/app/routers/test_workspace_router_watch.py
+++ b/tests/unit/app/routers/test_workspace_router_watch.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the workspace SSE file-watch endpoint.
+
+Covers the pure-Python polling watcher that replaced ``watchfiles.awatch``
+(https://github.com/agentscope-ai/QwenPaw/issues/7721): the baseline
+snapshot walker, the snapshot diff, the background poller thread, and the
+SSE generator (connected / ready / file_change / heartbeat / disconnect).
+"""
+
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app.routers import workspace as workspace_router
+from qwenpaw.app.routers.workspace import (
+    _diff_events,
+    _poll_watch_worker,
+    _scan_snapshot,
+    workspace_watch_events,
+)
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.disconnected = False
+
+    async def is_disconnected(self) -> bool:
+        return self.disconnected
+
+
+def _touch(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _fast_watch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workspace_router, "_WATCH_POLL_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_QUEUE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_HEARTBEAT_SECONDS", 0.2)
+
+
+# ---------------------------------------------------------------------------
+# _scan_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_scan_snapshot_prunes_ignored_dirs(tmp_path):
+    _touch(tmp_path / "src" / "main.py")
+    _touch(tmp_path / "src" / "sub" / "mod.py")
+    _touch(tmp_path / "node_modules" / "pkg" / "index.js")
+    _touch(tmp_path / ".venv" / "lib" / "site.py")
+    _touch(tmp_path / ".hidden" / "secret.txt")
+    _touch(tmp_path / ".git" / "config")
+
+    snap = _scan_snapshot(tmp_path)
+    assert set(snap) == {"src/main.py", "src/sub/mod.py"}
+    mtime, size = snap["src/main.py"]
+    assert size == 0
+    assert mtime > 0
+
+
+def test_scan_snapshot_missing_root_is_empty(tmp_path):
+    assert not _scan_snapshot(tmp_path / "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# _diff_events
+# ---------------------------------------------------------------------------
+
+
+def test_diff_events_detects_added_deleted_modified():
+    prev = {"a.txt": (1, 10), "b.txt": (1, 10), "c.txt": (1, 10)}
+    cur = {"b.txt": (1, 10), "c.txt": (2, 10), "d.txt": (1, 10)}
+    events = _diff_events(prev, cur)
+    assert events == [
+        {"change": "added", "path": "d.txt"},
+        {"change": "deleted", "path": "a.txt"},
+        {"change": "modified", "path": "c.txt"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _poll_watch_worker
+# ---------------------------------------------------------------------------
+
+
+def test_poll_worker_ready_changes_done(tmp_path):
+    _touch(tmp_path / "a.txt", "1")
+    out: queue.Queue[tuple[str, object]] = queue.Queue()
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_poll_watch_worker,
+        args=(tmp_path, out, stop, 0.05),
+        daemon=True,
+    )
+    thread.start()
+    try:
+        kind, payload = out.get(timeout=2)
+        assert kind == "ready"
+
+        _touch(tmp_path / "b.txt", "2")
+        kind, payload = out.get(timeout=2)
+        assert kind == "changes"
+        assert {"change": "added", "path": "b.txt"} in payload
+
+        (tmp_path / "a.txt").write_text("changed")
+        kind, payload = out.get(timeout=2)
+        assert kind == "changes"
+        assert {"change": "modified", "path": "a.txt"} in payload
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+        kind, payload = out.get(timeout=2)
+        assert kind == "done"
+
+
+# ---------------------------------------------------------------------------
+# workspace_watch_events (SSE generator)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_events_full_flow(tmp_path, monkeypatch):
+    _fast_watch_settings(monkeypatch)
+    _touch(tmp_path / "a.txt", "1")
+    request = _FakeRequest()
+    agen = workspace_watch_events(request, tmp_path)
+
+    assert (await anext(agen)) == 'data: {"type": "connected"}\n\n'
+    assert (await anext(agen)) == 'data: {"type": "ready"}\n\n'
+
+    _touch(tmp_path / "b.txt", "2")
+    msg = await anext(agen)
+    assert '"type": "file_change"' in msg
+    assert '"added"' in msg and '"b.txt"' in msg
+
+    # heartbeat fires when idle (window shortened by _fast_watch_settings)
+    msg = await anext(agen)
+    assert msg == ": heartbeat\n\n"
+
+    # disconnect stops the stream
+    request.disconnected = True
+    with pytest.raises(StopAsyncIteration):
+        await anext(agen)
+    await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_watch_events_loop_responsive_during_slow_scan(
+    tmp_path,
+    monkeypatch,
+):
+    """Regression: the initial scan must never block the event loop."""
+    monkeypatch.setattr(workspace_router, "_WATCH_QUEUE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_POLL_INTERVAL_SECONDS", 0.05)
+
+    def slow_scan(_watch_dir):
+        time.sleep(0.4)
+        return {}
+
+    monkeypatch.setattr(workspace_router, "_scan_snapshot", slow_scan)
+
+    request = _FakeRequest()
+    agen = workspace_watch_events(request, tmp_path)
+    assert (await anext(agen)) == 'data: {"type": "connected"}\n\n'
+
+    async def tick() -> None:
+        await asyncio.sleep(0.1)
+
+    task = asyncio.create_task(tick())
+    # Returns when the slow scan finishes (~0.4s); the concurrent task must
+    # already be done, proving the loop kept running during the scan.
+    msg = await anext(agen)
+    assert msg == 'data: {"type": "ready"}\n\n'
+    assert task.done()
+    await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_watch_events_heartbeat_during_scan(tmp_path, monkeypatch):
+    """Heartbeats keep flowing while the initial scan is still running."""
+    monkeypatch.setattr(workspace_router, "_WATCH_QUEUE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_POLL_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(workspace_router, "_WATCH_HEARTBEAT_SECONDS", 0.15)
+
+    def slow_scan(_watch_dir):
+        time.sleep(0.4)
+        return {}
+
+    monkeypatch.setattr(workspace_router, "_scan_snapshot", slow_scan)
+
+    request = _FakeRequest()
+    agen = workspace_watch_events(request, tmp_path)
+    assert (await anext(agen)) == 'data: {"type": "connected"}\n\n'
+    # Heartbeats (every 0.15s) must keep arriving while the scan (0.4s) is
+    # still in flight — i.e. at least one heartbeat before "ready".
+    frames = []
+    while True:
+        msg = await anext(agen)
+        if msg == 'data: {"type": "ready"}\n\n':
+            break
+        frames.append(msg)
+    assert frames
+    assert all(m == ": heartbeat\n\n" for m in frames)
+    await agen.aclose()


### PR DESCRIPTION
## Description

Opening the file browser on a large workspace froze the **entire server**. The
`/api/workspace/watch` SSE stream used `watchfiles.awatch`, whose
`RustNotify` performs a **synchronous recursive baseline scan** inside
`__init__` (notify crate `watcher.watch(path, RecursiveMode::Recursive)` on
inotify). With `awatch` that scan runs on the event loop at the first
`await watcher.__anext__()` and **holds the GIL for its whole duration**
(watchfiles only offloads the poll loop via `anyio.to_thread`; the init scan
has no `py.detach`/`allow_threads`). On a 192,898-file / 6.2 GB workspace the
scan takes 25 s+, during which the event loop cannot serve any request, the
WebUI is unresponsive, and even SIGTERM is not handled (container killed after
10 s, exit 137).

This PR replaces `awatch` with a **pure-Python polling watcher owned by a
background thread**:

- `_scan_snapshot()` walks the tree with `os.scandir`, pruning dotfiles and
  `_SKIP_NAMES` (`node_modules`, `.venv`, `.git`, ...) while walking, and
  snapshots `(mtime_ns, size)` per file.
- `_poll_watch_worker()` runs the initial baseline scan and then diffs each
  poll, pushing `("ready", ...)` / `("changes", ...)` / `("done", ...)` to a
  `queue.Queue`; the async generator consumes it with a bounded `get(timeout)`.
- Plain Python releases the GIL at bytecode boundaries, so the event loop
  stays responsive during even the initial scan — the key property the Rust
  init scan did not have (verified empirically: the Rust scan starves other
  threads to ~0.8 % of their normal progress).
- `watchfiles` is no longer used by this endpoint (it was the only user in the
  codebase).

Two behavioral improvements are included:

1. A `ready` SSE frame after the initial baseline scan completes, so consumers
   know incremental events have started. The frontend (`useWorkspaceWatch`)
   ignores unknown frame types, so this is backward compatible.
2. Heartbeat comments now also fire during a long initial scan (the loop is
   never blocked waiting for it), keeping proxies from timing out.

**Related Issue:** Fixes #7721

**Security Considerations:** No new external surface — the worker thread only
scans the filesystem paths the agent is already allowed to browse, event paths
are already relative to the watched root, and no credentials/env handling is
touched. The new `ready` frame is ignored by the existing frontend consumer.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
  (ran on the changed files — all applicable hooks pass: check-ast,
  check-docstring-first, fix-encoding-pragma, trailing-whitespace,
  detect-private-key, add-trailing-comma, mypy, black, flake8, pylint;
  actionlint/prettier skipped as no workflow/JS files are touched)
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
  (`pytest tests/unit/app/routers/ -q` → 689 passed, 1 skipped)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- New unit tests in `tests/unit/app/routers/test_workspace_router_watch.py`:
  snapshot pruning, diff (added/deleted/modified), worker
  ready→changes→done, full SSE flow (connected/ready/file_change/heartbeat/
  disconnect), event-loop-responsiveness during a slow scan, and
  heartbeat-during-scan.
- Updated the two existing watch contract tests
  (`test_workspace_files_router.py`) to the new implementation: idle polls
  keep the stream open and disconnect is observed after an idle wake-up.
- End-to-end in a Docker test image containing the real 6.3 GB / 33k-file
  workspace: `connected` at 0 ms, `ready` at 0.4 s (previously the server
  froze for 25 s+), file-change events arrive within one poll interval, and a
  concurrent request responds in ~2 ms while the baseline scan is running.

## Evidence

```bash
pre-commit run --files src/qwenpaw/app/routers/workspace.py \
  tests/unit/app/routers/test_workspace_router_watch.py \
  tests/unit/app/routers/test_workspace_files_router.py
# check python ast ............ Passed
# check docstring is first .... Passed
# fix python encoding pragma .. Passed
# detect private key .......... Passed
# trim trailing whitespace .... Passed
# Add trailing commas ......... Passed
# mypy ........................ Passed
# black ....................... Passed
# flake8 ...................... Passed
# pylint ...................... Passed

pytest tests/unit/app/routers/ -q
# 689 passed, 1 skipped, 7 warnings in 19.65s
```

Real-behavior verification inside the test container (6.3 GB workspace):

```
[connected] 'data: {"type": "connected"}'  (0ms)
[ready]     'data: {"type": "ready"}'      (0.40s)   # baseline scan of the full tree
[file_change added]   +2.7s  {"change":"added",   "path":"watch_e2e_probe.txt"}
[file_change deleted] +4.7s  {"change":"deleted", "path":"watch_e2e_probe.txt"}
# during the scan, a concurrent request to the console returned in 0.002s
# (event loop NOT blocked) — previously the whole server froze for 25s+
```

## Additional Notes

- Trade-offs of polling vs inotify: event latency is bounded by the poll
  interval (default 2 s, module constant `_WATCH_POLL_INTERVAL_SECONDS`), and
  while a file browser is open on a very large tree the pruned walk costs
  ~0.3 s per poll (~13 % CPU at the 2 s interval). This only occurs for trees
  where the previous implementation was completely unusable, and the walk is
  pruned so `node_modules`/`.venv`/`.git` are never scanned.
- Changes detected by `(mtime_ns, size)` — content edits that preserve both
  within one poll are not reported (rare; the next poll's size/mtime change
  catches most cases).
- The root cause also exists upstream in
  [samuelcolvin/watchfiles](https://github.com/samuelcolvin/watchfiles):
  `awatch`'s `RustNotify.__init__` should wrap the initial scan in
  `py.allow_threads`. If/when that ships, this endpoint could switch back to
  `awatch` + `asyncio.to_thread` — the polling watcher here is self-contained
  and dependency-free, so it works today.
